### PR TITLE
Status check updates

### DIFF
--- a/server/handlers/awsJobs.js
+++ b/server/handlers/awsJobs.js
@@ -430,6 +430,10 @@ let handlers = {
                 batchStatus = job.analysis.batchStatus.map((statusObj) => {
                     return batchStatus[statusObj.job] ? batchStatus[statusObj.job] : statusObj;
                 });
+                // update status array to include ALL job statuses
+                statusArray = batchStatus.map((statusObj) => {
+                    return statusObj.status;
+                });
             }
 
             analysis.batchStatus = batchStatus;

--- a/server/handlers/awsJobs.js
+++ b/server/handlers/awsJobs.js
@@ -422,6 +422,16 @@ let handlers = {
                 return (a.job.split('-')[0] > b.job.split('-')[0]) ? 1 : -1;
             });
 
+            // Check the number of returned jobs from batch (describeJobs) versus the total number of jobs in the analysis
+            // If these are different, this means that some jobs have disappeared from batch and their status is no longer being returned
+            // NOTE: disappearing from batch is not necessarily a bad thing. Batch only keeps jobs around for 24 hours after they have entered
+            // a failed or succeeded state
+            if(batchStatus.length != job.analysis.jobs.length) {
+                batchStatus = job.analysis.batchStatus.map((statusObj) => {
+                    return batchStatus[statusObj.job] ? batchStatus[statusObj.job] : statusObj;
+                });
+            }
+
             analysis.batchStatus = batchStatus;
 
             let finished = handlers._checkJobStatus(statusArray);
@@ -454,6 +464,7 @@ let handlers = {
                 let jobId = typeof job._id === 'object' ? job._id : ObjectID(job._id);
                 let jobUpdate = {
                     'analysis.status': analysis.status,
+                    'analysis.batchStatus': analysis.batchStatus,
                     results: results
                 };
                 c.crn.jobs.updateOne({_id: jobId}, {

--- a/server/libs/aws/batch.js
+++ b/server/libs/aws/batch.js
@@ -307,7 +307,7 @@ export default (aws) => {
             // create initial batchStatus array
             let batchStatus = batchIds.map((id) => {
                 return {
-                    status: "SUBMITTED",
+                    status: 'SUBMITTED',
                     job: id
                 };
             });

--- a/server/libs/aws/batch.js
+++ b/server/libs/aws/batch.js
@@ -304,11 +304,20 @@ export default (aws) => {
          * returns no return. Batch job start is happening after response has been send to client
          */
         _updateJobOnSubmitSuccessful(jobId, batchIds) {
+            // create initial batchStatus array
+            let batchStatus = batchIds.map((id) => {
+                return {
+                    status: "SUBMITTED",
+                    job: id
+                };
+            });
+
             c.crn.jobs.updateOne({_id: ObjectID(jobId)}, {
                 $set:{
                     'analysis.status': 'PENDING', //setting status to pending as soon as job submissions is successful
                     'analysis.attempts': 1,
                     'analysis.jobs': batchIds, // Should be an array of AWS ids for each AWS batch job
+                    'analysis.batchStatus': batchStatus,
                     uploadSnapshotComplete: true
                 }
             }, () => {


### PR DESCRIPTION
* resolves https://github.com/OpenNeuroOrg/openneuro/issues/4 and should resolve some other issues with long running jobs.
* adding a batchStatus property to job.analysis in mongo.
* checking for consistency between the number of jobs returned during status check from batch and the total number expected. If there is a mismatch, the the dropped job statuses from the previous check are used for the missing ones.
