### PR TITLE
Handle all versions of the log stream names after Batch API changes

### DIFF
--- a/server/handlers/awsJobs.js
+++ b/server/handlers/awsJobs.js
@@ -330,7 +330,7 @@ let handlers = {
         let appName = req.params.app;
         let jobId = req.params.jobId;
         let taskArn = req.params.taskArn;
-        let key = appName + '/default/' + taskArn;
+        let key = appName + '/' + jobId + '/' + taskArn;
 
         aws.cloudwatch.getLogs(key, [], null, true, (err, logs) => {
             if (err) {

--- a/server/handlers/awsJobs.js
+++ b/server/handlers/awsJobs.js
@@ -330,7 +330,7 @@ let handlers = {
         let appName = req.params.app;
         let jobId = req.params.jobId;
         let taskArn = req.params.taskArn;
-        let key = appName + '/' + jobId + '/' + taskArn;
+        let key = appName + '/default/' + taskArn;
 
         aws.cloudwatch.getLogs(key, [], null, true, (err, logs) => {
             if (err) {
@@ -495,7 +495,8 @@ let handlers = {
                 if (job.attempts && job.attempts.length > 0) {
                     job.attempts.forEach((attempt)=> {
                         let streamObj = {
-                            name: job.jobName + '/' + job.jobId + '/' + attempt.container.taskArn.split('/').pop(),
+                            // Prior to August 21st, 2017 default was job.jobId
+                            name: job.jobName + '/default/' + attempt.container.taskArn.split('/').pop(),
                             environment: job.container.environment,
                             exitCode: job.container.exitCode
                         };

--- a/server/handlers/jobs.js
+++ b/server/handlers/jobs.js
@@ -134,7 +134,11 @@ let handlers = {
             if (err) {return next(err);}
             for (let job of jobs) {
                 if (job.analysis.logstreams) {
-                    job.analysis.logstreams = job.analysis.logstreams.map(aws.cloudwatch.formatLegacyLogStream);
+                    let streamNameVersion = aws.cloudwatch.streamNameVersion(job);
+                    job.analysis.logstreams = job.analysis.logstreams.map((stream) => {
+                        // Fix legacy internal logstream values and adapt for changes in Batch names
+                        return aws.cloudwatch.formatLegacyLogStream(stream, streamNameVersion);
+                    });
                 }
             }
             if (snapshot) {


### PR DESCRIPTION
This solves issue #12. There's three situations to handle here.

1. Jobs run prior to 2017-08-21T14:00-07:00. These use the old log stream names in CloudWatch and are correct. These need to be served without changes.
1. Jobs run prior to pulling in this fix but after the August 21st date. These use the old log stream name internally but CloudWatch uses the new format.
1. Jobs run after this branch is merged. These store the new CloudWatch stream name format.

All of these should have accessible logs (for individual tasks or download all) with these changes.