### PR TITLE
Add check submit status method to componentWillReceiveProps

### DIFF
--- a/app/src/scripts/dataset/tools/jobs/index.js
+++ b/app/src/scripts/dataset/tools/jobs/index.js
@@ -74,6 +74,8 @@ export default class JobMenu extends React.Component {
                 }
             });
         }
+
+        this._checkSubmitStatus();
     }
 
     render() {


### PR DESCRIPTION
* resolves #14 
* moving submission button status check to different lifecycle method as modal is mounted on page load, whether shown or not, and does not get unmounted unless we navigate away from dataset page.