### PR TITLE
Adding canceled to ignored statuses for auth

### DIFF
--- a/server/libs/auth.js
+++ b/server/libs/auth.js
@@ -115,7 +115,7 @@ let auth = {
             return next();
         }
 
-        c.crn.jobs.find({userId: user, 'analysis.status': {$nin: ['SUCCEEDED', 'FAILED', 'REJECTED']}}).toArray((err, jobs) => {
+        c.crn.jobs.find({userId: user, 'analysis.status': {$nin: ['SUCCEEDED', 'FAILED', 'REJECTED', 'CANCELED']}}).toArray((err, jobs) => {
             let totalRunningJobs = jobs.length;
             if(totalRunningJobs < 2) {
                 return next();


### PR DESCRIPTION
CANCELED status was counting against job run limit for non-admin users.  This should not happen.  Adding that status to ignored status list for jobs