### PR TITLE
Fix displaying a browser upgrade warning to Googlebot

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -18,7 +18,7 @@
     "async": "^1.2.1",
     "babel-polyfill": "^6.6.1",
     "bids-validator": "0.21.6",
-    "bowser": "^1.0.0",
+    "bowser": "^1.7.3",
     "bytes": "^2.3.0",
     "favico.js": "git://github.com/ejci/favico.js#0.3.10",
     "moment": "^2.10.3",

--- a/app/src/scripts/common/partials/__tests__/__snapshots__/happybrowser.spec.jsx.snap
+++ b/app/src/scripts/common/partials/__tests__/__snapshots__/happybrowser.spec.jsx.snap
@@ -1,0 +1,54 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`common/partials/happybrowser renders successfully 1`] = `
+<div
+  className="happybrowser-markup hidden"
+>
+  <div
+    className="hb-wrap clearfix"
+  >
+    <div
+      className="hb-text clearfix"
+    >
+      <img
+        alt="warning"
+        src="./assets/warning.jpg"
+      />
+      <p>
+        We have detected that you are using an incompatible browser. This site may not work as expected. 
+        <strong>
+          <a
+            href="http://www.google.com/chrome/"
+          >
+            Please consider using Chrome, V49.0 or higher, as your browser
+          </a>
+          .
+        </strong>
+      </p>
+    </div>
+    <div
+      className="hb-upgrade clearfix"
+    >
+      <div
+        className="hb-img-wrap hb-dismiss"
+        id="dismiss"
+        onClick={[Function]}
+      >
+        X
+      </div>
+      <div
+        className="hb-img-wrap hb-chrome"
+      >
+        <a
+          href="http://www.google.com/chrome/"
+        >
+          <img
+            alt="upgrade chrome"
+            src="./assets/chrome.jpg"
+          />
+        </a>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/app/src/scripts/common/partials/__tests__/happybrowser.spec.jsx
+++ b/app/src/scripts/common/partials/__tests__/happybrowser.spec.jsx
@@ -2,6 +2,7 @@ import Happybrowser from '../happybrowser';
 
 const chrome = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.78 Safari/537.36';
 const chromium = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Ubuntu Chromium/60.0.3112.113 Chrome/60.0.3112.113 Safari/537.36';
+const googlebot = 'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)';
 const ie = 'Mozilla/5.0 (Windows; U; MSIE 6.0; Windows NT 5.1; SV1; .NET CLR 2.0.50727)';
 const firefox = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:57.0) Gecko/20100101 Firefox/57.0';
 
@@ -21,6 +22,12 @@ describe('common/partials/happybrowser', () => {
     it('is hidden in Chromium', () => {
         const wrapper = shallow(
             <Happybrowser ua={chromium} />
+        );
+        expect(wrapper.hasClass('hidden')).toBe(true);
+    });
+    it('is hidden when accessed by Googlebot', () => {
+        const wrapper = shallow(
+            <Happybrowser ua={googlebot} />
         );
         expect(wrapper.hasClass('hidden')).toBe(true);
     });

--- a/app/src/scripts/common/partials/__tests__/happybrowser.spec.jsx
+++ b/app/src/scripts/common/partials/__tests__/happybrowser.spec.jsx
@@ -1,0 +1,39 @@
+import Happybrowser from '../happybrowser';
+
+const chrome = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.78 Safari/537.36';
+const chromium = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Ubuntu Chromium/60.0.3112.113 Chrome/60.0.3112.113 Safari/537.36';
+const ie = 'Mozilla/5.0 (Windows; U; MSIE 6.0; Windows NT 5.1; SV1; .NET CLR 2.0.50727)';
+const firefox = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:57.0) Gecko/20100101 Firefox/57.0';
+
+describe('common/partials/happybrowser', () => {
+    it('renders successfully', () => {
+        const wrapper = shallow(
+            <Happybrowser ua={chrome} />
+        );
+        expect(wrapper).toMatchSnapshot();
+    });
+    it('is hidden in Chrome', () => {
+        const wrapper = shallow(
+            <Happybrowser ua={chrome} />
+        );
+        expect(wrapper.hasClass('hidden')).toBe(true);
+    });
+    it('is hidden in Chromium', () => {
+        const wrapper = shallow(
+            <Happybrowser ua={chromium} />
+        );
+        expect(wrapper.hasClass('hidden')).toBe(true);
+    });
+    it('is visible in IE', () => {
+        const wrapper = shallow(
+            <Happybrowser ua={ie} />
+        );
+        expect(wrapper.hasClass('hidden')).toBe(false);
+    });
+    it('is visible in Firefox', () => {
+        const wrapper = shallow(
+            <Happybrowser ua={firefox} />
+        );
+        expect(wrapper.hasClass('hidden')).toBe(false);
+    });
+});

--- a/app/src/scripts/common/partials/happybrowser.jsx
+++ b/app/src/scripts/common/partials/happybrowser.jsx
@@ -1,16 +1,16 @@
 // dependencies ------------------------------------------------------------------
-import React     from 'react';
+import React from 'react';
+import bowser from 'bowser';
 
 export default class Happybrowser extends React.Component {
 
 // life cycle methods ------------------------------------------------------------
-    constructor () {
-        super();
+    constructor (props) {
+        super(props);
         this.state = {
-            hbVisible: true
+            hbVisible: this._incompatibleBrowser(props.ua),
         };
     }
-
 
     render () {
         return (
@@ -37,6 +37,10 @@ export default class Happybrowser extends React.Component {
         );
     }
 
+    _incompatibleBrowser(ua) {
+        let check = bowser.check({chrome: "49", chromium: "49"}, true, ua || window.navigator.userAgent);
+        return !check;
+    }
 
     _dismiss () {
         let self = this;

--- a/app/src/scripts/common/partials/happybrowser.jsx
+++ b/app/src/scripts/common/partials/happybrowser.jsx
@@ -38,7 +38,7 @@ export default class Happybrowser extends React.Component {
     }
 
     _incompatibleBrowser(ua) {
-        let check = bowser.check({chrome: "49", chromium: "49"}, true, ua || window.navigator.userAgent);
+        let check = bowser.check({chrome: "49", chromium: "49", googlebot: "0"}, true, ua || window.navigator.userAgent);
         return !check;
     }
 

--- a/app/src/scripts/index.jsx
+++ b/app/src/scripts/index.jsx
@@ -3,7 +3,6 @@
 import React                    from 'react';
 import Reflux                   from 'reflux';
 import Navbar                   from './nav/navbar.jsx';
-import bowser                   from 'bowser';
 import Happybrowser             from './common/partials/happybrowser.jsx';
 import {RouteHandler, State}    from 'react-router';
 import Alert                    from './notification/notification.alert.jsx';
@@ -35,7 +34,7 @@ let App = React.createClass({
         return (
             <span>
                 <div className={'page' + pageClasses}>
-                    {this._incompatibleBrowser(bowser) ? <Happybrowser /> : null }
+                    <Happybrowser />
                     <span className={'nav-alert-state-' + alertState}>
                         <Alert />
                     </span>
@@ -50,20 +49,7 @@ let App = React.createClass({
                 </div>
             </span>
         );
-    },
-
-    _incompatibleBrowser(browser) {
-        if(browser.chrome || browser.chromium) {
-            if(browser.version < 49) {
-                return true;
-            }
-
-            return false;
-        }
-
-        return true;
     }
-
 });
 
 export default App;

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -1117,7 +1117,7 @@ boom@2.x.x:
   dependencies:
     hoek "2.x.x"
 
-bowser@^1.0.0:
+bowser@^1.7.3:
   version "1.7.3"
   resolved "https://registry.yarnpkg.com/bowser/-/bowser-1.7.3.tgz#504bdb43118ca8db9cbbadf28fd60f265af96e4f"
 


### PR DESCRIPTION
This adds user agent based happy browser unit tests and fixes the previously broken case of googlebot getting an upgrade warning. Fixes #35.