### PR TITLE
Remove bids-validator string handling from Validation component and catch this in Dataset

### DIFF
--- a/app/jestsetup.js
+++ b/app/jestsetup.js
@@ -6,3 +6,8 @@ global.React = React;
 global.shallow = shallow;
 global.render = render;
 global.mount = mount;
+
+// Fail tests on any warning
+console.error = message => {
+    throw new Error(message);
+};

--- a/app/src/scripts/dataset/__tests__/__snapshots__/dataset.validation.spec.jsx.snap
+++ b/app/src/scripts/dataset/__tests__/__snapshots__/dataset.validation.spec.jsx.snap
@@ -61,7 +61,7 @@ exports[`dataset/Validation renders successfully when validating 1`] = `
 </div>
 `;
 
-exports[`dataset/Validation renders when the dataset is marked invalid 1`] = `
+exports[`dataset/Validation renders with default props when errors prop is undefined 1`] = `
 <div
   className="fade-in col-xs-12 validation"
 >
@@ -96,10 +96,51 @@ exports[`dataset/Validation renders when the dataset is marked invalid 1`] = `
         </div>
       }
     >
-      <div>
-        This does not appear to be a BIDS dataset.
-         
-      </div>
+      <br />
+      <ValidationResults
+        errors={Array []}
+        warnings={Array []}
+      />
+    </Panel>
+  </Accordion>
+</div>
+`;
+
+exports[`dataset/Validation renders with default props when warnings prop is undefined 1`] = `
+<div
+  className="fade-in col-xs-12 validation"
+>
+  <h3
+    className="metaheader"
+  >
+    BIDS Validation
+  </h3>
+  <Accordion
+    activeKey="2"
+    className="validation-wrap"
+    onSelect={[Function]}
+  >
+    <Panel
+      bsClass="panel"
+      bsStyle="default"
+      className="status"
+      defaultExpanded={false}
+      eventKey="1"
+      header={
+        <div
+          className="super-valid"
+        >
+          <span
+            className="dataset-status ds-success"
+          >
+            <i
+              className="fa fa-check-circle"
+            />
+             Valid
+          </span>
+        </div>
+      }
+    >
       <br />
       <ValidationResults
         errors={Array []}

--- a/app/src/scripts/dataset/__tests__/__snapshots__/dataset.validation.spec.jsx.snap
+++ b/app/src/scripts/dataset/__tests__/__snapshots__/dataset.validation.spec.jsx.snap
@@ -1,57 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`dataset/Validation does not crash when errors is "Invalid" 1`] = `
-<div
-  className="fade-in col-xs-12 validation"
->
-  <h3
-    className="metaheader"
-  >
-    BIDS Validation
-  </h3>
-  <Accordion
-    activeKey="2"
-    className="validation-wrap"
-    onSelect={[Function]}
-  >
-    <Panel
-      bsClass="panel"
-      bsStyle="default"
-      className="status"
-      defaultExpanded={false}
-      eventKey="1"
-      header={
-        <div>
-          <span
-            className="dataset-status ds-danger"
-          >
-            <i
-              className="fa fa-exclamation-circle"
-            />
-             Invalid
-          </span>
-          <span
-            className="label text-danger pull-right"
-          >
-             
-          </span>
-        </div>
-      }
-    >
-      <div>
-        This does not appear to be a BIDS dataset
-         
-      </div>
-      <br />
-      <ValidationResults
-        errors="Invalid"
-        warnings={Array []}
-      />
-    </Panel>
-  </Accordion>
-</div>
-`;
-
 exports[`dataset/Validation renders successfully 1`] = `
 <div
   className="fade-in col-xs-12 validation"
@@ -110,5 +58,54 @@ exports[`dataset/Validation renders successfully when validating 1`] = `
     active={true}
     text="Validating"
   />
+</div>
+`;
+
+exports[`dataset/Validation renders when the dataset is marked invalid 1`] = `
+<div
+  className="fade-in col-xs-12 validation"
+>
+  <h3
+    className="metaheader"
+  >
+    BIDS Validation
+  </h3>
+  <Accordion
+    activeKey="2"
+    className="validation-wrap"
+    onSelect={[Function]}
+  >
+    <Panel
+      bsClass="panel"
+      bsStyle="default"
+      className="status"
+      defaultExpanded={false}
+      eventKey="1"
+      header={
+        <div
+          className="super-valid"
+        >
+          <span
+            className="dataset-status ds-success"
+          >
+            <i
+              className="fa fa-check-circle"
+            />
+             Valid
+          </span>
+        </div>
+      }
+    >
+      <div>
+        This does not appear to be a BIDS dataset.
+         
+      </div>
+      <br />
+      <ValidationResults
+        errors={Array []}
+        warnings={Array []}
+      />
+    </Panel>
+  </Accordion>
 </div>
 `;

--- a/app/src/scripts/dataset/__tests__/__snapshots__/dataset.validation.spec.jsx.snap
+++ b/app/src/scripts/dataset/__tests__/__snapshots__/dataset.validation.spec.jsx.snap
@@ -1,5 +1,57 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`dataset/Validation does not crash when errors is "Invalid" 1`] = `
+<div
+  className="fade-in col-xs-12 validation"
+>
+  <h3
+    className="metaheader"
+  >
+    BIDS Validation
+  </h3>
+  <Accordion
+    activeKey="2"
+    className="validation-wrap"
+    onSelect={[Function]}
+  >
+    <Panel
+      bsClass="panel"
+      bsStyle="default"
+      className="status"
+      defaultExpanded={false}
+      eventKey="1"
+      header={
+        <div>
+          <span
+            className="dataset-status ds-danger"
+          >
+            <i
+              className="fa fa-exclamation-circle"
+            />
+             Invalid
+          </span>
+          <span
+            className="label text-danger pull-right"
+          >
+             
+          </span>
+        </div>
+      }
+    >
+      <div>
+        This does not appear to be a BIDS dataset
+         
+      </div>
+      <br />
+      <ValidationResults
+        errors="Invalid"
+        warnings={Array []}
+      />
+    </Panel>
+  </Accordion>
+</div>
+`;
+
 exports[`dataset/Validation renders successfully 1`] = `
 <div
   className="fade-in col-xs-12 validation"

--- a/app/src/scripts/dataset/__tests__/__snapshots__/dataset.validation.spec.jsx.snap
+++ b/app/src/scripts/dataset/__tests__/__snapshots__/dataset.validation.spec.jsx.snap
@@ -1,0 +1,62 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`dataset/Validation renders successfully 1`] = `
+<div
+  className="fade-in col-xs-12 validation"
+>
+  <h3
+    className="metaheader"
+  >
+    BIDS Validation
+  </h3>
+  <Accordion
+    activeKey="2"
+    className="validation-wrap"
+    onSelect={[Function]}
+  >
+    <Panel
+      bsClass="panel"
+      bsStyle="default"
+      className="status"
+      defaultExpanded={false}
+      eventKey="1"
+      header={
+        <div
+          className="super-valid"
+        >
+          <span
+            className="dataset-status ds-success"
+          >
+            <i
+              className="fa fa-check-circle"
+            />
+             Valid
+          </span>
+        </div>
+      }
+    >
+      <br />
+      <ValidationResults
+        errors={Array []}
+        warnings={Array []}
+      />
+    </Panel>
+  </Accordion>
+</div>
+`;
+
+exports[`dataset/Validation renders successfully when validating 1`] = `
+<div
+  className="fade-in col-xs-12 validation"
+>
+  <h3
+    className="metaheader"
+  >
+    BIDS Validation
+  </h3>
+  <Spinner
+    active={true}
+    text="Validating"
+  />
+</div>
+`;

--- a/app/src/scripts/dataset/__tests__/dataset.validation.spec.jsx
+++ b/app/src/scripts/dataset/__tests__/dataset.validation.spec.jsx
@@ -25,4 +25,10 @@ describe('dataset/Validation', () => {
         );
         expect(wrapper.html()).toBe(null);
     });
+    it('renders when errors is "Invalid" instead of a list', () => {
+        const wrapper = shallow(
+            <Validation {...defProps} errors={'Invalid'} />
+        )
+        expect(wrapper).toMatchSnapshot();
+    });
 });

--- a/app/src/scripts/dataset/__tests__/dataset.validation.spec.jsx
+++ b/app/src/scripts/dataset/__tests__/dataset.validation.spec.jsx
@@ -25,10 +25,16 @@ describe('dataset/Validation', () => {
         );
         expect(wrapper.html()).toBe(null);
     });
-    it('renders when errors is "Invalid" instead of a list', () => {
+    it('renders when the dataset is marked invalid', () => {
         const wrapper = shallow(
-            <Validation {...defProps} errors={'Invalid'} />
-        )
+            <Validation {...defProps} invalid={true} />
+        );
         expect(wrapper).toMatchSnapshot();
+    });
+    it('returns the correct message on invalid datasets', () => {
+        const wrapper = shallow(
+            <Validation {...defProps} invalid={true} />
+        );
+        expect(wrapper.contains('This does not appear to be a BIDS dataset.')).toBe(true);
     });
 });

--- a/app/src/scripts/dataset/__tests__/dataset.validation.spec.jsx
+++ b/app/src/scripts/dataset/__tests__/dataset.validation.spec.jsx
@@ -25,16 +25,42 @@ describe('dataset/Validation', () => {
         );
         expect(wrapper.html()).toBe(null);
     });
-    it('renders when the dataset is marked invalid', () => {
+    it('invalid dataset is not super-valid', () => {
         const wrapper = shallow(
             <Validation {...defProps} invalid={true} />
         );
-        expect(wrapper).toMatchSnapshot();
+        const div = wrapper.find('Panel > div.super-valid');
+        expect(div).toHaveLength(0);
+    });
+    it('invalid dataset panel span has class ds-danger and is "Invalid"', () => {
+        const validation = new Validation();
+        const header = shallow(validation._header([], [], true));
+        const span = header.find('span.ds-danger');
+        expect(span).toHaveLength(1);
+        expect(span.text()).toBe('Invalid');
     });
     it('returns the correct message on invalid datasets', () => {
         const wrapper = shallow(
             <Validation {...defProps} invalid={true} />
         );
         expect(wrapper.contains('This does not appear to be a BIDS dataset.')).toBe(true);
+    });
+    it('renders with default props when errors prop is undefined', () => {
+        const wrapper = shallow(
+            <Validation {...defProps} errors={undefined} />
+        );
+        expect(wrapper).toMatchSnapshot();
+    });
+    it('renders with default props when warnings prop is undefined', () => {
+        const wrapper = shallow(
+            <Validation {...defProps} warnings={undefined} />
+        );
+        expect(wrapper).toMatchSnapshot();
+    });
+    it('renders as invalid when errors prop is undefined', () => {
+        const wrapper = shallow(
+            <Validation {...defProps} errors={undefined} invalid={true} />
+        );
+        expect(wrapper.find('Panel > div').text()).toBe('This does not appear to be a BIDS dataset. ');
     });
 });

--- a/app/src/scripts/dataset/__tests__/dataset.validation.spec.jsx
+++ b/app/src/scripts/dataset/__tests__/dataset.validation.spec.jsx
@@ -1,0 +1,28 @@
+import Validation from '../dataset.validation.jsx';
+
+describe('dataset/Validation', () => {
+    const defProps = {
+        errors: [],
+        warnings: [],
+        validating: false,
+        display: true
+    };
+    it('renders successfully', () => {
+        const wrapper = shallow(
+            <Validation {...defProps} />
+        );
+        expect(wrapper).toMatchSnapshot();
+    });
+    it('renders successfully when validating', () => {
+        const wrapper = shallow(
+            <Validation {...defProps} validating={true} />
+        );
+        expect(wrapper).toMatchSnapshot();
+    });
+    it('displays nothing with display set to false', () => {
+        const wrapper = shallow(
+            <Validation {...defProps} display={false} />
+        );
+        expect(wrapper.html()).toBe(null);
+    });
+});

--- a/app/src/scripts/dataset/dataset.jsx
+++ b/app/src/scripts/dataset/dataset.jsx
@@ -58,8 +58,9 @@ let Dataset = React.createClass({
         let content;
 
         if (dataset) {
-            let errors = dataset.validation.errors;
-            let warnings = dataset.validation.warnings;
+            let invalid = typeof dataset.validation.errors === 'string' ? true : false;
+            let errors = invalid ? [] : dataset.validation.errors;
+            let warnings = invalid ? [] : dataset.validation.warnings;
             content = (
                 <div className="clearfix dataset-wrap">
                     <div className="dataset-annimation">
@@ -86,7 +87,12 @@ let Dataset = React.createClass({
                                 </div>
                                 <div className="col-xs-6">
                                     <div>
-                                        <Validation errors={errors} warnings={warnings} validating={dataset.status.validating} display={!dataset.status.incomplete} />
+                                        <Validation
+                                            errors={errors}
+                                            warnings={warnings}
+                                            validating={dataset.status.validating}
+                                            display={!dataset.status.incomplete}
+                                            invalid={invalid} />
                                         <div className="fade-in col-xs-12">
                                             <Jobs />
                                         </div>

--- a/app/src/scripts/dataset/dataset.jsx
+++ b/app/src/scripts/dataset/dataset.jsx
@@ -58,9 +58,9 @@ let Dataset = React.createClass({
         let content;
 
         if (dataset) {
-            let invalid = typeof dataset.validation.errors === 'string' ? true : false;
-            let errors = invalid ? [] : dataset.validation.errors;
-            let warnings = invalid ? [] : dataset.validation.warnings;
+            let invalid = typeof dataset.validation === 'string' ? true : false;
+            let errors = dataset.validation.errors;
+            let warnings = dataset.validation.warnings;
             content = (
                 <div className="clearfix dataset-wrap">
                     <div className="dataset-annimation">

--- a/app/src/scripts/dataset/dataset.validation.jsx
+++ b/app/src/scripts/dataset/dataset.validation.jsx
@@ -52,7 +52,7 @@ export default class Validation extends React.Component {
         } else {
             return (
                 <Accordion className="validation-wrap" activeKey={this.state.activeKey} onSelect={this._togglePanel.bind(this)}>
-                    <Panel className="status" header={this._header(errors, warnings)} eventKey="1">
+                    <Panel className="status" header={this._header(errors, warnings, invalid)} eventKey="1">
                         {this._message(errors, warnings, invalid)}<br />
                         <Results errors={errors} warnings={warnings} />
                     </Panel>
@@ -61,12 +61,13 @@ export default class Validation extends React.Component {
         }
     }
 
-    _header(errors, warnings) {
+    _header(errors, warnings, invalid) {
         let errs, warns, superValid;
 
-        let status = errors.length ? <span className="dataset-status ds-danger"><i className="fa fa-exclamation-circle" /> Invalid</span> : <span className="dataset-status ds-success"><i className="fa fa-check-circle" /> Valid</span>;
+        let failed = errors.length || invalid;
+        let status = failed ? <span className="dataset-status ds-danger"><i className="fa fa-exclamation-circle" />Invalid</span> : <span className="dataset-status ds-success"><i className="fa fa-check-circle" /> Valid</span>;
         if (errors.length > 0) {
-            errs =  <span className="label text-danger pull-right"> {errors != 'Invalid' ? errors.length +' '+ pluralize('Error', errors.length) : null}</span>;
+            errs = <span className="label text-danger pull-right"> {errors != 'Invalid' ? errors.length +' '+ pluralize('Error', errors.length) : null}</span>;
         }
         if (warnings && warnings.length > 0) {
             warns = <span className="label text-warning pull-right">{warnings.length} {pluralize('Warning', warnings.length)}</span>;

--- a/app/src/scripts/dataset/dataset.validation.jsx
+++ b/app/src/scripts/dataset/dataset.validation.jsx
@@ -113,7 +113,7 @@ Validation.propTypes = {
     invalid:    React.PropTypes.bool
 };
 
-Validation.props = {
+Validation.defaultProps = {
     errors:     [],
     warnings:   [],
     validating: false,

--- a/app/src/scripts/dataset/dataset.validation.jsx
+++ b/app/src/scripts/dataset/dataset.validation.jsx
@@ -31,28 +31,29 @@ export default class Validation extends React.Component {
         let errors     = this.props.errors,
             warnings   = this.props.warnings,
             validating = this.props.validating,
-            display    = this.props.display;
+            display    = this.props.display,
+            invalid    = this.props.invalid;
 
         if (!display) {return false;}
 
         return (
             <div className="fade-in col-xs-12 validation">
                 <h3 className="metaheader">BIDS Validation</h3>
-                {this._accordion(errors, warnings, validating)}
+                {this._accordion(errors, warnings, validating, invalid)}
             </div>
         );
     }
 
 // templates methods --------------------------------------------------
 
-    _accordion(errors, warnings, validating) {
+    _accordion(errors, warnings, validating, invalid) {
         if (validating) {
             return <Spinner text="Validating" active={true} />;
         } else {
             return (
                 <Accordion className="validation-wrap" activeKey={this.state.activeKey} onSelect={this._togglePanel.bind(this)}>
                     <Panel className="status" header={this._header(errors, warnings)} eventKey="1">
-                        {this._message(errors, warnings)}<br />
+                        {this._message(errors, warnings, invalid)}<br />
                         <Results errors={errors} warnings={warnings} />
                     </Panel>
                 </Accordion>
@@ -76,10 +77,10 @@ export default class Validation extends React.Component {
         return <div className={superValid}>{status}{errs}{warns}</div>;
     }
 
-    _message(errors, warnings) {
+    _message(errors, warnings, invalid) {
         let errMessage, warnMessage;
-        if (errors === 'Invalid') {
-            errMessage = 'This does not appear to be a BIDS dataset';
+        if (invalid) {
+            errMessage = 'This does not appear to be a BIDS dataset.';
         } else {
             if (errors.length > 0) {
                 errMessage = <span className="message error fade-in">Your dataset is no longer valid. You must fix the <strong>{errors.length + ' ' + pluralize('Error', errors.length)}</strong> to use all of the site features.</span>;
@@ -107,11 +108,14 @@ Validation.propTypes = {
     errors:     React.PropTypes.array,
     warnings:   React.PropTypes.array,
     validating: React.PropTypes.bool,
-    display:    React.PropTypes.bool
+    display:    React.PropTypes.bool,
+    invalid:    React.PropTypes.bool
 };
 
 Validation.props = {
     errors:     [],
     warnings:   [],
-    validating: false
+    validating: false,
+    display: true,
+    invalid: false
 };


### PR DESCRIPTION
This is a second pass at fixing #32. This uses defaultProps to handle the undefined errors/warnings case and fixes a broken check in the Dataset component to flag a Validation component as Invalid when there's no errors or warnings.

Replaces #34.