### PR TITLE
Fix boolean shell flags

### DIFF
--- a/server/libs/aws/batch.js
+++ b/server/libs/aws/batch.js
@@ -429,7 +429,7 @@ export default (aws) => {
          */
         _prepareArguments(parameters) {
             return Object.keys(parameters).filter((key) => {
-                // Skip empty arguments
+                // Skip empty or false boolean arguments
                 let value = parameters[key];
                 if (value instanceof Array) {
                     return value.length > 0;
@@ -438,7 +438,16 @@ export default (aws) => {
                 }
             }).map((key) => {
                 let argument = '--' + key + ' ';
-                let value = typeof parameters[key] === 'string' ? this._formatString(parameters[key]) : parameters[key];
+                let value = parameters[key];
+                if (typeof value === 'boolean') {
+                    // Don't include the value if it is a boolean
+                    // Arguments should be '--<key>' not '--<key> true'
+                    value = '';
+                    // Trim the extra space added after the flag
+                    argument = argument.slice(0, -1);
+                } else if (typeof value === 'string') {
+                    value = this._formatString(parameters[key]);
+                }
                 if (value instanceof Array) {
                     value = value.map((item)=> {
                         return typeof item === 'string' ? this._formatString(item) : item;

--- a/server/tests/libs/aws.spec.js
+++ b/server/tests/libs/aws.spec.js
@@ -63,6 +63,11 @@ describe('libs/aws/batch.js', () => {
             let args = aws.batch._prepareArguments(params);
             assert.equal(args, '--participant_label 01 02 03 --ica --n_cpus 4');
         });
+        it('should exclude false booleans correctly in mixed parameters', () => {
+            let params = Object.assign({}, subjectParam, falseBoolParam, nCpusParam);
+            let args = aws.batch._prepareArguments(params);
+            assert.equal(args, '--participant_label 01 02 03 --n_cpus 4');
+        });
     });
     describe('_partitionLabels()', () => {
         it('should produce 3 expected groupings from 3 labels', () => {

--- a/server/tests/libs/aws.spec.js
+++ b/server/tests/libs/aws.spec.js
@@ -6,6 +6,7 @@ const subjectParam = {participant_label: ['01', '02', '03']};
 const nCpusParam = {n_cpus: 4};
 const templateNameParam = {template_name: 'template1'};
 const boolParam = {ica: true};
+const falseBoolParam = {ica: false};
 const emptyParam = {template_name: []};
 const nullParam = {template_name: null};
 const spaceParam = {license_key: 'Super Secret Shhhhhh', cartoons: ['Ren and Stimpy']};
@@ -51,6 +52,11 @@ describe('libs/aws/batch.js', () => {
             let params = Object.assign({}, boolParam);
             let args = aws.batch._prepareArguments(params);
             assert.equal(args, '--ica');
+        });
+        it('should exclude false booleans as bare flags', () => {
+            let params = Object.assign({}, falseBoolParam);
+            let args = aws.batch._prepareArguments(params);
+            assert.equal(args, '');
         });
         it('should include booleans correctly in mixed parameters', () => {
             let params = Object.assign({}, subjectParam, boolParam, nCpusParam);

--- a/server/tests/libs/aws.spec.js
+++ b/server/tests/libs/aws.spec.js
@@ -5,6 +5,7 @@ var aws = require('../../libs/aws');
 const subjectParam = {participant_label: ['01', '02', '03']};
 const nCpusParam = {n_cpus: 4};
 const templateNameParam = {template_name: 'template1'};
+const boolParam = {ica: true};
 const emptyParam = {template_name: []};
 const nullParam = {template_name: null};
 const spaceParam = {license_key: 'Super Secret Shhhhhh', cartoons: ['Ren and Stimpy']};
@@ -45,6 +46,16 @@ describe('libs/aws/batch.js', () => {
             let params = Object.assign({}, subjectParam, spaceParam);
             let args = aws.batch._prepareArguments(params);
             assert.equal(args, '--participant_label 01 02 03 --license_key \'Super Secret Shhhhhh\' --cartoons \'Ren and Stimpy\'');
+        });
+        it('should include booleans as bare flags', () => {
+            let params = Object.assign({}, boolParam);
+            let args = aws.batch._prepareArguments(params);
+            assert.equal(args, '--ica');
+        });
+        it('should include booleans correctly in mixed parameters', () => {
+            let params = Object.assign({}, subjectParam, boolParam, nCpusParam);
+            let args = aws.batch._prepareArguments(params);
+            assert.equal(args, '--participant_label 01 02 03 --ica --n_cpus 4');
         });
     });
     describe('_partitionLabels()', () => {


### PR DESCRIPTION
This adds tests for and handles the case where boolean flags should be converted to '--flag' instead of '--flag true'. Fixes #11.