### PR TITLE
Chrome + Linux boolean job parameter css fixes

### DIFF
--- a/app/src/sass/crn_app/_common.modals.scss
+++ b/app/src/sass/crn_app/_common.modals.scss
@@ -123,6 +123,29 @@
         color: $c-9e;
         background: $eee;
     }
+
+    label > input[type=checkbox] {
+        width: 30px;
+        border: 0;
+        box-shadow: none;
+        &:focus {
+            box-shadow: none;
+            outline: 0;
+        }
+    }
+
+    label.help-text {
+        display: flex;
+        align-items: center;
+        justify-content: left;
+        background: none;
+        border: 0;
+
+        span {
+            padding-left: 8px;
+        }
+    }
+
 }
 
 .sign-in-block,

--- a/app/src/sass/main.scss
+++ b/app/src/sass/main.scss
@@ -235,48 +235,6 @@ $bootstrap-sass-asset-helper: true;
     }
 }
 
-/* fixes for modals */
-
-div.form-inline > span {
-    div:nth-child(4) {
-        width: 70% !important;
-        label {
-            background: transparent !important;
-            padding-right: 6px !important;
-        }
-    }
-    div:nth-child(5), 
-    div:nth-child(6) {
-        width: 15% !important;
-    }
-}
-
-div.input-group {
-
-    div.clearfix {            
-        width: 99%;
-        display: flex;
-        .Select--multi {
-            width: 75%;
-        }
-
-        input[type='checkbox']{
-            width: 15%;
-            border: none;
-            box-shadow: none;
-        }
-
-        input[type='checkbox']:focus {
-            outline: none;
-        }
-
-        span.help-text {
-            background: transparent;
-            border: none !important;
-        }
-    }
-}
-
 #hidden {
     display: none;
 }

--- a/app/src/scripts/dataset/tools/jobs/__tests__/__snapshots__/parameters.spec.jsx.snap
+++ b/app/src/scripts/dataset/tools/jobs/__tests__/__snapshots__/parameters.spec.jsx.snap
@@ -1,0 +1,197 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`dataset/tools/jobs/parameters renders successfully 1`] = `
+<div>
+  <br />
+  <hr />
+  <br />
+  <div
+    className="row"
+  >
+    <div
+      className="col-xs-6"
+    >
+      <h5>
+        Parameters
+      </h5>
+    </div>
+    <div
+      className="col-xs-6 default-reset"
+    >
+      <button
+        className="btn-reset"
+        onClick={[Function]}
+      >
+        Restore Default Parameters
+      </button>
+    </div>
+  </div>
+  <div
+    className={null}
+    id={null}
+  >
+    <div
+      className="parameters form-horizontal"
+    >
+      <div
+        className="form-group"
+      >
+        <label
+          className="sr-only"
+        >
+          boolean
+        </label>
+        <div
+          className="input-group"
+        >
+          <div
+            className="input-group-addon"
+          >
+            boolean
+          </div>
+          <div
+            className="clearfix"
+          >
+            <label
+              className="help-text"
+            >
+              <input
+                className="form-control"
+                name="boolean"
+                onChange={[Function]}
+                type="checkbox"
+              />
+              some kind of checkbox
+            </label>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    className={null}
+    id={null}
+  >
+    <div
+      className="parameters form-horizontal"
+    >
+      <div
+        className="form-group"
+      >
+        <label
+          className="sr-only"
+        >
+          participant_label
+        </label>
+        <div
+          className="input-group"
+        >
+          <div
+            className="input-group-addon"
+          >
+            participant_label
+          </div>
+          <div
+            className="clearfix"
+          >
+            <Select
+              addLabelText="Add \\"{label}\\"?"
+              arrowRenderer={[Function]}
+              autosize={true}
+              backspaceRemoves={true}
+              backspaceToRemoveMessage="Press backspace to remove {label}"
+              clearAllText="Clear all"
+              clearRenderer={[Function]}
+              clearValueText="Clear value"
+              clearable={true}
+              deleteRemoves={true}
+              delimiter=","
+              disabled={false}
+              escapeClearsValue={true}
+              filterOptions={[Function]}
+              ignoreAccents={true}
+              ignoreCase={true}
+              inputProps={Object {}}
+              isLoading={false}
+              joinValues={false}
+              labelKey="label"
+              matchPos="any"
+              matchProp="any"
+              menuBuffer={0}
+              menuRenderer={[Function]}
+              multi={true}
+              noResultsText="No results found"
+              onBlurResetsInput={true}
+              onChange={[Function]}
+              onCloseResetsInput={true}
+              optionComponent={[Function]}
+              options={
+                Array [
+                  "01",
+                  "02",
+                ]
+              }
+              pageSize={5}
+              placeholder="Select your subject(s)"
+              required={false}
+              scrollMenuIntoView={true}
+              searchable={true}
+              simpleValue={true}
+              tabSelectsValue={true}
+              value="01,02"
+              valueComponent={[Function]}
+              valueKey="value"
+            />
+            <span
+              className="help-text"
+            >
+              job participants
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    className="required-param"
+    id={null}
+  >
+    <div
+      className="parameters form-horizontal"
+    >
+      <div
+        className="form-group"
+      >
+        <label
+          className="sr-only"
+        >
+          another_option
+        </label>
+        <div
+          className="input-group"
+        >
+          <div
+            className="input-group-addon"
+          >
+            another_option
+          </div>
+          <div
+            className="clearfix"
+          >
+            <input
+              className="form-control"
+              onChange={[Function]}
+              value="some_string_value"
+            />
+            <span
+              className="help-text"
+            >
+              some kind of text option
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/app/src/scripts/dataset/tools/jobs/__tests__/parameters.spec.jsx
+++ b/app/src/scripts/dataset/tools/jobs/__tests__/parameters.spec.jsx
@@ -1,0 +1,48 @@
+import JobParameters from '../parameters';
+
+describe('dataset/tools/jobs/parameters', () => {
+    const onChange = jest.fn();
+    const onRestoreDefaults = jest.fn();
+    const params = {
+        'boolean': true,
+        'participant_label': '01,02',
+        'another_option': 'some_string_value'
+    };
+    const metadata = {
+        'boolean': {
+            type: 'checkbox',
+            required: false,
+            description: 'some kind of checkbox'
+        },
+        'participant_label': {
+            type: 'select',
+            required: false,
+            description: 'job participants'
+        },
+        'another_option': {
+            type: 'text',
+            required: true,
+            description: 'some kind of text option'
+        }
+    };
+    const subjects = ['01', '02'];
+
+    it('renders successfully', () => {
+        const wrapper = shallow(
+            <JobParameters 
+                parameters={params} 
+                parametersMetadata={metadata}
+                subjects={subjects}
+                onChange={onChange}
+                onRestoreDefaults={onRestoreDefaults}
+            />
+        );
+        expect(wrapper).toMatchSnapshot();
+    });
+    it('renders noscript with no parameters', () => {
+        const wrapper = shallow(
+            <JobParameters />
+        );
+        expect(wrapper.first().type()).toBe('noscript');
+    });
+});

--- a/app/src/scripts/dataset/tools/jobs/parameters.jsx
+++ b/app/src/scripts/dataset/tools/jobs/parameters.jsx
@@ -6,6 +6,7 @@ const JobParameters = ({parameters, subjects, onChange, onRestoreDefaults, param
     if (Object.keys(parameters).length === 0) {return <noscript />;}
     const parameterInputs = Object.keys(parameters).map((parameter) => {
         let input;
+        let isCheckbox = parametersMetadata[parameter].type === 'checkbox';
         if (parameter.indexOf('participant_label') > -1) {
             // Adapt the Select's onChange call to match the expected input event
             let onSelectChange = (value) => {
@@ -20,20 +21,30 @@ const JobParameters = ({parameters, subjects, onChange, onRestoreDefaults, param
                         type="file" 
                         name={parameter} 
                         onChange={onChange.bind(null, parameter)} />;
-        } else if(parametersMetadata[parameter].type === 'checkbox') {
+        } else if(isCheckbox) {
             let onCheckChange = (e) => {
                 // using checked property for checkbox values
                 let event = {target: {value: e.target.checked}};
                 return onChange(parameter, event);
             };
-            input = <input className="form-control"
+            input = <label className="help-text">
+                        <input className="form-control"
                         type="checkbox"
                         name={parameter}
-                        onChange={onCheckChange} />;
+                        onChange={onCheckChange} />
+                        {parametersMetadata[parameter] ? parametersMetadata[parameter].description: parameter}
+                    </label>;
         } else {
             input = <input className="form-control"
                            value={parameters[parameter]}
                            onChange={onChange.bind(null, parameter)}/>;
+        }
+        let help_text;
+        if (isCheckbox) {
+            // The label has the help text.
+            help_text = '';
+        } else {
+            help_text = <span className="help-text">{parametersMetadata[parameter] ? parametersMetadata[parameter].description: parameter}</span>;
         }
         return (
             <div className={parametersMetadata[parameter] && parametersMetadata[parameter].required ? 'required-param' : null} id={parametersMetadata[parameter].hidden ? 'hidden' :null} key={parameter}>
@@ -44,7 +55,7 @@ const JobParameters = ({parameters, subjects, onChange, onRestoreDefaults, param
                             <div className="input-group-addon">{parameter}</div>
                             <div className="clearfix">
                                 {input}
-                                <span className="help-text">{parametersMetadata[parameter] ? parametersMetadata[parameter].description: parameter}</span>
+                                {help_text}
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
@Xesme I restructured your change to the job run parameters to only change the checkbox layout and support a clickable label. Let me know what you think of this.

> ![boolean option example](https://user-images.githubusercontent.com/11369795/30453620-4ab4d5d2-994e-11e7-832d-b1edc79ceda3.png)
> Parameter key is "boolean" and description is "some kind of boolean" in this example.

This reverts the flexbox change for the other components since it was breaking rendering for Chrome on Linux with the React-Select based parameters.