### PR TITLE
Fix tests succeeding with React warnings

### DIFF
--- a/app/jestsetup.js
+++ b/app/jestsetup.js
@@ -6,3 +6,8 @@ global.React = React;
 global.shallow = shallow;
 global.render = render;
 global.mount = mount;
+
+// Fail tests on any warning
+console.error = message => {
+    throw new Error(message);
+};

--- a/app/package.json
+++ b/app/package.json
@@ -26,7 +26,7 @@
     "load-google-api": "^0.1.3",
     "moment": "^2.10.3",
     "pluralize": "^1.1.2",
-    "react": "0.14.8",
+    "react": "0.14.9",
     "react-bootstrap": "0.29.4",
     "react-dom": "0.14.8",
     "react-ga": "^2.2.0",

--- a/app/src/scripts/dataset/__tests__/__snapshots__/dataset.validation.spec.jsx.snap
+++ b/app/src/scripts/dataset/__tests__/__snapshots__/dataset.validation.spec.jsx.snap
@@ -1,0 +1,62 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`dataset/Validation renders successfully 1`] = `
+<div
+  className="fade-in col-xs-12 validation"
+>
+  <h3
+    className="metaheader"
+  >
+    BIDS Validation
+  </h3>
+  <Accordion
+    activeKey="2"
+    className="validation-wrap"
+    onSelect={[Function]}
+  >
+    <Panel
+      bsClass="panel"
+      bsStyle="default"
+      className="status"
+      defaultExpanded={false}
+      eventKey="1"
+      header={
+        <div
+          className="super-valid"
+        >
+          <span
+            className="dataset-status ds-success"
+          >
+            <i
+              className="fa fa-check-circle"
+            />
+             Valid
+          </span>
+        </div>
+      }
+    >
+      <br />
+      <ValidationResults
+        errors={Array []}
+        warnings={Array []}
+      />
+    </Panel>
+  </Accordion>
+</div>
+`;
+
+exports[`dataset/Validation renders successfully when validating 1`] = `
+<div
+  className="fade-in col-xs-12 validation"
+>
+  <h3
+    className="metaheader"
+  >
+    BIDS Validation
+  </h3>
+  <Spinner
+    active={true}
+    text="Validating"
+  />
+</div>
+`;

--- a/app/src/scripts/dataset/__tests__/dataset.validation.spec.jsx
+++ b/app/src/scripts/dataset/__tests__/dataset.validation.spec.jsx
@@ -1,0 +1,28 @@
+import Validation from '../dataset.validation.jsx';
+
+describe('dataset/Validation', () => {
+    const defProps = {
+        errors: [],
+        warnings: [],
+        validating: false,
+        display: true
+    };
+    it('renders successfully', () => {
+        const wrapper = shallow(
+            <Validation {...defProps} />
+        );
+        expect(wrapper).toMatchSnapshot();
+    });
+    it('renders successfully when validating', () => {
+        const wrapper = shallow(
+            <Validation {...defProps} validating={true} />
+        );
+        expect(wrapper).toMatchSnapshot();
+    });
+    it('displays nothing with display set to false', () => {
+        const wrapper = shallow(
+            <Validation {...defProps} display={false} />
+        );
+        expect(wrapper.html()).toBe(null);
+    });
+});

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -5809,9 +5809,9 @@ react-select@^1.0.0-rc.5:
     prop-types "^15.5.8"
     react-input-autosize "^1.1.3"
 
-react@0.14.8:
-  version "0.14.8"
-  resolved "https://registry.yarnpkg.com/react/-/react-0.14.8.tgz#078dfa454d4745bcc54a9726311c2bf272c23684"
+react@0.14.9:
+  version "0.14.9"
+  resolved "https://registry.yarnpkg.com/react/-/react-0.14.9.tgz#9110a6497c49d44ba1c0edd317aec29c2e0d91d1"
   dependencies:
     envify "^3.0.0"
     fbjs "^0.6.1"


### PR DESCRIPTION
This fails any tests when console.error is called, which catches most React warnings in enzyme tests. The upgrade from React 0.14.8 to 0.14.9 is needed to fix an existing warning with PropTypes.