### PR TITLE
Event logs size/consistency improvements

### DIFF
--- a/app/src/scripts/admin/__tests__/__snapshots__/admin.logs.spec.jsx.snap
+++ b/app/src/scripts/admin/__tests__/__snapshots__/admin.logs.spec.jsx.snap
@@ -1,0 +1,86 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`admin/Logs renders successfully 1`] = `
+<div
+  className="dashboard-dataset-teasers fade-in admin-users clearfix"
+>
+  <div
+    className="header-wrap clearfix"
+  >
+    <div
+      className="col-sm-9"
+    >
+      <h2>
+        Events Log
+      </h2>
+    </div>
+    <div
+      className="col-sm-3"
+    >
+      <Input
+        className="pull-right"
+        onChange={[Function]}
+        placeholder="Search Type or Email"
+      />
+    </div>
+  </div>
+  <div>
+    <div
+      className="col-xs-12 users-panel-wrap"
+    >
+      <div
+        className="fade-in user-panel-header clearfix"
+      >
+        <div
+          className="col-xs-3 user-col"
+        >
+          <label>
+            Event Type
+          </label>
+        </div>
+        <div
+          className="col-xs-3 user-col"
+        >
+          <label>
+            User
+          </label>
+        </div>
+        <div
+          className="col-xs-3 user-col"
+        >
+          <label>
+            Date
+          </label>
+        </div>
+        <div
+          className="col-xs-3 user-col"
+        >
+          <label>
+            Link
+          </label>
+        </div>
+      </div>
+      <p
+        className="no-datasets"
+      >
+        There are no event logs.
+      </p>
+    </div>
+  </div>
+  <div
+    className="pager-wrapper"
+  >
+    <Paginator
+      activePageRangeDisplayed={1}
+      breakLabel="..."
+      containerClass="pagination"
+      nextLabel="»"
+      onPageSelect={[Function]}
+      page={0}
+      pageRangeDisplayed={5}
+      pagesTotal={0}
+      prevLabel="«"
+    />
+  </div>
+</div>
+`;

--- a/app/src/scripts/admin/__tests__/admin.logs.spec.jsx
+++ b/app/src/scripts/admin/__tests__/admin.logs.spec.jsx
@@ -1,0 +1,10 @@
+import Logs from '../admin.logs';
+
+describe('admin/Logs', () => {
+    it('renders successfully', () => {
+        const wrapper = shallow(
+            <Logs />
+        );
+        expect(wrapper).toMatchSnapshot();
+    });
+});

--- a/app/src/scripts/admin/admin.logs.jsx
+++ b/app/src/scripts/admin/admin.logs.jsx
@@ -2,6 +2,7 @@
 
 import React      from 'react';
 import Reflux     from 'reflux';
+import { Link }   from 'react-router';
 import Input      from '../common/forms/input.jsx';
 import adminStore from './admin.store';
 import actions    from './admin.actions';
@@ -29,12 +30,23 @@ let Logs = React.createClass({
             var pagesTotal = Math.ceil(filteredLogs.length / this.state.resultsPerPage);
             let paginatedResults = this._paginate(filteredLogs, this.state.resultsPerPage, this.state.page);
             paginatedResults.map((log, index) => {
+                let link;
+                if ('job' in log.data) {
+                    let job = log.data.job;
+                    // Jobs are always run against snapshots, so we link to a snapshot + job ref for those
+                    link = <Link to={'snapshot'}
+                                params={{datasetId: job.datasetId, snapshotId: job.snapshotId}}
+                                query={{app: job.appLabel, version: job.appVersion, job: job.jobId}} >
+                              {job.datasetLabel} <br /> {job.appLabel}:{job.appVersion}
+                           </Link>;
+                }
                 if(log.visible){
                     logs.push(
                         <div className="fade-in user-panel-header clearfix" key={index}>
-                            <div className="col-xs-4 user-col"><label>{log.type}</label></div>
-                            <div className="col-xs-4 user-col"><label>{log.user}</label></div>
-                            <div className="col-xs-4 user-col"><label>{log.date}</label></div>
+                            <div className="col-xs-3 user-col"><label>{log.type}</label></div>
+                            <div className="col-xs-3 user-col"><label>{log.user}</label></div>
+                            <div className="col-xs-3 user-col"><label>{log.date}</label></div>
+                            <div className="col-xs-3 user-col"><label>{link}</label></div>
                         </div>
                     );
                 }
@@ -58,9 +70,10 @@ let Logs = React.createClass({
                 <div>
                     <div className="col-xs-12 users-panel-wrap">
                         <div className="fade-in user-panel-header clearfix" >
-                            <div className="col-xs-4 user-col"><label>Event Type</label></div>
-                            <div className="col-xs-4 user-col"><label>User</label></div>
-                            <div className="col-xs-4 user-col"><label>Date</label></div>
+                            <div className="col-xs-3 user-col"><label>Event Type</label></div>
+                            <div className="col-xs-3 user-col"><label>User</label></div>
+                            <div className="col-xs-3 user-col"><label>Date</label></div>
+                            <div className="col-xs-3 user-col"><label>Link</label></div>
                         </div>
                         {results.length != 0 ? results : null}
                     </div>

--- a/server/handlers/eventLogs.js
+++ b/server/handlers/eventLogs.js
@@ -14,6 +14,7 @@ let handlers = {
     getEventLogs (req, res, next) {
         // This stuff could be a middleware?
         let limit = 30;
+        /*eslint-disable no-unused-vars*/
         let skip = 0;
         let reqLimit = parseInt(req.query.limit);
         let reqSkip = parseInt(req.query.skip);
@@ -25,9 +26,7 @@ let handlers = {
         }
         c.crn.logs.find({type:{$in: events}},
             {
-                sort : [['date', 'desc']],
-                limit: limit,
-                skip: skip
+                sort : [['date', 'desc']]
             }).toArray((err, logs) => {
                 if(err) return next(err);
                 res.send(logs);

--- a/server/handlers/eventLogs.js
+++ b/server/handlers/eventLogs.js
@@ -12,10 +12,26 @@ let events = Object.keys(config.events);
  */
 let handlers = {
     getEventLogs (req, res, next) {
-        c.crn.logs.find({type:{$in: events}}, {sort : [['date', 'desc']]}).toArray((err, logs)=> {
-            if(err) return next(err);
-            res.send(logs);
-        });
+        // This stuff could be a middleware?
+        let limit = 30;
+        let skip = 0;
+        let reqLimit = parseInt(req.query.limit);
+        let reqSkip = parseInt(req.query.skip);
+        if (!isNaN(reqLimit) && reqLimit < limit) {
+            limit = req.query.limit;
+        }
+        if (!isNaN(reqSkip) && reqSkip) {
+            skip = reqSkip;
+        }
+        c.crn.logs.find({type:{$in: events}},
+            {
+                sort : [['date', 'desc']],
+                limit: limit,
+                skip: skip
+            }).toArray((err, logs) => {
+                if(err) return next(err);
+                res.send(logs);
+            });
     }
 };
 

--- a/server/libs/aws/batch.js
+++ b/server/libs/aws/batch.js
@@ -26,6 +26,20 @@ function _depsObjects(depsIds) {
     });
 }
 
+const extractJobLog = (job) => {
+    let jobLog = {
+        'datasetId': job.datasetId,
+        'datasetLabel': job.datasetLabel,
+        'snapshotId': job.snapshotId,
+        'appLabel': job.appLabel,
+        'appVersion': job.appVersion,
+        'status': job.analysis.status,
+        'created': job.analysis.created,
+        'parameters': job.parameters
+    };
+    return jobLog;
+};
+
 export default (aws) => {
 
     const batch = new aws.Batch();
@@ -527,7 +541,9 @@ export default (aws) => {
          */
         jobComplete(job, userId) {
             if(!job.analysis.notification) {
-                emitter.emit(events.JOB_COMPLETED, {job: job, completedDate: new Date()}, userId);
+                // Save a summary of the job object instead of the whole dataset
+                let jobLog = extractJobLog(job);
+                emitter.emit(events.JOB_COMPLETED, {job: jobLog, completedDate: new Date()}, userId);
                 notifications.jobComplete(job);
                 let jobId = typeof job._id === 'object' ? job._id : ObjectID(job._id);
                 c.crn.jobs.updateOne({_id: jobId}, {

--- a/server/libs/aws/batch.js
+++ b/server/libs/aws/batch.js
@@ -191,7 +191,8 @@ export default (aws) => {
                         // TODO - Maybe we save the error message into another field for display?
                         c.crn.jobs.updateOne({_id: ObjectID(jobId)}, {$set: {'analysis.status': 'REJECTED'}});
                     } else {
-                        emitter.emit(events.JOB_STARTED, {job: batchJobParams, createdDate: job.analysis.created}, userId);
+                        let jobLog = extractJobLog(job);
+                        emitter.emit(events.JOB_STARTED, {job: jobLog, createdDate: job.analysis.created}, userId);
                     }
                     callback();
                 });


### PR DESCRIPTION
This reduces the size of the JOB_COMPLETED logs by filtering out stuff like the results and logs file references, and adds a link to the related object for jobs events in the admin dashboard.

The current logs collection has to be truncated to test/deploy this. This fixes #8, fixes #40, and part of #3.