### PR TITLE
Add admin datasets/jobs dashboards

### DIFF
--- a/app/src/scripts/admin/admin.jsx
+++ b/app/src/scripts/admin/admin.jsx
@@ -26,6 +26,7 @@ class Dashboard extends React.Component {
                         <li><Link to="app-definitions" className="btn-tab">App Definitions</Link></li>
                         <li><Link to="event-logs" className="btn-tab">Event Logs</Link></li>
                         <li><Link to="admin-datasets" className="btn-tab">All Datasets</Link></li>
+                        <li><Link to="admin-jobs" className="btn-tab">All Jobs</Link></li>
                     </ul>
                     <RouteHandler/>
                 </div>

--- a/app/src/scripts/admin/admin.jsx
+++ b/app/src/scripts/admin/admin.jsx
@@ -25,6 +25,7 @@ class Dashboard extends React.Component {
                         <li><Link to="blacklist" className="btn-tab">Blocked Users</Link></li>
                         <li><Link to="app-definitions" className="btn-tab">App Definitions</Link></li>
                         <li><Link to="event-logs" className="btn-tab">Event Logs</Link></li>
+                        <li><Link to="admin-datasets" className="btn-tab">All Datasets</Link></li>
                     </ul>
                     <RouteHandler/>
                 </div>

--- a/app/src/scripts/dashboard/dashboard.datasets.jsx
+++ b/app/src/scripts/dashboard/dashboard.datasets.jsx
@@ -26,20 +26,23 @@ let Datasets = React.createClass({
 
     componentDidMount() {
         let isPublic = this.getPath().indexOf('dashboard') === -1;
-        Actions.update({isPublic});
-        Actions.getDatasets(isPublic);
+        let isAdmin = this.getPath().indexOf('admin') !== -1;
+        Actions.update({isPublic, isAdmin});
+        Actions.getDatasets(isPublic, isAdmin);
     },
 
     componentWillReceiveProps() {
         let isPublic = this.getPath().indexOf('dashboard') === -1;
-        Actions.update({isPublic});
-        Actions.getDatasets(isPublic);
+        let isAdmin = this.getPath().indexOf('admin') !== -1;
+        Actions.update({isPublic, isAdmin});
+        Actions.getDatasets(isPublic, isAdmin);
     },
 
     render() {
         let datasets = this.state.datasets;
         let visibleDatasets = this.state.visibleDatasets;
         let isPublic  = this.state.isPublic;
+        let isAdmin = this.state.isAdmin;
         let results;
         if (datasets.length === 0 && isPublic) {
             let noDatasets = 'There are no public datasets.';
@@ -58,12 +61,21 @@ let Datasets = React.createClass({
             results = this._datasets(paginatedResults, isPublic);
         }
 
+        let title;
+        if (isAdmin) {
+            title = 'All Datasets';
+        } else if (isPublic) {
+            title = 'Public Datasets';
+        } else {
+            title = 'My Datasets';
+        }
+
         let datasetsDash =(
             <div>
                 <div className="dashboard-dataset-teasers datasets datasets-private">
                     <div className="header-filter-sort clearfix">
                         <div className="header-wrap clearfix">
-                             <h2>{!isPublic ? 'My Datasets' : 'Public Datasets'}</h2>
+                             <h2>{title}</h2>
                         </div>
                         <div className="filters-sort-wrap clearfix">
                             <Sort options={this.state.sortOptions}

--- a/app/src/scripts/dashboard/dashboard.datasets.store.js
+++ b/app/src/scripts/dashboard/dashboard.datasets.store.js
@@ -44,6 +44,7 @@ let UploadStore = Reflux.createStore({
             loading: false,
             datasets: [],
             isPublic: false,
+            isAdmin: false,
             visibleDatasets: [],
             resultsPerPage: 30,
             page: 0,
@@ -72,8 +73,9 @@ let UploadStore = Reflux.createStore({
      * a list of datasets and sorts by the current
      * sort setting.
      */
-    getDatasets(isPublic) {
+    getDatasets(isPublic, isAdmin) {
         if (isPublic === undefined) {isPublic = this.data.isPublic;}
+        if (typeof isAdmin === 'undefined') {isAdmin = false;}
         let isSignedOut = !userStore.data.token;
         this.update({
             loading: true,
@@ -85,7 +87,7 @@ let UploadStore = Reflux.createStore({
         }, () => {
             bids.getDatasets((datasets) => {
                 if (isPublic === this.data.isPublic) {this.sort('created', '+', datasets, true);}
-            }, isPublic, isSignedOut);
+            }, isPublic, isSignedOut, isAdmin);
         });
     },
 

--- a/app/src/scripts/dashboard/dashboard.jobs.jsx
+++ b/app/src/scripts/dashboard/dashboard.jobs.jsx
@@ -20,14 +20,19 @@ let Jobs = React.createClass({
 // life cycle events --------------------------------------------------
     componentDidMount() {
         let isPublic = this.getPath().indexOf('dashboard') === -1;
+        let isAdmin = this.getPath().indexOf('admin') !== -1;
         let query = this.getQuery();
         let selectedPipeline = typeof query.pipeline != 'undefined' && query.pipeline || null;
-        Actions.update({isPublic});
-        Actions.getJobs(isPublic, {pipeline: selectedPipeline, version: null});
+        Actions.update({isPublic, isAdmin});
+        // Admin views grab all jobs
+        Actions.getJobs(isPublic, isAdmin, {pipeline: selectedPipeline, version: null});
     },
 
     render () {
         let isPublic = this.state.isPublic;
+        let isAdmin = this.state.isAdmin;
+        let title = !isPublic ? 'My' : 'Public';
+        title = isAdmin ? 'All' : title;
         let jobs = this.state.visiblejobs.length === 0 ? <div className="col-xs-12"><h3>no results please try again</h3></div> : this._jobs(this.state.visiblejobs) ;
         return (
             <div>
@@ -35,7 +40,7 @@ let Jobs = React.createClass({
                     <div className="header-filter-sort clearfix">
                         <div className="header-wrap clearfix">
                             <div className="row">
-                                <div className="col-md-5"><h2>{!isPublic ? 'My' : 'Public'} Analyses</h2></div>
+                                <div className="col-md-5"><h2>{title} Analyses</h2></div>
                                 <div className="col-md-7">{this._filter()}</div>
                             </div>
                         </div>

--- a/app/src/scripts/dashboard/dashboard.jobs.store.js
+++ b/app/src/scripts/dashboard/dashboard.jobs.store.js
@@ -76,14 +76,14 @@ let DashboardJobStore = Reflux.createStore({
      * a list of jobs and sorts by the current
      * sort setting.
      */
-    getJobs(isPublic, filter) {
+    getJobs(isPublic, all, filter) {
         if (isPublic === undefined) {isPublic = this.data.isPublic;}
         this.update({loading: true, filter: filter}, () => {
             crn.getJobs((err, res) => {
                 for (let app of res.body.availableApps) {app.value = app.label;}
                 this.update({apps: res.body.availableApps, appsLoading: false});
                 this.sort('analysis.created', '+', res.body.jobs, true);
-            }, isPublic);
+            }, isPublic, all);
         });
     },
 

--- a/app/src/scripts/routes.jsx
+++ b/app/src/scripts/routes.jsx
@@ -74,6 +74,7 @@ let routes = (
             <Route name="app-definitions-edit" path="app-definitions/:app-definitionsId" handler={AppDefinitions} />
             <Route name="event-logs" path="event-logs" handler={EventLogs} />
             <Route name="admin-datasets" path="datasets" handler={Datasets}/>
+            <Route name="admin-jobs" path="jobs" handler={Jobs}/>
             <NotFoundRoute handler={RedirectUsers}/>
         </Route>
         <Route name="dataset" path="datasets/:datasetId" handler={Dataset} />

--- a/app/src/scripts/routes.jsx
+++ b/app/src/scripts/routes.jsx
@@ -73,6 +73,7 @@ let routes = (
             <Route name="app-definitions" path="app-definitions" handler={AppDefinitions} />
             <Route name="app-definitions-edit" path="app-definitions/:app-definitionsId" handler={AppDefinitions} />
             <Route name="event-logs" path="event-logs" handler={EventLogs} />
+            <Route name="admin-datasets" path="datasets" handler={Datasets}/>
             <NotFoundRoute handler={RedirectUsers}/>
         </Route>
         <Route name="dataset" path="datasets/:datasetId" handler={Dataset} />

--- a/app/src/scripts/utils/bids.js
+++ b/app/src/scripts/utils/bids.js
@@ -24,8 +24,8 @@ export default  {
      * boolean as second argument to specifiy if request
      * is made with authentication. Defaults to true.
      */
-    getDatasets (callback, isPublic, isSignedOut) {
-        scitran.getProjects({authenticate: !isPublic, snapshot: false, metadata: true}, (projects) => {
+    getDatasets (callback, isPublic, isSignedOut, isAdmin=false) {
+        scitran.getProjects({authenticate: isAdmin || !isPublic, snapshot: false, metadata: true}, (projects) => {
             scitran.getProjects({authenticate: !isPublic, snapshot: true, metadata: true}, (pubProjects) => {
                 projects = projects.concat(pubProjects);
                 scitran.getUsers((err, res) => {

--- a/app/src/scripts/utils/crn.js
+++ b/app/src/scripts/utils/crn.js
@@ -108,8 +108,8 @@ export default {
     /**
      * Get Jobs
      */
-    getJobs(callback, isPublic, appName = null, status = null, latest = null) {
-        let query = {public: isPublic, appName: appName, status: status, latest: latest};
+    getJobs(callback, isPublic, all, appName = null, status = null, latest = null) {
+        let query = {public: isPublic, appName: appName, status: status, latest: latest, all: all};
         request.get(config.crn.url + 'jobs', {query: query}, callback);
     },
 

--- a/server/handlers/jobs.js
+++ b/server/handlers/jobs.js
@@ -267,7 +267,9 @@ let handlers = {
         if (req.isSuperUser) {
             reqAll = req.query.all === 'true';
             // If all jobs are requested, skip the public query
-            reqPublic = false;
+            if (reqAll) {
+                reqPublic = false;
+            }
         }
         let jobsQuery = {};
         // Optionally select by app


### PR DESCRIPTION
This adds two new tabs to the admin view that let admins explore all datasets and jobs. @chrisfilo I think this is a decent solution to allowing you to quickly see new datasets being added over time? Let me know what you think of adding these two tabs.

![screenshot from 2017-09-17 16-33-34](https://user-images.githubusercontent.com/11369795/30525941-0c529aac-9bc6-11e7-93fe-4d7a1faf8fe6.png)

This works the same as the user or public dashboards, but without the user / public filters.