### PR TITLE
Display bids app container versions next to OpenNeuro internal versions

### DIFF
--- a/app/src/scripts/dataset/dataset.jobs.jsx
+++ b/app/src/scripts/dataset/dataset.jobs.jsx
@@ -24,8 +24,13 @@ let Jobs = React.createClass({
         let app = this.state.jobs.map((app) => {
 
             version = app.versions.map((version) => {
+                let appDef = this.state.apps[app.label][version.label];
+                let bidsAppVersion = appDef.containerProperties.environment.filter((tuple) => {
+                    return tuple.name === 'BIDS_CONTAINER';
+                })[0].value;
+                let compositeVersion = bidsAppVersion + ' - #' + version.label;
                 return (
-                    <Panel className="jobs" header={'Version ' + version.label}  key={version.label} eventKey={version.label}>
+                    <Panel className="jobs" header={compositeVersion}  key={version.label} eventKey={version.label}>
                         {this._runs(version)}
                     </Panel>
                 );


### PR DESCRIPTION
![screenshot from 2017-09-17 18-11-19](https://user-images.githubusercontent.com/11369795/30526669-a5fcca4e-9bd3-11e7-99b7-58e3c0904687.png)

Tried to make it obvious the OpenNeuro version is kind of a revision of the bids app version for internal settings at the moment. We'll remove the internal versions concept in #62.

Fixes #61