### PR TITLE
Don't request metadata loading projects from SciTran

### DIFF
--- a/app/src/scripts/utils/bids.js
+++ b/app/src/scripts/utils/bids.js
@@ -23,12 +23,22 @@ export default {
      * boolean as second argument to specifiy if request
      * is made with authentication. Defaults to true.
      */
-  getDatasets(callback, isPublic, isSignedOut, isAdmin = false) {
+  getDatasets(
+    callback,
+    isPublic,
+    isSignedOut,
+    isAdmin = false,
+    metadata = false,
+  ) {
     scitran.getProjects(
-      { authenticate: isAdmin || !isPublic, snapshot: false, metadata: true },
+      {
+        authenticate: isAdmin || !isPublic,
+        snapshot: false,
+        metadata: metadata,
+      },
       projects => {
         scitran.getProjects(
-          { authenticate: !isPublic, snapshot: true, metadata: true },
+          { authenticate: !isPublic, snapshot: true, metadata: metadata },
           pubProjects => {
             projects = projects.concat(pubProjects)
             scitran.getUsers((err, res) => {


### PR DESCRIPTION
This reduces the data loaded on dashboard views and fixes #6. I expected this to require some changes elsewhere but it looks like this use of the endpoint was intended and the metadata flag was just set incorrectly. Needs some careful testing before it can go into a release.