### PR TITLE
fix for issue #92: Long dataset titles are not wrapped

### DIFF
--- a/app/src/sass/crn_app/_dataset.file-tree.scss
+++ b/app/src/sass/crn_app/_dataset.file-tree.scss
@@ -74,10 +74,15 @@
                         list-style: none;
                         margin: 2px;
 
+                        span.item-name > * {
+                            white-space: normal;
+                        }
+
                         .btn-file-folder {
                             color: $c-66;
                             width: 100%;
                             text-align: left;
+
                         }
 
                         .child-files {


### PR DESCRIPTION
fix for issue #92  span.item-name was inheriting a style from another element. This should fix the issue. 