### PR TITLE
Fix >20 dependencies rejection with more than two analysis levels

### DIFF
--- a/server/tests/libs/aws.spec.js
+++ b/server/tests/libs/aws.spec.js
@@ -165,7 +165,7 @@ describe('libs/aws/batch.js', () => {
         done,
       )
       expect(parallelSubmit).toHaveBeenCalledTimes(1) // One participant level
-      expect(singleSubmit).toHaveBeenCalledTimes(2) // One group level
+      expect(singleSubmit).toHaveBeenCalledTimes(2) // Two group levels
       expect(done).toHaveBeenCalled()
     })
     it('passes dependencies up exactly one level', () => {


### PR DESCRIPTION
The "passes dependencies up exactly one level" test covers this case.

This fixes #100 