### PR TITLE
Enable cache busting

### DIFF
--- a/app/src/index.html
+++ b/app/src/index.html
@@ -17,7 +17,7 @@
         data-app-id="3b8e3e7b79"
         async>
         </script>
-        <script src="/papaya.js" async></script>
+        <script src="/papaya-831b0eb6.js" async></script>
     </body>
 </html>
 

--- a/app/src/index.html
+++ b/app/src/index.html
@@ -2,7 +2,8 @@
 <html>
     <head>
         <base href="/"></base>
-        <meta charset="utf-8">
+        <meta http-equiv="expires" content="0" />
+        <meta charset="utf-8" />
         <!-- SITE IS NOT RESPONSIVE // Works better on mobile devices without this
         <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no"/>
         -->

--- a/app/webpack.common.js
+++ b/app/webpack.common.js
@@ -1,9 +1,8 @@
 const path = require('path')
 const webpack = require('webpack')
-const ExtractTextPlugin = require('extract-text-webpack-plugin')
 const HtmlWebpackPlugin = require('html-webpack-plugin')
 const CleanWebpackPlugin = require('clean-webpack-plugin')
-const CopyWebpackPlugin = require('copy-webpack-plugin')
+const ExtractTextPlugin = require('extract-text-webpack-plugin')
 
 const env = {
   CRN_SERVER_URL: JSON.stringify(process.env.CRN_SERVER_URL),
@@ -31,8 +30,6 @@ module.exports = {
     new webpack.DefinePlugin({
       'process.env': env,
     }),
-    new ExtractTextPlugin('style.css'),
-    new CopyWebpackPlugin([{ from: './assets/papaya.js' }]),
   ],
   module: {
     rules: [
@@ -58,7 +55,7 @@ module.exports = {
         test: /\.(jpg|png|svg|ico)$/,
         loader: 'file-loader',
         options: {
-          name: './img/[name].[hash].[ext]',
+          name: './img/[name].[hash:8].[ext]',
         },
       },
     ],

--- a/app/webpack.dev.js
+++ b/app/webpack.dev.js
@@ -1,6 +1,8 @@
 const path = require('path')
 const merge = require('webpack-merge')
 const common = require('./webpack.common.js')
+const ExtractTextPlugin = require('extract-text-webpack-plugin')
+const CopyWebpackPlugin = require('copy-webpack-plugin')
 
 module.exports = merge(common, {
   devtool: 'inline-source-map',
@@ -12,4 +14,13 @@ module.exports = merge(common, {
     disableHostCheck: true,
     historyApiFallback: true,
   },
+  plugins: [
+    new CopyWebpackPlugin([
+      {
+        from: './assets/papaya.js',
+        to: './papaya.js',
+      },
+    ]),
+    new ExtractTextPlugin('style.css'),
+  ],
 })

--- a/app/webpack.prod.js
+++ b/app/webpack.prod.js
@@ -3,10 +3,19 @@ const merge = require('webpack-merge')
 const MinifyPlugin = require('babel-minify-webpack-plugin')
 const common = require('./webpack.common.js')
 const CompressionPlugin = require('compression-webpack-plugin')
+const ExtractTextPlugin = require('extract-text-webpack-plugin')
+const CopyWebpackPlugin = require('copy-webpack-plugin')
 
 module.exports = merge(common, {
   devtool: 'source-map',
   plugins: [
+    new ExtractTextPlugin('style-[contenthash:8].css'),
+    new CopyWebpackPlugin([
+      {
+        from: './assets/papaya.js',
+        to: './papaya-[hash:8].js',
+      },
+    ]),
     new MinifyPlugin(),
     new webpack.DefinePlugin({
       'process.env': {
@@ -19,4 +28,7 @@ module.exports = merge(common, {
       test: /\.(js|html|css)$/,
     }),
   ],
+  output: {
+    filename: '[name]-[hash:8].bundle.js',
+  },
 })


### PR DESCRIPTION
This updates the asset pipeline to produce filenames that can be cached for long durations and only update once index.html is swapped out.

Fixes #113 