### PR TITLE
Workarounds for issue #6 for jobs endpoint

### DIFF
--- a/app/src/scripts/utils/crn.js
+++ b/app/src/scripts/utils/crn.js
@@ -136,6 +136,7 @@ export default {
       status: status,
       latest: latest,
       all: all,
+      results: false,
     }
     request.get(config.crn.url + 'jobs', { query: query }, callback)
   },


### PR DESCRIPTION
This hides results and logstreams to reduce the size of the jobs data returned. This improves the bandwidth requirements for issue #6.