### PR TITLE
Cleanup jobs after 48 hours of run time

### DIFF
--- a/server/libs/aws/batch.js
+++ b/server/libs/aws/batch.js
@@ -125,7 +125,7 @@ export default aws => {
       // Tasks are filtered to only long run times in _terminateOldJobs
       const query = {
         'analysis.status': 'RUNNING',
-        'analysis.started': { $lte: twoDaysAgo },
+        'analysis.created': { $lte: twoDaysAgo },
       }
       const projection = { 'analysis.batchStatus': true }
       c.crn.jobs.find(query, projection).toArray((err, jobs) => {

--- a/server/libs/aws/batch.js
+++ b/server/libs/aws/batch.js
@@ -3,7 +3,7 @@ import crypto from 'crypto'
 import uuid from 'uuid'
 import mongo from '../mongo'
 import { ObjectID } from 'mongodb'
-import { parallel, reduce } from 'async'
+import { parallel, reduce, eachOfSeries } from 'async'
 import config from '../../config'
 import emitter from '../events'
 import notifications from '../notifications'
@@ -55,15 +55,22 @@ export default aws => {
         true,
         'America/Los_Angeles',
       )
+      new cron.CronJob(
+        '10 * * * * *',
+        this._cleanupJobs,
+        null,
+        true,
+        'America/Los_Angeles',
+      )
     },
 
     _pollJob() {
       /**
-             * queries mongo to find running jobs and runs getJobStatus to check status and update if needed.
-             * excluding 'UPLOADING' because jobs in that state have not been submitted to Batch
-             * also just query jobs that have not had a notification sent otherwise REJECTED jobs will always be returned
-             * polling occurs on a 10 second interval
-             */
+       * queries mongo to find running jobs and runs getJobStatus to check status and update if needed.
+       * excluding 'UPLOADING' because jobs in that state have not been submitted to Batch
+       * also just query jobs that have not had a notification sent otherwise REJECTED jobs will always be returned
+       * polling occurs on a 10 second interval
+       */
       c.crn.jobs.findAndModify(
         {
           'analysis.status': { $nin: ['SUCCEEDED', 'FAILED', 'UPLOADING'] },
@@ -85,6 +92,61 @@ export default aws => {
           }
         },
       )
+    },
+
+    /*
+     * Looks for rogue jobs and terminates them as needed
+     */
+    _cleanupJobs() {
+      // Subtract two days from the current date to search
+      const twoDaysAgo = new Date()
+      twoDaysAgo.setDate(twoDaysAgo.getDate() - 2)
+      const query = {
+        'analysis.status': 'RUNNING',
+        'analysis.started': { $lte: twoDaysAgo },
+      }
+      const projection = { 'analysis.batchStatus': true }
+      c.crn.jobs.find(query, projection).toArray((err, jobs) => {
+        // For each analysis, collect the running task ids
+        const runningTasks = jobs.reduce((tasks, job) => {
+          return tasks.concat(
+            job.analysis.batchStatus
+              .filter(status => status.status === 'RUNNING')
+              .map(status => status.job),
+          )
+        }, [])
+        this._terminateOldJobs(runningTasks)
+      })
+    },
+
+    /*
+     * Takes a list of job ids to check for on Batch and kill if they have been running for too long
+     * Up to 100 jobs can be killed at once
+     */
+    _terminateOldJobs(jobs) {
+      const params = { jobs: jobs.slice(0, 100) }
+      const now = new Date()
+      aws.batch.describeJobs(params, (err, data) => {
+        const terminate = data.jobs.filter(job => {
+          // Kill jobs that are still running and where the actual container start time was 48 hours ago
+          if (
+            'startedAt' in job &&
+            now.getTime() - job.startedAt > 60 * 60 * 48 &&
+            job.status === 'RUNNING'
+          ) {
+            return true
+          }
+          return false
+        })
+        eachOfSeries(terminate, job => {
+          const params = {
+            jobId: job.jobId,
+            reason:
+              'This analysis task did not complete within 48 hours and has failed due to timeout',
+          }
+          aws.batch.terminateJob(params)
+        })
+      })
     },
 
     /**

--- a/server/libs/aws/batch.js
+++ b/server/libs/aws/batch.js
@@ -41,7 +41,9 @@ const extractJobLog = job => {
 }
 
 /*
- * Filter for stale jobs
+ * Factory to create a stale job filter for a specific time
+ * Takes a current Date object and the function returned is 
+ * used with any filter
  */
 const staleJobFilter = (now) => job => {
   // Kill jobs that are still running and where the actual container start time was 48 hours ago
@@ -118,6 +120,9 @@ export default aws => {
       // Subtract two days from the current date to search
       const twoDaysAgo = new Date()
       twoDaysAgo.setDate(twoDaysAgo.getDate() - 2)
+      // This query will get some jobs we don't want to stop since
+      // those jobs may have spent time in pending or runnable
+      // Tasks are filtered to only long run times in _terminateOldJobs
       const query = {
         'analysis.status': 'RUNNING',
         'analysis.started': { $lte: twoDaysAgo },

--- a/server/libs/aws/batch.js
+++ b/server/libs/aws/batch.js
@@ -73,7 +73,7 @@ export default aws => {
         'America/Los_Angeles',
       )
       new cron.CronJob(
-        '15 * * * * *',
+        '0 15 * * * *',
         this._cleanupJobs,
         null,
         true,

--- a/server/tests/libs/aws.spec.js
+++ b/server/tests/libs/aws.spec.js
@@ -205,6 +205,23 @@ describe('libs/aws/batch.js', () => {
       )
     })
   })
+  describe('staleJobFilter', () => {
+    it('excludes one day running jobs', () => {
+      const oldJob = {startedAt: 1, status: 'RUNNING'}
+      const now = new Date(1 + 60 * 60 * 24)
+      assert(!aws.batch.staleJobFilter(now)(oldJob))
+    })
+    it('excludes two day old jobs that are not running', () => {
+      const oldJob = {startedAt: 1, status: 'FAILED'}
+      const now = new Date(1 + 60 * 60 * 48)
+      assert(!aws.batch.staleJobFilter(now)(oldJob))
+    })
+    it('includes two day running jobs', () => {
+      const oldJob = {startedAt: 1, status: 'RUNNING'}
+      const now = new Date(1 + 60 * 60 * 48)
+      assert(aws.batch.staleJobFilter(now)(oldJob))
+    })
+  })
 })
 
 describe('libs/aws/cloudwatchlogs.js', () => {


### PR DESCRIPTION
This runs once per hour and checks if the actual run time of any tasks has exceeded 48 hours, then kills up to 100 tasks that meet the criteria. This will fail a job if any part of it takes over 48 hours to run. If lots of jobs are stuck at once, killing 100 at a time prevents overwhelming the Batch API with extra calls.

Fixes #37