### PR TITLE
Fix download of one log file and send text instead of raw json

### DIFF
--- a/app/src/scripts/dataset/dataset.store.js
+++ b/app/src/scripts/dataset/dataset.store.js
@@ -306,7 +306,7 @@ let datasetStore = Reflux.createStore({
         displayFile: {
           name: 'Logs',
           text: logsText,
-          link: config.crn.url + 'logs/' + logstreamName,
+          link: config.crn.url + 'logs/' + logstreamName + '/raw',
         },
         modals,
       })

--- a/app/src/scripts/dataset/dataset.store.js
+++ b/app/src/scripts/dataset/dataset.store.js
@@ -306,7 +306,7 @@ let datasetStore = Reflux.createStore({
         displayFile: {
           name: 'Logs',
           text: logsText,
-          link: '/logs/' + logstreamName + '.json',
+          link: config.crn.url + 'logs/' + logstreamName,
         },
         modals,
       })

--- a/server/handlers/awsJobs.js
+++ b/server/handlers/awsJobs.js
@@ -423,6 +423,27 @@ let handlers = {
     })
   },
 
+  getLogstreamRaw(req, res, next) {
+    let appName = req.params.app
+    let jobId = req.params.jobId
+    let taskArn = req.params.taskArn
+    let key = appName + '/' + jobId + '/' + taskArn
+
+    aws.cloudwatch.getLogs(key, [], null, true, (err, logs) => {
+      if (err) {
+        return next(err)
+      } else {
+        res.writeHead(200, {
+          'Content-Type': 'text/plain',
+          'Transfer-Encoding': 'chunked',
+          'Content-Disposition': 'attachment; filename="' + key + '.txt"',
+        })
+        logs.map(log => res.write(log.message + '\n'))
+        res.end()
+      }
+    })
+  },
+
   /**
      * Retry a job using existing parameters
      */

--- a/server/routes.js
+++ b/server/routes.js
@@ -183,6 +183,11 @@ const routes = [
   },
   {
     method: 'get',
+    url: '/logs/:app/:jobId/:taskArn/raw',
+    handler: awsJobs.getLogstreamRaw,
+  },
+  {
+    method: 'get',
     url: '/eventlogs',
     middleware: [auth.superuser],
     handler: eventLogs.getEventLogs,


### PR DESCRIPTION
This is to fix the download button in the logs modal (fixes #147).