### PR TITLE
Remove client initiated batch polling

### DIFF
--- a/server/handlers/awsJobs.js
+++ b/server/handlers/awsJobs.js
@@ -250,7 +250,7 @@ let handlers = {
         return
       }
       //Send back job object to client
-      // server side polling handles all interactions with Batch now therefore we are not initiating batch polling from server
+      // server side polling handles all interactions with Batch now therefore we are not initiating batch polling from client
       res.send(job)
     })
   },

--- a/server/handlers/awsJobs.js
+++ b/server/handlers/awsJobs.js
@@ -248,28 +248,9 @@ let handlers = {
         res.status(404).send({ message: 'Job not found.' })
         return
       }
-      let status = job.analysis.status
-      let jobs = job.analysis.jobs
-
-      // check if job is already known to be completed
-      // there could be a scenario where we are polling before the AWS batch job has been setup. !jobs check handles this.
-      if (
-        (status === 'SUCCEEDED' && job.results && job.results.length > 0) ||
-        status === 'FAILED' ||
-        status === 'REJECTED' ||
-        status === 'CANCELED' ||
-        !jobs ||
-        !jobs.length
-      ) {
-        res.send(job)
-      } else {
-        handlers.getJobStatus(job, userId, (err, data) => {
-          if (err) {
-            return next(err)
-          }
-          res.send(data)
-        })
-      }
+      //Send back job object to client
+      // server side polling handles all interactions with Batch now therefore we are not initiating batch polling from server
+      res.send(job)
     })
   },
 

--- a/server/handlers/awsJobs.js
+++ b/server/handlers/awsJobs.js
@@ -240,10 +240,11 @@ let handlers = {
      * GET Job
      */
   getJob(req, res, next) {
-    let userId = req.user
     let jobId = req.params.jobId //this is the mongo id for the job.
 
     c.crn.jobs.findOne({ _id: ObjectID(jobId) }, {}, (err, job) => {
+      if (err) next(err)
+
       if (!job) {
         res.status(404).send({ message: 'Job not found.' })
         return

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -874,9 +874,9 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
-bids-validator@^0.23.10:
-  version "0.23.10"
-  resolved "https://registry.yarnpkg.com/bids-validator/-/bids-validator-0.23.10.tgz#288e514f8cf6bdb8e5834d62247540f7dfb93090"
+bids-validator@^0.23.11:
+  version "0.23.11"
+  resolved "https://registry.yarnpkg.com/bids-validator/-/bids-validator-0.23.11.tgz#8ce83e3406d924c2a0ae0884f4f5387a0a517fc6"
   dependencies:
     ajv "^5.2.2"
     async "^2.1.5"


### PR DESCRIPTION
* Removing client initiated batch polling since we have server side polling now.
* Client will still poll the server jobs but the handler will only return the current state of the job in mongo as opposed to triggering a poll of AWS Batch for job status.
* this is intended to resolve #68 but will need testing on some longer running jobs.