### PR TITLE
Fix resume upload regression due to missing files in SciTran endpoints.

### DIFF
--- a/app/src/scripts/dataset/dataset.jsx
+++ b/app/src/scripts/dataset/dataset.jsx
@@ -367,7 +367,7 @@ class Dataset extends Reflux.Component {
                   <span className="dataset-status ds-warning">
                     <i className="fa fa-warning" /> Incomplete
                   </span>
-                  <FileSelect resume={true} onChange={this._onFileSelect} />
+                  <FileSelect resume={true} onChange={this._onFileSelect.bind(this)} />
                 </h4>
               </div>
               <div className="panel-collapse" aria-expanded="false">

--- a/app/src/scripts/upload/upload.js
+++ b/app/src/scripts/upload/upload.js
@@ -79,25 +79,34 @@ export default {
       }
 
       if (existingProject) {
-        this.currentProjectId = existingProject._id
-        diff.datasets(
-          fileList,
-          existingProject.files,
-          (newFiles, completedFiles) => {
-            this.completed = this.completed + completedFiles.length + 1
-            progress({
-              status: 'calculating',
-              total: this.total,
-              completed: this.completed,
-              currentFiles: this.currentFiles,
-            })
-            this.uploadFiles(
-              datasetName,
-              newFiles,
-              this.currentProjectId,
-              metadata,
+        // Since files are no longer included with getProjects
+        // we have to make a second request
+        scitran.getProject(
+          existingProject._id,
+          response => {
+            const existingProject = response.body
+            this.currentProjectId = existingProject._id
+            diff.datasets(
+              fileList,
+              existingProject.files,
+              (newFiles, completedFiles) => {
+                this.completed = this.completed + completedFiles.length + 1
+                progress({
+                  status: 'calculating',
+                  total: this.total,
+                  completed: this.completed,
+                  currentFiles: this.currentFiles,
+                })
+                this.uploadFiles(
+                  datasetName,
+                  newFiles,
+                  this.currentProjectId,
+                  metadata,
+                )
+              },
             )
           },
+          { query: { metadata: true } },
         )
       } else {
         this.createContainer(


### PR DESCRIPTION
Resuming uploads has been broken since we made the quick fix for #6. This adds an extra request for resuming uploads to get the current files so the diff works.

Fixes #167 and #140.