### PR TITLE
Fix a crash where logged out users could not view public datasets

### DIFF
--- a/app/src/scripts/dataset/tools/index.js
+++ b/app/src/scripts/dataset/tools/index.js
@@ -34,9 +34,10 @@ class Tools extends React.Component {
       isIncomplete = !!dataset.status.incomplete,
       isInvalid = !!dataset.status.invalid,
       isSnapshot = !!dataset.original,
-      isSuperuser = window.localStorage.scitran
-        ? JSON.parse(window.localStorage.scitran).root
-        : null
+      isSuperuser =
+        window.localStorage.scitran && JSON.parse(window.localStorage.scitran)
+          ? JSON.parse(window.localStorage.scitran).root
+          : null
 
     let displayDelete = this._deleteDataset(
       isAdmin,


### PR DESCRIPTION
Users who have logged out (but not users who have never logged in) are seeing a crash on any public datasets because localStorage.scitran is set to the string "null" in this check. This fixes the check to work if it is undefined or if a null value is set.