### PR TITLE
Restore admin versions of the jobs/dataset components.

### DIFF
--- a/app/src/scripts/admin/admin.jsx
+++ b/app/src/scripts/admin/admin.jsx
@@ -88,13 +88,13 @@ class Dashboard extends React.Component {
                 name="admin-datasets"
                 path="/admin/datasets"
                 exact
-                component={Datasets}
+                render={(props) => (<Datasets admin {...props}/>)}
               />
               <Route
                 name="admin-jobs"
                 path="/admin/jobs"
                 exact
-                component={Jobs}
+                render={(props) => (<Jobs admin {...props}/>)}
               />
             </Switch>
           </div>


### PR DESCRIPTION
As part of the React 16 upgrade, I removed the route detection from these components and replaced it with a prop but left the prop out of the component instantiation in the admin parent.

Fixes #181 