### PR TITLE
Fix email notifications for ORCID users.

### DIFF
--- a/server/libs/notifications.js
+++ b/server/libs/notifications.js
@@ -55,7 +55,7 @@ let notifications = {
           _id: job.snapshotId + '_' + job.appId + '_' + job.analysis.created,
           type: 'email',
           email: {
-            to: job.userId,
+            to: user.email,
             subject:
               'Analysis - ' +
               job.appLabel +


### PR DESCRIPTION
Fixes #182. For Google users, the id and email fields are the same. For ORCID, they are different and we need to use the correct field.