### PR TITLE
Fix Upload Modal Issues with Resume and Same Name Datasets

### DIFF
--- a/app/src/scripts/common/forms/file-select.jsx
+++ b/app/src/scripts/common/forms/file-select.jsx
@@ -48,6 +48,7 @@ class Upload extends Reflux.Component {
 
   _click(e) {
     e.stopPropagation()
+    e.target.value = null
     if (!bowser.chrome && !bowser.chromium) {
       let chromeMessage = (
         <span>

--- a/app/src/scripts/upload/upload.jsx
+++ b/app/src/scripts/upload/upload.jsx
@@ -30,7 +30,7 @@ class Upload extends Reflux.Component {
 
     // conditional variables -----------------------
 
-    let totalTabs = this.state.upload.showResume ? 5 : 5
+    let totalTabs = this.state.upload.showResume ? 6 : 5
     let activeBar = 'active-tab-' + activeKey
     if (activeKey === 6 && totalTabs < 6) {
       activeBar = 'active-tab-5'
@@ -131,12 +131,12 @@ class Upload extends Reflux.Component {
     if (this.state.upload.showResume) {
       let tabName = (
         <span>
-          <span>2:</span>
+          <span>5:</span>
           <span> Resume</span>
         </span>
       )
       resume = (
-        <Tab eventKey={2} title={tabName} disabled={disabledTab}>
+        <Tab eventKey={5} title={tabName} disabled={disabledTab}>
           <div className={activePane}>
             <Resume />
           </div>
@@ -168,7 +168,7 @@ class Upload extends Reflux.Component {
 
     return (
       <div className="uploader">
-        <div className="upload-wrap panel-group" defaultActiveKey="1">
+        <div className="upload-wrap panel-group" defaultactivekey="1">
           <div className="upload-panel panel panel-default">
             <div className="panel-collapse collapse in">
               <div className="panel-body">
@@ -183,9 +183,9 @@ class Upload extends Reflux.Component {
                     <div className={activeBar} />
                     {select}
                     {rename}
-                    {resume}
                     {issues}
                     {disclaimer}
+                    {resume}
                     {progress}
                   </Tabs>
                 </div>

--- a/app/src/scripts/upload/upload.store.js
+++ b/app/src/scripts/upload/upload.store.js
@@ -153,8 +153,8 @@ let UploadStore = Reflux.createStore({
     this.setInitialState({
       dirName: originalName,
       uploadStatus: 'files-selected',
-      showRename: false,
-      showResume: true,
+      showRename: true,
+      showResume: false,
       showModal: true,
       showIssues: true,
       showDisclaimer: true,
@@ -237,7 +237,7 @@ let UploadStore = Reflux.createStore({
               uploadStatus: 'dataset-exists',
               showDisclaimer: true,
               showResume: true,
-              activeKey: 4,
+              activeKey: 5,
             })
           } else {
             self.update({ showDisclaimer: true, activeKey: 4 })


### PR DESCRIPTION
* resolves #204 
* reverted modal order and keys back to how they were before the last upload modal change. 
* tested by uploading a dataset with same name as existing dataset. After validation, you are directed to 
![image](https://user-images.githubusercontent.com/5668826/32580117-b9b30a24-c498-11e7-9262-d593254f35b9.png)
you can rename dataset and continue through process of uploading a new, unique name dataset.
* I also verified that I can still resume an upload.
![image](https://user-images.githubusercontent.com/5668826/32580215-10dcb688-c499-11e7-8c1f-fd3051115530.png)

