### PR TITLE
Add auth for rerun of failed jobs

### DIFF
--- a/app/src/scripts/dataset/__tests__/__snapshots__/dataset.jobs.run.spec.jsx.snap
+++ b/app/src/scripts/dataset/__tests__/__snapshots__/dataset.jobs.run.spec.jsx.snap
@@ -76,23 +76,6 @@ exports[`dataset/dataset.job.run/JobAccordion renders a failed run 1`] = `
               if this analysis continues to fail.
             </span>
           </h5>
-          <WarnButton
-            action={[Function]}
-            cancel={
-              <i
-                className="fa fa-times"
-              />
-            }
-            confirm={
-              <i
-                className="fa fa-check"
-              />
-            }
-            icon="fa fa-repeat"
-            message="re-run"
-            tooltip={null}
-            warn={false}
-          />
         </div>
       </div>
     }

--- a/app/src/scripts/dataset/dataset.jobs.run.jsx
+++ b/app/src/scripts/dataset/dataset.jobs.run.jsx
@@ -204,6 +204,12 @@ class JobAccordion extends React.Component {
   }
 
   _failedMessage(run) {
+    let userCanRerun =
+      this.props.currentUser && this.props.currentUser.scitran
+        ? this.props.currentUser.scitran.root ||
+          this.props.currentUser.scitran._id === run.userId
+        : false
+
     if (
       run.analysis.status === 'FAILED' ||
       run.analysis.status === 'REJECTED'
@@ -228,12 +234,14 @@ class JobAccordion extends React.Component {
           <h5 className="text-danger">
             {message} {adminMessage}
           </h5>
-          <WarnButton
-            icon="fa fa-repeat"
-            message="re-run"
-            warn={false}
-            action={actions.retryJob.bind(this, run._id)}
-          />
+          {userCanRerun ? (
+            <WarnButton
+              icon="fa fa-repeat"
+              message="re-run"
+              warn={false}
+              action={actions.retryJob.bind(this, run._id)}
+            />
+          ) : null}
         </div>
       )
     }
@@ -390,7 +398,9 @@ class JobAccordion extends React.Component {
   _batchStatus(run) {
     let batchStatus = run.analysis.batchStatus
     if (batchStatus && batchStatus.length) {
-      const failed = run.analysis.batchStatus.filter(status => status.status !== 'SUCCEEDED')
+      const failed = run.analysis.batchStatus.filter(
+        status => status.status !== 'SUCCEEDED',
+      )
       if (failed.length === 0) {
         return null
       }

--- a/circle.yml
+++ b/circle.yml
@@ -46,8 +46,8 @@ deployment:
       # Update latest tag
       - docker tag -f openneuro/server openneuro/server:$CIRCLE_BRANCH
       - docker tag -f openneuro/app openneuro/app:$CIRCLE_BRANCH
-      - docker push openneuro/server
-      - docker push openneuro/app
+      - docker push openneuro/server:$CIRCLE_BRANCH
+      - docker push openneuro/app:$CIRCLE_BRANCH
   production:
     tag: /v.*/
     commands:
@@ -56,5 +56,5 @@ deployment:
       - docker build --pull -t openneuro/app app
       - docker tag openneuro/server openneuro/server:$CIRCLE_TAG
       - docker tag openneuro/app openneuro/app:$CIRCLE_TAG
-      - docker push openneuro/server
-      - docker push openneuro/app
+      - docker push openneuro/server:$CIRCLE_TAG
+      - docker push openneuro/app:$CIRCLE_TAG

--- a/server/libs/auth.js
+++ b/server/libs/auth.js
@@ -145,6 +145,32 @@ let auth = {
       })
   },
 
+  rerunJobAccess(req, res, next) {
+    let jobId = req.params.jobId
+    let mongoJobId = typeof jobId != 'object' ? ObjectID(jobId) : jobId
+    let user = req.user
+    let admin = !!req.isSuperUser
+    if (admin) {
+      return next()
+    }
+
+    c.crn.jobs.findOne(
+      {
+        _id: mongoJobId,
+      },
+      (err, job) => {
+        let jobOwner = job.userId
+        if (jobOwner === user) {
+          return next()
+        }
+
+        return res
+          .status(403)
+          .send({ error: 'You do not have access to rerun this job.' })
+      },
+    )
+  },
+
   /**
      * Ticket
      *

--- a/server/routes.js
+++ b/server/routes.js
@@ -158,7 +158,11 @@ const routes = [
   {
     method: 'post',
     url: '/datasets/:datasetId/jobs/:jobId/retry',
-    middleware: [auth.datasetAccess()],
+    middleware: [
+      auth.datasetAccess(),
+      auth.rerunJobAccess,
+      auth.submitJobAccess,
+    ],
     handler: awsJobs.retry,
   },
   {


### PR DESCRIPTION
* resolves #202 
* hiding the rerun link unless user is admin or is the user who ran the job
* adding in an auth middleware on server side just to make sure no one without proper access can trigger rerun by hitting endpoint.