### PR TITLE
Fix bad state after a job is retried

### DIFF
--- a/server/handlers/awsJobs.js
+++ b/server/handlers/awsJobs.js
@@ -469,6 +469,9 @@ let handlers = {
             'analysis.status': 'RETRYING',
             'analysis.jobs': [],
             'analysis.logstreams': [],
+            'analysis.results': [],
+            'analysis.batchStatus': [],
+            'analysis.created': new Date(),
           },
         },
       )


### PR DESCRIPTION
This fixes an issue where old jobs are terminated unexpectedly by the job timeout after a retry and cleans up any partial results and batchStatus.