### PR TITLE
Integrate Sentry to replace OpBeat

### DIFF
--- a/app/.eslintrc.json
+++ b/app/.eslintrc.json
@@ -4,6 +4,11 @@
     "es6": true,
     "jest": true
   },
+  "globals": {
+    "process": true,
+    "__GIT_HASH__": true,
+    "__GIT_BRANCH__": true
+  },
   "extends": ["eslint:recommended", "plugin:react/recommended"],
   "parser": "babel-eslint",
   "parserOptions": {

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -6,10 +6,10 @@ RUN apk --no-cache --update add git
 ARG branch
 
 # setup app directory
-WORKDIR /srv/crn-app
+WORKDIR /srv/app
 
 # install web app
-ADD . /srv/crn-app
+ADD . /srv/app
 RUN npm install -g yarn && yarn install --pure-lockfile
 
 # build app

--- a/app/package.json
+++ b/app/package.json
@@ -30,6 +30,7 @@
     "moment": "^2.10.3",
     "pluralize": "^1.1.2",
     "prop-types": "^15.6.0",
+    "raven-js": "^3.20.1",
     "react": "16",
     "react-bootstrap": "0.31.3",
     "react-dom": "16",

--- a/app/package.json
+++ b/app/package.json
@@ -67,6 +67,7 @@
     "eslint-plugin-react": "^4.3.0",
     "extract-text-webpack-plugin": "^3.0.0",
     "file-loader": "^0.11.2",
+    "git-rev-sync": "^1.9.1",
     "html-webpack-plugin": "^2.30.1",
     "husky": "^0.14.3",
     "jest": "^20.0.4",

--- a/app/src/scripts/client.jsx
+++ b/app/src/scripts/client.jsx
@@ -1,10 +1,15 @@
 // dependencies ---------------------------------------------------------
 import 'url-search-params-polyfill'
+import Raven from 'raven-js'
 import React from 'react'
 import ReactDOM from 'react-dom'
 import { BrowserRouter as Router, Route } from 'react-router-dom'
 import Index from './index.jsx'
 import analyticsWrapper from './utils/analytics.js'
+
+Raven.config(
+  'https://ba0c58863b3e40a2a412132bfd2711ea@sentry.io/251076',
+).install()
 
 ReactDOM.render(
   <Router>

--- a/app/src/scripts/client.jsx
+++ b/app/src/scripts/client.jsx
@@ -7,8 +7,15 @@ import { BrowserRouter as Router, Route } from 'react-router-dom'
 import Index from './index.jsx'
 import analyticsWrapper from './utils/analytics.js'
 
+const ravenConfig = {
+  release: __GIT_HASH__,
+  tags: { branch: __GIT_BRANCH__ },
+  environment: process.env.AWS_BATCH_QUEUE,
+}
+
 Raven.config(
   'https://ba0c58863b3e40a2a412132bfd2711ea@sentry.io/251076',
+  ravenConfig,
 ).install()
 
 ReactDOM.render(

--- a/app/src/scripts/client.jsx
+++ b/app/src/scripts/client.jsx
@@ -10,7 +10,8 @@ import analyticsWrapper from './utils/analytics.js'
 const ravenConfig = {
   release: __GIT_HASH__,
   tags: { branch: __GIT_BRANCH__ },
-  environment: process.env.AWS_BATCH_QUEUE,
+  environment: process.env.ENVIRONMENT,
+  autoBreadcrumbs: true,
 }
 
 Raven.config(

--- a/app/src/scripts/user/user.store.js
+++ b/app/src/scripts/user/user.store.js
@@ -1,5 +1,5 @@
 // dependencies ----------------------------------------------------------------------
-
+import Raven from 'raven-js'
 import React from 'react'
 import Reflux from 'reflux'
 import actions from './user.actions.js'
@@ -41,6 +41,10 @@ let UserStore = Reflux.createStore({
             this.signOut()
           } else {
             this.update({ scitran: res.body }, { persist: true })
+            Raven.setUserContext({
+              email: user.profile.email,
+              id: user.profile._id,
+            })
           }
         })
       }
@@ -153,6 +157,11 @@ let UserStore = Reflux.createStore({
         { persist: true },
       )
 
+      Raven.setUserContext({
+        email: user.profile.email,
+        id: user.profile._id,
+      })
+
       crn.verifyUser((err, res) => {
         if (res.body.code === 403) {
           // Pass only the scitran required user values to createUser
@@ -261,6 +270,7 @@ let UserStore = Reflux.createStore({
      * browser storage.
      */
   clearAuth() {
+    Raven.setUserContext()
     delete window.localStorage.token
     delete window.localStorage.provider
     delete window.localStorage.profile

--- a/app/webpack.common.js
+++ b/app/webpack.common.js
@@ -4,6 +4,7 @@ const HtmlWebpackPlugin = require('html-webpack-plugin')
 const CleanWebpackPlugin = require('clean-webpack-plugin')
 const ExtractTextPlugin = require('extract-text-webpack-plugin')
 const CopyWebpackPlugin = require('copy-webpack-plugin')
+const git = require('git-rev-sync')
 
 const env = {
   CRN_SERVER_URL: JSON.stringify(process.env.CRN_SERVER_URL),
@@ -33,6 +34,8 @@ module.exports = {
     }),
     new webpack.DefinePlugin({
       'process.env': env,
+      __GIT_HASH__: JSON.stringify(git.long()),
+      __GIT_BRANCH__: JSON.stringify(git.branch()),
     }),
     new CopyWebpackPlugin([
       {

--- a/app/webpack.common.js
+++ b/app/webpack.common.js
@@ -13,6 +13,7 @@ const env = {
   ORCID_AUTH_CLIENT_ID: JSON.stringify(process.env.ORCID_AUTH_CLIENT_ID),
   ORCID_AUTH_REDIRECT_URI: JSON.stringify(process.env.ORCID_AUTH_REDIRECT_URI),
   ORCID_URI: JSON.stringify(process.env.ORCID_URI),
+  ENVIRONMENT: JSON.stringify(process.env.AWS_BATCH_QUEUE),
 }
 
 module.exports = {

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -2718,7 +2718,7 @@ escape-html@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
 
-escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
+escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
 
@@ -3298,6 +3298,14 @@ getpass@^0.1.1:
   dependencies:
     assert-plus "^1.0.0"
 
+git-rev-sync@^1.9.1:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/git-rev-sync/-/git-rev-sync-1.9.1.tgz#a0c2e3dd392abcf6b76962e27fc75fb3223449ce"
+  dependencies:
+    escape-string-regexp "1.0.5"
+    graceful-fs "4.1.11"
+    shelljs "0.7.7"
+
 glob-base@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/glob-base/-/glob-base-0.3.0.tgz#dbb164f6221b1c0b1ccf82aea328b497df0ea3c4"
@@ -3388,7 +3396,7 @@ globule@^1.0.0:
     lodash "~4.17.4"
     minimatch "~3.0.2"
 
-graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.4, graceful-fs@^4.1.6, graceful-fs@^4.1.9:
+graceful-fs@4.1.11, graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.4, graceful-fs@^4.1.6, graceful-fs@^4.1.9:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
 
@@ -6773,6 +6781,14 @@ shell-quote@~0.0.1:
 shelljs@0.3.x:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.3.0.tgz#3596e6307a781544f591f37da618360f31db57b1"
+
+shelljs@0.7.7:
+  version "0.7.7"
+  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.7.7.tgz#b2f5c77ef97148f4b4f6e22682e10bba8667cff1"
+  dependencies:
+    glob "^7.0.0"
+    interpret "^1.0.0"
+    rechoir "^0.6.2"
 
 shelljs@^0.7.5:
   version "0.7.8"

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -6060,6 +6060,10 @@ range-parser@^1.0.3, range-parser@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.0.tgz#f49be6b487894ddc40dcc94a322f611092e00d5e"
 
+raven-js@^3.20.1:
+  version "3.20.1"
+  resolved "https://registry.yarnpkg.com/raven-js/-/raven-js-3.20.1.tgz#3170bdb35c05098ddb8548ee5be0687f9d763330"
+
 rc@^1.1.7:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.1.tgz#2e03e8e42ee450b8cb3dce65be1bf8974e1dfd95"


### PR DESCRIPTION
OpBeat still does not work in the same page as React 16, this replaces the client side crash reporting functionality and sorts the tracebacks by their source environment in Sentry.

Obsoletes #173