### PR TITLE
Quick fix for no dataset title in search results

### DIFF
--- a/app/src/scripts/dataset/dataset.jsx
+++ b/app/src/scripts/dataset/dataset.jsx
@@ -67,6 +67,7 @@ class Dataset extends Reflux.Component {
   componentWillUnmount() {
     actions.setInitialState({ apps: this.state.datasets.apps })
     super.componentWillUnmount()
+    document.title = 'OpenNeuro'
   }
 
   render() {
@@ -84,6 +85,7 @@ class Dataset extends Reflux.Component {
     let content
 
     if (dataset) {
+      document.title = 'OpenNeuro - ' + dataset.label
       let errors = dataset.validation.errors
       let warnings = dataset.validation.warnings
       content = (
@@ -367,7 +369,10 @@ class Dataset extends Reflux.Component {
                   <span className="dataset-status ds-warning">
                     <i className="fa fa-warning" /> Incomplete
                   </span>
-                  <FileSelect resume={true} onChange={this._onFileSelect.bind(this)} />
+                  <FileSelect
+                    resume={true}
+                    onChange={this._onFileSelect.bind(this)}
+                  />
                 </h4>
               </div>
               <div className="panel-collapse" aria-expanded="false">


### PR DESCRIPTION
This just sets the page title to 'OpenNeuro - <dataset label>' if the label is loaded. When the component unmounts it resets the title to 'OpenNeuro' (currently on every page).