### PR TITLE
Streaming job logs

### DIFF
--- a/app/src/scripts/dataset/dataset.store.js
+++ b/app/src/scripts/dataset/dataset.store.js
@@ -262,7 +262,7 @@ let datasetStore = Reflux.createStore({
   },
 
   downloadLogs(id, callback) {
-    callback(config.crn.url + 'jobs/' + id + '/logs/download')
+    callback(config.crn.url + 'jobs/' + id + '/logs')
   },
 
   getLogstream(logstreamName, callback) {

--- a/server/handlers/awsJobs.js
+++ b/server/handlers/awsJobs.js
@@ -364,18 +364,6 @@ let handlers = {
     }
   },
 
-  getJobLogs(req, res, next) {
-    let jobId = req.params.jobId //this will be the mongoId for a given analysis
-
-    aws.cloudwatch.getLogsByJobId(jobId, (err, logs) => {
-      if (err) {
-        return next(err)
-      } else {
-        res.send(logs)
-      }
-    })
-  },
-
   downloadJobLogs(req, res, next) {
     const jobId = req.params.jobId //this will be the mongoId for a given analysis
     const prefix = {}

--- a/server/routes.js
+++ b/server/routes.js
@@ -188,11 +188,6 @@ const routes = [
   {
     method: 'get',
     url: '/jobs/:jobId/logs',
-    handler: awsJobs.getJobLogs,
-  },
-  {
-    method: 'get',
-    url: '/jobs/:jobId/logs/download',
     handler: awsJobs.downloadJobLogs,
   },
   {


### PR DESCRIPTION
This refactors all the logs endpoints to return streaming results, so we don't build up large job log blobs and run out of memory when download all logs is used.

Logs begin streaming as soon as CloudWatch has returned them, so there's less of a delay opening logs in bandwidth constrained scenarios since the client can download them earlier.

Fixes #222.