### PR TITLE
Replace archiver with yazl

### DIFF
--- a/server/handlers/jobs.js
+++ b/server/handlers/jobs.js
@@ -8,7 +8,6 @@ import scitran from '../libs/scitran'
 import mongo from '../libs/mongo'
 import async from 'async'
 import crypto from 'crypto'
-import archiver from 'archiver'
 import notifications from '../libs/notifications'
 import { ObjectID } from 'mongodb'
 
@@ -503,89 +502,6 @@ let handlers = {
     }
 
     res.send(ticket)
-  },
-
-  /**
-     * GET File
-     */
-  getFile(req, res) {
-    let jobId = req.params.jobId
-
-    const path = req.ticket.filePath
-    if (path === 'all-results' || path === 'all-logs') {
-      const type = path.replace('all-', '')
-
-      // initialize archive
-      let archive = archiver('zip')
-
-      // log archiving errors
-      archive.on('error', err => {
-        console.log('archiving error - job: ' + jobId)
-        console.log(err)
-      })
-
-      c.crn.jobs.findOne({ jobId }, {}, (err, job) => {
-        let archiveName = job.datasetLabel + '__' + job.appId + '__' + type
-
-        // set archive name
-        res.attachment(archiveName + '.zip')
-
-        // begin streaming archive
-        archive.pipe(res)
-
-        // recurse outputs
-        getOutputs(archiveName, job[type], type, archive, () => {
-          archive.finalize()
-        })
-      })
-    } else {
-      // download individual file
-      agave.api.getPathProxy('jobs/v2/' + jobId + '/outputs/media' + path, res)
-    }
-
-    // recurse through tree outputs
-    function getOutputs(archiveName, results, type, archive, callback) {
-      const baseDir = type === 'results' ? '/out/' : '/log/'
-      async.eachSeries(
-        results,
-        (result, cb) => {
-          let outputName = result.path.replace(baseDir, archiveName + '/')
-          if (result.type === 'file') {
-            let path = 'jobs/v2/' + jobId + '/outputs/media' + result.path
-            agave.api.getPath(path, (err, res) => {
-              let body = res.body
-              if (body && body.status && body.status === 'error') {
-                // error from AGAVE
-                console.log('Error downloading - ', path)
-                console.log(body)
-              } else {
-                // stringify JSON
-                if (typeof body === 'object' && !Buffer.isBuffer(body)) {
-                  body = JSON.stringify(body)
-                }
-                // stringify numbers
-                if (typeof body === 'number') {
-                  body = body.toString()
-                }
-                // handle empty files
-                if (typeof body === 'undefined') {
-                  body = ''
-                }
-                // append file to archive
-                archive.append(body, { name: outputName })
-              }
-              cb()
-            })
-          } else if (result.type === 'dir') {
-            archive.append(null, { name: outputName + '/' })
-            getOutputs(archiveName, result.children, type, archive, cb)
-          } else {
-            cb()
-          }
-        },
-        callback,
-      )
-    }
   },
 
   /**

--- a/server/package.json
+++ b/server/package.json
@@ -19,7 +19,6 @@
   "author": "Squishymedia",
   "dependencies": {
     "ajv": "4.9.0",
-    "archiver": "^2.0.3",
     "async": "^2.4.1",
     "aws-sdk": "2.50.0",
     "babel-core": "^6.26.0",
@@ -40,7 +39,8 @@
     "tar-fs": "^1.9.0",
     "underscore": "^1.8.3",
     "uuid": "^3.0.1",
-    "xmldoc": "^1.1.0"
+    "xmldoc": "^1.1.0",
+    "yazl": "^2.4.3"
   },
   "devDependencies": {
     "babel-eslint": "^8.0.0",

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -145,30 +145,6 @@ aproba@^1.0.3:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/aproba/-/aproba-1.1.2.tgz#45c6629094de4e96f693ef7eab74ae079c240fc1"
 
-archiver-utils@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/archiver-utils/-/archiver-utils-1.3.0.tgz#e50b4c09c70bf3d680e32ff1b7994e9f9d895174"
-  dependencies:
-    glob "^7.0.0"
-    graceful-fs "^4.1.0"
-    lazystream "^1.0.0"
-    lodash "^4.8.0"
-    normalize-path "^2.0.0"
-    readable-stream "^2.0.0"
-
-archiver@^2.0.3:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/archiver/-/archiver-2.1.0.tgz#d2df2e8d5773a82c1dcce925ccc41450ea999afd"
-  dependencies:
-    archiver-utils "^1.3.0"
-    async "^2.0.0"
-    buffer-crc32 "^0.2.1"
-    glob "^7.0.0"
-    lodash "^4.8.0"
-    readable-stream "^2.0.0"
-    tar-stream "^1.5.0"
-    zip-stream "^1.2.0"
-
 are-we-there-yet@~1.1.2:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz#bb5dca382bb94f05e15194373d16fd3ba1ca110d"
@@ -249,12 +225,6 @@ async@^0.9.0:
 async@^1.4.0:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
-
-async@^2.0.0:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/async/-/async-2.6.0.tgz#61a29abb6fcc026fea77e56d1c6ec53a795951f4"
-  dependencies:
-    lodash "^4.14.0"
 
 async@^2.0.1, async@^2.1.4, async@^2.1.5, async@^2.4.1:
   version "2.5.0"
@@ -987,7 +957,7 @@ bson@~1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/bson/-/bson-1.0.4.tgz#93c10d39eaa5b58415cbc4052f3e53e562b0b72c"
 
-buffer-crc32@^0.2.1:
+buffer-crc32@~0.2.3:
   version "0.2.13"
   resolved "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242"
 
@@ -1249,15 +1219,6 @@ commander@^2.9.0:
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.11.0.tgz#157152fd1e7a6c8d98a5b715cf376df928004563"
 
-compress-commons@^1.2.0:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/compress-commons/-/compress-commons-1.2.2.tgz#524a9f10903f3a813389b0225d27c48bb751890f"
-  dependencies:
-    buffer-crc32 "^0.2.1"
-    crc32-stream "^2.0.0"
-    normalize-path "^2.0.0"
-    readable-stream "^2.0.0"
-
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
@@ -1324,17 +1285,6 @@ cosmiconfig@^1.1.0:
     parse-json "^2.2.0"
     pinkie-promise "^2.0.0"
     require-from-string "^1.1.0"
-
-crc32-stream@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/crc32-stream/-/crc32-stream-2.0.0.tgz#e3cdd3b4df3168dd74e3de3fbbcb7b297fe908f4"
-  dependencies:
-    crc "^3.4.4"
-    readable-stream "^2.0.0"
-
-crc@^3.4.4:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/crc/-/crc-3.5.0.tgz#98b8ba7d489665ba3979f59b21381374101a1964"
 
 cron@^1.1.0:
   version "1.2.1"
@@ -2182,7 +2132,7 @@ globby@^5.0.0:
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
 
-graceful-fs@^4.1.0, graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6:
+graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
 
@@ -3109,12 +3059,6 @@ lazy-cache@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/lazy-cache/-/lazy-cache-1.0.4.tgz#a1d78fc3a50474cb80845d3b3b6e1da49a446e8e"
 
-lazystream@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/lazystream/-/lazystream-1.0.0.tgz#f6995fe0f820392f61396be89462407bb77168e4"
-  dependencies:
-    readable-stream "^2.0.5"
-
 lcid@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/lcid/-/lcid-1.0.0.tgz#308accafa0bc483a3867b4b6f2b9506251d1b835"
@@ -3312,7 +3256,7 @@ lodash@^3.10.1:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
 
-lodash@^4.0.0, lodash@^4.1.0, lodash@^4.14.0, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.3.0, lodash@^4.8.0:
+lodash@^4.0.0, lodash@^4.1.0, lodash@^4.14.0, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.3.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
@@ -4727,15 +4671,6 @@ tar-stream@^1.1.2:
     readable-stream "^2.0.0"
     xtend "^4.0.0"
 
-tar-stream@^1.5.0:
-  version "1.5.5"
-  resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-1.5.5.tgz#5cad84779f45c83b1f2508d96b09d88c7218af55"
-  dependencies:
-    bl "^1.0.0"
-    end-of-stream "^1.0.0"
-    readable-stream "^2.0.0"
-    xtend "^4.0.0"
-
 tar@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/tar/-/tar-2.2.1.tgz#8e4d2a256c0e2185c6b18ad694aec968b83cb1d1"
@@ -5170,11 +5105,8 @@ yargs@~3.10.0:
     decamelize "^1.0.0"
     window-size "0.1.0"
 
-zip-stream@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/zip-stream/-/zip-stream-1.2.0.tgz#a8bc45f4c1b49699c6b90198baacaacdbcd4ba04"
+yazl@^2.4.3:
+  version "2.4.3"
+  resolved "https://registry.yarnpkg.com/yazl/-/yazl-2.4.3.tgz#ec26e5cc87d5601b9df8432dbdd3cd2e5173a071"
   dependencies:
-    archiver-utils "^1.3.0"
-    compress-commons "^1.2.0"
-    lodash "^4.8.0"
-    readable-stream "^2.0.0"
+    buffer-crc32 "~0.2.3"


### PR DESCRIPTION
The goal here is to fix the blocking case where aws streams and archiver zips deadlock.

This also removes one of the agave endpoints that depends on archiver. I think we should start cleaning these up anyways.