### PR TITLE
Skip node_modules for docker builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+app/node_modules
+server/node_modules

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,5 @@
+app/dist
+app/coverage
 app/node_modules
 server/node_modules
+server/coverage


### PR DESCRIPTION
@Xesme This should let you do a build without having to remove node_modules.