### PR TITLE
Fix ORCID logins for Chrome 63+

### DIFF
--- a/app/src/scripts/utils/orcid.js
+++ b/app/src/scripts/utils/orcid.js
@@ -76,7 +76,7 @@ let orcid = {
       'ORCID',
     )
 
-    const pooling = callback => {
+    this.oauthWindow.addEventListener('beforeunload', () => {
       try {
         if (!this.oauthWindow || this.oauthWindow.closed) {
           callback(true)
@@ -99,13 +99,7 @@ let orcid = {
       } catch (e) {
         console.log(e)
       }
-
-      retryUrlCheck()
-    }
-
-    const retryUrlCheck = () => window.setTimeout(() => pooling(callback), 50)
-
-    retryUrlCheck()
+    })
   },
 
   signOut(callback) {

--- a/app/src/scripts/utils/orcid.js
+++ b/app/src/scripts/utils/orcid.js
@@ -98,8 +98,9 @@ let orcid = {
           // Any other errors should stop polling
           // TODO - could reset login state here in case of failures
           clearInterval(this.oauthTimer)
+        } else {
+          console.log(e)
         }
-        console.log(e)
       }
     }, 200)
   },

--- a/app/src/scripts/utils/orcid.js
+++ b/app/src/scripts/utils/orcid.js
@@ -73,7 +73,7 @@ let orcid = {
         config.auth.orcid.clientID +
         '&response_type=code&scope=/authenticate&redirect_uri=' +
         config.auth.orcid.redirectURI,
-      '_blank',
+      'ORCID',
     )
 
     const pooling = callback => {

--- a/server/handlers/users.js
+++ b/server/handlers/users.js
@@ -6,7 +6,6 @@ import orcid from '../libs/orcid'
 
 let c = mongo.collections
 
-
 // handlers ----------------------------------------------------------------
 
 /**
@@ -20,7 +19,7 @@ export default {
   validateORCIDToken(req, res) {
     let { code, home } = req.query
     if (!home) {
-      res.status(400).send()
+      res.status(200).send()
       return
     }
     orcid.validateToken(code, (error, result) => {

--- a/server/handlers/users.js
+++ b/server/handlers/users.js
@@ -19,7 +19,12 @@ export default {
   validateORCIDToken(req, res) {
     let { code, home } = req.query
     if (!home) {
-      res.status(200).send()
+      res.set('Content-Type', 'text/html')
+      res
+        .status(200)
+        .send(
+          '<!doctype html><meta charset=utf-8><title>Logged in!</title><script>window.onload = function () {window.close()}</script>',
+        )
       return
     }
     orcid.validateToken(code, (error, result) => {


### PR DESCRIPTION
1d4a455 is the fix, Chrome 63 returns a different URL for the error 400 request because it's a failed request. This request should succeed since it's the end of the oauth redirect flow, returning an empty 200 makes it work again in Chrome 63+

a63800a replaces the polling loop that checks for the redirect URL in the login window with an event handler for when the window closes and a document to trigger it.

Fixes #267 