### PR TITLE
197 human readable orcid identifiers in jobs

### DIFF
--- a/app/src/scripts/dataset/dataset.jobs.run.jsx
+++ b/app/src/scripts/dataset/dataset.jobs.run.jsx
@@ -43,7 +43,12 @@ class JobAccordion extends React.Component {
       <span>
         <br />
         <label>By </label>
-        <strong>{run.userId}</strong>
+        <strong>
+          {run.hasOwnProperty('userMetaData') &&
+          run.userMetaData.hasOwnProperty('email')
+            ? run.userMetadata.email
+            : run.userId}
+        </strong>
       </span>
     ) : null
     let userCanCancel =

--- a/app/src/scripts/dataset/dataset.jobs.run.jsx
+++ b/app/src/scripts/dataset/dataset.jobs.run.jsx
@@ -44,8 +44,8 @@ class JobAccordion extends React.Component {
         <br />
         <label>By </label>
         <strong>
-          {run.hasOwnProperty('userMetaData') &&
-          run.userMetaData.hasOwnProperty('email')
+          {run.hasOwnProperty('userMetadata') &&
+          run.userMetadata.hasOwnProperty('email')
             ? run.userMetadata.email
             : run.userId}
         </strong>

--- a/server/handlers/awsJobs.js
+++ b/server/handlers/awsJobs.js
@@ -3,6 +3,7 @@
 import crypto from 'crypto'
 import aws from '../libs/aws'
 import mongo from '../libs/mongo'
+import scitran from '../libs/scitran'
 import { ObjectID } from 'mongodb'
 import yazl from 'yazl'
 import S3StreamDownload from 's3-stream-download'
@@ -262,9 +263,19 @@ let handlers = {
         res.status(404).send({ message: 'Job not found.' })
         return
       }
-      //Send back job object to client
-      // server side polling handles all interactions with Batch now therefore we are not initiating batch polling from client
-      res.send(job)
+
+      //Pair the job data with the scitran user info
+      scitran.getUser(job.userId, (err, response) => {
+        if (err) next(err)
+
+        job.userMetadata = {}
+        if (response.statusCode == 200) {
+          job.userMetadata = response.body
+        }
+        //Send back job object to client
+        // server side polling handles all interactions with Batch now therefore we are not initiating batch polling from client
+        res.send(job)
+      })
     })
   },
 

--- a/server/handlers/awsJobs.js
+++ b/server/handlers/awsJobs.js
@@ -264,18 +264,9 @@ let handlers = {
         return
       }
 
-      //Pair the job data with the scitran user info
-      scitran.getUser(job.userId, (err, response) => {
-        if (err) next(err)
-
-        job.userMetadata = {}
-        if (response.statusCode == 200) {
-          job.userMetadata = response.body
-        }
-        //Send back job object to client
-        // server side polling handles all interactions with Batch now therefore we are not initiating batch polling from client
-        res.send(job)
-      })
+      //Send back job object to client
+      // server side polling handles all interactions with Batch now therefore we are not initiating batch polling from client
+      res.send(job)
     })
   },
 


### PR DESCRIPTION
updated getDatasetJobs function to tie metadata of the user that submitted the job. this is stored in job.userMetadata.  -- server/handlers/jobs.js

utilize run.userMetadata.email in jobs side panel to display the email of the user that ran the job, if it exists. (note the header in commit c6bb86e should say userMetadata, not user.metaData) --
 app/src/scripts/dataset/dataset.jobs.run.jsx