### PR TITLE
Fix NavMenu eventKey prop warning

### DIFF
--- a/app/src/scripts/nav/__tests__/__snapshots__/navbar.navmenu.spec.jsx.snap
+++ b/app/src/scripts/nav/__tests__/__snapshots__/navbar.navmenu.spec.jsx.snap
@@ -56,13 +56,117 @@ exports[`NavMenu renders successfully 1`] = `
     className="link-dashboard"
   />
   <li>
-    <NavbarCollapse
-      eventKey={0}
-    >
+    <NavbarCollapse>
       <SignIn
         loading={false}
       />
     </NavbarCollapse>
   </li>
 </ul>
+`;
+
+exports[`NavMenu renders without "eventKey" warnings 1`] = `
+<NavMenu
+  isLoggedIn={false}
+  loading={false}
+>
+  <ul
+    className="nav navbar-nav main-nav"
+  >
+    <li
+      className="link-dashboard"
+    />
+    <li
+      className="link-public"
+    >
+      <NavLink
+        className="nav-link"
+        to="/public/datasets"
+      />
+    </li>
+    <li
+      className="link-support"
+    >
+      <a
+        className="nav-link"
+        onClick={[Function]}
+      >
+        <span
+          className="link-name"
+        >
+          Support
+        </span>
+      </a>
+    </li>
+    <li
+      className="link-faq"
+    >
+      <NavLink
+        className="nav-link"
+        to="/faq"
+      />
+    </li>
+    <li
+      className="link-admin"
+    />
+    <li
+      className="link-dashboard"
+    />
+    <li>
+      <NavbarCollapse>
+        <Collapse
+          dimension="height"
+          getDimensionValue={[Function]}
+          in={false}
+          mountOnEnter={false}
+          timeout={300}
+          transitionAppear={false}
+          unmountOnExit={false}
+        >
+          <Transition
+            aria-expanded={null}
+            className=""
+            enteredClassName="collapse in"
+            enteringClassName="collapsing"
+            exitedClassName="collapse"
+            exitingClassName="collapsing"
+            in={false}
+            mountOnEnter={false}
+            onEnter={[Function]}
+            onEntered={[Function]}
+            onEntering={[Function]}
+            onExit={[Function]}
+            onExited={[Function]}
+            onExiting={[Function]}
+            timeout={300}
+            transitionAppear={false}
+            unmountOnExit={false}
+          >
+            <div
+              aria-expanded={null}
+              className="navbar-collapse collapse"
+            >
+              <SignIn
+                loading={false}
+              >
+                <div
+                  className="navbar-right sign-in-nav-btn"
+                >
+                  <button
+                    className="btn-blue"
+                    onClick={[Function]}
+                  >
+                    <span>
+                      Sign in
+                    </span>
+                  </button>
+                </div>
+              </SignIn>
+            </div>
+          </Transition>
+        </Collapse>
+      </NavbarCollapse>
+    </li>
+  </ul>
+</NavMenu>
 `;

--- a/app/src/scripts/nav/__tests__/__snapshots__/navbar.navmenu.spec.jsx.snap
+++ b/app/src/scripts/nav/__tests__/__snapshots__/navbar.navmenu.spec.jsx.snap
@@ -11,8 +11,6 @@ exports[`NavMenu renders successfully 1`] = `
     className="link-public"
   >
     <NavLink
-      activeClassName="active"
-      ariaCurrent="true"
       className="nav-link"
       to="/public/datasets"
     >
@@ -41,8 +39,6 @@ exports[`NavMenu renders successfully 1`] = `
     className="link-faq"
   >
     <NavLink
-      activeClassName="active"
-      ariaCurrent="true"
       className="nav-link"
       to="/faq"
     >

--- a/app/src/scripts/nav/__tests__/navbar.navmenu.spec.jsx
+++ b/app/src/scripts/nav/__tests__/navbar.navmenu.spec.jsx
@@ -1,13 +1,24 @@
 import React from 'react'
-import { shallow } from 'enzyme'
+import { shallow, mount } from 'enzyme'
 import NavMenu from '../navbar.navmenu.jsx'
 
 jest.mock('../../user/user.store.js')
 jest.mock('../../upload/upload.store.js')
+// Need to mock the router because of withRouter in these components
+jest.mock('react-router-dom', () => {
+  return {
+    NavLink: () => '',
+    withRouter: component => component,
+  }
+})
 
 describe('NavMenu', () => {
   it('renders successfully', () => {
     const wrapper = shallow(<NavMenu isLoggedIn={false} loading={false} />)
     expect(wrapper).toMatchSnapshot()
+  })
+  it('renders without "eventKey" warnings', () => {
+    const component = mount(<NavMenu isLoggedIn={false} loading={false} />)
+    expect(component).toMatchSnapshot()
   })
 })

--- a/app/src/scripts/nav/navbar.navmenu.jsx
+++ b/app/src/scripts/nav/navbar.navmenu.jsx
@@ -70,7 +70,7 @@ const NavMenu = ({ profile, scitran, isLoggedIn, loading }) => {
       </li>
       <li className="link-dashboard">{isLoggedIn ? <UploadBtn /> : null}</li>
       <li>
-        <Navbar.Collapse eventKey={0}>{loginButton}</Navbar.Collapse>
+        <Navbar.Collapse>{loginButton}</Navbar.Collapse>
       </li>
     </ul>
   )


### PR DESCRIPTION
The eventKey prop is not accomplishing anything but producing this warning. The test here is mostly useful as an example of a test that required mounting the component over shallow rendering but it does catch this issue with the changes in #276.