### PR TITLE
Adding spinner to top level dataset directory during directory upload

### DIFF
--- a/app/src/scripts/dataset/dataset.store.js
+++ b/app/src/scripts/dataset/dataset.store.js
@@ -867,12 +867,13 @@ let datasetStore = Reflux.createStore({
       this.updateWarn({
         message: message,
         action: () => {
-          async.each(
+          this.updateDirectoryState(dataset._id, { loading: true })
+          async.eachLimit(
             uploads,
+            3,
             (upload, cb) => {
               let file = upload.file
               let container = upload.container
-              this.updateDirectoryState(container._id, { loading: true })
               file.modifiedName = (container.dirPath || '') + file.name
               scitran.updateFile(
                 'projects',
@@ -886,7 +887,6 @@ let datasetStore = Reflux.createStore({
             err => {
               if (err && callback) callback(err)
               this.loadDataset(bids.encodeId(dataset._id), undefined, true) // forcing reload
-              this.updateDirectoryState(dataset._id, { error: '' })
               if (callback) callback()
             },
           )
@@ -908,8 +908,9 @@ let datasetStore = Reflux.createStore({
       this.updateWarn({
         message: message,
         action: () => {
-          async.each(
+          async.eachLimit(
             fileList,
+            3,
             (file, cb) => {
               scitran.deleteFile(
                 'projects',


### PR DESCRIPTION
* spinner was currently setup to spin in a non-existent directory. Fixed that issue so now there is a spinner at the top level of the dataset during directory add.  Also, set the file upload limit to 3 for add directory and also to 3 for deletion of directories.