### PR TITLE
Add progress indicator and navigation warning for directory uploads in datasets

### DIFF
--- a/app/src/sass/crn_app/_dataset.file-tree.scss
+++ b/app/src/sass/crn_app/_dataset.file-tree.scss
@@ -164,6 +164,23 @@
                         }
                     }
                 }
+
+                .panel-collapse {
+                    .panel-body {
+                        >ul.uploading-directory {
+                            >li.uploading-spinner {
+                                padding: 10px;
+                                .loading-wrap {
+                                    padding: 30px;
+                                    width: 100%;
+                                }
+                            }
+                            >li.uploading-progress {
+                                padding: 10px;
+                            }
+                        }
+                    }
+                }
             }
         }
     }

--- a/app/src/scripts/dataset/dataset.actions.js
+++ b/app/src/scripts/dataset/dataset.actions.js
@@ -4,6 +4,7 @@ var Actions = Reflux.createActions([
   'addFile',
   'addDirectoryFile',
   'createSnapshot',
+  'cancelDirectoryUpload',
   'deleteAttachment',
   'deleteDataset',
   'deleteFile',

--- a/app/src/scripts/dataset/dataset.jsx
+++ b/app/src/scripts/dataset/dataset.jsx
@@ -36,24 +36,15 @@ class Dataset extends Reflux.Component {
     )
   }
 
-  componentWillUpdate(nextProps, nextState) {
-    let unblock
-    // transtion from not uploading to uploading
-    if (nextState.datasets.uploading && !this.state.datasets.uploading) {
-      unblock = this.props.history.block(
-        'You are currently uploading files. Leaving this page will cancel the upload process.',
-      )
-    } else {
-      if (typeof unblock == 'function') {
-        unblock()
-      }
-    }
-  }
-
   componentDidMount() {
     const datasetId = this.props.match.params.datasetId
     const snapshotId = this.props.match.params.snapshotId
     this._loadData(datasetId, snapshotId)
+    this.props.history.block(() => {
+      if (this.state.datasets.uploading) {
+        return 'You are currently uploading files. Leaving this page will cancel the upload process.'
+      }
+    })
   }
 
   _loadData(datasetId, snapshotId) {

--- a/app/src/scripts/dataset/dataset.jsx
+++ b/app/src/scripts/dataset/dataset.jsx
@@ -263,6 +263,14 @@ class Dataset extends Reflux.Component {
             <span className="count">{snapshot.analysisCount}</span>
           </span>
         )
+      } else if (this.state.datasets.uploading) {
+        analysisCount = (
+          <span className="job-count">
+            <span className="warning-loading">
+              <i className="fa fa-spin fa-circle-o-notch" />
+            </span>
+          </span>
+        )
       }
 
       const datasetId = bids.decodeId(

--- a/app/src/scripts/dataset/dataset.jsx
+++ b/app/src/scripts/dataset/dataset.jsx
@@ -57,14 +57,18 @@ class Dataset extends Reflux.Component {
     const snapshotId = this.props.match.params.snapshotId
     this._loadData(datasetId, snapshotId)
     this.props.history.block(({ pathname }) => {
-      const datasetId =
-        this.state.datasets.dataset.linkOriginal ||
-        this.state.datasets.dataset.linkID
       const slugs = pathname.split('/')
-      // Dataset or snapshot URLs
-      if (slugs.length === 3 || slugs.length === 5) {
+      if (
+        slugs.length &&
+        slugs[1] === 'datasets' &&
+        this.state.datasets.dataset
+      ) {
+        let datasetId = this.state.datasets.dataset.linkID
+        if ('linkOriginal' in this.state.datasets.dataset) {
+          datasetId = this.state.datasets.dataset.linkOriginal
+        }
         // The same dataset
-        if (slugs[1] === 'datasets' && slugs[2] === datasetId) {
+        if (slugs[2] === datasetId) {
           return // Don't block this
         }
       }

--- a/app/src/scripts/dataset/dataset.jsx
+++ b/app/src/scripts/dataset/dataset.jsx
@@ -48,14 +48,9 @@ class Dataset extends Reflux.Component {
       }
       return false
     }
-    const unblock = this.props.history.block(({ pathname }) => {
+    const unblock = props.history.block(({ pathname }) => {
       if (!isDataset(pathname) && this.state.datasets.uploading) {
         return uploadWarning
-      }
-    })
-    this.props.history.listen(({ pathname }) => {
-      if (!isDataset(pathname) && this.state.datasets.uploading) {
-        actions.cancelDirectoryUpload()
       }
     })
     this.state = { unblock }
@@ -85,6 +80,29 @@ class Dataset extends Reflux.Component {
     const datasetId = this.props.match.params.datasetId
     const snapshotId = this.props.match.params.snapshotId
     this._loadData(datasetId, snapshotId)
+    const isDataset = pathname => {
+      const slugs = pathname.split('/')
+      if (
+        slugs.length &&
+        slugs[1] === 'datasets' &&
+        this.state.datasets.dataset
+      ) {
+        let datasetId = this.state.datasets.dataset.linkID
+        if ('linkOriginal' in this.state.datasets.dataset) {
+          datasetId = this.state.datasets.dataset.linkOriginal
+        }
+        // The same dataset
+        if (slugs[2] === datasetId) {
+          return true
+        }
+      }
+      return false
+    }
+    this.props.history.listen(({ pathname }) => {
+      if (!isDataset(pathname) && this.state.datasets.uploading) {
+        actions.cancelDirectoryUpload()
+      }
+    })
   }
 
   _loadData(datasetId, snapshotId) {

--- a/app/src/scripts/dataset/dataset.jsx
+++ b/app/src/scripts/dataset/dataset.jsx
@@ -36,6 +36,20 @@ class Dataset extends Reflux.Component {
     )
   }
 
+  componentWillUpdate(nextProps, nextState) {
+    let unblock
+    // transtion from not uploading to uploading
+    if (nextState.datasets.uploading && !this.state.datasets.uploading) {
+      unblock = this.props.history.block(
+        'You are currently uploading files. Leaving this page will cancel the upload process.',
+      )
+    } else {
+      if (typeof unblock == 'function') {
+        unblock()
+      }
+    }
+  }
+
   componentDidMount() {
     const datasetId = this.props.match.params.datasetId
     const snapshotId = this.props.match.params.snapshotId

--- a/app/src/scripts/dataset/dataset.jsx
+++ b/app/src/scripts/dataset/dataset.jsx
@@ -30,6 +30,35 @@ class Dataset extends Reflux.Component {
   constructor(props) {
     super(props)
     refluxConnect(this, datasetStore, 'datasets')
+    const isDataset = pathname => {
+      const slugs = pathname.split('/')
+      if (
+        slugs.length &&
+        slugs[1] === 'datasets' &&
+        this.state.datasets.dataset
+      ) {
+        let datasetId = this.state.datasets.dataset.linkID
+        if ('linkOriginal' in this.state.datasets.dataset) {
+          datasetId = this.state.datasets.dataset.linkOriginal
+        }
+        // The same dataset
+        if (slugs[2] === datasetId) {
+          return true
+        }
+      }
+      return false
+    }
+    const unblock = this.props.history.block(({ pathname }) => {
+      if (!isDataset(pathname) && this.state.datasets.uploading) {
+        return uploadWarning
+      }
+    })
+    this.props.history.listen(({ pathname }) => {
+      if (!isDataset(pathname) && this.state.datasets.uploading) {
+        actions.cancelDirectoryUpload()
+      }
+    })
+    this.state = { unblock }
   }
   // life cycle events --------------------------------------------------
 
@@ -56,34 +85,6 @@ class Dataset extends Reflux.Component {
     const datasetId = this.props.match.params.datasetId
     const snapshotId = this.props.match.params.snapshotId
     this._loadData(datasetId, snapshotId)
-    const isDataset = pathname => {
-      const slugs = pathname.split('/')
-      if (
-        slugs.length &&
-        slugs[1] === 'datasets' &&
-        this.state.datasets.dataset
-      ) {
-        let datasetId = this.state.datasets.dataset.linkID
-        if ('linkOriginal' in this.state.datasets.dataset) {
-          datasetId = this.state.datasets.dataset.linkOriginal
-        }
-        // The same dataset
-        if (slugs[2] === datasetId) {
-          return true
-        }
-      }
-      return false
-    }
-    this.props.history.block(({ pathname }) => {
-      if (!isDataset(pathname) && this.state.datasets.uploading) {
-        return uploadWarning
-      }
-    })
-    this.props.history.listen(({ pathname }) => {
-      if (!isDataset(pathname) && this.state.datasets.uploading) {
-        actions.cancelDirectoryUpload()
-      }
-    })
   }
 
   _loadData(datasetId, snapshotId) {
@@ -113,6 +114,9 @@ class Dataset extends Reflux.Component {
     super.componentWillUnmount()
     document.title = 'OpenNeuro'
     window.onbeforeunload = () => {}
+    if (this.state.unblock) {
+      this.state.unblock()
+    }
   }
 
   render() {

--- a/app/src/scripts/dataset/dataset.jsx
+++ b/app/src/scripts/dataset/dataset.jsx
@@ -237,6 +237,7 @@ class Dataset extends Reflux.Component {
             dataset={dataset}
             selectedSnapshot={this.state.datasets.selectedSnapshot}
             snapshots={this.state.datasets.snapshots}
+            uploading={this.state.datasets.uploading}
           />
         </div>
       )

--- a/app/src/scripts/dataset/dataset.jsx
+++ b/app/src/scripts/dataset/dataset.jsx
@@ -267,7 +267,7 @@ class Dataset extends Reflux.Component {
             <span className="count">{snapshot.analysisCount}</span>
           </span>
         )
-      } else if (this.state.datasets.uploading) {
+      } else if (snapshot.isOriginal && this.state.datasets.uploading) {
         analysisCount = (
           <span className="job-count">
             <span className="warning-loading">

--- a/app/src/scripts/dataset/dataset.jsx
+++ b/app/src/scripts/dataset/dataset.jsx
@@ -56,7 +56,18 @@ class Dataset extends Reflux.Component {
     const datasetId = this.props.match.params.datasetId
     const snapshotId = this.props.match.params.snapshotId
     this._loadData(datasetId, snapshotId)
-    this.props.history.block(() => {
+    this.props.history.block(({ pathname }) => {
+      const datasetId =
+        this.state.datasets.dataset.linkOriginal ||
+        this.state.datasets.dataset.linkID
+      const slugs = pathname.split('/')
+      // Dataset or snapshot URLs
+      if (slugs.length === 3 || slugs.length === 5) {
+        // The same dataset
+        if (slugs[1] === 'datasets' && slugs[2] === datasetId) {
+          return // Don't block this
+        }
+      }
       if (this.state.datasets.uploading) {
         return uploadWarning
       }
@@ -367,8 +378,7 @@ class Dataset extends Reflux.Component {
         topLevel
       />
     )
-
-    if (this.state.datasets.uploading) {
+    if (this.state.datasets.uploading && !('original' in dataset)) {
       const max = this.state.datasets.uploadingFileCount
       const now = this.state.datasets.uploadingProgress
       const progress = {

--- a/app/src/scripts/dataset/dataset.jsx
+++ b/app/src/scripts/dataset/dataset.jsx
@@ -23,6 +23,9 @@ import uploadActions from '../upload/upload.actions.js'
 import bids from '../utils/bids'
 import { refluxConnect } from '../utils/reflux'
 
+const uploadWarning =
+  'You are currently uploading files. Leaving this page will cancel the upload process.'
+
 class Dataset extends Reflux.Component {
   constructor(props) {
     super(props)
@@ -37,13 +40,25 @@ class Dataset extends Reflux.Component {
     )
   }
 
+  componentWillUpdate() {
+    // Prevent navigation away if adding a directory
+    if (this.state.datasets.uploading) {
+      window.onbeforeunload = () => {
+        // Warning not shown in modern browsers but we have to return something
+        return uploadWarning
+      }
+    } else {
+      window.onbeforeunload = () => {}
+    }
+  }
+
   componentDidMount() {
     const datasetId = this.props.match.params.datasetId
     const snapshotId = this.props.match.params.snapshotId
     this._loadData(datasetId, snapshotId)
     this.props.history.block(() => {
       if (this.state.datasets.uploading) {
-        return 'You are currently uploading files. Leaving this page will cancel the upload process.'
+        return uploadWarning
       }
     })
   }
@@ -74,6 +89,7 @@ class Dataset extends Reflux.Component {
     actions.setInitialState({ apps: this.state.datasets.apps })
     super.componentWillUnmount()
     document.title = 'OpenNeuro'
+    window.onbeforeunload = () => {}
   }
 
   render() {

--- a/app/src/scripts/dataset/dataset.jsx
+++ b/app/src/scripts/dataset/dataset.jsx
@@ -129,7 +129,10 @@ class Dataset extends Reflux.Component {
                       errors={errors}
                       warnings={warnings}
                       validating={dataset.status.validating}
-                      display={!dataset.status.incomplete}
+                      display={
+                        !dataset.status.incomplete &&
+                        !this.state.datasets.uploading
+                      }
                     />
                     <div className="fade-in col-xs-12">
                       <Jobs />

--- a/app/src/scripts/dataset/dataset.jsx
+++ b/app/src/scripts/dataset/dataset.jsx
@@ -56,7 +56,7 @@ class Dataset extends Reflux.Component {
     const datasetId = this.props.match.params.datasetId
     const snapshotId = this.props.match.params.snapshotId
     this._loadData(datasetId, snapshotId)
-    this.props.history.block(({ pathname }) => {
+    const isDataset = pathname => {
       const slugs = pathname.split('/')
       if (
         slugs.length &&
@@ -69,11 +69,19 @@ class Dataset extends Reflux.Component {
         }
         // The same dataset
         if (slugs[2] === datasetId) {
-          return // Don't block this
+          return true
         }
       }
-      if (this.state.datasets.uploading) {
+      return false
+    }
+    this.props.history.block(({ pathname }) => {
+      if (!isDataset(pathname) && this.state.datasets.uploading) {
         return uploadWarning
+      }
+    })
+    this.props.history.listen(({ pathname }) => {
+      if (!isDataset(pathname) && this.state.datasets.uploading) {
+        actions.cancelDirectoryUpload()
       }
     })
   }

--- a/app/src/scripts/dataset/dataset.jsx
+++ b/app/src/scripts/dataset/dataset.jsx
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types'
 import Reflux from 'reflux'
 import { Link, withRouter } from 'react-router-dom'
 import moment from 'moment'
+import { ProgressBar } from 'react-bootstrap'
 import Spinner from '../common/partials/spinner.jsx'
 import datasetStore from './dataset.store'
 import actions from './dataset.actions.js'
@@ -139,7 +140,7 @@ class Dataset extends Reflux.Component {
                     </div>
                     <div className="dataset-files">
                       {this._incompleteMessage(dataset)}
-                      {this._fileTree(dataset, canEdit)}
+                      {this._fileTree.bind(this)(dataset, canEdit)}
                     </div>
                   </div>
                 </div>
@@ -333,6 +334,44 @@ class Dataset extends Reflux.Component {
   }
 
   _fileTree(dataset, canEdit) {
+    let fileTree = (
+      <FileTree
+        tree={[dataset]}
+        editable={canEdit}
+        loading={this.state.datasets.loadingTree}
+        dismissError={actions.dismissError}
+        deleteFile={actions.deleteFile}
+        getFileDownloadTicket={actions.getFileDownloadTicket}
+        displayFile={actions.displayFile.bind(this, null, null)}
+        toggleFolder={actions.toggleFolder}
+        addFile={actions.addFile}
+        addDirectoryFile={actions.addDirectoryFile}
+        deleteDirectory={actions.deleteDirectory}
+        updateFile={actions.updateFile}
+        topLevel
+      />
+    )
+
+    if (this.state.datasets.uploading) {
+      const max = this.state.datasets.uploadingFileCount
+      const now = this.state.datasets.uploadingProgress
+      const progress = {
+        max,
+        now,
+        label: now + '/' + max + ' files uploaded',
+      }
+      fileTree = (
+        <ul className="uploading-directory">
+          <li className="clearfix uploading-spinner">
+            <Spinner active={true} text="Adding files..." />
+          </li>
+          <li className="clearfix uploading-progress">
+            <ProgressBar active {...progress} />
+          </li>
+        </ul>
+      )
+    }
+
     if (!dataset.status.incomplete) {
       return (
         <div className="col-xs-12">
@@ -342,23 +381,7 @@ class Dataset extends Reflux.Component {
                 <h3 className="panel-title">Dataset File Tree</h3>
               </div>
               <div className="panel-collapse" aria-expanded="false">
-                <div className="panel-body">
-                  <FileTree
-                    tree={[dataset]}
-                    editable={canEdit}
-                    loading={this.state.datasets.loadingTree}
-                    dismissError={actions.dismissError}
-                    deleteFile={actions.deleteFile}
-                    getFileDownloadTicket={actions.getFileDownloadTicket}
-                    displayFile={actions.displayFile.bind(this, null, null)}
-                    toggleFolder={actions.toggleFolder}
-                    addFile={actions.addFile}
-                    addDirectoryFile={actions.addDirectoryFile}
-                    deleteDirectory={actions.deleteDirectory}
-                    updateFile={actions.updateFile}
-                    topLevel
-                  />
-                </div>
+                <div className="panel-body">{fileTree}</div>
               </div>
             </div>
           </div>

--- a/app/src/scripts/dataset/dataset.store.js
+++ b/app/src/scripts/dataset/dataset.store.js
@@ -857,8 +857,8 @@ let datasetStore = Reflux.createStore({
   addDirectoryFile(uploads, dirTree, callback) {
     // get the top level directory name to display in warning message
     let topLevelDirectory = `${uploads[0].container.dirPath.split('/')[0]}/`
-    let dataset = this.data.dataset
-    let childExistsIndex = dataset.children.findIndex(el => {
+    let datasetId = this.data.dataset._id
+    let childExistsIndex = this.data.dataset.children.findIndex(el => {
       return el.name === dirTree.name
     })
     if (childExistsIndex === -1) {
@@ -873,7 +873,7 @@ let datasetStore = Reflux.createStore({
             uploadingFileCount: uploads.length,
             uploadingProgress: 0,
           })
-          this.updateDirectoryState(dataset._id, { loading: true })
+          this.updateDirectoryState(datasetId, { loading: true })
           async.eachLimit(
             uploads,
             3,
@@ -881,29 +881,24 @@ let datasetStore = Reflux.createStore({
               let file = upload.file
               let container = upload.container
               file.modifiedName = (container.dirPath || '') + file.name
-              scitran.updateFile(
-                'projects',
-                this.data.dataset._id,
-                file,
-                () => {
-                  this.update({
-                    uploadingProgress: this.data.uploadingProgress + 1,
-                  })
-                  cb()
-                },
-              )
+              scitran.updateFile('projects', datasetId, file, () => {
+                this.update({
+                  uploadingProgress: this.data.uploadingProgress + 1,
+                })
+                cb()
+              })
             },
             err => {
               this.update({ uploading: false })
               if (err && callback) callback(err)
-              this.loadDataset(bids.encodeId(dataset._id), undefined, true) // forcing reload
+              this.loadDataset(bids.encodeId(datasetId), undefined, true) // forcing reload
               if (callback) callback()
             },
           )
         },
       })
     } else {
-      this.updateDirectoryState(dataset._id, {
+      this.updateDirectoryState(datasetId, {
         error: '"' + topLevelDirectory + '" already exists in this dataset.',
       })
     }

--- a/app/src/scripts/dataset/dataset.store.js
+++ b/app/src/scripts/dataset/dataset.store.js
@@ -92,6 +92,7 @@ let datasetStore = Reflux.createStore({
       selectedSnapshot: '',
       status: null,
       users: [],
+      uploading: false,
       showSidebar: window.localStorage.hasOwnProperty('showSidebar')
         ? window.localStorage.showSidebar === 'true'
         : true,
@@ -867,6 +868,7 @@ let datasetStore = Reflux.createStore({
       this.updateWarn({
         message: message,
         action: () => {
+          this.update({ uploading: true })
           this.updateDirectoryState(dataset._id, { loading: true })
           async.eachLimit(
             uploads,
@@ -885,6 +887,7 @@ let datasetStore = Reflux.createStore({
               )
             },
             err => {
+              this.update({ uploading: false })
               if (err && callback) callback(err)
               this.loadDataset(bids.encodeId(dataset._id), undefined, true) // forcing reload
               if (callback) callback()

--- a/app/src/scripts/dataset/dataset.store.js
+++ b/app/src/scripts/dataset/dataset.store.js
@@ -868,7 +868,11 @@ let datasetStore = Reflux.createStore({
       this.updateWarn({
         message: message,
         action: () => {
-          this.update({ uploading: true })
+          this.update({
+            uploading: true,
+            uploadingFileCount: uploads.length,
+            uploadingProgress: 0,
+          })
           this.updateDirectoryState(dataset._id, { loading: true })
           async.eachLimit(
             uploads,
@@ -882,6 +886,9 @@ let datasetStore = Reflux.createStore({
                 this.data.dataset._id,
                 file,
                 () => {
+                  this.update({
+                    uploadingProgress: this.data.uploadingProgress + 1,
+                  })
                   cb()
                 },
               )

--- a/app/src/scripts/dataset/dataset.store.js
+++ b/app/src/scripts/dataset/dataset.store.js
@@ -904,12 +904,12 @@ let datasetStore = Reflux.createStore({
                 scitranUploads.forEach(upload => {
                   upload.abort()
                 })
-                // Reset to original state after canceled
-                this.update({ uploadingCanceled: false })
                 this.loadDataset(bids.encodeId(datasetId), undefined, false)
               } else {
                 this.loadDataset(bids.encodeId(datasetId), undefined, true) // forcing reload
               }
+              // Reset canceled when an upload is done (canceled or otherwise)
+              this.update({ uploadingCanceled: false })
               if (callback) callback()
             },
           )

--- a/app/src/scripts/dataset/tools/index.js
+++ b/app/src/scripts/dataset/tools/index.js
@@ -53,6 +53,14 @@ class Tools extends React.Component {
         prepDownload: actions.getDatasetDownloadTicket,
         action: actions.trackDownload,
         display: !isIncomplete,
+        validations: [
+          {
+            check: this.props.uploading,
+            message: 'Files are currently uploading',
+            timeout: 5000,
+            type: 'Error',
+          },
+        ],
       },
       {
         tooltip: 'Publish Dataset',
@@ -60,6 +68,14 @@ class Tools extends React.Component {
         action: actions.toggleModal.bind(null, 'publish'),
         display: isAdmin && !isPublic && !isIncomplete,
         warn: false,
+        validations: [
+          {
+            check: this.props.uploading,
+            message: 'Files are currently uploading',
+            timeout: 5000,
+            type: 'Error',
+          },
+        ],
       },
       {
         tooltip: 'Unpublish Dataset',
@@ -67,6 +83,14 @@ class Tools extends React.Component {
         action: actions.publish.bind(this, dataset._id, false),
         display: isPublic && isSuperuser,
         warn: true,
+        validations: [
+          {
+            check: this.props.uploading,
+            message: 'Files are currently uploading',
+            timeout: 5000,
+            type: 'Error',
+          },
+        ],
       },
       {
         tooltip: isSnapshot ? 'Delete Snapshot' : 'Delete Dataset',
@@ -78,6 +102,14 @@ class Tools extends React.Component {
         ),
         display: displayDelete,
         warn: isSnapshot,
+        validations: [
+          {
+            check: this.props.uploading,
+            message: 'Files are currently uploading',
+            timeout: 5000,
+            type: 'Error',
+          },
+        ],
       },
       {
         tooltip: 'Share Dataset',
@@ -85,6 +117,14 @@ class Tools extends React.Component {
         action: actions.toggleModal.bind(null, 'share'),
         display: isAdmin && !isSnapshot && !isIncomplete,
         warn: false,
+        validations: [
+          {
+            check: this.props.uploading,
+            message: 'Files are currently uploading',
+            timeout: 5000,
+            type: 'Error',
+          },
+        ],
       },
       {
         tooltip: 'Create Snapshot',
@@ -109,6 +149,12 @@ class Tools extends React.Component {
             timeout: 6000,
             type: 'Error',
           },
+          {
+            check: this.props.uploading,
+            message: 'Files are currently uploading',
+            timeout: 5000,
+            type: 'Error',
+          },
         ],
       },
       {
@@ -117,6 +163,14 @@ class Tools extends React.Component {
         action: actions.toggleModal.bind(null, 'jobs'),
         display: isSignedIn && !isIncomplete,
         warn: false,
+        validations: [
+          {
+            check: this.props.uploading,
+            message: 'Files are currently uploading',
+            timeout: 5000,
+            type: 'Error',
+          },
+        ],
       },
     ]
 
@@ -191,6 +245,7 @@ Tools.propTypes = {
   snapshots: PropTypes.array.isRequired,
   selectedSnapshot: PropTypes.string.isRequired,
   history: PropTypes.object,
+  uploading: PropTypes.bool,
 }
 
 export default withRouter(Tools)

--- a/app/src/scripts/dataset/tools/index.js
+++ b/app/src/scripts/dataset/tools/index.js
@@ -55,7 +55,7 @@ class Tools extends React.Component {
         display: !isIncomplete,
         validations: [
           {
-            check: this.props.uploading,
+            check: this.props.uploading && !isSnapshot,
             message: 'Files are currently uploading',
             timeout: 5000,
             type: 'Error',
@@ -70,7 +70,7 @@ class Tools extends React.Component {
         warn: false,
         validations: [
           {
-            check: this.props.uploading,
+            check: this.props.uploading && !isSnapshot,
             message: 'Files are currently uploading',
             timeout: 5000,
             type: 'Error',
@@ -85,7 +85,7 @@ class Tools extends React.Component {
         warn: true,
         validations: [
           {
-            check: this.props.uploading,
+            check: this.props.uploading && !isSnapshot,
             message: 'Files are currently uploading',
             timeout: 5000,
             type: 'Error',
@@ -104,7 +104,7 @@ class Tools extends React.Component {
         warn: isSnapshot,
         validations: [
           {
-            check: this.props.uploading,
+            check: this.props.uploading && !isSnapshot,
             message: 'Files are currently uploading',
             timeout: 5000,
             type: 'Error',
@@ -119,7 +119,7 @@ class Tools extends React.Component {
         warn: false,
         validations: [
           {
-            check: this.props.uploading,
+            check: this.props.uploading && !isSnapshot,
             message: 'Files are currently uploading',
             timeout: 5000,
             type: 'Error',
@@ -150,7 +150,7 @@ class Tools extends React.Component {
             type: 'Error',
           },
           {
-            check: this.props.uploading,
+            check: this.props.uploading && !isSnapshot,
             message: 'Files are currently uploading',
             timeout: 5000,
             type: 'Error',
@@ -165,7 +165,7 @@ class Tools extends React.Component {
         warn: false,
         validations: [
           {
-            check: this.props.uploading,
+            check: this.props.uploading && !isSnapshot,
             message: 'Files are currently uploading',
             timeout: 5000,
             type: 'Error',

--- a/app/src/scripts/utils/request.js
+++ b/app/src/scripts/utils/request.js
@@ -66,8 +66,8 @@ var Request = {
   },
 
   upload(url, options, callback) {
-    handleRequest(url, options, function(url, options) {
-      request
+    return handleRequest(url, options, function(url, options) {
+      return request
         .post(url)
         .query(options.query)
         .set(options.headers)

--- a/app/src/scripts/utils/scitran.js
+++ b/app/src/scripts/utils/scitran.js
@@ -400,7 +400,7 @@ export default {
      *
      */
   updateFile(level, id, file, callback) {
-    request.upload(
+    return request.upload(
       config.scitran.url + level + '/' + id + '/files',
       {
         fields: {


### PR DESCRIPTION
![screenshot from 2017-12-20 19-59-22](https://user-images.githubusercontent.com/11369795/34240068-745452a0-e5c0-11e7-9f61-ef0692fe97d9.png)

This hides validation until the new directory upload completes and shows a progress bar for the count of files uploaded.

If you navigate away from the page during an upload, you get a browser warning that says `You are currently uploading files. Leaving this page will cancel the upload process.` and you have to confirm this is what you wanted. There's no way to resume an upload if you do interrupt it like this but you can delete the directory and try again or add a missing file.

Fixes #285 and #289 

@chrisfilo This is on dev for testing.