### PR TITLE
#218 - display results only when all jobs are complete

### DIFF
--- a/app/src/scripts/dataset/run/__tests__/__snapshots__/results.spec.jsx.snap
+++ b/app/src/scripts/dataset/run/__tests__/__snapshots__/results.spec.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`dataset/run/Results should render something 1`] = `
+exports[`dataset/run/Results should render something when all job results are in 1`] = `
 <Accordion
   accordion={true}
   className="results"
@@ -32,6 +32,11 @@ exports[`dataset/run/Results should render something 1`] = `
     <DownloadAll
       run={
         Object {
+          "analysis": Object {
+            "jobs": Array [
+              "only_one_job",
+            ],
+          },
           "results": Array [
             Object {
               "dirPath": "avg_brain_size.txt",

--- a/app/src/scripts/dataset/run/__tests__/__snapshots__/results.spec.jsx.snap
+++ b/app/src/scripts/dataset/run/__tests__/__snapshots__/results.spec.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`dataset/run/Results should render something when all job results are in 1`] = `
+exports[`dataset/run/Results should render something when the job status is "FAILED" 1`] = `
 <Accordion
   accordion={true}
   className="results"
@@ -33,9 +33,90 @@ exports[`dataset/run/Results should render something when all job results are in
       run={
         Object {
           "analysis": Object {
-            "jobs": Array [
-              "only_one_job",
-            ],
+            "status": "FAILED",
+          },
+          "results": Array [
+            Object {
+              "dirPath": "avg_brain_size.txt",
+              "name": "avg_brain_size.txt",
+              "path": "openneuro.outputs/cf02b5bf17df80d056effadccffd65bd/dcedf0c3-4438-466d-9f85-61c75275b355/avg_brain_size.txt",
+              "type": "file",
+            },
+          ],
+        }
+      }
+    />
+    <div
+      className="file-structure fade-in panel-group"
+    >
+      <div
+        className="panel panel-default"
+      >
+        <div
+          aria-expanded="false"
+          className="panel-collapse"
+        >
+          <div
+            className="panel-body"
+          >
+            <FileTree
+              displayFile={[Function]}
+              editable={false}
+              getFileDownloadTicket={[Function]}
+              toggleFolder={[MockFunction]}
+              tree={
+                Array [
+                  Object {
+                    "dirPath": "avg_brain_size.txt",
+                    "name": "avg_brain_size.txt",
+                    "path": "openneuro.outputs/cf02b5bf17df80d056effadccffd65bd/dcedf0c3-4438-466d-9f85-61c75275b355/avg_brain_size.txt",
+                    "type": "file",
+                  },
+                ]
+              }
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </Panel>
+</Accordion>
+`;
+
+exports[`dataset/run/Results should render something when the job status is "SUCCEEDED" 1`] = `
+<Accordion
+  accordion={true}
+  className="results"
+>
+  <Panel
+    bsClass="panel"
+    bsStyle="default"
+    className="fade-in"
+    defaultExpanded={false}
+    header="results"
+  >
+    <div
+      className="app-acknowledgements"
+    >
+      <label>
+        Acknowledgements
+      </label>
+      <div
+        className="markdown"
+        dangerouslySetInnerHTML={
+          Object {
+            "__html": "<p>acknowledge</p>
+",
+          }
+        }
+      />
+    </div>
+    <hr />
+    <DownloadAll
+      run={
+        Object {
+          "analysis": Object {
+            "status": "SUCCEEDED",
           },
           "results": Array [
             Object {

--- a/app/src/scripts/dataset/run/__tests__/results.spec.jsx
+++ b/app/src/scripts/dataset/run/__tests__/results.spec.jsx
@@ -3,8 +3,8 @@ import { shallow } from 'enzyme'
 import Results from '../results.jsx'
 
 describe('dataset/run/Results', () => {
-  it('should render something when all job results are in', () => {
-    const exampleRun = {
+  it('should render something when the job status is "SUCCEEDED"', () => {
+    const successfulRun = {
       results: [
         {
           type: 'file',
@@ -15,13 +15,13 @@ describe('dataset/run/Results', () => {
         },
       ],
       analysis: {
-        jobs: ['only_one_job'],
+        status: 'SUCCEEDED',
       },
     }
     expect(
       shallow(
         <Results
-          run={exampleRun}
+          run={successfulRun}
           acknowledgements="acknowledge"
           displayFile={jest.fn()}
           toggleFolder={jest.fn()}
@@ -29,8 +29,8 @@ describe('dataset/run/Results', () => {
       ),
     ).toMatchSnapshot()
   })
-  it('should render nothing if there are less results than there are jobs', () => {
-    const lessResultsRun = {
+  it('should render something when the job status is "FAILED"', () => {
+    const failedRun = {
       results: [
         {
           type: 'file',
@@ -41,23 +41,26 @@ describe('dataset/run/Results', () => {
         },
       ],
       analysis: {
-        jobs: ['job_one', 'job_two'],
+        status: 'FAILED',
       },
     }
     expect(
       shallow(
         <Results
-          run={lessResultsRun}
+          run={failedRun}
           acknowledgements="acknowledge"
           displayFile={jest.fn()}
           toggleFolder={jest.fn()}
         />,
-      ).getElement(),
-    ).toBe(null)
+      ),
+    ).toMatchSnapshot()
   })
-  it('should render nothing when there are no results', () => {
+  it('should render nothing when job status is neither "SUCCEEDED" nor "FAILED"', () => {
     const noResultsRun = {
       results: [],
+      analysis: {
+        status: 'RUNNING',
+      },
     }
     expect(
       shallow(

--- a/app/src/scripts/dataset/run/__tests__/results.spec.jsx
+++ b/app/src/scripts/dataset/run/__tests__/results.spec.jsx
@@ -3,7 +3,7 @@ import { shallow } from 'enzyme'
 import Results from '../results.jsx'
 
 describe('dataset/run/Results', () => {
-  it('should render something', () => {
+  it('should render something when all job results are in', () => {
     const exampleRun = {
       results: [
         {
@@ -14,6 +14,9 @@ describe('dataset/run/Results', () => {
             'openneuro.outputs/cf02b5bf17df80d056effadccffd65bd/dcedf0c3-4438-466d-9f85-61c75275b355/avg_brain_size.txt',
         },
       ],
+      analysis: {
+        jobs: ['only_one_job'],
+      },
     }
     expect(
       shallow(
@@ -25,6 +28,32 @@ describe('dataset/run/Results', () => {
         />,
       ),
     ).toMatchSnapshot()
+  })
+  it('should render nothing if there are less results than there are jobs', () => {
+    const lessResultsRun = {
+      results: [
+        {
+          type: 'file',
+          dirPath: 'avg_brain_size.txt',
+          name: 'avg_brain_size.txt',
+          path:
+            'openneuro.outputs/cf02b5bf17df80d056effadccffd65bd/dcedf0c3-4438-466d-9f85-61c75275b355/avg_brain_size.txt',
+        },
+      ],
+      analysis: {
+        jobs: ['job_one', 'job_two'],
+      },
+    }
+    expect(
+      shallow(
+        <Results
+          run={lessResultsRun}
+          acknowledgements="acknowledge"
+          displayFile={jest.fn()}
+          toggleFolder={jest.fn()}
+        />,
+      ).getElement(),
+    ).toBe(null)
   })
   it('should render nothing when there are no results', () => {
     const noResultsRun = {

--- a/app/src/scripts/dataset/run/results.jsx
+++ b/app/src/scripts/dataset/run/results.jsx
@@ -8,9 +8,8 @@ import markdown from '../../utils/markdown'
 
 const JobResults = ({ run, acknowledgements, displayFile, toggleFolder }) => {
   const type = 'results'
-  const jobs = run.analysis ? run.analysis.jobs : null
-  const jobLength = jobs ? jobs.length : false
-  if (run[type] && run[type].length > 0 && run[type].length === jobLength) {
+  const jobStatus = run.analysis ? run.analysis.status : null
+  if (run[type] && (jobStatus === 'FAILED' || jobStatus === 'SUCCEEDED')) {
     return (
       <Accordion accordion className="results">
         <Panel

--- a/app/src/scripts/dataset/run/results.jsx
+++ b/app/src/scripts/dataset/run/results.jsx
@@ -8,7 +8,8 @@ import markdown from '../../utils/markdown'
 
 const JobResults = ({ run, acknowledgements, displayFile, toggleFolder }) => {
   const type = 'results'
-  const jobLength = run.analysis.jobs ? run.analysis.jobs.length : false
+  const jobs = run.analysis ? run.analysis.jobs : null
+  const jobLength = jobs ? jobs.length : false
   if (run[type] && run[type].length > 0 && run[type].length === jobLength) {
     return (
       <Accordion accordion className="results">

--- a/app/src/scripts/dataset/run/results.jsx
+++ b/app/src/scripts/dataset/run/results.jsx
@@ -8,7 +8,8 @@ import markdown from '../../utils/markdown'
 
 const JobResults = ({ run, acknowledgements, displayFile, toggleFolder }) => {
   const type = 'results'
-  if (run[type] && run[type].length > 0) {
+  const jobLength = run.analysis.jobs ? run.analysis.jobs.length : false
+  if (run[type] && run[type].length > 0 && run[type].length === jobLength) {
     return (
       <Accordion accordion className="results">
         <Panel


### PR DESCRIPTION
fixes #218. 

only display job results tab when results.length == run.analysis.jobs.length