### PR TITLE
Return a 500 error and message when the validator exits unexpectedly

### DIFF
--- a/server/handlers/validation.js
+++ b/server/handlers/validation.js
@@ -19,32 +19,42 @@ export default {
     // get project id
     let datasetId = req.params.datasetId
 
+    const generic_failure =
+      'This dataset could not be validated, it may have been deleted during validation'
+
     scitran.downloadSymlinkDataset(datasetId, (err, hash) => {
-      validate.BIDS(
-        config.location + '/persistent/datasets/' + hash,
-        {},
-        (validation, summary) => {
-          scitran.updateProject(
-            datasetId,
-            {
-              metadata: { validation, summary },
-            },
-            () => {
-              scitran.removeTag('projects', datasetId, 'validating', () => {
-                if (validation.errors && validation.errors.length > 0) {
-                  scitran.addTag('projects', datasetId, 'invalid', () => {
-                    res.send({ validation, summary })
-                  })
-                } else {
-                  scitran.removeTag('projects', datasetId, 'invalid', () => {
-                    res.send({ validation, summary })
-                  })
-                }
-              })
-            },
-          )
-        },
-      )
+      if (err) {
+        return res.status(500).send({ error: generic_failure })
+      }
+      try {
+        validate.BIDS(
+          config.location + '/persistent/datasets/' + hash,
+          {},
+          (validation, summary) => {
+            scitran.updateProject(
+              datasetId,
+              {
+                metadata: { validation, summary },
+              },
+              () => {
+                scitran.removeTag('projects', datasetId, 'validating', () => {
+                  if (validation.errors && validation.errors.length > 0) {
+                    scitran.addTag('projects', datasetId, 'invalid', () => {
+                      res.send({ validation, summary })
+                    })
+                  } else {
+                    scitran.removeTag('projects', datasetId, 'invalid', () => {
+                      res.send({ validation, summary })
+                    })
+                  }
+                })
+              },
+            )
+          },
+        )
+      } catch (err) {
+        return res.status(500).send({ error: generic_failure })
+      }
     })
   },
 }


### PR DESCRIPTION
This catches the error and returns a 500 status code if validation is requested for a dataset that no longer exists or the validator exits unexpectedly.

Fixes #99