### PR TITLE
Updating validator to 0.25.0

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "async": "^1.2.1",
     "babel-polyfill": "^6.6.1",
-    "bids-validator": "^0.24.1",
+    "bids-validator": "^0.25.0",
     "bowser": "^1.7.3",
     "bytes": "^2.3.0",
     "favico.js": "git://github.com/ejci/favico.js#0.3.10",

--- a/server/package.json
+++ b/server/package.json
@@ -23,7 +23,7 @@
     "aws-sdk": "2.50.0",
     "babel-core": "^6.26.0",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
-    "bids-validator": "^0.24.1",
+    "bids-validator": "^0.25.0",
     "body-parser": "^1.14.0",
     "cron": "^1.1.0",
     "express": "^4.13.3",


### PR DESCRIPTION
This version is much more strict so it should avoid datasets with poor compatibility to be uploaded.