### PR TITLE
Remove fade in class from warn button

### DIFF
--- a/app/src/scripts/common/forms/__tests__/__snapshots__/warn-button.spec.jsx.snap
+++ b/app/src/scripts/common/forms/__tests__/__snapshots__/warn-button.spec.jsx.snap
@@ -2,7 +2,7 @@
 
 exports[`common/forms/WarnButton renders successfully 1`] = `
 <span
-  className="fade-in"
+  className=""
 >
   <button
     className="btn-warn-component warning"
@@ -19,7 +19,7 @@ exports[`common/forms/WarnButton renders successfully 1`] = `
 
 exports[`common/forms/WarnButton renders with warnings disable 1`] = `
 <span
-  className="fade-in"
+  className=""
 >
   <button
     className="btn-warn-component warning"

--- a/app/src/scripts/common/forms/warn-button.jsx
+++ b/app/src/scripts/common/forms/warn-button.jsx
@@ -75,7 +75,7 @@ export default class WarnButton extends React.Component {
     )
 
     let hideAction = (
-      <span className={'fade-in' + (disabled ? ' disabled' : '')}>
+      <span className={disabled ? ' disabled' : ''}>
         <button
           className="btn-warn-component warning"
           onClick={this.toggle.bind(this, this.props.action)}


### PR DESCRIPTION
* resolves #281 
* removes the fade-in class from the warn button to avoid inconsistent animation between the option buttons (DELETE, VIEW, etc) in the file tree component.