### PR TITLE
Revalidate if upload has been canceled

### DIFF
--- a/app/src/scripts/utils/bids.js
+++ b/app/src/scripts/utils/bids.js
@@ -357,6 +357,7 @@ export default {
         project.metadata && project.metadata.validation
           ? project.metadata.validation
           : { errors: [], warnings: [] },
+      tags: project.tags || [],
       type: 'folder',
       children: files,
       description: this.formatDescription(project.metadata, description),


### PR DESCRIPTION
* Resolves #296 
* added an updating tag to dataset during directory upload and checking for uploading state and updating tag to verify whether upload was started and then canceled without validation.