### PR TITLE
Hide browser check dialog from markup for Googlebot

### DIFF
--- a/app/src/scripts/common/partials/__tests__/__snapshots__/happybrowser.spec.jsx.snap
+++ b/app/src/scripts/common/partials/__tests__/__snapshots__/happybrowser.spec.jsx.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`common/partials/happybrowser renders successfully 1`] = `
+exports[`common/partials/happybrowser renders for unsupported browsers 1`] = `
 <div
-  className="happybrowser-markup hidden"
+  className="happybrowser-markup"
 >
   <div
     className="hb-wrap clearfix"
@@ -53,3 +53,5 @@ exports[`common/partials/happybrowser renders successfully 1`] = `
   </div>
 </div>
 `;
+
+exports[`common/partials/happybrowser renders successfully 1`] = `""`;

--- a/app/src/scripts/common/partials/__tests__/happybrowser.spec.jsx
+++ b/app/src/scripts/common/partials/__tests__/happybrowser.spec.jsx
@@ -20,28 +20,32 @@ describe('common/partials/happybrowser', () => {
     const wrapper = shallow(<Happybrowser ua={chrome} />)
     expect(wrapper).toMatchSnapshot()
   })
+  it('renders for unsupported browsers', () => {
+    const wrapper = shallow(<Happybrowser ua={ie} />)
+    expect(wrapper).toMatchSnapshot()
+  })
   it('is hidden in Chrome', () => {
     const wrapper = shallow(<Happybrowser ua={chrome} />)
-    expect(wrapper.hasClass('hidden')).toBe(true)
+    expect(wrapper.text()).toBe('')
   })
   it('is hidden in Chromium', () => {
     const wrapper = shallow(<Happybrowser ua={chromium} />)
-    expect(wrapper.hasClass('hidden')).toBe(true)
+    expect(wrapper.text()).toBe('')
   })
   it('is hidden when accessed by Googlebot', () => {
     const wrapper = shallow(<Happybrowser ua={googlebot} />)
-    expect(wrapper.hasClass('hidden')).toBe(true)
+    expect(wrapper.text()).toBe('')
   })
   it('is hidden when accessed by Chrome 41', () => {
     const wrapper = shallow(<Happybrowser ua={chrome41} />)
-    expect(wrapper.hasClass('hidden')).toBe(true)
+    expect(wrapper.text()).toBe('')
   })
   it('is visible in IE', () => {
     const wrapper = shallow(<Happybrowser ua={ie} />)
-    expect(wrapper.hasClass('hidden')).toBe(false)
+    expect(wrapper.text()).not.toBe('')
   })
   it('is hidden in Firefox', () => {
     const wrapper = shallow(<Happybrowser ua={firefox} />)
-    expect(wrapper.hasClass('hidden')).toBe(true)
+    expect(wrapper.text()).toBe('')
   })
 })

--- a/app/src/scripts/common/partials/happybrowser.jsx
+++ b/app/src/scripts/common/partials/happybrowser.jsx
@@ -16,43 +16,42 @@ export default class Happybrowser extends React.Component {
   }
 
   render() {
-    return (
-      <div
-        className={
-          this.state.hbVisible
-            ? 'happybrowser-markup'
-            : 'happybrowser-markup hidden'
-        }>
-        <div className="hb-wrap clearfix">
-          <div className="hb-text clearfix">
-            <img src={warning} alt="warning" />
-            <p>
-              We have detected that you are using an incompatible browser. This
-              site may not work as expected.{' '}
-              <strong>
-                <a href="http://www.google.com/chrome/">
-                  Please consider using a minimum of Chrome V49.0 or Firefox
-                  V50.0 as your browser
-                </a>.
-              </strong>
-            </p>
-          </div>
-          <div className="hb-upgrade clearfix">
-            <div
-              className="hb-img-wrap hb-dismiss"
-              id="dismiss"
-              onClick={this._dismiss.bind(this)}>
-              X
+    if (this.state.hbVisible) {
+      return (
+        <div className="happybrowser-markup">
+          <div className="hb-wrap clearfix">
+            <div className="hb-text clearfix">
+              <img src={warning} alt="warning" />
+              <p>
+                We have detected that you are using an incompatible browser.
+                This site may not work as expected.{' '}
+                <strong>
+                  <a href="http://www.google.com/chrome/">
+                    Please consider using a minimum of Chrome V49.0 or Firefox
+                    V50.0 as your browser
+                  </a>.
+                </strong>
+              </p>
             </div>
-            <div className="hb-img-wrap hb-chrome">
-              <a href="http://www.google.com/chrome/">
-                <img src={chrome} alt="upgrade chrome" />
-              </a>
+            <div className="hb-upgrade clearfix">
+              <div
+                className="hb-img-wrap hb-dismiss"
+                id="dismiss"
+                onClick={this._dismiss.bind(this)}>
+                X
+              </div>
+              <div className="hb-img-wrap hb-chrome">
+                <a href="http://www.google.com/chrome/">
+                  <img src={chrome} alt="upgrade chrome" />
+                </a>
+              </div>
             </div>
           </div>
         </div>
-      </div>
-    )
+      )
+    } else {
+      return null
+    }
   }
 
   _incompatibleBrowser(ua) {


### PR DESCRIPTION
Googlebot might be indexing the hidden text, this removes it from the DOM tree to prevent that. Fix for #35 