### PR TITLE
36 resume s3 uploads

### DIFF
--- a/server/handlers/awsJobs.js
+++ b/server/handlers/awsJobs.js
@@ -196,7 +196,7 @@ let handlers = {
         queue.enqueue(
           'batch',
           'startAnalysis',
-          { job: preparedJob, jobId: jobId, userId: userId },
+          { job: preparedJob, jobId: jobId, userId: userId, retry: false },
           () => {
             // Finish the client request so S3 upload can happen async
             res.send({ jobId: jobId })
@@ -519,7 +519,7 @@ let handlers = {
       queue.enqueue(
         'batch',
         'startAnalysis',
-        { job: job, jobId: mongoJobId, userId: userId },
+        { job: job, jobId: mongoJobId, userId: userId, retry: true },
         () => {
           // Finish the client request so S3 upload can happen async
           res.send({ jobId: mongoJobId })

--- a/server/handlers/awsJobs.js
+++ b/server/handlers/awsJobs.js
@@ -518,35 +518,15 @@ let handlers = {
           },
         },
       )
-
-      res.send({ jobId: mongoJobId })
-
-      const batchJobParams = aws.batch.buildBatchParams(job)
-
-      aws.batch.startBatchJobs(batchJobParams, mongoJobId, err => {
-        if (err) {
-          // This is an unexpected error, probably from batch.
-          console.log(err)
-          // Cleanup the failed to submit job
-          // TODO - Maybe we save the error message into another field for display?
-          c.crn.jobs.updateOne(
-            { _id: mongoJobId },
-            { $set: { 'analysis.status': 'REJECTED' } },
-          )
-          return
-        } else {
-          let jobLog = aws.batch.extractJobLog(job)
-          emitter.emit(
-            events.JOB_STARTED,
-            {
-              job: jobLog,
-              createdDate: job.analysis.created,
-              retry: true,
-            },
-            userId,
-          )
-        }
-      })
+      queue.enqueue(
+        'batch',
+        'startAnalysis',
+        { job: job, jobId: mongoJobId, userId: userId },
+        () => {
+          // Finish the client request so S3 upload can happen async
+          res.send({ jobId: mongoJobId })
+        },
+      )
     })
   },
 }

--- a/server/handlers/awsJobs.js
+++ b/server/handlers/awsJobs.js
@@ -8,11 +8,9 @@ import yazl from 'yazl'
 import S3StreamDownload from 's3-stream-download'
 import config from '../config'
 import async from 'async'
-import emitter from '../libs/events'
 import { queue } from '../libs/queue'
 
 let c = mongo.collections
-let events = config.events
 
 //Job Polling
 

--- a/server/libs/aws/batch.js
+++ b/server/libs/aws/batch.js
@@ -532,7 +532,7 @@ export default aws => {
          *
          * This is called by worker processes and must be process safe.
          */
-    startAnalysis(job, jobId, userId, callback) {
+    startAnalysis(job, jobId, userId, retry, callback) {
       let hash = job.datasetHash
       s3.uploadSnapshot(hash, err => {
         // If the snapshot upload fails, set the job analysis.status = 'FAILED'
@@ -560,7 +560,7 @@ export default aws => {
             let jobLog = extractJobLog(job)
             emitter.emit(
               events.JOB_STARTED,
-              { job: jobLog, createdDate: job.analysis.created },
+              { job: jobLog, createdDate: job.analysis.created, retry: retry },
               userId,
             )
           }

--- a/server/libs/aws/batch.js
+++ b/server/libs/aws/batch.js
@@ -538,7 +538,6 @@ export default aws => {
         // If the snapshot upload fails, set the job analysis.status = 'FAILED'
         // so the user can retry.
         if (err) {
-          console.log(err)
           c.crn.jobs.updateOne(
             { _id: ObjectID(jobId) },
             { $set: { 'analysis.status': 'FAILED' } },

--- a/server/libs/queue/tasks.js
+++ b/server/libs/queue/tasks.js
@@ -10,6 +10,7 @@ export default {
         options.job,
         options.jobId,
         options.userId,
+        options.retry,
         callback,
       )
     },


### PR DESCRIPTION
fixes #36. 

uploads that have at least one part failed cause the job status to be flagged as 'FAILED'.

retrying a job after a failed attempt checks to see if the snapshot exists, so that if the failure came from s3 upload the snapshot is properly uploaded.