### PR TITLE
305 fix bsStyle

### DIFF
--- a/app/src/scripts/common/partials/wrapper.jsx
+++ b/app/src/scripts/common/partials/wrapper.jsx
@@ -1,0 +1,18 @@
+// dependencies ------------------------------------------------------------------------------
+
+import React from 'react'
+import PropTypes from 'prop-types'
+
+// component setup ---------------------------------------------------------------------------
+
+export default class Wrapper extends React.Component {
+  // life cycle events -------------------------------------------------------------------------
+
+  render() {
+    return this.props.children
+  }
+}
+
+Wrapper.propTypes = {
+  children: PropTypes.object,
+}

--- a/app/src/scripts/dashboard/dashboard.datasets.jsx
+++ b/app/src/scripts/dashboard/dashboard.datasets.jsx
@@ -9,6 +9,7 @@ import { Link } from 'react-router-dom'
 import moment from 'moment'
 import { PanelGroup } from 'react-bootstrap'
 import Paginator from '../common/partials/paginator.jsx'
+import Wrapper from '../common/partials/wrapper.jsx'
 import Spinner from '../common/partials/spinner.jsx'
 import Timeout from '../common/partials/timeout.jsx'
 import ErrorBoundary from '../errors/errorBoundary.jsx'
@@ -74,7 +75,11 @@ class Datasets extends Reflux.Component {
       )
 
       // map results
-      results = this._datasets(paginatedResults, isPublic)
+      results = (
+        <div className="dataset-results">
+          {this._datasets(paginatedResults, isPublic)}
+        </div>
+      )
     }
 
     let title
@@ -108,13 +113,15 @@ class Datasets extends Reflux.Component {
             message="The dataset server failed to respond."
             className="loading-wrap fade-in">
             <PanelGroup>
-              {this.state.datasets.loading ? (
-                <Timeout timeout={20000}>
-                  <Spinner active={true} />
-                </Timeout>
-              ) : (
-                results
-              )}
+              <Wrapper>
+                {this.state.datasets.loading ? (
+                  <Timeout timeout={20000}>
+                    <Spinner active={true} />
+                  </Timeout>
+                ) : (
+                  results
+                )}
+              </Wrapper>
             </PanelGroup>
           </ErrorBoundary>
         </div>

--- a/app/src/scripts/dashboard/dashboard.jobs.jsx
+++ b/app/src/scripts/dashboard/dashboard.jobs.jsx
@@ -10,6 +10,7 @@ import { withRouter, Link } from 'react-router-dom'
 import moment from 'moment'
 import { PanelGroup } from 'react-bootstrap'
 import Spinner from '../common/partials/spinner.jsx'
+import Wrapper from '../common/partials/wrapper.jsx'
 import Timeout from '../common/partials/timeout.jsx'
 import ErrorBoundary from '../errors/errorBoundary.jsx'
 import Sort from './dashboard.sort.jsx'
@@ -79,15 +80,17 @@ class Jobs extends Reflux.Component {
             message="The jobs server has failed to respond."
             className="loading-wrap fade-in">
             <PanelGroup>
-              <div className="clearfix">
-                {this.state.jobs.loading ? (
-                  <Timeout timeout={20000}>
-                    <Spinner active={true} />
-                  </Timeout>
-                ) : (
-                  jobs
-                )}
-              </div>
+              <Wrapper>
+                <div className="clearfix">
+                  {this.state.jobs.loading ? (
+                    <Timeout timeout={20000}>
+                      <Spinner active={true} />
+                    </Timeout>
+                  ) : (
+                    jobs
+                  )}
+                </div>
+              </Wrapper>
             </PanelGroup>
           </ErrorBoundary>
         </div>

--- a/app/src/scripts/dataset/dataset.jobs.jsx
+++ b/app/src/scripts/dataset/dataset.jobs.jsx
@@ -6,6 +6,7 @@ import datasetStore from './dataset.store'
 import actions from './dataset.actions'
 import Spinner from '../common/partials/spinner.jsx'
 import Timeout from '../common/partials/timeout.jsx'
+import Wrapper from '../common/partials/wrapper.jsx'
 import Run from './run'
 import { Accordion, Panel } from 'react-bootstrap'
 import { refluxConnect } from '../utils/reflux'
@@ -46,7 +47,11 @@ class Jobs extends Reflux.Component {
             header={compositeVersion}
             key={version.label}
             eventKey={version.label}>
-            {this._runs(version, appDef.descriptions)}
+            <Wrapper>
+              <div className="wrapper">
+                {this._runs(version, appDef.descriptions)}
+              </div>
+            </Wrapper>
           </Panel>
         )
       })
@@ -84,7 +89,6 @@ class Jobs extends Reflux.Component {
           ) : (
             app
           )}
-          <div />
         </Accordion>
       </div>
     )

--- a/app/src/scripts/dataset/run/index.js
+++ b/app/src/scripts/dataset/run/index.js
@@ -21,27 +21,25 @@ class JobAccordion extends React.Component {
   render() {
     let run = this.props.run
     return (
-      <span>
-        <Panel
-          className={run.active ? 'job border-flash' : 'job'}
-          header={this._header(run)}
-          eventKey={run._id}>
-          <Wrapper>
-            <span className="inner">
-              {this._support(run)}
-              {this._parameters(run)}
-              <Results
-                run={run}
-                acknowledgements={this.props.acknowledgements}
-                displayFile={this.props.displayFile}
-                toggleFolder={this.props.toggleFolder}
-              />
-              {this._logs(run)}
-              {this._batchStatus(run)}
-            </span>
-          </Wrapper>
-        </Panel>
-      </span>
+      <Panel
+        className={run.active ? 'job border-flash' : 'job'}
+        header={this._header(run)}
+        eventKey={run._id}>
+        <Wrapper>
+          <span className="inner">
+            {this._support(run)}
+            {this._parameters(run)}
+            <Results
+              run={run}
+              acknowledgements={this.props.acknowledgements}
+              displayFile={this.props.displayFile}
+              toggleFolder={this.props.toggleFolder}
+            />
+            {this._logs(run)}
+            {this._batchStatus(run)}
+          </span>
+        </Wrapper>
+      </Panel>
     )
   }
 

--- a/app/src/scripts/dataset/run/index.js
+++ b/app/src/scripts/dataset/run/index.js
@@ -5,6 +5,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import actions from '../dataset.actions'
 import WarnButton from '../../common/forms/warn-button.jsx'
+import Wrapper from '../../common/partials/wrapper.jsx'
 import moment from 'moment'
 import Results from './results.jsx'
 import { Accordion, Panel } from 'react-bootstrap'
@@ -20,22 +21,25 @@ class JobAccordion extends React.Component {
   render() {
     let run = this.props.run
     return (
-      <span eventKey={run._id}>
+      <span>
         <Panel
           className={run.active ? 'job border-flash' : 'job'}
-          header={this._header(run)}>
-          <span className="inner">
-            {this._support(run)}
-            {this._parameters(run)}
-            <Results
-              run={run}
-              acknowledgements={this.props.acknowledgements}
-              displayFile={this.props.displayFile}
-              toggleFolder={this.props.toggleFolder}
-            />
-            {this._logs(run)}
-            {this._batchStatus(run)}
-          </span>
+          header={this._header(run)}
+          eventKey={run._id}>
+          <Wrapper>
+            <span className="inner">
+              {this._support(run)}
+              {this._parameters(run)}
+              <Results
+                run={run}
+                acknowledgements={this.props.acknowledgements}
+                displayFile={this.props.displayFile}
+                toggleFolder={this.props.toggleFolder}
+              />
+              {this._logs(run)}
+              {this._batchStatus(run)}
+            </span>
+          </Wrapper>
         </Panel>
       </span>
     )
@@ -132,7 +136,9 @@ class JobAccordion extends React.Component {
             header="Parameters"
             key={run._id}
             eventKey={run._id}>
-            <ul>{parameters}</ul>
+            <Wrapper>
+              <ul>{parameters}</ul>
+            </Wrapper>
           </Panel>
         </Accordion>
       )
@@ -225,12 +231,14 @@ class JobAccordion extends React.Component {
             header="Support"
             key={run._id}
             eventKey={run._id}>
-            <div className="app-support">
-              <div
-                className="markdown"
-                dangerouslySetInnerHTML={markdown.format(this.props.support)}
-              />
-            </div>
+            <Wrapper>
+              <div className="app-support">
+                <div
+                  className="markdown"
+                  dangerouslySetInnerHTML={markdown.format(this.props.support)}
+                />
+              </div>
+            </Wrapper>
           </Panel>
         </Accordion>
       )
@@ -341,20 +349,24 @@ class JobAccordion extends React.Component {
             header="Logs"
             key={run._id}
             eventKey={run._id}>
-            <span className="download-all">
-              <WarnButton
-                icon="fa-download"
-                message=" DOWNLOAD All LOGS"
-                prepDownload={actions.downloadLogs.bind(this, run._id)}
-              />
-            </span>
-            <div className="file-structure fade-in panel-group">
-              <div className="panel panel-default">
-                <div className="panel-collapse" aria-expanded="false">
-                  {logstreams}
+            <Wrapper>
+              <div className="wrapper">
+                <span className="download-all">
+                  <WarnButton
+                    icon="fa-download"
+                    message=" DOWNLOAD All LOGS"
+                    prepDownload={actions.downloadLogs.bind(this, run._id)}
+                  />
+                </span>
+                <div className="file-structure fade-in panel-group">
+                  <div className="panel panel-default">
+                    <div className="panel-collapse" aria-expanded="false">
+                      {logstreams}
+                    </div>
+                  </div>
                 </div>
               </div>
-            </div>
+            </Wrapper>
           </Panel>
         </Accordion>
       )
@@ -393,13 +405,15 @@ class JobAccordion extends React.Component {
             header="Jobs Status"
             key={run._id}
             eventKey={run._id}>
-            <ul>
-              <div className=" job-status col-xs-12" key={run._id}>
-                <div className="col-xs-8">Job Id</div>
-                <div className="col-xs-4">Status</div>
-              </div>
-              {batchStatus}
-            </ul>
+            <Wrapper>
+              <ul>
+                <div className=" job-status col-xs-12" key={run._id}>
+                  <div className="col-xs-8">Job Id</div>
+                  <div className="col-xs-4">Status</div>
+                </div>
+                {batchStatus}
+              </ul>
+            </Wrapper>
           </Panel>
         </Accordion>
       )

--- a/app/src/scripts/dataset/run/results.jsx
+++ b/app/src/scripts/dataset/run/results.jsx
@@ -2,6 +2,7 @@
 import React from 'react'
 import actions from '../dataset.actions'
 import { Accordion, Panel } from 'react-bootstrap'
+import Wrapper from '../../common/partials/wrapper.jsx'
 import FileTree from '../../common/partials/file-tree.jsx'
 import DownloadAll from './download-all.jsx'
 import markdown from '../../utils/markdown'
@@ -17,39 +18,43 @@ const JobResults = ({ run, acknowledgements, displayFile, toggleFolder }) => {
           header={type}
           key={run._id}
           eventKey={run._id}>
-          <div className="app-acknowledgements">
-            <label>Acknowledgements</label>
-            <div
-              className="markdown"
-              dangerouslySetInnerHTML={markdown.format(acknowledgements)}
-            />
-          </div>
-          <hr />
-          <DownloadAll run={run} />
-          <div className="file-structure fade-in panel-group">
-            <div className="panel panel-default">
-              <div className="panel-collapse" aria-expanded="false">
-                <div className="panel-body">
-                  <FileTree
-                    tree={run[type]}
-                    treeId={run._id}
-                    editable={false}
-                    getFileDownloadTicket={actions.getResultDownloadTicket.bind(
-                      this,
-                      run.snapshotId,
-                      run._id,
-                    )}
-                    displayFile={displayFile.bind(
-                      this,
-                      run.snapshotId,
-                      run._id,
-                    )}
-                    toggleFolder={toggleFolder}
-                  />
+          <Wrapper>
+            <div className="wrapper">
+              <div className="app-acknowledgements">
+                <label>Acknowledgements</label>
+                <div
+                  className="markdown"
+                  dangerouslySetInnerHTML={markdown.format(acknowledgements)}
+                />
+              </div>
+              <hr />
+              <DownloadAll run={run} />
+              <div className="file-structure fade-in panel-group">
+                <div className="panel panel-default">
+                  <div className="panel-collapse" aria-expanded="false">
+                    <div className="panel-body">
+                      <FileTree
+                        tree={run[type]}
+                        treeId={run._id}
+                        editable={false}
+                        getFileDownloadTicket={actions.getResultDownloadTicket.bind(
+                          this,
+                          run.snapshotId,
+                          run._id,
+                        )}
+                        displayFile={displayFile.bind(
+                          this,
+                          run.snapshotId,
+                          run._id,
+                        )}
+                        toggleFolder={toggleFolder}
+                      />
+                    </div>
+                  </div>
                 </div>
               </div>
             </div>
-          </div>
+          </Wrapper>
         </Panel>
       </Accordion>
     )

--- a/app/src/scripts/notification/notification.alert.jsx
+++ b/app/src/scripts/notification/notification.alert.jsx
@@ -3,6 +3,7 @@
 import React from 'react'
 import Reflux from 'reflux'
 import { Alert } from 'react-bootstrap'
+import Wrapper from '../common/partials/wrapper.jsx'
 import notificationStore from './notification.store'
 import actions from './notification.actions'
 import { refluxConnect } from '../utils/reflux'
@@ -32,15 +33,19 @@ class alert extends Reflux.Component {
 
     let alert = (
       <Alert className="clearfix" bsStyle={bsStyle}>
-        <div className="alert-left">
-          <strong>{type}! </strong>
-          {this.state.notification.alertMessage}
-        </div>
-        <button
-          className="alert-right dismiss-button-x"
-          onClick={actions.closeAlert}>
-          <i className="fa fa-times" />
-        </button>
+        <Wrapper>
+          <div className="wrapper">
+            <div className="alert-left">
+              <strong>{type}! </strong>
+              {this.state.notification.alertMessage}
+            </div>
+            <button
+              className="alert-right dismiss-button-x"
+              onClick={actions.closeAlert}>
+              <i className="fa fa-times" />
+            </button>
+          </div>
+        </Wrapper>
       </Alert>
     )
 

--- a/app/src/scripts/upload/upload.validation-results.issues.jsx
+++ b/app/src/scripts/upload/upload.validation-results.issues.jsx
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types'
 import { Accordion, Panel } from 'react-bootstrap'
 import pluralize from 'pluralize'
 import Issue from './upload.validation-results.issues.issue.jsx'
+import Wrapper from '../common/partials/wrapper.jsx'
 
 // component setup --------------------------------------------------------
 
@@ -66,7 +67,9 @@ class Issues extends React.Component {
           header={header}
           className="validation-error fade-in"
           eventKey={index}>
-          {subErrors}
+          <Wrapper>
+            <div className="wrapper">{subErrors}</div>
+          </Wrapper>
         </Panel>
       )
     })


### PR DESCRIPTION
fixes #305. 

introduces the '<Wrapper>' component.

the react-bootstrap package applies unused properties to their children native DOM elements. this causes the console to output all kinds of annoying messages.

Placing a <Wrapper> component between a react-bootstrap component and any SINGLE native DOM child element will solve this issue. 

If the react-bootstrap component has an array of children, then this will be fixed by placing a '<Wrapper><div class='wrapper'> array-like dom content </div></Wrapper>' as a buffer between bootstrap component and its content.
