### PR TITLE
286 - App parameters are removed in the wrong order when deleted.

### DIFF
--- a/app/src/scripts/common/forms/array-input.jsx
+++ b/app/src/scripts/common/forms/array-input.jsx
@@ -208,10 +208,11 @@ class ArrayInput extends React.Component {
     this.setState(initialState)
   }
 
-  _remove(index) {
+  _remove(index, callback) {
     let array = this.props.value
     array.splice(index, 1)
     this.props.onChange({ target: { value: array } })
+    callback()
   }
 
   _edit(index, value) {


### PR DESCRIPTION
fixes #286.

actually the problem is that when we delete a parameter, the loading spinner on the \< ArrayItem \> below was triggered and did not go away. 

<WarningButton> requires a callback on whatever action is assigned to toggle(). \<ArrayItem\> _remove() was not providing one. 

solved by adding arbitrary callback to the <ArrayItem> _remove() function. 
