### PR TITLE
implement redis queue for obtaining usermetadata

### DIFF
--- a/server/config.js
+++ b/server/config.js
@@ -41,7 +41,6 @@ let config = {
   redis: {
     port: 6379,
     host: 'redis',
-    cacheTimeout: 3600,
   },
   notifications: {
     email: {

--- a/server/config.js
+++ b/server/config.js
@@ -41,7 +41,7 @@ let config = {
   redis: {
     port: 6379,
     host: 'redis',
-    cacheTimeout: 30,
+    cacheTimeout: 3600,
   },
   notifications: {
     email: {

--- a/server/config.js
+++ b/server/config.js
@@ -41,6 +41,7 @@ let config = {
   redis: {
     port: 6379,
     host: 'redis',
+    cacheTimeout: 30,
   },
   notifications: {
     email: {

--- a/server/libs/cache/userCache.js
+++ b/server/libs/cache/userCache.js
@@ -17,10 +17,11 @@ export default {
     })
   },
   store(res, callback) {
-    const data = res
-    const data_store = JSON.stringify(data)
-    const userId = data.body._id
-    redis.setex(userId, config.redis.cacheTimeout, data_store)
+    if (res.statusCode && res.statusCode == 200) {
+      const data = JSON.stringify(res)
+      const userId = res.body._id
+      redis.setex(userId, config.redis.cacheTimeout, data)
+    }
     callback()
   },
 }

--- a/server/libs/cache/userCache.js
+++ b/server/libs/cache/userCache.js
@@ -1,0 +1,26 @@
+import { redis } from '../redis'
+import config from '../../config'
+
+export default {
+  get(req, callback) {
+    const userId = req.json.userId
+    redis.get(userId, (err, data) => {
+      if (err) {
+        return callback(err, null)
+      }
+      if (data != null) {
+        const data_obj = JSON.parse(data)
+        return callback(null, data_obj)
+      } else {
+        return callback()
+      }
+    })
+  },
+  store(res, callback) {
+    const data = res
+    const data_store = JSON.stringify(data)
+    const userId = data.body._id
+    redis.setex(userId, config.redis.cacheTimeout, data_store)
+    callback()
+  },
+}

--- a/server/libs/cache/userCache.js
+++ b/server/libs/cache/userCache.js
@@ -1,5 +1,4 @@
 import { redis } from '../redis'
-import config from '../../config'
 
 export default {
   get(req, callback) {
@@ -9,19 +8,22 @@ export default {
         return callback(err, null)
       }
       if (data != null) {
-        const data_obj = JSON.parse(data)
-        return callback(null, data_obj)
+        const body = JSON.parse(data)
+        const res = { statusCode: 200, body: body }
+        return callback(null, res)
       } else {
         return callback()
       }
     })
   },
-  store(res, callback) {
-    if (res.statusCode && res.statusCode == 200) {
-      const data = JSON.stringify(res)
-      const userId = res.body._id
-      redis.setex(userId, config.redis.cacheTimeout, data)
-    }
+  store(userData, callback) {
+    console.log(
+      'storing user info in the cache. here is the userData:',
+      userData,
+    )
+    const data = JSON.stringify(userData)
+    const userId = userData._id
+    redis.set(userId, data)
     callback()
   },
 }

--- a/server/libs/cache/userCache.js
+++ b/server/libs/cache/userCache.js
@@ -1,25 +1,40 @@
 import { redis } from '../redis'
 
 export default {
-  get(req, callback) {
-    const userId = req.json.userId
-    redis.get(userId, (err, data) => {
-      if (err) {
-        return callback(err, null)
-      }
-      if (data != null) {
-        const body = JSON.parse(data)
-        const res = { statusCode: 200, body: body }
-        return callback(null, res)
-      } else {
-        return callback()
-      }
-    })
+  keyPrefix: 'scitran:users:',
+
+  getKey(id) {
+    return this.keyPrefix.concat(id)
   },
+
+  get(req, callback) {
+    const userId = req.json ? req.json.userId : null
+    const userKey = userId ? this.getKey(userId) : null
+    if (userKey) {
+      redis.get(userKey, (err, data) => {
+        if (err) {
+          return callback(err, null)
+        }
+        if (data != null) {
+          const body = JSON.parse(data)
+          const res = { statusCode: 200, body: body }
+          return callback(null, res)
+        } else {
+          return callback()
+        }
+      })
+    } else {
+      return callback()
+    }
+  },
+
   store(userData, callback) {
+    const userId = userData && userData._id ? userData._id : null
+    const userKey = userId ? this.getKey(userId) : null
     const data = JSON.stringify(userData)
-    const userId = userData._id
-    redis.set(userId, data)
+    if (userKey) {
+      redis.set(userKey, data)
+    }
     callback()
   },
 }

--- a/server/libs/cache/userCache.js
+++ b/server/libs/cache/userCache.js
@@ -17,10 +17,6 @@ export default {
     })
   },
   store(userData, callback) {
-    console.log(
-      'storing user info in the cache. here is the userData:',
-      userData,
-    )
     const data = JSON.stringify(userData)
     const userId = userData._id
     redis.set(userId, data)

--- a/server/libs/request.js
+++ b/server/libs/request.js
@@ -26,18 +26,34 @@ export default {
    */
   getCache(url, cache, options, callback) {
     handleRequest(url, options, req => {
-      cache.get(req, (err, data) => {
-        if (data) {
-          handleResponse(err, data, callback)
+      cache.get(req, (err, res1) => {
+        if (res1) {
+          handleResponse(err, res1, callback)
         } else {
-          request.get(req, (err, res) => {
+          request.get(req, (err, res2) => {
             if (err) {
-              handleResponse(err, res, callback)
+              handleResponse(err, res2, callback)
             } else {
-              cache.store(res, () => {
-                handleResponse(err, res, callback)
+              const data = res2.body
+              cache.store(data, () => {
+                handleResponse(err, res2, callback)
               })
             }
+          })
+        }
+      })
+    })
+  },
+
+  postCache(url, cache, options, callback) {
+    handleRequest(url, options, req => {
+      request.post(req, (err, res) => {
+        if (err) {
+          handleResponse(err, res, callback)
+        } else {
+          const data = req.json
+          cache.store(data, () => {
+            handleResponse(err, res, callback)
           })
         }
       })

--- a/server/libs/request.js
+++ b/server/libs/request.js
@@ -31,9 +31,13 @@ export default {
           handleResponse(err, data, callback)
         } else {
           request.get(req, (err, res) => {
-            cache.store(res, () => {
+            if (err) {
               handleResponse(err, res, callback)
-            })
+            } else {
+              cache.store(res, () => {
+                handleResponse(err, res, callback)
+              })
+            }
           })
         }
       })

--- a/server/libs/request.js
+++ b/server/libs/request.js
@@ -16,6 +16,30 @@ export default {
     })
   },
 
+  /** 
+   * GET CACHE
+   * 
+   * Functions the same as request but takes a
+   * cache function, checks to see if the response is
+   * already cached. If so, responds with the cached data.
+   * If not, stores the response in the cache before responding.
+   */
+  getCache(url, cache, options, callback) {
+    handleRequest(url, options, req => {
+      cache.get(req, (err, data) => {
+        if (data) {
+          handleResponse(err, data, callback)
+        } else {
+          request.get(req, (err, res) => {
+            cache.store(res, () => {
+              handleResponse(err, res, callback)
+            })
+          })
+        }
+      })
+    })
+  },
+
   /**
      * GET PROXY
      *

--- a/server/libs/scitran.js
+++ b/server/libs/scitran.js
@@ -3,7 +3,7 @@ import config from '../config'
 import fs from 'fs'
 import crypto from 'crypto'
 import files from './files'
-import checkUserCache from '../libs/cache/userCache.js'
+import userCache from '../libs/cache/userCache.js'
 
 /**
  * Scitran
@@ -50,7 +50,7 @@ export default {
   getUser(userId, callback) {
     request.getCache(
       config.scitran.url + 'users/' + userId,
-      checkUserCache,
+      userCache,
       { body: { userId: userId } },
       callback,
     )

--- a/server/libs/scitran.js
+++ b/server/libs/scitran.js
@@ -75,9 +75,14 @@ export default {
      * Create User
      */
   createUser(user, callback) {
-    request.post(config.scitran.url + 'users', { body: user }, () => {
-      this.createGroup(user._id, user._id, callback)
-    })
+    request.postCache(
+      config.scitran.url + 'users',
+      userCache,
+      { body: user },
+      () => {
+        this.createGroup(user._id, user._id, callback)
+      },
+    )
   },
 
   /**

--- a/server/libs/scitran.js
+++ b/server/libs/scitran.js
@@ -3,6 +3,7 @@ import config from '../config'
 import fs from 'fs'
 import crypto from 'crypto'
 import files from './files'
+import checkUserCache from '../libs/cache/userCache.js'
 
 /**
  * Scitran
@@ -47,7 +48,12 @@ export default {
      * Get User
      */
   getUser(userId, callback) {
-    request.get(config.scitran.url + 'users/' + userId, {}, callback)
+    request.getCache(
+      config.scitran.url + 'users/' + userId,
+      checkUserCache,
+      { body: { userId: userId } },
+      callback,
+    )
   },
 
   /**

--- a/server/package.json
+++ b/server/package.json
@@ -37,6 +37,7 @@
     "node-resque": "^4.0.7",
     "nodemailer": "^2.5.0",
     "raven": "^2.2.1",
+    "redis": "^2.8.0",
     "request": "^2.83.0",
     "s3-stream-download":
       "https://github.com/OpenNeuroOrg/s3-stream-download.git",

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -1580,6 +1580,10 @@ domutils@^1.5.1:
     dom-serializer "0"
     domelementtype "1"
 
+double-ended-queue@^2.1.0-0:
+  version "2.1.0-0"
+  resolved "https://registry.yarnpkg.com/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz#103d3527fd31528f40188130c841efdd78264e5c"
+
 ecc-jsbn@~0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz#0fc73a9ed5f0d53c38193398523ef7e543777505"
@@ -4289,9 +4293,17 @@ redis-commands@^1.2.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/redis-commands/-/redis-commands-1.3.1.tgz#81d826f45fa9c8b2011f4cd7a0fe597d241d442b"
 
-redis-parser@^2.4.0:
+redis-parser@^2.4.0, redis-parser@^2.6.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/redis-parser/-/redis-parser-2.6.0.tgz#52ed09dacac108f1a631c07e9b69941e7a19504b"
+
+redis@^2.8.0:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/redis/-/redis-2.8.0.tgz#202288e3f58c49f6079d97af7a10e1303ae14b02"
+  dependencies:
+    double-ended-queue "^2.1.0-0"
+    redis-commands "^1.2.0"
+    redis-parser "^2.6.0"
 
 regenerate@^1.2.1:
   version "1.3.2"


### PR DESCRIPTION
fixes #322 

there was a small but somewhat significant performance hit when obtaining user metadata on datasets / jobs / events logs. 

this pr introduces a new getCache() function to the request library, and uses the cacheing middleware in server/libs/cache/userCache.js to return cached user data when server/scitran.getUser() is called (if available), or make the original request and cache the response (if cache unavailable). 

the length of time that a cached response persists is determined by the new setting in server/config.js:44  - config.redis.cacheTimeout. 