### PR TITLE
redirect to public snapshots when dataset permissions restrict access

### DIFF
--- a/app/src/scripts/dataset/dataset.jsx
+++ b/app/src/scripts/dataset/dataset.jsx
@@ -81,36 +81,30 @@ class Dataset extends Reflux.Component {
   componentDidMount() {
     const datasetId = this.props.match.params.datasetId
     const snapshotId = this.props.match.params.snapshotId
-
-    // has access
-    // this._checkAccess(datasetId, snapshotId)
-    if (this.state.datasets.userAccess) {
-      this._loadData(datasetId, snapshotId)
-
-      const isDataset = pathname => {
-        const slugs = pathname.split('/')
-        if (
-          slugs.length &&
-          slugs[1] === 'datasets' &&
-          this.state.datasets.dataset
-        ) {
-          let datasetId = this.state.datasets.dataset.linkID
-          if ('linkOriginal' in this.state.datasets.dataset) {
-            datasetId = this.state.datasets.dataset.linkOriginal
-          }
-          // The same dataset
-          if (slugs[2] === datasetId) {
-            return true
-          }
+    this._loadData(datasetId, snapshotId)
+    const isDataset = pathname => {
+      const slugs = pathname.split('/')
+      if (
+        slugs.length &&
+        slugs[1] === 'datasets' &&
+        this.state.datasets.dataset
+      ) {
+        let datasetId = this.state.datasets.dataset.linkID
+        if ('linkOriginal' in this.state.datasets.dataset) {
+          datasetId = this.state.datasets.dataset.linkOriginal
         }
-        return false
+        // The same dataset
+        if (slugs[2] === datasetId) {
+          return true
+        }
       }
-      this.props.history.listen(({ pathname }) => {
-        if (!isDataset(pathname) && this.state.datasets.uploading) {
-          actions.cancelDirectoryUpload()
-        }
-      })
+      return false
     }
+    this.props.history.listen(({ pathname }) => {
+      if (!isDataset(pathname) && this.state.datasets.uploading) {
+        actions.cancelDirectoryUpload()
+      }
+    })
   }
 
   _loadData(datasetId, snapshotId) {

--- a/app/src/scripts/dataset/dataset.jsx
+++ b/app/src/scripts/dataset/dataset.jsx
@@ -120,6 +120,7 @@ class Dataset extends Reflux.Component {
         app: app,
         version: version,
         job: job,
+        datasetId: bids.encodeId(datasetId),
       })
     } else if (
       (datasetId && !this.state.datasets.dataset) ||

--- a/app/src/scripts/dataset/dataset.store.js
+++ b/app/src/scripts/dataset/dataset.store.js
@@ -92,7 +92,6 @@ let datasetStore = Reflux.createStore({
       snapshots: [],
       selectedSnapshot: '',
       status: null,
-      userAccess: true,
       users: [],
       uploading: false,
       uploadingCanceled: false,

--- a/app/src/scripts/dataset/dataset.store.js
+++ b/app/src/scripts/dataset/dataset.store.js
@@ -156,8 +156,8 @@ let datasetStore = Reflux.createStore({
             loading: false,
             snapshot: snapshot,
           })
-
-          this.generateFallbackUrl(datasetId, snapshot)
+          const fallbackDatasetId = snapshot ? options.datasetId : datasetId
+          this.generateFallbackUrl(fallbackDatasetId)
         } else {
           // don't update data if the user has selected another version during loading
           let selectedSnapshot = this.data.selectedSnapshot
@@ -196,40 +196,34 @@ let datasetStore = Reflux.createStore({
   },
 
   // generates a fallback url
-  async generateFallbackUrl(datasetId, snapshot) {
-    if (!snapshot) {
-      const snapshotRes = await scitran.getProjectSnapshots(datasetId)
-      const snapshots = snapshotRes ? snapshotRes.body : null
+  async generateFallbackUrl(datasetId) {
+    const snapshotRes = await scitran.getProjectSnapshots(datasetId)
+    const snapshots = snapshotRes ? snapshotRes.body : null
 
-      if (snapshots && snapshots.length) {
-        // sort snapshots
-        snapshots.sort((a, b) => {
-          if (a.snapshot_version < b.snapshot_version) {
-            return 1
-          } else if (a.snapshot_version > b.snapshot_version) {
-            return -1
-          } else {
-            return 0
-          }
-        })
-
-        const project = snapshots[0]
-        if (project.snapshot_version) {
-          const redirectUrl = String.prototype.concat(
-            '/datasets/',
-            bids.decodeId(datasetId),
-            '/versions/',
-            bids.formatVersionNumber(project.snapshot_version),
-          )
-          this.update({
-            redirectUrl: redirectUrl,
-          })
+    if (snapshots && snapshots.length) {
+      // sort snapshots
+      snapshots.sort((a, b) => {
+        if (a.snapshot_version < b.snapshot_version) {
+          return 1
+        } else if (a.snapshot_version > b.snapshot_version) {
+          return -1
+        } else {
+          return 0
         }
-      }
-    } else {
-      this.update({
-        redirectUrl: '/public/datasets/',
       })
+
+      const project = snapshots[0]
+      if (project.snapshot_version) {
+        const redirectUrl = String.prototype.concat(
+          '/datasets/',
+          bids.decodeId(datasetId),
+          '/versions/',
+          bids.formatVersionNumber(project.snapshot_version),
+        )
+        this.update({
+          redirectUrl: redirectUrl,
+        })
+      }
     }
   },
 

--- a/app/src/scripts/dataset/dataset.store.js
+++ b/app/src/scripts/dataset/dataset.store.js
@@ -195,35 +195,46 @@ let datasetStore = Reflux.createStore({
     )
   },
 
-  // generates a fallback url
+  /**
+   * Generate Fallback Url
+   * 
+   * Given a datasetId, return the most recent
+   * publicly available snapshot url
+   */
   async generateFallbackUrl(datasetId) {
-    const snapshotRes = await scitran.getProjectSnapshots(datasetId)
-    const snapshots = snapshotRes ? snapshotRes.body : null
+    try {
+      const snapshotRes = await scitran.getProjectSnapshots(datasetId)
+      const snapshots = snapshotRes ? snapshotRes.body : null
 
-    if (snapshots && snapshots.length) {
-      // sort snapshots
-      snapshots.sort((a, b) => {
-        if (a.snapshot_version < b.snapshot_version) {
-          return 1
-        } else if (a.snapshot_version > b.snapshot_version) {
-          return -1
-        } else {
-          return 0
-        }
-      })
-
-      const project = snapshots[0]
-      if (project.snapshot_version) {
-        const redirectUrl = String.prototype.concat(
-          '/datasets/',
-          bids.decodeId(datasetId),
-          '/versions/',
-          bids.formatVersionNumber(project.snapshot_version),
-        )
-        this.update({
-          redirectUrl: redirectUrl,
+      if (snapshots && snapshots.length) {
+        // sort snapshots
+        snapshots.sort((a, b) => {
+          if (a.snapshot_version < b.snapshot_version) {
+            return 1
+          } else if (a.snapshot_version > b.snapshot_version) {
+            return -1
+          } else {
+            return 0
+          }
         })
+
+        const project = snapshots[0]
+        if (project.snapshot_version) {
+          const redirectUrl = String.prototype.concat(
+            '/datasets/',
+            bids.decodeId(datasetId),
+            '/versions/',
+            bids.formatVersionNumber(project.snapshot_version),
+          )
+          this.update({
+            redirectUrl: redirectUrl,
+          })
+        }
       }
+    } catch (err) {
+      this.update({
+        redirectUrl: null,
+      })
     }
   },
 

--- a/app/src/scripts/utils/bids.js
+++ b/app/src/scripts/utils/bids.js
@@ -138,8 +138,8 @@ export default {
       // we don't care if the users returns 403, but we want to catch the error separately
     }
 
+    // get projects
     try {
-      // get projects
       const projectRes = await scitran.getProject(projectId, options)
 
       // if the response isnt successful, callback with the response

--- a/app/src/scripts/utils/bids.js
+++ b/app/src/scripts/utils/bids.js
@@ -129,27 +129,21 @@ export default {
    * nested BIDS dataset.
    */
   async getDataset(projectId, callback, options) {
-    // get users
+    // Users
     let users = null
     try {
       const userRes = await scitran.getUsers()
       users = !options.isPublic && userRes ? userRes.body : null
     } catch (err) {
-      // we don't care if the users returns 403, but we want to catch the error separately
+      // The user request failed
     }
 
-    // get projects
+    // Dataset
     try {
       const projectRes = await scitran.getProject(projectId, options)
-
-      // if the response isnt successful, callback with the response
-      // for error handling
       if (projectRes.status !== 200) {
         return callback(projectRes)
       }
-
-      // associate tempFiles, metadata, and jobs with the dataset
-      // object and return it
       const project = projectRes ? projectRes.body : null
       if (project) {
         let tempFiles = project.files ? this._formatFiles(project.files) : null


### PR DESCRIPTION
Fixes #313 

In the case a user is not signed in and navigates to a dataset url that is not publicly available, we redirect them to the most recent public snapshot (if it exists).

Similarly, access to non-public snapshot versions will redirect the user to the most recent public snapshot (if it exists).