### PR TITLE
Fix loading order issue in user.store for orcid logins

### DIFF
--- a/app/src/scripts/user/user.store.js
+++ b/app/src/scripts/user/user.store.js
@@ -2,6 +2,7 @@
 import Raven from 'raven-js'
 import React from 'react'
 import Reflux from 'reflux'
+import { setImmediate } from 'async'
 import actions from './user.actions.js'
 import google from '../utils/google'
 import orcid from '../utils/orcid'
@@ -56,9 +57,11 @@ let UserStore = Reflux.createStore({
           })
       }
     }
-
-    google.init(initCallback('google'))
-    orcid.init(this.data.token, initCallback('orcid'))
+    // Workaround for webpack loading order issues with createStore
+    setImmediate(() => {
+      google.init(initCallback('google'))
+      orcid.init(this.data.token, initCallback('orcid'))
+    })
   },
 
   getInitialState() {


### PR DESCRIPTION
This fixes the missing request library when the userStore is initialized with a logged in ORCID user token.

Fixes #358 