### PR TITLE
Add a redirect from www.openneuro.org to openneuro.org

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,4 +1,10 @@
 server {
+    listen 80;
+    server_name www.openneuro.org;
+    return 301 https://openneuro.org$request_uri;
+}
+
+server {
     listen 80 default_server;
     listen [::]:80 default_server;
     server_name _;


### PR DESCRIPTION
This fixes an SSL error when you visit the www prefixed domain.