### PR TITLE
Fix failure to load analysis due to a race condition

### DIFF
--- a/app/src/scripts/dataset/dataset.jobs.jsx
+++ b/app/src/scripts/dataset/dataset.jobs.jsx
@@ -31,58 +31,62 @@ class Jobs extends Reflux.Component {
       return false
     }
 
-    let app = this.state.datasets.jobs.map(app => {
-      version = app.versions.map(version => {
-        let appDef = this.state.datasets.apps[app.label][version.label]
-        let bidsAppVersion = appDef.containerProperties.environment.filter(
-          tuple => {
-            return tuple.name === 'BIDS_CONTAINER'
-          },
-        )[0].value
-        let compositeVersion = bidsAppVersion + ' - #' + version.label
+    let appTree = []
+    if (!this.state.datasets.loadingApps) {
+      appTree = this.state.datasets.jobs.map(app => {
+        version = app.versions.map(version => {
+          let appDef = this.state.datasets.apps[app.label][version.label]
+          let bidsAppVersion = appDef.containerProperties.environment.filter(
+            tuple => {
+              return tuple.name === 'BIDS_CONTAINER'
+            },
+          )[0].value
+          let compositeVersion = bidsAppVersion + ' - #' + version.label
+          return (
+            <Panel
+              className="jobs"
+              header={compositeVersion}
+              key={version.label}
+              eventKey={version.label}>
+              {this._runs(version, appDef.descriptions)}
+            </Panel>
+          )
+        })
+
         return (
           <Panel
             className="jobs"
-            header={compositeVersion}
-            key={version.label}
-            eventKey={version.label}>
-            {this._runs(version, appDef.descriptions)}
+            header={app.label}
+            key={app.label}
+            eventKey={app.label}>
+            <Accordion
+              accordion
+              className="jobs-wrap"
+              activeKey={this.state.datasets.activeJob.version}
+              onSelect={actions.selectJob.bind(null, 'version')}>
+              {version}
+            </Accordion>
           </Panel>
         )
       })
-
-      return (
-        <Panel
-          className="jobs"
-          header={app.label}
-          key={app.label}
-          eventKey={app.label}>
-          <Accordion
-            accordion
-            className="jobs-wrap"
-            activeKey={this.state.datasets.activeJob.version}
-            onSelect={actions.selectJob.bind(null, 'version')}>
-            {version}
-          </Accordion>
-        </Panel>
-      )
-    })
+    }
 
     let header = <h3 className="metaheader">Analyses</h3>
     return (
       <div className="analyses">
-        {app.length === 0 ? null : header}
+        {appTree.length === 0 ? null : header}
         <Accordion
           accordion
           className="jobs-wrap"
           activeKey={this.state.datasets.activeJob.app}
           onSelect={actions.selectJob.bind(null, 'app')}>
-          {this.state.datasets.loadingJobs ? (
+          {this.state.datasets.loadingJobs ||
+          this.state.datasets.loadingApps ? (
             <Timeout timeout={20000}>
               <Spinner active={true} text="Loading Analyses" />
             </Timeout>
           ) : (
-            app
+            appTree
           )}
         </Accordion>
       </div>


### PR DESCRIPTION
This happens when datasets are done loading but the apps request is waiting. This is easier to hit if datasets load very quickly, so local environments can reproduce more easily.