### PR TITLE
allow macOS webpack watch-poll with configurable watch interval

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -8,8 +8,7 @@
     "type": "git"
   },
   "scripts": {
-    "start":
-      "webpack-dev-server --config webpack.dev.js --progress --watch --color",
+    "start": "webpack-dev-server --config webpack.dev.js --progress --color",
     "build": "webpack --config webpack.prod.js",
     "lint": "eslint --ext .jsx --ext .js src/scripts/",
     "test": "jest",

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -12,7 +12,7 @@ services:
     build:
       context: .
       dockerfile: app/Dockerfile
-    command: sh -c "yarn install --pure-lockfile && yarn start"
+    command: sh -c "yarn install --pure-lockfile && yarn start --watch --watch-poll ${WEBPACK_POLL_INTERVAL}"
     volumes:
       - .:/srv
       - yarn_cache:/root/.cache


### PR DESCRIPTION
fixes #370.

mac developers can now specify the WEBPACK_POLL_INTERVAL variable in their environment variables (.env or config.env) to trigger webpack --watch-poll with the specified interval (in milliseconds).

leaving WEBPACK_POLL_INTERVAL blank will result in the default webpack --watch behaviour for developers who do not wish to incorporate this feature.