### PR TITLE
377 separate json edit button

### DIFF
--- a/app/src/scripts/common/partials/file-tree.jsx
+++ b/app/src/scripts/common/partials/file-tree.jsx
@@ -56,6 +56,7 @@ class FileTree extends React.Component {
             displayFile={this.props.displayFile}
             deleteFile={this.props.deleteFile}
             deleteDirectory={this.props.deleteDirectory}
+            editFile={this.props.editFile}
             getFileDownloadTicket={this.props.getFileDownloadTicket}
             toggleFolder={this.props.toggleFolder}
             addFile={this.props.addFile}
@@ -188,7 +189,7 @@ class FileTree extends React.Component {
               icon="fa-pencil"
               warn={false}
               message=" Edit"
-              action={this.props.displayFile.bind(this, item)}
+              action={this.props.editFile.bind(this, item)}
             />
           </span>
         )
@@ -382,6 +383,7 @@ FileTree.propTypes = {
   deleteDirectory: PropTypes.func,
   updateFile: PropTypes.func,
   displayFile: PropTypes.func,
+  editFile: PropTypes.func,
   topLevel: PropTypes.bool,
 }
 

--- a/app/src/scripts/common/partials/file-tree.jsx
+++ b/app/src/scripts/common/partials/file-tree.jsx
@@ -90,7 +90,7 @@ class FileTree extends React.Component {
   }
 
   _fileTools(item, editable, topLevel) {
-    let deleteFile, editFile, addFile, addDirectory, deleteDirectory
+    let deleteFile, uploadFile, editFile, addFile, addDirectory, deleteDirectory
     if (editable) {
       let inputId = item.hasOwnProperty('_id') ? item._id : item.name
       let label = item.label ? item.label : item.name
@@ -130,7 +130,7 @@ class FileTree extends React.Component {
           </span>
         )
 
-        editFile = (
+        uploadFile = (
           <div className="edit-file">
             <span>
               <i className="fa fa-file-o" /> Update
@@ -178,6 +178,21 @@ class FileTree extends React.Component {
           />
         </span>
       )
+    }
+
+    if (!item.children) {
+      if (this.props.editable && files.hasExtension(item.name, ['.json'])) {
+        editFile = (
+          <span className="view-file">
+            <WarnButton
+              icon="fa-pencil"
+              warn={false}
+              message=" Edit"
+              action={this.props.displayFile.bind(this, item)}
+            />
+          </span>
+        )
+      }
     }
 
     let displayBtn
@@ -231,16 +246,24 @@ class FileTree extends React.Component {
       }
     }
 
-    if (addFile || editFile || deleteFile || downloadFile || displayBtn) {
+    if (
+      addFile ||
+      uploadFile ||
+      editFile ||
+      deleteFile ||
+      downloadFile ||
+      displayBtn
+    ) {
       return (
         <span className="filetree-editfile">
           {addFile}
           {deleteDirectory}
           {addDirectory}
-          {editFile}
+          {uploadFile}
           {deleteFile}
           {downloadFile}
           {displayBtn}
+          {editFile}
         </span>
       )
     } else {
@@ -296,8 +319,8 @@ class FileTree extends React.Component {
   // custom methods -----------------------------------------------------
 
   /**
-     * Add File
-     */
+   * Add File
+   */
   _addFile(container, event) {
     this.props.addFile(container, event.target.files[0])
   }
@@ -324,15 +347,15 @@ class FileTree extends React.Component {
   }
 
   /**
-     * Clear Input
-     */
+   * Clear Input
+   */
   _clearInput(ref) {
     this.refs[ref].value = null
   }
 
   /**
-     * Update File
-     */
+   * Update File
+   */
   _updateFile(item, event) {
     this.props.updateFile(item, event.target.files[0])
   }

--- a/app/src/scripts/dataset/dataset.actions.js
+++ b/app/src/scripts/dataset/dataset.actions.js
@@ -16,6 +16,7 @@ var Actions = Reflux.createActions([
   'dismissMetadataIssue',
   'displayFile',
   'downloadLogs',
+  'editFile',
   'flagForValidation',
   'getAttachmentDownloadTicket',
   'getDatasetDownloadTicket',

--- a/app/src/scripts/dataset/dataset.file-edit.jsx
+++ b/app/src/scripts/dataset/dataset.file-edit.jsx
@@ -6,7 +6,6 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { Modal } from '../utils/modal.jsx'
 import files from '../utils/files'
-import Papaya from '../common/partials/papaya.jsx'
 import ReactTable from 'react-table'
 import JsonEditor from './tools/json/jsoneditor.jsx'
 

--- a/app/src/scripts/dataset/dataset.file-edit.jsx
+++ b/app/src/scripts/dataset/dataset.file-edit.jsx
@@ -1,0 +1,143 @@
+/*eslint react/no-danger: 0 */
+
+// dependencies -------------------------------------------------------
+
+import React from 'react'
+import PropTypes from 'prop-types'
+import { Modal } from '../utils/modal.jsx'
+import files from '../utils/files'
+import Papaya from '../common/partials/papaya.jsx'
+import ReactTable from 'react-table'
+import JsonEditor from './tools/json/jsoneditor.jsx'
+
+export default class FileEdit extends React.Component {
+  // life cycle events --------------------------------------------------
+
+  render() {
+    if (!this.props.show) {
+      return false
+    }
+    let file = this.props.file
+
+    return (
+      <Modal
+        show={this.props.show}
+        onHide={this.props.onHide}
+        className={'display-file-modal ' + this._extension(file.name)}>
+        <Modal.Header closeButton>
+          <Modal.Title>
+            {file.name.split('/')[file.name.split('/').length - 1]}
+          </Modal.Title>
+        </Modal.Header>
+        <hr className="modal-inner" />
+        <Modal.Body>{this._format(file)}</Modal.Body>
+      </Modal>
+    )
+  }
+
+  // template methods ---------------------------------------------------
+
+  _format(file) {
+    let name = file.name
+    let content = file.text
+    if (files.hasExtension(name, ['.json'])) {
+      return (
+        <div>
+          <JsonEditor
+            data={content}
+            file={file}
+            onSave={this.props.onSave.bind(file)}
+            isSnapshot={this.props.isSnapshot}
+            editing={true}
+          />
+        </div>
+      )
+    } else if (files.hasExtension(name, ['.tsv', '.csv'])) {
+      let tableData = this._parseTabular(name, content)
+      let data = tableData.data
+      let columns = tableData.columns
+      return (
+        <div className="table-responsive">
+          <ReactTable
+            data={data}
+            columns={columns}
+            sortable={true}
+            defaultPageSize={100}
+            showPageSizeOptions={false}
+            editing={true}
+          />
+        </div>
+      )
+    } else {
+      return content
+    }
+  }
+
+  // custom methods -----------------------------------------------------
+
+  _htmlFormat(value) {
+    return { __html: value }
+  }
+
+  _extension(name) {
+    let nameParts = name.split('.')
+    nameParts.shift()
+    let ext = nameParts.join('-')
+    return ext
+  }
+
+  /**
+   * Parse Tabular
+   *
+   * Parse raw tabular data into an array of
+   * objects readable by Reactable.
+   */
+  _parseTabular(name, data) {
+    // determine separator
+    let separator
+    if (files.hasExtension(name, ['.tsv'])) {
+      separator = '\t'
+    } else if (files.hasExtension(name, ['.csv'])) {
+      separator = ','
+    }
+
+    let tableData = { data: [], columns: [] }
+    let rows = data.split('\n')
+    let headers = rows[0].split(separator)
+
+    //create columns from headers:
+    for (let header of headers) {
+      let headerObj = {
+        Header: header,
+        accessor: header,
+      }
+      tableData['columns'].push(headerObj)
+    }
+    // remove headers from rows
+    rows.shift()
+
+    // convert rows to object format
+    for (let row of rows) {
+      if (row && !/^\s*$/.test(row)) {
+        row = row.split(separator)
+        let rowObj = {}
+        for (let i = 0; i < headers.length; i++) {
+          rowObj[headers[i]] = row[i]
+        }
+        tableData['data'].push(rowObj)
+      }
+    }
+
+    return tableData
+  }
+}
+
+// prop validation ----------------------------------------------------
+
+FileEdit.propTypes = {
+  file: PropTypes.object,
+  onHide: PropTypes.func,
+  show: PropTypes.bool,
+  onSave: PropTypes.func,
+  isSnapshot: PropTypes.bool,
+}

--- a/app/src/scripts/dataset/dataset.jsx
+++ b/app/src/scripts/dataset/dataset.jsx
@@ -436,6 +436,7 @@ class Dataset extends Reflux.Component {
         deleteFile={actions.deleteFile}
         getFileDownloadTicket={actions.getFileDownloadTicket}
         displayFile={actions.displayFile.bind(this, null, null)}
+        editFile={actions.editFile.bind(this, null, null)}
         toggleFolder={actions.toggleFolder}
         addFile={actions.addFile}
         addDirectoryFile={actions.addDirectoryFile}

--- a/app/src/scripts/dataset/tools/json/jsoneditor.jsx
+++ b/app/src/scripts/dataset/tools/json/jsoneditor.jsx
@@ -11,9 +11,7 @@ export default class JsonEditor extends Reflux.Component {
     refluxConnect(this, JsonEditorStore, 'json')
 
     this.widgets = {
-      edit: this.editWidget.bind(this),
       save: this.saveWidget.bind(this),
-      cancel: this.cancelWidget.bind(this),
       error: this.errorWidget.bind(this),
       errorDetail: this.errorDetailWidget.bind(this),
     }
@@ -23,12 +21,13 @@ export default class JsonEditor extends Reflux.Component {
   }
 
   componentDidMount() {
+    let editing = this.props.editing ? this.props.editing : false
     let data = {
       isSnapshot: this.props.isSnapshot,
       onSave: this.props.onSave,
       originalData: this.props.data,
       originalFile: this.props.file.info,
-      editing: false,
+      editing: editing,
       editable: !this.props.isSnapshot,
     }
     actions.setInitialState(data)
@@ -50,32 +49,6 @@ export default class JsonEditor extends Reflux.Component {
       this.refs.text.selectionStart = startIdx + 1
       this.refs.text.selectionEnd = startIdx + 1
       this.forceUpdate()
-    }
-  }
-
-  editWidget() {
-    if (!this.state.json.editing && this.state.json.editable) {
-      return (
-        <span>
-          <a title="edit json" onClick={actions.startEdit}>
-            <i className="fa fa-pencil" />
-            EDIT FILE
-          </a>
-        </span>
-      )
-    }
-  }
-
-  cancelWidget() {
-    if (this.state.json.editing && this.state.json.editable) {
-      return (
-        <span>
-          <a title="cancel edit" onClick={actions.cancelEdit}>
-            <i className="fa fa-times" />
-            CANCEL EDIT
-          </a>
-        </span>
-      )
     }
   }
 
@@ -139,8 +112,6 @@ export default class JsonEditor extends Reflux.Component {
   headerBar() {
     return (
       <div className="json-editor-controls">
-        {this.widgets.edit()}
-        {this.widgets.cancel()}
         {this.widgets.save()}
         {this.widgets.error()}
         {this.widgets.errorDetail()}

--- a/app/src/scripts/dataset/tools/json/jsoneditor.store.js
+++ b/app/src/scripts/dataset/tools/json/jsoneditor.store.js
@@ -113,7 +113,7 @@ let JsonEditorStore = Reflux.createStore({
 
           this.data.onSave(this.data.originalFile, file)
 
-          this.update({ editing: false, error: null, data: jsonContent })
+          this.update({ error: null, data: jsonContent })
         }
       })
     } catch (e) {

--- a/app/src/scripts/dataset/tools/modals.jsx
+++ b/app/src/scripts/dataset/tools/modals.jsx
@@ -7,6 +7,7 @@ import Share from './share.jsx'
 import Jobs from './jobs'
 import Publish from './publish.jsx'
 import FileDisplay from '../dataset.file-display.jsx'
+import FileEdit from '../dataset.file-edit.jsx'
 import UpdateWarn from '../dataset.update-warning.jsx'
 import datasetStore from '../dataset.store'
 import datasetActions from '../dataset.actions.js'
@@ -55,6 +56,13 @@ class ToolModals extends Reflux.Component {
           show={modals.displayFile}
           isSnapshot={this.state.datasets.snapshot}
           onHide={datasetActions.toggleModal.bind(null, 'displayFile')}
+          onSave={datasetActions.updateFile}
+        />
+        <FileEdit
+          file={this.state.datasets.editFile}
+          show={modals.editFile}
+          isSnapshot={this.state.datasets.snapshot}
+          onHide={datasetActions.toggleModal.bind(null, 'editFile')}
           onSave={datasetActions.updateFile}
         />
         <UpdateWarn


### PR DESCRIPTION
fixes #377 

* creates a separate button next to 'view' for editable json files

* creates a separate component, FileEdit, which incorporates into the modal for files with editable types.

* updates the workflow for file editing - saving valid changes automatically closes the FileEdit modal and triggers validation. 