### PR TITLE
default sort order is "newest first"

### DIFF
--- a/app/src/scripts/dataset/dataset.jsx
+++ b/app/src/scripts/dataset/dataset.jsx
@@ -494,8 +494,8 @@ class Dataset extends Reflux.Component {
           value={this.state.datasets.commentSortOrder}
           onChange={actions.sortComments}
           className="comment-sort-select">
-          <option value="DESC">Date: Oldest First</option>
           <option value="ASC">Date: Newest First</option>
+          <option value="DESC">Date: Oldest First</option>
         </select>
       )
     }

--- a/app/src/scripts/dataset/dataset.store.js
+++ b/app/src/scripts/dataset/dataset.store.js
@@ -66,7 +66,7 @@ let datasetStore = Reflux.createStore({
       },
       comments: [],
       commentTree: [],
-      commentSortOrder: 'DESC',
+      commentSortOrder: 'ASC',
       currentUpdate: null,
       currentUploadId: null,
       dataset: null,
@@ -1856,6 +1856,7 @@ let datasetStore = Reflux.createStore({
       } else {
         let comments = res.body
         this.createCommentTree(comments)
+        this.sortComments()
         this.update({
           comments: comments,
           content: '',
@@ -1931,7 +1932,9 @@ let datasetStore = Reflux.createStore({
 
   sortComments(e) {
     let commentTree
-    let commentSortOrder = e.currentTarget.value
+    let commentSortOrder = e
+      ? e.currentTarget.value
+      : this.data.commentSortOrder
     if (commentSortOrder === 'ASC') {
       commentTree = this.data.commentTree.sort((a, b) => {
         return a.createDate < b.createDate


### PR DESCRIPTION
fixes #408 

* comments should now be sorted in reverse chronological order by default (newest first)