### PR TITLE
admins can no longer see deleted comment avatars

### DIFF
--- a/app/src/scripts/common/partials/comment-tree.jsx
+++ b/app/src/scripts/common/partials/comment-tree.jsx
@@ -171,7 +171,7 @@ class CommentTree extends React.Component {
 
   _userAvatar() {
     let comment = this.props.node
-    if (!comment.deleted || this.props.isAdmin) {
+    if (!comment.deleted) {
       return (
         <div className="comment-avatar">
           <img src={comment.user.imageUrl} />

--- a/server/handlers/comments.js
+++ b/server/handlers/comments.js
@@ -87,7 +87,17 @@ export default {
         if (err) {
           return next(err)
         }
-        res.send(comments)
+        // remove text and user info from deleted comments before sending back to the server
+        let filteredComments = comments.map(comment => {
+          if (comment.deleted) {
+            comment.user = {}
+            comment.text = '[deleted]'
+            return comment
+          } else {
+            return comment
+          }
+        })
+        res.send(filteredComments)
       })
   },
 }


### PR DESCRIPTION
fixes #407 

* admins can no longer see the avatars of deleted comments