### PR TITLE
show comment subthreads by default

### DIFF
--- a/app/src/scripts/common/partials/comment-tree.jsx
+++ b/app/src/scripts/common/partials/comment-tree.jsx
@@ -9,7 +9,7 @@ class CommentTree extends React.Component {
   constructor(props) {
     super(props)
 
-    let showSubtree = this.props.showSubtree ? this.props.showSubtree : false
+    let showSubtree = this.props.showSubtree ? this.props.showSubtree : true
 
     this.state = {
       showNewComment: false,


### PR DESCRIPTION
fixes #406 

comments and their subthreads will now be visible by default, with the option to show / hide subthreads as needed.