### PR TITLE
Updating validator to 0.25.11

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "async": "^2.6.0",
     "babel-runtime": "^6.26.0",
-    "bids-validator": "^0.25.7",
+    "bids-validator": "^0.25.11",
     "bowser": "^1.7.3",
     "bytes": "^3.0.0",
     "downloadjs": "^1.4.7",

--- a/server/package.json
+++ b/server/package.json
@@ -23,7 +23,7 @@
     "aws-sdk": "2.50.0",
     "babel-core": "^6.26.0",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
-    "bids-validator": "^0.25.7",
+    "bids-validator": "^0.25.11",
     "body-parser": "^1.14.0",
     "cron": "^1.1.0",
     "draft-js": "^0.10.5",


### PR DESCRIPTION
Could this be part of the next prod deployment? One of the users is stuck on upload due to an error this fixes.