### PR TITLE
allow embedded filenames in the file display url

### DIFF
--- a/app/src/scripts/common/partials/file-tree.jsx
+++ b/app/src/scripts/common/partials/file-tree.jsx
@@ -1,15 +1,22 @@
 // dependencies -------------------------------------------------------
-
 import React from 'react'
+import Reflux from 'reflux'
 import PropTypes from 'prop-types'
 import WarnButton from '../forms/warn-button.jsx'
 import Spinner from './spinner.jsx'
 import files from '../../utils/files'
 import config from '../../../../config'
+import datasetStore from '../../dataset/dataset.store.js'
+import { refluxConnect } from '../../utils/reflux'
+import { Link } from 'react-router-dom'
 
 let uploadBlacklist = config.upload.blacklist
 
-class FileTree extends React.Component {
+class FileTree extends Reflux.Component {
+  constructor() {
+    super()
+    refluxConnect(this, datasetStore, 'datasets')
+  }
   // life cycle events --------------------------------------------------
 
   render() {
@@ -235,14 +242,23 @@ class FileTree extends React.Component {
           </span>
         )
       } else {
+        let to = {
+          pathname: this.state.datasets.datasetUrl + '/file-display',
+          search: '?file=' + item.name,
+        }
         displayBtn = (
           <span className="view-file">
-            <WarnButton
-              icon="fa-eye"
-              warn={false}
-              message=" View"
-              action={this.props.displayFile.bind(this, item)}
-            />
+            <Link to={to}>
+              <WarnButton
+                icon="fa-eye"
+                warn={false}
+                message=" View"
+                // action={this.props.displayFile.bind(this, item)}
+                action={() => {
+                  return null
+                }}
+              />
+            </Link>
           </span>
         )
       }

--- a/app/src/scripts/common/partials/file-tree.jsx
+++ b/app/src/scripts/common/partials/file-tree.jsx
@@ -242,18 +242,17 @@ class FileTree extends Reflux.Component {
           </span>
         )
       } else {
-        let to = {
-          pathname: this.state.datasets.datasetUrl + '/file-display',
-          search: '?file=' + item.name,
-        }
+        let itemUrl =
+          this.state.datasets.datasetUrl +
+          '/file-display/' +
+          encodeURIComponent(item.name)
         displayBtn = (
           <span className="view-file">
-            <Link to={to}>
+            <Link to={itemUrl}>
               <WarnButton
                 icon="fa-eye"
                 warn={false}
                 message=" View"
-                // action={this.props.displayFile.bind(this, item)}
                 action={() => {
                   return null
                 }}

--- a/app/src/scripts/dataset/dataset.file-display.jsx
+++ b/app/src/scripts/dataset/dataset.file-display.jsx
@@ -22,11 +22,42 @@ class FileDisplay extends Reflux.Component {
   constructor() {
     super()
     refluxConnect(this, datasetStore, 'datasets')
+    this.state = {
+      fileRequested: false,
+    }
+  }
+
+  componentWillReceiveProps() {
+    let datasets = this.state.datasets
+
+    const file = datasets ? datasets.displayFile : null
+    const fileName = file ? file.name : null
+
+    if (!fileName) {
+      let params = new URLSearchParams(this.props.location.search)
+      let fileName = params.get('file')
+      if (
+        fileName &&
+        datasets &&
+        datasets.dataset &&
+        !this.state.fileRequested
+      ) {
+        this.setState({ fileRequested: true })
+        let displayFile = {
+          name: fileName,
+          history: this.props.history,
+        }
+        actions.displayFile(null, null, displayFile, null)
+        // return null
+      }
+      // return null
+    }
   }
 
   render() {
-    let datasets = this.state.datasets
-
+    const datasets = this.state.datasets
+    const dataset = datasets ? datasets.dataset : null
+    const status = datasets ? datasets.status : null
     const file = datasets ? datasets.displayFile : null
     const fileName = file ? file.name : null
     const fileLink = file ? file.link : null
@@ -37,34 +68,76 @@ class FileDisplay extends Reflux.Component {
         ? datasets.loading
         : 'loading'
 
-    if (!file) {
-      return null
+    let content
+    if (dataset) {
+      if (!fileName) {
+        if (status) {
+          let message
+          if (status === 404) {
+            message = 'The file you wish to view does not exist'
+          }
+          if (status === 403) {
+            message = 'You are not authorized to view this file'
+          }
+          content = (
+            <div className="page dataset">
+              <div className="dataset-container">
+                <h2 className="message-4">{message}</h2>
+              </div>
+            </div>
+          )
+        } else {
+          return null
+        }
+      } else {
+        content = (
+          <div
+            className={
+              'dataset-form display-file ' + this._extension(fileName)
+            }>
+            <div className="display-file-content">
+              <div className="col-xs-12 dataset-form-header display-file-header">
+                <div className="form-group modal-title">
+                  <label>
+                    {fileName.split('/')[fileName.split('/').length - 1]}
+                  </label>
+                  <div className="modal-download btn-admin-blue">
+                    {this._download(fileLink)}
+                  </div>
+                </div>
+                <hr className="modal-inner" />
+              </div>
+              <div className="dataset-form-body display-file-body col-xs-12">
+                <div className="dataset-form-content col-xs-12">
+                  <div className="dataset file-display-modal">
+                    {this._format(file)}
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        )
+      }
+    } else {
+      if (status) {
+        let message
+        if (status === 404) {
+          message = 'Dataset not found'
+        }
+        if (status === 403) {
+          message = 'You are not authorized to view this dataset'
+        }
+        content = (
+          <div className="page dataset">
+            <div className="dataset-container">
+              <h2 className="message-4">{message}</h2>
+            </div>
+          </div>
+        )
+      } else {
+        return null
+      }
     }
-
-    let content = (
-      <div className={'dataset-form display-file ' + this._extension(fileName)}>
-        <div className="display-file-content">
-          <div className="col-xs-12 dataset-form-header display-file-header">
-            <div className="form-group modal-title">
-              <label>
-                {fileName.split('/')[fileName.split('/').length - 1]}
-              </label>
-              <div className="modal-download btn-admin-blue">
-                {this._download(fileLink)}
-              </div>
-            </div>
-            <hr className="modal-inner" />
-          </div>
-          <div className="dataset-form-body display-file-body col-xs-12">
-            <div className="dataset-form-content col-xs-12">
-              <div className="dataset file-display-modal">
-                {this._format(file)}
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    )
 
     return (
       <ErrorBoundary

--- a/app/src/scripts/dataset/dataset.file-display.jsx
+++ b/app/src/scripts/dataset/dataset.file-display.jsx
@@ -14,10 +14,31 @@ import JsonEditor from './tools/json/jsoneditor.jsx'
 import Spinner from '../common/partials/spinner.jsx'
 import Timeout from '../common/partials/timeout.jsx'
 import ErrorBoundary from '../errors/errorBoundary.jsx'
-import { withRouter } from 'react-router-dom'
+import { Switch, Route, withRouter } from 'react-router-dom'
 import { refluxConnect } from '../utils/reflux'
 
-class FileDisplay extends Reflux.Component {
+class FileDisplay extends React.Component {
+  render() {
+    return (
+      <Switch>
+        <Route
+          name="dataset-file-display"
+          path="/datasets/:datasetId/file-display/:fileName"
+          exact
+          component={FileContent}
+        />
+        <Route
+          name="snapshot-file-display"
+          path="/datasets/:datasetId/versions/:snapshotId/file-display/:fileName"
+          exact
+          component={FileContent}
+        />
+      </Switch>
+    )
+  }
+}
+
+class FileContent extends Reflux.Component {
   // life cycle events --------------------------------------------------
   constructor() {
     super()
@@ -34,8 +55,7 @@ class FileDisplay extends Reflux.Component {
     const fileName = file ? file.name : null
 
     if (!fileName) {
-      let params = new URLSearchParams(this.props.location.search)
-      let fileName = params.get('file')
+      let fileName = decodeURIComponent(this.props.match.params.fileName)
       if (
         fileName &&
         datasets &&
@@ -48,9 +68,7 @@ class FileDisplay extends Reflux.Component {
           history: this.props.history,
         }
         actions.displayFile(null, null, displayFile, null)
-        // return null
       }
-      // return null
     }
   }
 
@@ -294,6 +312,10 @@ FileDisplay.propTypes = {
   show: PropTypes.bool,
   onSave: PropTypes.func,
   isSnapshot: PropTypes.bool,
+}
+
+FileContent.propTypes = {
+  match: PropTypes.object,
 }
 
 export default withRouter(FileDisplay)

--- a/app/src/scripts/dataset/dataset.routes.jsx
+++ b/app/src/scripts/dataset/dataset.routes.jsx
@@ -83,7 +83,6 @@ export default class DatasetRoutes extends React.Component {
           />
           <Route
             name="fileDisplay"
-            exact
             path="/datasets/:datasetId/file-display"
             component={FileDisplay}
           />
@@ -127,7 +126,6 @@ export default class DatasetRoutes extends React.Component {
           />
           <Route
             name="fileDisplay"
-            exact
             path="/datasets/:datasetId/versions/:snapshotId/file-display"
             component={FileDisplay}
           />

--- a/app/src/scripts/dataset/dataset.store.js
+++ b/app/src/scripts/dataset/dataset.store.js
@@ -569,7 +569,7 @@ let datasetStore = Reflux.createStore({
             ? this.data.displayFile.name
             : null
           if (fileName) {
-            redirectUrl = redirectUrl + '?file=' + fileName
+            redirectUrl = redirectUrl + '/' + encodeURIComponent(fileName)
           }
         }
       }

--- a/app/src/scripts/dataset/dataset.store.js
+++ b/app/src/scripts/dataset/dataset.store.js
@@ -563,7 +563,16 @@ let datasetStore = Reflux.createStore({
       let redirectUrl = datasetUrl
       if (name !== '') {
         redirectUrl = datasetUrl + '/' + name
+        if (name === 'file-display') {
+          let fileName = this.data.displayFile
+            ? this.data.displayFile.name
+            : null
+          if (fileName) {
+            redirectUrl = redirectUrl + '?file=' + fileName
+          }
+        }
       }
+
       history.push(redirectUrl)
       if (callback) {
         callback()
@@ -1233,14 +1242,26 @@ let datasetStore = Reflux.createStore({
    * direct download url.
    */
   getFileDownloadTicket(file, callback) {
+    let isSnapshot =
+      this.data.dataset && this.data.dataset && this.data.dataset.linkOriginal
+        ? true
+        : false
+
     scitran
       .getDownloadTicket('projects', this.data.dataset._id, file.name, {
-        snapshot: this.data.snapshot,
+        snapshot: isSnapshot,
       })
       .then(res => {
         let ticket = res.body.ticket
         let downloadUrl = res.req.url.split('?')[0] + '?ticket=' + ticket
         callback(downloadUrl)
+      })
+      .catch(err => {
+        console.log(err)
+        this.update({
+          status: err.status,
+        })
+        callback()
       })
   },
 
@@ -1677,42 +1698,54 @@ let datasetStore = Reflux.createStore({
    */
   displayFile(snapshotId, jobId, file, history, callback) {
     let requestAndDisplay = link => {
-      if (
-        files.hasExtension(file.name, [
-          '.pdf',
-          '.nii.gz',
-          '.jpg',
-          '.jpeg',
-          '.png',
-          '.gif',
-        ])
-      ) {
-        if (callback) {
-          callback()
-        }
-        this.showDatasetComponent('file-display', file.history)
-        this.update({
-          displayFile: {
-            name: file.name,
-            text: null,
-            link: link,
-          },
-        })
-      } else {
-        request.get(link, {}).then(res => {
+      if (link) {
+        if (
+          files.hasExtension(file.name, [
+            '.pdf',
+            '.nii.gz',
+            '.jpg',
+            '.jpeg',
+            '.png',
+            '.gif',
+          ])
+        ) {
           if (callback) {
             callback()
           }
-          this.showDatasetComponent('file-display', file.history)
-          this.update({
-            displayFile: {
-              name: file.name,
-              text: res.text,
-              link: link,
-              info: file,
+          this.update(
+            {
+              displayFile: {
+                name: file.name,
+                text: null,
+                link: link,
+              },
             },
+            () => {
+              this.showDatasetComponent('file-display', file.history)
+            },
+          )
+        } else {
+          request.get(link, {}).then(res => {
+            if (callback) {
+              callback()
+            }
+            this.update(
+              {
+                displayFile: {
+                  name: file.name,
+                  text: res.text,
+                  link: link,
+                  info: file,
+                },
+              },
+              () => {
+                this.showDatasetComponent('file-display', file.history)
+              },
+            )
           })
-        })
+        }
+      } else {
+        this.showDatasetComponent('file-display', file.history)
       }
     }
 

--- a/app/src/scripts/dataset/dataset.store.js
+++ b/app/src/scripts/dataset/dataset.store.js
@@ -1257,7 +1257,6 @@ let datasetStore = Reflux.createStore({
         callback(downloadUrl)
       })
       .catch(err => {
-        console.log(err)
         this.update({
           status: err.status,
         })

--- a/app/src/scripts/dataset/dataset.store.js
+++ b/app/src/scripts/dataset/dataset.store.js
@@ -109,9 +109,10 @@ let datasetStore = Reflux.createStore({
       uploading: false,
       uploadingCanceled: false,
       uploadingScitranRequests: [],
-      showSidebar: window.localStorage.hasOwnProperty('showSidebar')
-        ? window.localStorage.showSidebar === 'true'
-        : true,
+      showSidebar:
+        window.localStorage && window.localStorage.hasOwnProperty('showSidebar')
+          ? window.localStorage.showSidebar === 'true'
+          : true,
     }
     for (let prop in diffs) {
       data[prop] = diffs[prop]

--- a/app/webpack.dev.js
+++ b/app/webpack.dev.js
@@ -12,7 +12,9 @@ module.exports = merge(common, {
     host: '0.0.0.0',
     port: 9876,
     disableHostCheck: true,
-    historyApiFallback: true,
+    historyApiFallback: {
+      disableDotRule: true,
+    },
   },
   plugins: [new ExtractTextPlugin('style.css'), new Visualizer()],
 })


### PR DESCRIPTION
fixes #404 

viewing files now navigates the user to datasetURL/file-display?file=filename.fileextension

this allows the user to copy the link from the browser, and share with other users (given they have access to the dataset). 