### PR TITLE
json-ld dataset microdata

### DIFF
--- a/app/src/scripts/dataset/dataset.jsx
+++ b/app/src/scripts/dataset/dataset.jsx
@@ -8,6 +8,7 @@ import Helmet from 'react-helmet'
 import { withRouter } from 'react-router-dom'
 import { refluxConnect } from '../utils/reflux'
 import { pageTitle } from '../resources/strings'
+import schemaGenerator from '../utils/json-ld.js'
 
 // let uploadWarning = 'You are currently uploading files. Leaving this page will cancel the upload process.'
 
@@ -20,6 +21,7 @@ class Dataset extends Reflux.Component {
   // life cycle events --------------------------------------------------
 
   render() {
+    let datasets = this.state.datasets
     let showSidebar = this.state.datasets.showSidebar
     let dataset = this.state.datasets.dataset
     let datasetLabel = dataset ? dataset.label : ''
@@ -37,6 +39,9 @@ class Dataset extends Reflux.Component {
               {pageTitle} - {datasetLabel}
             </title>
             <meta name="description" content={description} />
+            <script type="application/ld+json">
+              {schemaGenerator(datasets)}
+            </script>
           </Helmet>
           <LeftSidebar />
           <LeftSidebarButton />

--- a/app/src/scripts/utils/json-ld.js
+++ b/app/src/scripts/utils/json-ld.js
@@ -1,0 +1,63 @@
+const schemaGenerator = datasets => {
+  const dataset = datasets ? datasets.dataset : null
+  const context = 'http://schema.org'
+  const type = 'Dataset'
+  let publisher = 'OpenNeuro'
+
+  if (dataset) {
+    let description = dataset.description
+    let name = description ? description.Name : null
+    let authors = formatAuthors(dataset.authors)
+    let datePublished = dataset.created
+    let dateModified = dataset.modified
+    let license = description ? description.License : null
+    let version = dataset.snapshot_version
+    let datasetDescription = dataset.README ? dataset.README : dataset.label
+
+    let schema = {
+      '@context': context,
+      '@type': type,
+      '@id': 'linktodoi',
+      name: name,
+      author: authors,
+      datePublished: datePublished,
+      dateModified: dateModified,
+      license: license,
+      publisher: publisher,
+      description: datasetDescription,
+      version: version,
+    }
+    return JSON.stringify(schema)
+  } else {
+    return null
+  }
+}
+
+const formatAuthors = authorList => {
+  if (authorList.length) {
+    let authorsArray = []
+    for (let author of authorList) {
+      let nameParts = author.name ? author.name.split(' ') : []
+      let familyName = nameParts.length ? nameParts[nameParts.length - 1] : null
+      nameParts.pop()
+      let givenName = nameParts.length ? nameParts.join(' ') : null
+      let authorObj = {
+        '@type': 'Person',
+      }
+      if (givenName) {
+        authorObj.givenName = givenName
+      }
+      if (familyName) {
+        authorObj.familyName = familyName
+      }
+      if (familyName || givenName) {
+        authorsArray.push(authorObj)
+      }
+    }
+    return authorsArray
+  } else {
+    return []
+  }
+}
+
+export default schemaGenerator

--- a/app/src/scripts/utils/json-ld.js
+++ b/app/src/scripts/utils/json-ld.js
@@ -17,7 +17,9 @@ const schemaGenerator = datasets => {
     let schema = {
       '@context': context,
       '@type': type,
-      '@id': 'linktodoi',
+      // TODO: add @id field to doi reference uri when
+      // added to each dataset
+      // '@id': 'linktodoi',
       name: name,
       author: authors,
       datePublished: datePublished,


### PR DESCRIPTION
fixes #352 

helmet now includes tagged dataset metadata in json-ld format for search indexing. the format conforms with the Dataset schema from schema.org, found [here](http://schema.org/Dataset)