### PR TITLE
Changes listed twice

### DIFF
--- a/app/src/scripts/dataset/dataset.store.js
+++ b/app/src/scripts/dataset/dataset.store.js
@@ -1765,7 +1765,7 @@ let datasetStore = Reflux.createStore({
 
   // Snapshots ---------------------------------------------------------------------
 
-  createSnapshot(history, callback, transition) {
+  createSnapshot(changes, history, callback, transition) {
     let datasetId = this.data.dataset.original
       ? this.data.dataset.original
       : this.data.dataset._id
@@ -1805,22 +1805,36 @@ let datasetStore = Reflux.createStore({
               'No modifications have been made since the last snapshot was created. Please use the most recent snapshot.',
           })
         } else {
-          crn.createSnapshot(datasetId).then(res => {
-            let snapshotId = res.body._id
-            this.toggleSidebar(true)
-            if (transition) {
-              const url =
-                '/datasets/' +
-                this.data.dataset.linkID +
-                '/versions/' +
-                snapshotId
-              history.push(url)
-            }
-            this.loadSnapshots(this.data.dataset, [], () => {
-              if (callback) {
-                callback(snapshotId)
+          this.updateCHANGES(changes, err => {
+            if (err) {
+              callback({
+                error: err,
+              })
+            } else {
+              if (!res) {
+                callback({
+                  error:
+                    'There was an error while updating the dataset changelog.',
+                })
               }
-            })
+              crn.createSnapshot(datasetId).then(res => {
+                let snapshotId = res.body._id
+                this.toggleSidebar(true)
+                if (transition) {
+                  const url =
+                    '/datasets/' +
+                    this.data.dataset.linkID +
+                    '/versions/' +
+                    snapshotId
+                  history.push(url)
+                }
+                this.loadSnapshots(this.data.dataset, [], () => {
+                  if (callback) {
+                    callback(snapshotId)
+                  }
+                })
+              })
+            }
           })
         }
       }

--- a/app/src/scripts/dataset/tools/snapshot.jsx
+++ b/app/src/scripts/dataset/tools/snapshot.jsx
@@ -85,8 +85,14 @@ class Snapshot extends Reflux.Component {
       },
       latestVersion: snapshotVersion,
       newSnapshotVersion: snapshotVersion,
+      changes: [],
+      currentChange: '',
     })
   }
+
+  // componentWillMount() {
+  //   // this._onHide()
+  // }
 
   componentDidMount() {
     const datasetId = this.props.match.params.datasetId
@@ -321,21 +327,13 @@ class Snapshot extends Reflux.Component {
       this.state.changes,
       this.state.datasets.dataset.CHANGES,
     )
-
-    actions.updateCHANGES(changes, (err, res) => {
-      if (err) {
-        return
-      } else {
-        if (res) {
-          actions.createSnapshot(this.props.history, res => {
-            if (res && res.error) {
-              this.setState({
-                error: true,
-                message: res.error,
-              })
-            }
-          })
-        }
+    actions.createSnapshot(changes, this.props.history, res => {
+      if (res && res.error) {
+        this.setState({
+          changes: [],
+          error: true,
+          message: res.error,
+        })
       }
     })
   }

--- a/app/src/scripts/dataset/tools/snapshot.jsx
+++ b/app/src/scripts/dataset/tools/snapshot.jsx
@@ -90,10 +90,6 @@ class Snapshot extends Reflux.Component {
     })
   }
 
-  // componentWillMount() {
-  //   // this._onHide()
-  // }
-
   componentDidMount() {
     const datasetId = this.props.match.params.datasetId
     const snapshotId = this.props.match.params.snapshotId


### PR DESCRIPTION
fixes #468 

changelogs are now cleared when the snapshot creation is interrupted due to validation (authors, description, etc) errors