### PR TITLE
Proper publish redirects

### DIFF
--- a/app/src/scripts/dataset/dataset.store.js
+++ b/app/src/scripts/dataset/dataset.store.js
@@ -421,7 +421,12 @@ let datasetStore = Reflux.createStore({
         if (snapshotId === this.data.dataset._id) {
           dataset.status.public = value
         } else {
-          history.push('/datasets/' + datasetId + '/versions/' + snapshotId)
+          history.push(
+            '/datasets/' +
+              bids.decodeId(datasetId) +
+              '/versions/' +
+              bids.decodeId(snapshotId),
+          )
         }
       } else {
         if (!hasPublic) {
@@ -435,6 +440,15 @@ let datasetStore = Reflux.createStore({
           snapshot.public = value
         }
       }
+
+      // redirect to the snapshot page
+      history.push(
+        '/datasets/' +
+          bids.decodeId(datasetId) +
+          '/versions/' +
+          bids.decodeId(snapshotId),
+      )
+
       this.update({ dataset, snapshots })
     })
   },

--- a/app/src/scripts/dataset/tools/index.js
+++ b/app/src/scripts/dataset/tools/index.js
@@ -105,7 +105,12 @@ class Tools extends Reflux.Component {
       {
         tooltip: 'Unpublish Dataset',
         icon: 'fa-globe icon-ban',
-        action: actions.publish.bind(this, dataset._id, false),
+        action: actions.publish.bind(
+          this,
+          dataset._id,
+          false,
+          this.props.history,
+        ),
         display: isPublic && isSuperuser,
         warn: true,
         validations: [

--- a/app/src/scripts/dataset/tools/publish.jsx
+++ b/app/src/scripts/dataset/tools/publish.jsx
@@ -58,6 +58,23 @@ class Publish extends Reflux.Component {
     }
   }
 
+  _submitButton() {
+    let snapshots = this.state.datasets.snapshots
+    if (snapshots) {
+      let selectedSnapshot = snapshots.filter(snapshot => {
+        return snapshot._id === this.state.selectedSnapshot
+      })
+      if (selectedSnapshot && selectedSnapshot.length) {
+        return selectedSnapshot[0].public ? null : (
+          <div className="dataset-form-controls col-xs-12">
+            {this._submit()}
+          </div>
+        )
+      }
+    }
+    return null
+  }
+
   render() {
     let datasets = this.state.datasets
     let loading = datasets && datasets.loading
@@ -91,7 +108,7 @@ class Publish extends Reflux.Component {
             </a>. This operation cannot be undone.
           </p>
         </div>
-        <div className="dataset-form-controls col-xs-12">{this._submit()}</div>
+        {this._submitButton()}
       </div>
     )
 


### PR DESCRIPTION
fixes #474 

* publishing a dataset will now redirect the page on successful publish

* the publish button is not visible if the selected snapshot is already public

* fixed route issue for unpublishing datasets