### PR TITLE
Copy comment link to clipboard

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -38,6 +38,7 @@
     "raven-js": "^3.20.1",
     "react": "16",
     "react-bootstrap": "0.31.3",
+    "react-copy-to-clipboard": "^5.0.1",
     "react-dom": "16",
     "react-ga": "^2.2.0",
     "react-helmet": "^5.2.0",
@@ -50,9 +51,9 @@
     "spark-md5": "^3.0.0",
     "stream-browserify": "^2.0.1",
     "superagent": "^3.6.0",
-    "victory": "^0.23.1",
     "url-search-params-polyfill": "^2.0.1",
     "urlite": "^1.2.8",
+    "victory": "^0.23.1",
     "xmldoc": "^1.1.0"
   },
   "devDependencies": {

--- a/app/src/sass/crn_app/_dataset.comments.scss
+++ b/app/src/sass/crn_app/_dataset.comments.scss
@@ -106,18 +106,24 @@
         font-weight: bold;
       }
 
-      .copy-notification-active, .copy-notification {
+      .copy-notification-active, .copy-notification-hidden {
         color: $ocean;
         cursor: default;
       }
 
       .copy-notification-active {
         opacity: 1;
+        visibility: visible;
+        transition: visibility 1s, opacity 1s;
+        cursor: pointer;
       }
 
-      .copy-notification {
+      .copy-notification-hidden {
         opacity: 0;
-        transition: opacity 1s;
+        height: 0;
+        width: 0;
+        visibility: hidden;
+        transition: visibility 1s, opacity 1s;
       }
     }
     .comment-actions {

--- a/app/src/sass/crn_app/_dataset.comments.scss
+++ b/app/src/sass/crn_app/_dataset.comments.scss
@@ -101,8 +101,23 @@
     margin: 0px 0px 10px 0px;
     .user-info {
       font-size: 13px;
+      
       .username {
         font-weight: bold;
+      }
+
+      .copy-notification-active, .copy-notification {
+        color: $ocean;
+        cursor: default;
+      }
+
+      .copy-notification-active {
+        opacity: 1;
+      }
+
+      .copy-notification {
+        opacity: 0;
+        transition: opacity 1s;
       }
     }
     .comment-actions {

--- a/app/src/scripts/common/partials/comment-tree.jsx
+++ b/app/src/scripts/common/partials/comment-tree.jsx
@@ -220,13 +220,7 @@ class CommentTree extends React.Component {
     let copyClass = this.state.linkCopied
       ? 'copy-notification-active'
       : 'copy-notification'
-    // let copyText = this.state.linkCopied ? 'Copied!' : ''
-    return (
-      <span className={copyClass}>
-        {/* {copyText} */}
-        Copied!
-      </span>
-    )
+    return <span className={copyClass}>Copied!</span>
   }
 
   _actions(comment) {

--- a/app/src/scripts/common/partials/comment-tree.jsx
+++ b/app/src/scripts/common/partials/comment-tree.jsx
@@ -5,6 +5,8 @@ import moment from 'moment'
 import { withRouter } from 'react-router-dom'
 import Comment from './comment.jsx'
 import WarnButton from '../forms/warn-button.jsx'
+import Tooltip from '../partials/tooltip.jsx'
+import { CopyToClipboard } from 'react-copy-to-clipboard'
 
 class CommentTree extends React.Component {
   constructor(props) {
@@ -16,6 +18,7 @@ class CommentTree extends React.Component {
       showNewComment: false,
       showSubtree: showSubtree,
       editing: false,
+      linkCopied: false,
     }
     this.handleDelete = this._handleDelete.bind(this)
     this.toggleNewComment = this._toggleNewComment.bind(this)
@@ -74,6 +77,13 @@ class CommentTree extends React.Component {
 
   _cancelEdit() {
     this.setState({ editing: false })
+  }
+
+  _onCopy() {
+    this.setState({ linkCopied: true })
+    setTimeout(() => {
+      this.setState({ linkCopied: false })
+    }, 3000)
   }
 
   _deleteButton(comment) {
@@ -190,6 +200,35 @@ class CommentTree extends React.Component {
     )
   }
 
+  _commentLink(comment) {
+    return (
+      <Tooltip tooltip="Click to save comment link to clipboard.">
+        <CopyToClipboard
+          text={`${window.location.origin}${
+            this.props.location.pathname
+          }#comment-${comment._id}`}
+          onCopy={this._onCopy.bind(this)}>
+          <a>
+            <i className="fa fa-link" aria-hidden="true" />
+          </a>
+        </CopyToClipboard>
+      </Tooltip>
+    )
+  }
+
+  _copyNotification() {
+    let copyClass = this.state.linkCopied
+      ? 'copy-notification-active'
+      : 'copy-notification'
+    // let copyText = this.state.linkCopied ? 'Copied!' : ''
+    return (
+      <span className={copyClass}>
+        {/* {copyText} */}
+        Copied!
+      </span>
+    )
+  }
+
   _actions(comment) {
     if ((this.props.user && !this.props.node.deleted) || this.props.isAdmin) {
       return (
@@ -246,9 +285,8 @@ class CommentTree extends React.Component {
           {this._userTag(comment.user.email)}
           {this._ownerTag(comment.user._id)}
           {this._timestamp(comment.createDate)}
-          <a href={`${this.props.location.pathname}#comment-${comment._id}`}>
-            <i className="fa fa-link" aria-hidden="true" />
-          </a>
+          {this._commentLink(comment)}
+          {this._copyNotification()}
           {this._showRepliesButton()}
         </div>
         {this._userAvatar()}

--- a/app/src/scripts/common/partials/comment-tree.jsx
+++ b/app/src/scripts/common/partials/comment-tree.jsx
@@ -208,7 +208,9 @@ class CommentTree extends React.Component {
             this.props.location.pathname
           }#comment-${comment._id}`}
           onCopy={this._onCopy.bind(this)}>
-          <a href={`${this.props.location.pathname}#comment-${comment._id}`}>
+          <a
+            href={`${this.props.location.pathname}#comment-${comment._id}`}
+            onClick={e => e.preventDefault()}>
             <i className="fa fa-link" aria-hidden="true" />{' '}
             {this._copyNotification()}
           </a>

--- a/app/src/scripts/common/partials/comment-tree.jsx
+++ b/app/src/scripts/common/partials/comment-tree.jsx
@@ -208,8 +208,9 @@ class CommentTree extends React.Component {
             this.props.location.pathname
           }#comment-${comment._id}`}
           onCopy={this._onCopy.bind(this)}>
-          <a>
-            <i className="fa fa-link" aria-hidden="true" />
+          <a href={`${this.props.location.pathname}#comment-${comment._id}`}>
+            <i className="fa fa-link" aria-hidden="true" />{' '}
+            {this._copyNotification()}
           </a>
         </CopyToClipboard>
       </Tooltip>
@@ -218,9 +219,14 @@ class CommentTree extends React.Component {
 
   _copyNotification() {
     let copyClass = this.state.linkCopied
-      ? 'copy-notification-active'
-      : 'copy-notification'
-    return <span className={copyClass}>Copied!</span>
+      ? 'copy-notification-active copy-notification-copied'
+      : 'copy-notification-active'
+    let copyText = this.state.linkCopied ? 'Copied!' : 'Copy comment link'
+    return (
+      <span>
+        <span className={copyClass}>{copyText}</span>
+      </span>
+    )
   }
 
   _actions(comment) {
@@ -280,7 +286,6 @@ class CommentTree extends React.Component {
           {this._ownerTag(comment.user._id)}
           {this._timestamp(comment.createDate)}
           {this._commentLink(comment)}
-          {this._copyNotification()}
           {this._showRepliesButton()}
         </div>
         {this._userAvatar()}

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -2144,6 +2144,12 @@ copy-descriptor@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
 
+copy-to-clipboard@^3:
+  version "3.0.8"
+  resolved "https://registry.yarnpkg.com/copy-to-clipboard/-/copy-to-clipboard-3.0.8.tgz#f4e82f4a8830dce4666b7eb8ded0c9bcc313aba9"
+  dependencies:
+    toggle-selection "^1.0.3"
+
 copy-webpack-plugin@^4.0.1:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/copy-webpack-plugin/-/copy-webpack-plugin-4.3.1.tgz#19ba6370bf6f8e263cbd66185a2b79f2321a9302"
@@ -6906,6 +6912,13 @@ react-bootstrap@0.31.3:
     uncontrollable "^4.1.0"
     warning "^3.0.0"
 
+react-copy-to-clipboard@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/react-copy-to-clipboard/-/react-copy-to-clipboard-5.0.1.tgz#8eae107bb400be73132ed3b6a7b4fb156090208e"
+  dependencies:
+    copy-to-clipboard "^3"
+    prop-types "^15.5.8"
+
 react-dom@16:
   version "16.2.0"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.2.0.tgz#69003178601c0ca19b709b33a83369fe6124c044"
@@ -8303,6 +8316,10 @@ to-regex@^3.0.1:
     define-property "^0.2.5"
     extend-shallow "^2.0.1"
     regex-not "^1.0.0"
+
+toggle-selection@^1.0.3:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/toggle-selection/-/toggle-selection-1.0.6.tgz#6e45b1263f2017fa0acc7d89d78b15b8bf77da32"
 
 toposort@^1.0.0:
   version "1.0.6"


### PR DESCRIPTION
fixes #427 

* clicking the link button on a comment will copy the comment link to the user's clipboard. 
* clicking the link will no longer redirect the user to the comment url
* the link has a useful tooltip
* when the link is copied, a useful 'copied!' flag appears to inform the user they have copied the link to clipboard, and then fades out after a couple of seconds.