### PR TITLE
Download count to dashboard

### DIFF
--- a/app/src/sass/crn_app/_common.status.scss
+++ b/app/src/sass/crn_app/_common.status.scss
@@ -12,7 +12,8 @@
             > span {
                 @extend %clearfix;
                 padding: 20px 0 0;
-                display: block;
+                margin-right: 15px;
+                display: inline-block;
             }
 
             .status {

--- a/app/src/sass/crn_app/_dashboard.datasets.scss
+++ b/app/src/sass/crn_app/_dashboard.datasets.scss
@@ -276,12 +276,12 @@
                 box-sizing: border-box;
                 padding: 10px 20px;
 
-                .status-wrap {
+                .status-wrap, .metrics-wrap {
                     list-style: none;
                     padding: 0;
                     margin: 0;
 
-                    .status {
+                    .status, .metric {
                         display: inline-block;
                         float: right;
                         margin-right: 0;
@@ -294,7 +294,7 @@
                             width: 80px;
 
                             i {
-                                margin: 0;
+                                margin: 0 5px 0 0;
                             }
                         }
                     }

--- a/app/src/scripts/common/partials/metric.jsx
+++ b/app/src/scripts/common/partials/metric.jsx
@@ -25,7 +25,7 @@ export default class Metric extends React.Component {
       case 'downloads':
         spanClass = 'dataset-status ds-primary'
         iconClass = 'fa fa-download'
-        tip = 'This dataset has ' + value + ' download.'
+        tip = 'This dataset has ' + value + ' downloads.'
         break
     }
 

--- a/app/src/scripts/common/partials/metric.jsx
+++ b/app/src/scripts/common/partials/metric.jsx
@@ -20,7 +20,12 @@ export default class Metric extends React.Component {
       case 'stars':
         spanClass = 'dataset-status ds-primary'
         iconClass = 'fa fa-star'
-        tip = value + ' users like this dataset'
+        tip = 'This dataset has ' + value + ' likes.'
+        break
+      case 'downloads':
+        spanClass = 'dataset-status ds-primary'
+        iconClass = 'fa fa-download'
+        tip = 'This dataset has ' + value + ' download.'
         break
     }
 
@@ -36,7 +41,7 @@ export default class Metric extends React.Component {
     }
 
     return (
-      <span className="clearfix status">
+      <span className="metric">
         <span>
           <span className={spanClass}>{content}</span>
         </span>

--- a/app/src/scripts/dashboard/dashboard.datasets.store.js
+++ b/app/src/scripts/dashboard/dashboard.datasets.store.js
@@ -57,6 +57,7 @@ let UploadStore = Reflux.createStore({
         { label: 'Date', property: 'created', isTimestamp: true },
         { label: 'User', property: 'user.lastname' },
         { label: 'Stars', property: 'starCount' },
+        { label: 'Downloads', property: 'downloads' },
       ],
       filters: [],
     }
@@ -183,7 +184,7 @@ let UploadStore = Reflux.createStore({
    * Sort
    *
    * Takes a value and a direction (+ or -) and
-   * sorts the current datasets acordingly.
+   * sorts the current datasets accordingly.
    */
   sort(value, direction, datasets, isTimeStamp) {
     datasets = datasets ? datasets : this.data.datasets

--- a/app/src/scripts/dataset/dataset.actions.js
+++ b/app/src/scripts/dataset/dataset.actions.js
@@ -8,6 +8,7 @@ var Actions = Reflux.createActions([
   'createSnapshot',
   'createComment',
   'cancelDirectoryUpload',
+  'confirmDatasetDownload',
   'constructDatasetUrl',
   'createSubscription',
   'deleteAttachment',

--- a/app/src/scripts/dataset/dataset.content.jsx
+++ b/app/src/scripts/dataset/dataset.content.jsx
@@ -143,7 +143,6 @@ class DatasetContent extends Reflux.Component {
             {this._authors(dataset.authors)}
             {this._views(dataset.views)}
             {this._followers(followers)}
-            {this._downloads(dataset.downloads)}
             <Summary summary={dataset.summary} />
             <div className="clearfix status-container">
               <Statuses dataset={dataset} />

--- a/app/src/scripts/dataset/dataset.content.jsx
+++ b/app/src/scripts/dataset/dataset.content.jsx
@@ -236,12 +236,6 @@ class DatasetContent extends Reflux.Component {
     }
   }
 
-  _downloads(downloads) {
-    if (downloads) {
-      return <h6>downloads: {downloads}</h6>
-    }
-  }
-
   _fileTree(dataset, canEdit) {
     let fileTree = (
       <FileTree

--- a/app/src/scripts/dataset/dataset.metrics.jsx
+++ b/app/src/scripts/dataset/dataset.metrics.jsx
@@ -13,9 +13,11 @@ class Metrics extends React.Component {
     let stars = dataset.stars ? '' + dataset.stars.length : '0'
     let downloads = dataset.downloads ? '' + dataset.downloads : '0'
     let displayStars = fromDashboard ? (stars !== '0' ? true : false) : true
+    let hasDownloads = downloads !== '0'
+    let isSnapshot = dataset.hasOwnProperty('original')
     let displayDownloads = fromDashboard
-      ? downloads !== '0' ? true : false
-      : true
+      ? hasDownloads ? true : false // don't display downloads on dash if the count is 0
+      : isSnapshot ? true : false // down't display downloads on dataset page if the dataset is a draft
 
     return (
       <span className="metrics-wrap">

--- a/app/src/scripts/dataset/dataset.metrics.jsx
+++ b/app/src/scripts/dataset/dataset.metrics.jsx
@@ -11,11 +11,16 @@ class Metrics extends React.Component {
     let dataset = this.props.dataset
     let fromDashboard = this.props.fromDashboard
     let stars = dataset.stars ? '' + dataset.stars.length : '0'
+    let downloads = dataset.downloads ? '' + dataset.downloads : '0'
     let displayStars = fromDashboard ? (stars !== '0' ? true : false) : true
+    let displayDownloads = fromDashboard
+      ? downloads !== '0' ? true : false
+      : true
 
     return (
       <span className="metrics-wrap">
         <Metric type="stars" value={stars} display={displayStars} />
+        <Metric type="downloads" value={downloads} display={displayDownloads} />
       </span>
     )
   }

--- a/app/src/scripts/dataset/dataset.store.js
+++ b/app/src/scripts/dataset/dataset.store.js
@@ -476,6 +476,20 @@ let datasetStore = Reflux.createStore({
   },
 
   /**
+   * Confirm Dataset Download
+   *
+   * Tracks the dataset download and encourages
+   * the user to subscribe to the dataset.
+   */
+  confirmDatasetDownload(history, callback) {
+    this.trackDownload(() => {
+      this.showDatasetComponent('subscribe', history, () => {
+        callback()
+      })
+    })
+  },
+
+  /**
    * Track Download
    *
    * Tracks download and increments download

--- a/app/src/scripts/dataset/tools/index.js
+++ b/app/src/scripts/dataset/tools/index.js
@@ -66,11 +66,7 @@ class Tools extends Reflux.Component {
         tooltip: 'Download Dataset',
         icon: 'fa-download',
         prepDownload: actions.getDatasetDownloadTicket.bind(this),
-        action: actions.showDatasetComponent.bind(
-          this,
-          'subscribe',
-          this.props.history,
-        ),
+        action: actions.confirmDatasetDownload.bind(this, this.props.history),
         display: !isIncomplete,
         warn: true,
         modalLink: datasets.datasetUrl + '/subscribe',


### PR DESCRIPTION
fixes #432 

* dataset usage statistics are now added to each dataset returned by the dashboard dataset store.
* dataset downloads are added to the metrics component in the dataset page
* dataset downloads are added to the public dataset dashboard
* dataset dashboard is filterable by download count