### PR TITLE
update yarn.lock for bids update

### DIFF
--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -1275,9 +1275,9 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
-bids-validator@^0.25.11:
-  version "0.25.12"
-  resolved "https://registry.yarnpkg.com/bids-validator/-/bids-validator-0.25.12.tgz#8f71bb38ad1c150e5e5714367a8bdbdd6b01d643"
+bids-validator@^0.26.0:
+  version "0.26.0"
+  resolved "https://registry.yarnpkg.com/bids-validator/-/bids-validator-0.26.0.tgz#bd7d3b95bab27e9ddcf917503a3e3c7d4fc6d0c4"
   dependencies:
     ajv "^5.2.2"
     async "^2.1.5"

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -1015,9 +1015,9 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
-bids-validator@^0.25.11:
-  version "0.25.12"
-  resolved "https://registry.yarnpkg.com/bids-validator/-/bids-validator-0.25.12.tgz#8f71bb38ad1c150e5e5714367a8bdbdd6b01d643"
+bids-validator@^0.26.0:
+  version "0.26.0"
+  resolved "https://registry.yarnpkg.com/bids-validator/-/bids-validator-0.26.0.tgz#bd7d3b95bab27e9ddcf917503a3e3c7d4fc6d0c4"
   dependencies:
     ajv "^5.2.2"
     async "^2.1.5"


### PR DESCRIPTION
yarn.lock files update to pair with upgrade of bids-validator to 26.0 (#512)