### PR TITLE
495 direct log links

### DIFF
--- a/app/src/scripts/dataset/dataset.routes.jsx
+++ b/app/src/scripts/dataset/dataset.routes.jsx
@@ -13,6 +13,7 @@ import FileDisplay from './dataset.file-display.jsx'
 import DatasetLoader from './dataset.dataset-loader.jsx'
 import SnapshotLoader from './dataset.snapshot-loader.jsx'
 import ResultsDisplay from './tools/jobs/results-display.jsx'
+import LogsDisplay from './tools/jobs/logs-display.jsx'
 
 /**
  * This redirects old URLs ending in /versions to the first snapshot
@@ -152,6 +153,11 @@ export default class DatasetRoutes extends React.Component {
             name="resultsDisplay"
             path="/datasets/:datasetId/versions/:snapshotId/results/:filePath"
             component={ResultsDisplay}
+          />
+          <Route
+            name="logsDisplay"
+            path="/datasets/:datasetId/versions/:snapshotId/logs/:filePath"
+            component={LogsDisplay}
           />
         </Switch>
       </div>

--- a/app/src/scripts/dataset/dataset.store.js
+++ b/app/src/scripts/dataset/dataset.store.js
@@ -373,6 +373,9 @@ let datasetStore = Reflux.createStore({
           .join('\n')
       })
       .catch(err => {
+        if (callback) {
+          callback(err)
+        }
         logsText = JSON.stringify(err)
       })
       .finally(() => {

--- a/app/src/scripts/dataset/dataset.store.js
+++ b/app/src/scripts/dataset/dataset.store.js
@@ -357,12 +357,10 @@ let datasetStore = Reflux.createStore({
   getLogstream(logstreamName, history, callback) {
     // Default text in case logs are missing
     let logsText = 'No logs available.'
-    const modals = this.data.modals
     crn
       .getLogstream(logstreamName)
       .then(res => {
         const logs = res.body
-        modals.displayFile = true
         if (callback) {
           callback()
         }
@@ -384,7 +382,6 @@ let datasetStore = Reflux.createStore({
             text: logsText,
             link: config.crn.url + 'logs/' + logstreamName + '/raw',
           },
-          modals,
         })
       })
   },

--- a/app/src/scripts/dataset/dataset.store.js
+++ b/app/src/scripts/dataset/dataset.store.js
@@ -378,11 +378,6 @@ let datasetStore = Reflux.createStore({
         logsText = JSON.stringify(err)
       })
       .finally(() => {
-        history.push(
-          this.data.datasetUrl +
-            '/file-display/' +
-            encodeURIComponent(logstreamName),
-        )
         this.update({
           displayFile: {
             name: 'Logs',

--- a/app/src/scripts/dataset/run/index.js
+++ b/app/src/scripts/dataset/run/index.js
@@ -316,15 +316,16 @@ class JobAccordion extends React.Component {
             )
           }
 
+          let logstreamUrl = 'logs/' + encodeURIComponent(logstream.name)
           return (
             <span className="job-log" key={label}>
               <WarnButton
                 icon="fa-eye"
                 message={label}
                 warn={false}
-                action={actions.getLogstream.bind(
+                action={actions.showDatasetComponent.bind(
                   this,
-                  logstream.name,
+                  logstreamUrl,
                   this.props.history,
                 )}
               />

--- a/app/src/scripts/dataset/tools/jobs/logs-display.jsx
+++ b/app/src/scripts/dataset/tools/jobs/logs-display.jsx
@@ -28,28 +28,17 @@ class LogsDisplay extends Reflux.Component {
     let fileName = file ? file.name : null
 
     if (!fileName) {
-      // file path should be of form analysisbucket/datasethash/jobid/filename
-      let filePath = decodeURIComponent(this.props.match.params.filePath)
-      let snapshotId = datasets.selectedSnapshot
-      let slugs = filePath.split('/')
-      if (slugs.length > 3) {
-        const jobId = slugs[2]
-        const fileSlugs = slugs.slice(3)
-        fileName = fileSlugs.join('/')
-        if (
-          fileName &&
-          datasets &&
-          datasets.dataset &&
-          !this.state.fileRequested
-        ) {
-          this.setState({ fileRequested: true })
-          let displayFile = {
-            name: fileName,
-            history: this.props.history,
-            path: filePath,
-          }
-          actions.displayFile(snapshotId, jobId, displayFile, null)
-        }
+      let fileName = decodeURIComponent(this.props.match.params.filePath)
+      if (
+        fileName &&
+        datasets &&
+        datasets.dataset &&
+        !this.state.fileRequested
+      ) {
+        this.setState({ fileRequested: true })
+        actions.getLogstream(fileName, this.props.history, err => {
+          if (err) throw new Error(err)
+        })
       }
     }
   }

--- a/app/src/scripts/dataset/tools/jobs/logs-display.jsx
+++ b/app/src/scripts/dataset/tools/jobs/logs-display.jsx
@@ -1,0 +1,77 @@
+/*eslint react/no-danger: 0 */
+
+// dependencies -------------------------------------------------------
+
+import React from 'react'
+import Reflux from 'reflux'
+import PropTypes from 'prop-types'
+import datasetStore from '../../dataset.store'
+import actions from '../../dataset.actions'
+import FileView from '../../../common/partials/file-view.jsx'
+import { withRouter } from 'react-router-dom'
+import { refluxConnect } from '../../../utils/reflux'
+
+class LogsDisplay extends Reflux.Component {
+  // life cycle events --------------------------------------------------
+  constructor() {
+    super()
+    refluxConnect(this, datasetStore, 'datasets')
+    this.state = {
+      fileRequested: false,
+    }
+  }
+
+  componentWillReceiveProps() {
+    let datasets = this.state.datasets
+
+    const file = datasets ? datasets.displayFile : null
+    let fileName = file ? file.name : null
+
+    if (!fileName) {
+      // file path should be of form analysisbucket/datasethash/jobid/filename
+      let filePath = decodeURIComponent(this.props.match.params.filePath)
+      let snapshotId = datasets.selectedSnapshot
+      let slugs = filePath.split('/')
+      if (slugs.length > 3) {
+        const jobId = slugs[2]
+        const fileSlugs = slugs.slice(3)
+        fileName = fileSlugs.join('/')
+        if (
+          fileName &&
+          datasets &&
+          datasets.dataset &&
+          !this.state.fileRequested
+        ) {
+          this.setState({ fileRequested: true })
+          let displayFile = {
+            name: fileName,
+            history: this.props.history,
+            path: filePath,
+          }
+          actions.displayFile(snapshotId, jobId, displayFile, null)
+        }
+      }
+    }
+  }
+
+  render() {
+    return (
+      <FileView
+        datasets={this.state.datasets}
+        updateFile={actions.updateFile.bind(this)}
+      />
+    )
+  }
+}
+
+// prop validation ----------------------------------------------------
+
+LogsDisplay.propTypes = {
+  file: PropTypes.object,
+  onHide: PropTypes.func,
+  show: PropTypes.bool,
+  onSave: PropTypes.func,
+  isSnapshot: PropTypes.bool,
+}
+
+export default withRouter(LogsDisplay)


### PR DESCRIPTION
fixes #495 

when the user navigates to /datasets/:datasetId/versions/:snapshotVersion/logs/:logstreamName, the router provides the logs-display.jsx LogsDisplay component. This component displays the logstream and allows for downloads. 

accordingly, the links to logs within the jobs results panel on the dataset page have been updated to reference the proper url.