### PR TITLE
catch missing metadata files and prevent dataset page timeout

### DIFF
--- a/packages/openneuro-app/src/scripts/utils/bids.js
+++ b/packages/openneuro-app/src/scripts/utils/bids.js
@@ -127,6 +127,9 @@ export default {
             }
             cb()
           })
+          .catch(() => {
+            cb()
+          })
       },
       () => {
         callback(metadata)


### PR DESCRIPTION
fixeds a bug where deleted / missing metadata files cause the dataset to crash.