### PR TITLE
CI build improvements

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,0 @@
-app/dist
-app/coverage
-app/node_modules
-server/node_modules
-server/coverage

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 /packages/*/node_modules
+/packages/*/coverage
 papaya.js

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ yarn-error.log
 node_modules
 lerna-debug.log
 .eslintcache
+coverage

--- a/circle.yml
+++ b/circle.yml
@@ -16,7 +16,7 @@ dependencies:
     # Lint
     - yarn lint
     # Unit Tests
-    - yarn coverage
+    - yarn coverage -w 2
 
 test:
   override:

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,18 +1,1 @@
 comment: false
-
-coverage:
-  status:
-    project:
-      default: off
-      app:
-        flags: app
-      server:
-        flags: server
-
-flags:
-  app:
-    paths:
-      - .
-  server:
-    paths:
-      - .

--- a/package.json
+++ b/package.json
@@ -6,14 +6,13 @@
     "coverage": "jest --projects packages/* --coverage",
     "codecov": "lerna run codecov",
     "prepare": "lerna run prepare",
-    "lint": "eslint --cache --ext .jsx --ext .js packages/",
-    "precommit": "lint-staged"
+    "lint": "eslint --cache --ext .jsx --ext .js packages/"
   },
   "devDependencies": {
     "babel-eslint": "8.2.2",
     "eslint": "4.19.1",
     "eslint-plugin-react": "^7.7.0",
-    "husky": "^0.14.3",
+    "husky": "^0.15.0-rc.13",
     "lerna": "^2.9.1",
     "lint-staged": "^6.0.1",
     "prettier": "^1.7.0"
@@ -22,6 +21,11 @@
   "lint-staged": {
     "linters": {
       "*.{js,jsx,json}": ["prettier --write", "git add"]
+    }
+  },
+  "husky": {
+    "hooks": {
+      "pre-commit": "lint-staged"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "private": true,
   "scripts": {
     "bootstrap": "lerna bootstrap",
-    "test": "jest --projects packages/*",
-    "coverage": "jest --projects packages/* --coverage",
+    "test": "jest",
+    "coverage": "jest --coverage",
     "codecov": "lerna run codecov",
     "lint": "eslint --cache --ext .jsx --ext .js packages/"
   },
@@ -27,5 +27,8 @@
     "hooks": {
       "pre-commit": "lint-staged"
     }
+  },
+  "jest": {
+    "projects": ["packages/*"]
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "private": true,
   "scripts": {
     "bootstrap": "lerna bootstrap",
-    "test": "lerna run test",
-    "coverage": "lerna run coverage",
+    "test": "jest --projects packages/*",
+    "coverage": "jest --projects packages/* --coverage",
     "codecov": "lerna run codecov",
     "prepare": "lerna run prepare",
     "lint": "eslint --cache --ext .jsx --ext .js packages/",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
     "test": "jest --projects packages/*",
     "coverage": "jest --projects packages/* --coverage",
     "codecov": "lerna run codecov",
-    "prepare": "lerna run prepare",
     "lint": "eslint --cache --ext .jsx --ext .js packages/"
   },
   "devDependencies": {
@@ -13,6 +12,7 @@
     "eslint": "4.19.1",
     "eslint-plugin-react": "^7.7.0",
     "husky": "^0.15.0-rc.13",
+    "jest": "^22.4.3",
     "lerna": "^2.9.1",
     "lint-staged": "^6.0.1",
     "prettier": "^1.7.0"

--- a/package.json
+++ b/package.json
@@ -4,11 +4,12 @@
     "bootstrap": "lerna bootstrap",
     "test": "jest",
     "coverage": "jest --coverage",
-    "codecov": "lerna run codecov",
+    "codecov": "codecov",
     "lint": "eslint --cache --ext .jsx --ext .js packages/"
   },
   "devDependencies": {
     "babel-eslint": "8.2.2",
+    "codecov": "^3.0.0",
     "eslint": "4.19.1",
     "eslint-plugin-react": "^7.7.0",
     "husky": "^0.15.0-rc.13",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,12 @@
     }
   },
   "jest": {
-    "projects": ["packages/*"]
+    "projects": ["packages/*"],
+    "collectCoverageFrom": [
+      "**/*.{js,jsx}",
+      "!**/*.spec.js",
+      "!**/node_modules/**",
+      "!**/vendor/**"
+    ]
   }
 }

--- a/packages/openneuro-app/.dockerignore
+++ b/packages/openneuro-app/.dockerignore
@@ -1,0 +1,3 @@
+./dist
+./coverage
+./node_modules

--- a/packages/openneuro-app/package.json
+++ b/packages/openneuro-app/package.json
@@ -12,9 +12,7 @@
     "start": "webpack-dev-server --config webpack.dev.js --progress --color",
     "build": "webpack --config webpack.prod.js",
     "lint": "eslint --ext .jsx --ext .js src/scripts/",
-    "test": "jest",
-    "coverage": "jest --coverage",
-    "codecov": "codecov -p ../../ -F app"
+    "test": "jest"
   },
   "author": "Squishymedia",
   "dependencies": {

--- a/packages/openneuro-app/package.json
+++ b/packages/openneuro-app/package.json
@@ -77,7 +77,7 @@
     "extract-text-webpack-plugin": "^3.0.0",
     "file-loader": "^1.1.6",
     "html-webpack-plugin": "^2.30.1",
-    "jest": "^22.0.0",
+    "jest": "^22.4.3",
     "jest-fetch-mock": "^1.4.1",
     "moment-timezone": "^0.5.13",
     "node-sass": "^4.5.3",

--- a/packages/openneuro-server/.dockerignore
+++ b/packages/openneuro-server/.dockerignore
@@ -1,0 +1,2 @@
+./coverage
+./node_modules

--- a/packages/openneuro-server/mongo-environment.js
+++ b/packages/openneuro-server/mongo-environment.js
@@ -6,19 +6,12 @@ const mongod = new MongodbMemoryServer()
 class MongoEnvironment extends NodeEnvironment {
   constructor(config) {
     super(config)
-    this.mongod = mongod
   }
 
   async setup() {
-    this.global.__MONGO_URI__ = `mongodb://localhost:${await this.mongod.getPort()}/`
+    this.global.__MONGO_URI__ = `mongodb://localhost:${await mongod.getPort()}/`
 
     await super.setup()
-  }
-
-  async teardown() {
-    //this.mongod.stop()
-
-    await super.teardown()
   }
 
   runScript(script) {

--- a/packages/openneuro-server/mongo-environment.js
+++ b/packages/openneuro-server/mongo-environment.js
@@ -1,10 +1,12 @@
 const MongodbMemoryServer = require('mongodb-memory-server').default
 const NodeEnvironment = require('jest-environment-node')
 
+const mongod = new MongodbMemoryServer()
+
 class MongoEnvironment extends NodeEnvironment {
   constructor(config) {
     super(config)
-    this.mongod = new MongodbMemoryServer()
+    this.mongod = mongod
   }
 
   async setup() {
@@ -14,7 +16,7 @@ class MongoEnvironment extends NodeEnvironment {
   }
 
   async teardown() {
-    this.mongod.stop()
+    //this.mongod.stop()
 
     await super.teardown()
   }

--- a/packages/openneuro-server/package.json
+++ b/packages/openneuro-server/package.json
@@ -7,9 +7,7 @@
   "scripts": {
     "lint": "eslint libs/ handlers/ tests/",
     "start": "node index.js",
-    "test": "jest",
-    "coverage": "jest --coverage --runInBand",
-    "codecov": "codecov -p ../../ -F server"
+    "test": "jest"
   },
   "repository": {
     "type": "git",

--- a/packages/openneuro-server/package.json
+++ b/packages/openneuro-server/package.json
@@ -66,7 +66,7 @@
     "babel-preset-env": "^1.6.0",
     "codecov": "^2.3.0",
     "eslint": "^4.18.1",
-    "jest": "^22.0.0",
+    "jest": "^22.4.3",
     "mongodb-memory-server": "^1.7.0",
     "supertest": "^3.0.0"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,8 @@
     "checkJs": true,
     "allowJs": true,
     "outDir": "./built",
-    "target": "es6"
+    "target": "es6",
+    "jsx": "preserve"
   },
   "include": ["./packages/**/*"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "checkJs": true,
+    "allowJs": true,
+    "outDir": "./built",
+    "target": "es6"
+  },
+  "include": ["./packages/**/*"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5967,7 +5967,7 @@ jest-worker@^22.4.3:
   dependencies:
     merge-stream "^1.0.1"
 
-jest@^22.0.0:
+jest@^22.0.0, jest@^22.4.3:
   version "22.4.3"
   resolved "https://registry.yarnpkg.com/jest/-/jest-22.4.3.tgz#2261f4b117dc46d9a4a1a673d2150958dee92f16"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -3935,6 +3935,18 @@ execa@^0.8.0:
     signal-exit "^3.0.0"
     strip-eof "^1.0.0"
 
+execa@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-0.9.0.tgz#adb7ce62cf985071f60580deb4a88b9e34712d01"
+  dependencies:
+    cross-spawn "^5.0.1"
+    get-stream "^3.0.0"
+    is-stream "^1.1.0"
+    npm-run-path "^2.0.0"
+    p-finally "^1.0.0"
+    signal-exit "^3.0.0"
+    strip-eof "^1.0.0"
+
 exenv@^1.2.1:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/exenv/-/exenv-1.2.2.tgz#2ae78e85d9894158670b03d47bec1f03bd91bb9d"
@@ -5054,13 +5066,18 @@ https-browserify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
 
-husky@^0.14.3:
-  version "0.14.3"
-  resolved "https://registry.yarnpkg.com/husky/-/husky-0.14.3.tgz#c69ed74e2d2779769a17ba8399b54ce0b63c12c3"
+husky@^0.15.0-rc.13:
+  version "0.15.0-rc.13"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-0.15.0-rc.13.tgz#a27550b7b51d2f472e284b48fc9257a6d6b3f681"
   dependencies:
-    is-ci "^1.0.10"
-    normalize-path "^1.0.0"
-    strip-indent "^2.0.0"
+    cosmiconfig "^4.0.0"
+    execa "^0.9.0"
+    is-ci "^1.1.0"
+    pkg-dir "^2.0.0"
+    pupa "^1.0.0"
+    read-pkg "^3.0.0"
+    run-node "^0.2.0"
+    slash "^1.0.0"
 
 iconv-lite@0.4.15:
   version "0.4.15"
@@ -5294,7 +5311,7 @@ is-callable@^1.1.1, is-callable@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.1.3.tgz#86eb75392805ddc33af71c92a0eedf74ee7604b2"
 
-is-ci@^1.0.10:
+is-ci@^1.0.10, is-ci@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-1.1.0.tgz#247e4162e7860cebbdaf30b774d6b0ac7dcfe7a5"
   dependencies:
@@ -7308,10 +7325,6 @@ normalize-package-data@^2.3.0, normalize-package-data@^2.3.2, normalize-package-
     semver "2 || 3 || 4 || 5"
     validate-npm-package-license "^3.0.1"
 
-normalize-path@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-1.0.0.tgz#32d0e472f91ff345701c15a8311018d3b0a90379"
-
 normalize-path@^2.0.0, normalize-path@^2.0.1, normalize-path@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-2.1.1.tgz#1ab28b556e198363a8c1a6f7e6fa20137fe6aed9"
@@ -8227,6 +8240,10 @@ punycode@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.0.tgz#5f863edc89b96db09074bad7947bf09056ca4e7d"
 
+pupa@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/pupa/-/pupa-1.0.0.tgz#9a9568a5af7e657b8462a6e9d5328743560ceff6"
+
 q@^1.1.2, q@^1.4.1, q@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/q/-/q-1.5.1.tgz#7e32f75b41381291d04611f1bf14109ac00651d7"
@@ -9056,6 +9073,10 @@ run-async@^2.2.0:
   resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.3.0.tgz#0371ab4ae0bdd720d4166d7dfda64ff7a445a6c0"
   dependencies:
     is-promise "^2.1.0"
+
+run-node@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/run-node/-/run-node-0.2.0.tgz#b26e942e94205dedbe532cddf0fd1dbd56649af6"
 
 run-queue@^1.0.0, run-queue@^1.0.3:
   version "1.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5967,7 +5967,7 @@ jest-worker@^22.4.3:
   dependencies:
     merge-stream "^1.0.1"
 
-jest@^22.0.0, jest@^22.4.3:
+jest@^22.4.3:
   version "22.4.3"
   resolved "https://registry.yarnpkg.com/jest/-/jest-22.4.3.tgz#2261f4b117dc46d9a4a1a673d2150958dee92f16"
   dependencies:


### PR DESCRIPTION
This fixes several build and test issues related to the #533 merge.

* Upgrades Jest and Husky.
* Uses the Jest projects configuration to test all packages from one Jest process. Fixes --watch at the project root.
* Limits concurrency for Jest processes on CircleCI to two worker processes to avoid out of resources issues.
* Reduces the number of mongodb instances launched during tests.
* Enables type checking errors for JS files, this only affects code editors since we don't use the TypeScript compiler anywhere in our build.