### PR TITLE
add error handling for job loading; fix bug in orphaned snapshots

### DIFF
--- a/packages/openneuro-app/src/scripts/dataset/dataset.store.js
+++ b/packages/openneuro-app/src/scripts/dataset/dataset.store.js
@@ -1492,8 +1492,11 @@ let datasetStore = Reflux.createStore({
           callback(err, null)
         })
       } else if (callback) {
-        callback(res.body)
+        callback(null, res.body)
       }
+    })
+    .catch(err => {
+      callback(err, null)
     })
   },
 
@@ -1581,7 +1584,7 @@ let datasetStore = Reflux.createStore({
             this.data.snapshot,
             datasetId,
             { job: jobId },
-            jobs => {
+            (err, jobs) => {
               this.loadSnapshots(this.data.dataset, jobs)
 
               // start polling job
@@ -1653,7 +1656,7 @@ let datasetStore = Reflux.createStore({
           true,
           this.data.dataset.original,
           {},
-          jobs => {
+          (err, jobs) => {
             this.loadSnapshots(this.data.dataset, jobs)
 
             // start polling job
@@ -1673,7 +1676,7 @@ let datasetStore = Reflux.createStore({
           true,
           this.data.dataset.original,
           {},
-          jobs => {
+          (err, jobs) => {
             this.loadSnapshots(this.data.dataset, jobs)
 
             // start polling job

--- a/packages/openneuro-app/src/scripts/dataset/dataset.store.js
+++ b/packages/openneuro-app/src/scripts/dataset/dataset.store.js
@@ -195,7 +195,7 @@ let datasetStore = Reflux.createStore({
                   },
                 ],
               },
-              this.loadJobs(datasetId, snapshot, originalId, options, jobs => {
+              this.loadJobs(datasetId, snapshot, originalId, options, (err, jobs) => {
                 this.loadSnapshots(dataset, jobs, () => {
                   this.loadComments(originalId)
                   this.getDatasetStars()
@@ -1488,6 +1488,9 @@ let datasetStore = Reflux.createStore({
         crn.getDatasetJobs(originalId, { snapshot: false }).then(res => {
           callback(null, res)
         })
+        .catch(err => {
+          callback(err, null)
+        })
       } else if (callback) {
         callback(res.body)
       }
@@ -1956,7 +1959,7 @@ let datasetStore = Reflux.createStore({
       }
 
       // add draft is available
-      if (dataset && dataset.access == 'orphaned') {
+      if (dataset && dataset.permissions && !dataset.permissions.length) {
         snapshots.unshift({
           orphaned: true,
         })


### PR DESCRIPTION
fixes #524 and #448. 

* orphaned snapshots no longer call loadJobs on their parent datasets.
* calls to loadJobs for datasets that no longer exist now have error handling to prevent dataset timeout