### PR TITLE
Openneuro CLI package

### DIFF
--- a/packages/openneuro-cli/.babelrc
+++ b/packages/openneuro-cli/.babelrc
@@ -1,0 +1,15 @@
+{
+  "plugins": [
+    "transform-object-rest-spread"
+  ],
+  "presets": [
+    [
+      "env",
+      {
+        "targets": {
+          "node": "current"
+        }
+      }
+    ]
+  ]
+}

--- a/packages/openneuro-cli/package.json
+++ b/packages/openneuro-cli/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "commander": "^2.15.1",
     "esm": "^3.0.16",
+    "home-config": "^0.1.0",
     "inquirer": "^5.2.0",
     "openneuro-client": "^1.10.0"
   },

--- a/packages/openneuro-cli/package.json
+++ b/packages/openneuro-cli/package.json
@@ -11,6 +11,7 @@
     "esm": "^3.0.16",
     "find-config": "^1.0.0",
     "inquirer": "^5.2.0",
+    "mkdirp": "^0.5.1",
     "openneuro-client": "^1.10.0"
   },
   "scripts": {

--- a/packages/openneuro-cli/package.json
+++ b/packages/openneuro-cli/package.json
@@ -7,6 +7,12 @@
   "author": "Squishymedia",
   "license": "MIT",
   "dependencies": {
+    "commander": "^2.15.1",
+    "esm": "^3.0.16",
+    "inquirer": "^5.2.0",
     "openneuro-client": "^1.10.0"
+  },
+  "scripts": {
+    "openneuro": "node src/index.js"
   }
 }

--- a/packages/openneuro-cli/package.json
+++ b/packages/openneuro-cli/package.json
@@ -15,5 +15,14 @@
   },
   "scripts": {
     "openneuro": "node src/index.js"
+  },
+  "jest": {
+    "testEnvironment": "node",
+    "collectCoverageFrom": [
+      "**/*.js",
+      "!**/*.spec.js",
+      "!**/node_modules/**",
+      "!**/vendor/**"
+    ]
   }
 }

--- a/packages/openneuro-cli/package.json
+++ b/packages/openneuro-cli/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "openneuro-cli",
+  "version": "1.10.0",
+  "description": "OpenNeuro command line uploader / editor.",
+  "main": "index.js",
+  "repository": "git@github.com:OpenNeuroOrg/openneuro.git",
+  "author": "Squishymedia",
+  "license": "MIT",
+  "dependencies": {
+    "openneuro-client": "^1.10.0"
+  }
+}

--- a/packages/openneuro-cli/package.json
+++ b/packages/openneuro-cli/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "commander": "^2.15.1",
     "esm": "^3.0.16",
-    "home-config": "^0.1.0",
+    "find-config": "^1.0.0",
     "inquirer": "^5.2.0",
     "openneuro-client": "^1.10.0"
   },
@@ -24,5 +24,8 @@
       "!**/node_modules/**",
       "!**/vendor/**"
     ]
+  },
+  "devDependencies": {
+    "metro-memory-fs": "^0.31.0"
   }
 }

--- a/packages/openneuro-cli/src/__tests__/actions.spec.js
+++ b/packages/openneuro-cli/src/__tests__/actions.spec.js
@@ -1,0 +1,10 @@
+import { login, upload, diff } from '../actions.js'
+
+describe('commands.js', () => {
+  describe('login', () => {
+    it('should accept an auth key', () => {
+      const apiKey = '123456'
+      login(apiKey)
+    })
+  })
+})

--- a/packages/openneuro-cli/src/__tests__/actions.spec.js
+++ b/packages/openneuro-cli/src/__tests__/actions.spec.js
@@ -1,10 +1,15 @@
-import { login, upload, diff } from '../actions.js'
+import { loginAnswers, upload } from '../actions.js'
 
-describe('commands.js', () => {
+describe('actions.js', () => {
   describe('login', () => {
+    const testKey = '123456'
     it('should accept an auth key', () => {
-      const apiKey = '123456'
-      login(apiKey)
+      loginAnswers({ apikey: testKey })
+    })
+  })
+  describe('upload', () => {
+    it('works!', () => {
+      upload()
     })
   })
 })

--- a/packages/openneuro-cli/src/__tests__/config.spec.js
+++ b/packages/openneuro-cli/src/__tests__/config.spec.js
@@ -1,0 +1,30 @@
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { getConfig, saveConfig } from '../config'
+
+const HOME = os.homedir()
+
+// Must be require for Jest's implementation
+jest.mock('fs', () => new (require('metro-memory-fs'))())
+beforeEach(() => {
+  require('fs').reset()
+  fs.mkdirSync('/home')
+  fs.mkdirSync(HOME)
+})
+
+describe('config.js', () => {
+  it('should find a config file if one exists', () => {
+    const mockPath = path.join(HOME, '.openneuro')
+    fs.writeFileSync(mockPath, JSON.stringify({}))
+    expect(getConfig()).not.toBeNull()
+  })
+  it('fails if no config file exists', () => {
+    expect(getConfig()).toBeNull()
+  })
+  it('saves a configuration in the right location', () => {
+    const testConfig = { testing: true }
+    saveConfig(testConfig)
+    expect(getConfig()).not.toBeNull()
+  })
+})

--- a/packages/openneuro-cli/src/__tests__/config.spec.js
+++ b/packages/openneuro-cli/src/__tests__/config.spec.js
@@ -1,6 +1,7 @@
 import fs from 'fs'
 import os from 'os'
 import path from 'path'
+import mkdirp from 'mkdirp'
 import { getConfig, saveConfig } from '../config'
 
 const HOME = os.homedir()
@@ -9,8 +10,7 @@ const HOME = os.homedir()
 jest.mock('fs', () => new (require('metro-memory-fs'))())
 beforeEach(() => {
   require('fs').reset()
-  fs.mkdirSync('/home')
-  fs.mkdirSync(HOME)
+  mkdirp.sync(HOME)
 })
 
 describe('config.js', () => {

--- a/packages/openneuro-cli/src/actions.js
+++ b/packages/openneuro-cli/src/actions.js
@@ -5,7 +5,7 @@ const loginQuestions = {
   type: 'input',
   name: 'apikey',
   message:
-    'Enter your API key for OpenNeuro (get an API key from https://openneuro.org/user/key)',
+    'Enter your API key for OpenNeuro (get an API key from https://openneuro.org/keygen)',
 }
 
 /**

--- a/packages/openneuro-cli/src/actions.js
+++ b/packages/openneuro-cli/src/actions.js
@@ -1,4 +1,5 @@
 import inquirer from 'inquirer'
+import { saveConfig } from './config'
 
 const loginQuestions = {
   type: 'input',
@@ -14,9 +15,17 @@ const loginQuestions = {
  * this is a prompted entry
  */
 export const login = () => {
-  inquirer.prompt(loginQuestions).then(answers => {
-    console.log(answers)
-  })
+  return inquirer
+    .prompt(loginQuestions)
+    .then(loginAnswers)
+    .then(saveConfig)
 }
+
+/**
+ * Handle login answers returned by inquirer
+ *
+ * @param {Object} answers
+ */
+export const loginAnswers = answers => answers
 
 export const upload = () => {}

--- a/packages/openneuro-cli/src/actions.js
+++ b/packages/openneuro-cli/src/actions.js
@@ -1,0 +1,22 @@
+import inquirer from 'inquirer'
+
+const loginQuestions = {
+  type: 'input',
+  name: 'apikey',
+  message:
+    'Enter your API key for OpenNeuro (get an API key from https://openneuro.org/user/key)',
+}
+
+/**
+ * Login action to save an auth key locally
+ *
+ * The user can do this manually as well, to allow for automation
+ * this is a prompted entry
+ */
+export const login = () => {
+  inquirer.prompt(loginQuestions).then(answers => {
+    console.log(answers)
+  })
+}
+
+export const upload = () => {}

--- a/packages/openneuro-cli/src/cli.js
+++ b/packages/openneuro-cli/src/cli.js
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+import commander from 'commander'
+import packageJson from '../package.json'
+import { login, upload } from './actions.js'
+
+commander.version(packageJson.version).description(packageJson.description)
+
+commander
+  .command('login')
+  .alias('l')
+  .description('Setup authentication with OpenNeuro')
+  .action(login)
+
+commander
+  .command('upload')
+  .alias('u')
+  .alias('sync')
+  .description('Upload or sync a dataset (if a accession number is provided)')
+  .action(upload)
+
+commander.parse(process.argv)

--- a/packages/openneuro-cli/src/config.js
+++ b/packages/openneuro-cli/src/config.js
@@ -1,3 +1,24 @@
-import homeConfig from 'home-config'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import findConfig from 'find-config'
 
-export default homeConfig.load('.openneuro')
+/**
+ * Get the nearest working configuration
+ */
+export const getConfig = () => {
+  return findConfig('.openneuro')
+}
+
+/**
+ * Save a config object to a default location
+ *
+ * `$HOME/.openneuro`
+ *
+ * @param {Object} config
+ */
+export const saveConfig = config => {
+  const home = os.homedir()
+  const savePath = path.join(home, '.openneuro')
+  fs.writeFileSync(savePath, JSON.stringify(config))
+}

--- a/packages/openneuro-cli/src/config.js
+++ b/packages/openneuro-cli/src/config.js
@@ -1,0 +1,3 @@
+import homeConfig from 'home-config'
+
+export default homeConfig.load('.openneuro')

--- a/packages/openneuro-cli/src/index.js
+++ b/packages/openneuro-cli/src/index.js
@@ -1,0 +1,3 @@
+// ES6 module shim
+require = require('esm')(module)
+module.exports = require('./cli.js')

--- a/packages/openneuro-cli/src/index.js
+++ b/packages/openneuro-cli/src/index.js
@@ -1,3 +1,4 @@
 // ES6 module shim
+// eslint-disable-next-line no-global-assign
 require = require('esm')(module)
 module.exports = require('./cli.js')

--- a/packages/openneuro-client/package.json
+++ b/packages/openneuro-client/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "openneuro-client",
+  "version": "1.10.0",
+  "description": "OpenNeuro shared client library.",
+  "main": "index.js",
+  "repository": "git@github.com:OpenNeuroOrg/openneuro.git",
+  "author": "Squishymedia",
+  "license": "MIT",
+  "dependencies": {
+    "apollo-boost": "^0.1.4"
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4286,6 +4286,12 @@ find-cache-dir@^1.0.0:
     make-dir "^1.0.0"
     pkg-dir "^2.0.0"
 
+find-config@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/find-config/-/find-config-1.0.0.tgz#eafa2b9bc07fa9c90e9a0c3ef9cecf1cc800f530"
+  dependencies:
+    user-home "^2.0.0"
+
 find-parent-dir@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/find-parent-dir/-/find-parent-dir-0.3.0.tgz#33c44b429ab2b2f0646299c5f9f718f376ff8d54"
@@ -4931,12 +4937,6 @@ hoist-non-react-statics@^2.3.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.0.tgz#d2ca2dfc19c5a91c5a6615ce8e564ef0347e2a40"
 
-home-config@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/home-config/-/home-config-0.1.0.tgz#1bce40cdeeb4fab819cdf6e686dd02f486a90147"
-  dependencies:
-    ini "~1.2.1"
-
 home-or-tmp@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/home-or-tmp/-/home-or-tmp-2.0.0.tgz#e36c3f2d2cae7d746a857e38d18d5f32a7882db8"
@@ -5207,10 +5207,6 @@ inherits@2.0.1:
 ini@^1.3.2, ini@~1.3.0:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
-
-ini@~1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/ini/-/ini-1.2.1.tgz#7f774e2f22752cd1dacbf9c63323df2a164ebca3"
 
 inline-source-map@~0.6.0:
   version "0.6.2"
@@ -6862,6 +6858,10 @@ merge@^1.1.3:
 methods@^1.1.1, methods@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
+
+metro-memory-fs@^0.31.0:
+  version "0.31.0"
+  resolved "https://registry.yarnpkg.com/metro-memory-fs/-/metro-memory-fs-0.31.0.tgz#71c251b5b4592a9c70a1f452bac758ba6d0ffc36"
 
 micromatch@^2.1.5, micromatch@^2.3.11:
   version "2.3.11"
@@ -10426,6 +10426,12 @@ use@^3.1.0:
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.0.tgz#14716bf03fdfefd03040aef58d8b4b85f3a7c544"
   dependencies:
     kind-of "^6.0.2"
+
+user-home@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/user-home/-/user-home-2.0.0.tgz#9c70bfd8169bc1dcbf48604e0f04b8b49cde9e9f"
+  dependencies:
+    os-homedir "^1.0.0"
 
 util-deprecate@~1.0.1:
   version "1.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2412,7 +2412,7 @@ commander@2.0.x:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.0.0.tgz#d1b86f901f8b64bd941bdeadaf924530393be928"
 
-commander@2.15.x, commander@^2.11.0, commander@^2.5.0, commander@^2.9.0, commander@~2.15.0:
+commander@2.15.x, commander@^2.11.0, commander@^2.15.1, commander@^2.5.0, commander@^2.9.0, commander@~2.15.0:
   version "2.15.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.15.1.tgz#df46e867d0fc2aec66a34662b406a9ccafff5b0f"
 
@@ -3851,6 +3851,10 @@ eslint@4.19.1, eslint@^4.18.1:
     table "4.0.2"
     text-table "~0.2.0"
 
+esm@^3.0.16:
+  version "3.0.16"
+  resolved "https://registry.yarnpkg.com/esm/-/esm-3.0.16.tgz#7874cc2f92694460029e66640a67a06f8e408930"
+
 espree@^3.5.4:
   version "3.5.4"
   resolved "https://registry.yarnpkg.com/espree/-/espree-3.5.4.tgz#b0f447187c8a8bed944b815a660bddf5deb5d1a7"
@@ -4079,7 +4083,7 @@ extend@^3.0.0, extend@~3.0.0, extend@~3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.1.tgz#a755ea7bc1adfcc5a31ce7e762dbaadc5e636444"
 
-external-editor@^2.0.4:
+external-editor@^2.0.4, external-editor@^2.1.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-2.2.0.tgz#045511cfd8d133f3846673d1047c154e214ad3d5"
   dependencies:
@@ -5219,6 +5223,24 @@ inquirer@^3.0.6, inquirer@^3.2.2:
     run-async "^2.2.0"
     rx-lite "^4.0.8"
     rx-lite-aggregates "^4.0.8"
+    string-width "^2.1.0"
+    strip-ansi "^4.0.0"
+    through "^2.3.6"
+
+inquirer@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-5.2.0.tgz#db350c2b73daca77ff1243962e9f22f099685726"
+  dependencies:
+    ansi-escapes "^3.0.0"
+    chalk "^2.0.0"
+    cli-cursor "^2.1.0"
+    cli-width "^2.0.0"
+    external-editor "^2.1.0"
+    figures "^2.0.0"
+    lodash "^4.3.0"
+    mute-stream "0.0.7"
+    run-async "^2.2.0"
+    rxjs "^5.5.2"
     string-width "^2.1.0"
     strip-ansi "^4.0.0"
     through "^2.3.6"
@@ -9119,7 +9141,7 @@ rx-lite@*, rx-lite@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-4.0.8.tgz#0b1e11af8bc44836f04a6407e92da42467b79444"
 
-rxjs@^5.4.2:
+rxjs@^5.4.2, rxjs@^5.5.2:
   version "5.5.8"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.5.8.tgz#b2b0809a57614ad6254c03d7446dea0d83ca3791"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -271,13 +271,25 @@ anymatch@^2.0.0:
     micromatch "^3.1.4"
     normalize-path "^2.1.1"
 
+apollo-boost@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/apollo-boost/-/apollo-boost-0.1.4.tgz#c17ce6cd17f5c2859e06880aab9af0265fc929e2"
+  dependencies:
+    apollo-cache-inmemory "^1.1.12"
+    apollo-client "^2.2.8"
+    apollo-link "^1.0.6"
+    apollo-link-error "^1.0.3"
+    apollo-link-http "^1.3.1"
+    apollo-link-state "^0.4.0"
+    graphql-tag "^2.4.2"
+
 apollo-cache-control@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/apollo-cache-control/-/apollo-cache-control-0.1.0.tgz#0c7c9abc312dea3a60e1cb70e0869df2cd970688"
   dependencies:
     graphql-extensions "^0.0.x"
 
-apollo-cache-inmemory@^1.1.7:
+apollo-cache-inmemory@^1.1.12, apollo-cache-inmemory@^1.1.7:
   version "1.1.12"
   resolved "https://registry.yarnpkg.com/apollo-cache-inmemory/-/apollo-cache-inmemory-1.1.12.tgz#ab489bf046b3e026556ab28bdebb6e010cac9531"
   dependencies:
@@ -301,7 +313,7 @@ apollo-client-preset@^1.0.8:
     apollo-link-http "^1.3.1"
     graphql-tag "^2.4.2"
 
-apollo-client@^2.2.2:
+apollo-client@^2.2.2, apollo-client@^2.2.8:
   version "2.2.8"
   resolved "https://registry.yarnpkg.com/apollo-client/-/apollo-client-2.2.8.tgz#b604d31ab2d2dd00db3105d8793b93ee02ce567e"
   dependencies:
@@ -318,6 +330,12 @@ apollo-client@^2.2.2:
 apollo-link-dedup@^1.0.0:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/apollo-link-dedup/-/apollo-link-dedup-1.0.8.tgz#8c3028cf32557bd040ab6ba8856f38067bdacead"
+  dependencies:
+    apollo-link "^1.2.1"
+
+apollo-link-error@^1.0.3:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/apollo-link-error/-/apollo-link-error-1.0.7.tgz#df6d7b13e9b73f9a615547b65ec9a4c930ca7f18"
   dependencies:
     apollo-link "^1.2.1"
 
@@ -339,6 +357,13 @@ apollo-link-schema@^1.0.6:
   resolved "https://registry.yarnpkg.com/apollo-link-schema/-/apollo-link-schema-1.0.6.tgz#a0dc6c2efb3c7678e15c27f4d8432e45bbaa8262"
   dependencies:
     apollo-link "^1.2.1"
+
+apollo-link-state@^0.4.0:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/apollo-link-state/-/apollo-link-state-0.4.1.tgz#65e9e0e12c67936b8c4b12b8438434f393104579"
+  dependencies:
+    apollo-utilities "^1.0.8"
+    graphql-anywhere "^4.1.0-alpha.0"
 
 apollo-link@^1.0.0, apollo-link@^1.0.6, apollo-link@^1.2.1:
   version "1.2.1"
@@ -373,7 +398,7 @@ apollo-tracing@^0.1.0:
   dependencies:
     graphql-extensions "~0.0.9"
 
-apollo-utilities@^1.0.0, apollo-utilities@^1.0.1, apollo-utilities@^1.0.11:
+apollo-utilities@^1.0.0, apollo-utilities@^1.0.1, apollo-utilities@^1.0.11, apollo-utilities@^1.0.8:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/apollo-utilities/-/apollo-utilities-1.0.11.tgz#cd36bfa6e5c04eea2caf0c204a0f38a0ad550802"
 
@@ -4685,7 +4710,7 @@ graceful-fs@^4.1.10, graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/graceful-readlink/-/graceful-readlink-1.0.1.tgz#4cafad76bc62f02fa039b2f94e9a3dd3a391a725"
 
-graphql-anywhere@^4.1.8:
+graphql-anywhere@^4.1.0-alpha.0, graphql-anywhere@^4.1.8:
   version "4.1.8"
   resolved "https://registry.yarnpkg.com/graphql-anywhere/-/graphql-anywhere-4.1.8.tgz#23882e6a16ec824febbe5bca40937cdd76c5acdc"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -4931,6 +4931,12 @@ hoist-non-react-statics@^2.3.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.0.tgz#d2ca2dfc19c5a91c5a6615ce8e564ef0347e2a40"
 
+home-config@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/home-config/-/home-config-0.1.0.tgz#1bce40cdeeb4fab819cdf6e686dd02f486a90147"
+  dependencies:
+    ini "~1.2.1"
+
 home-or-tmp@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/home-or-tmp/-/home-or-tmp-2.0.0.tgz#e36c3f2d2cae7d746a857e38d18d5f32a7882db8"
@@ -5201,6 +5207,10 @@ inherits@2.0.1:
 ini@^1.3.2, ini@~1.3.0:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
+
+ini@~1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/ini/-/ini-1.2.1.tgz#7f774e2f22752cd1dacbf9c63323df2a164ebca3"
 
 inline-source-map@~0.6.0:
   version "0.6.2"


### PR DESCRIPTION
This adds a WIP OpenNeuro CLI package with command line argument handling.

Login gives a link to directions for getting an API key (directions do not yet exist) and saves it to a common configuration path (platform user directory -> .openneuro) in JSON format.

Upload is a stub in this PR.

This depends on another new package, openneuro-client which is shared logic for the CLI tool and the React frontend.

Example usage for testing:
```shell
cd openneuro/packages/openneuro-cli
yarn run openneuro -h
```

A more complete version will be published to NPM and be installed via `npm install openneuro-cli` or `yarn add openneuro-cli`.

Related to issue #200 