### PR TITLE
update the from address in comment notifications

### DIFF
--- a/packages/openneuro-server/libs/email/index.js
+++ b/packages/openneuro-server/libs/email/index.js
@@ -38,7 +38,6 @@ export default {
     // configure mail options
     var mailOptions = {
       from: '"OpenNeuro" <notifications@openneuro.org>',
-      // sender: from2,
       replyTo: from,
       to: email.to,
       subject: email.subject,

--- a/packages/openneuro-server/libs/email/index.js
+++ b/packages/openneuro-server/libs/email/index.js
@@ -37,7 +37,9 @@ export default {
     
     // configure mail options
     var mailOptions = {
-      from: from,
+      from: '"OpenNeuro" <notifications@openneuro.org>',
+      // sender: from2,
+      replyTo: from,
       to: email.to,
       subject: email.subject,
       html: html,


### PR DESCRIPTION
 notification emails will now appear to be sent from "OpenNeuro <notifications@openneuro.org>"