### PR TITLE
relocate modal positive action buttons

### DIFF
--- a/packages/openneuro-app/src/sass/crn_app/_elements-wrappers.scss
+++ b/packages/openneuro-app/src/sass/crn_app/_elements-wrappers.scss
@@ -310,6 +310,12 @@ h6 {
     float: right !important;
 }
 
+.btn-modal-action { @extend %btn-submit-other}
+
+.btn-modal-action { 
+    margin-left: 30px;
+}
+
 .btn-modal-danger{
     border-color: $brand-danger;
     color: $brand-danger;

--- a/packages/openneuro-app/src/scripts/dataset/tools/jobs/index.js
+++ b/packages/openneuro-app/src/scripts/dataset/tools/jobs/index.js
@@ -405,7 +405,7 @@ class JobMenu extends Reflux.Component {
     let startLink =
       selectedAppKey && selectedVersionID ? (
         <button
-          className="btn-modal-submit"
+          className="btn-modal-action"
           onClick={this._checkSubmitStatus.bind(this)}>
           Start
         </button>
@@ -413,8 +413,8 @@ class JobMenu extends Reflux.Component {
 
     return (
       <div className="col-xs-12 dataset-form-controls modal-actions">
-        {startLink}
         {returnLink}
+        {startLink}
       </div>
     )
   }

--- a/packages/openneuro-app/src/scripts/dataset/tools/publish.jsx
+++ b/packages/openneuro-app/src/scripts/dataset/tools/publish.jsx
@@ -228,15 +228,15 @@ class Publish extends Reflux.Component {
     let submitButton
     if (this.state.selectedSnapshot) {
       submitButton = (
-        <button className="btn-modal-submit" onClick={this._publish.bind(this)}>
+        <button className="btn-modal-action" onClick={this._publish.bind(this)}>
           Publish
         </button>
       )
     }
     return (
       <div className="col-xs-12 modal-actions">
-        {submitButton}
         {this._datasetLink()}
+        {submitButton}
       </div>
     )
   }

--- a/packages/openneuro-app/src/scripts/dataset/tools/share.jsx
+++ b/packages/openneuro-app/src/scripts/dataset/tools/share.jsx
@@ -117,12 +117,13 @@ class Share extends Reflux.Component {
               </div>
             </div>
             <div className="dataset-form-controls col-xs-12">
+              {returnLink}
               <button
-                className="btn-modal-submit"
+                className="btn-modal-action"
                 onClick={this._addUser.bind(this)}>
                 share
               </button>
-              {returnLink}
+              
             </div>
           </div>
         </div>

--- a/packages/openneuro-app/src/scripts/dataset/tools/snapshot.jsx
+++ b/packages/openneuro-app/src/scripts/dataset/tools/snapshot.jsx
@@ -357,7 +357,7 @@ class Snapshot extends Reflux.Component {
       } else {
         return (
           <button
-            className="btn-modal-submit btn-dataset-submit"
+            className="btn-modal-action"
             onClick={this.submit.bind(this)}
             title={buttonTitle}
             disabled={disabled}>

--- a/packages/openneuro-app/src/scripts/dataset/tools/subscribe.jsx
+++ b/packages/openneuro-app/src/scripts/dataset/tools/subscribe.jsx
@@ -84,10 +84,10 @@ class Subscribe extends Reflux.Component {
   _controls() {
     return (
       <div className="follow-controls">
+        {this._returnButton()}
         {this._followButton()}
         {this._signinButton()}
         {this._continueButton()}
-        {this._returnButton()}
       </div>
     )
   }
@@ -101,7 +101,7 @@ class Subscribe extends Reflux.Component {
       return (
         <Link to={this.state.datasets.datasetUrl}>
           <button
-            className="btn-modal-submit"
+            className="btn-modal-action"
             onClick={this._createSubscription.bind(this)}>
             follow
           </button>
@@ -125,7 +125,7 @@ class Subscribe extends Reflux.Component {
     if (this.state.hasToken && this.state.datasets.subscribed) {
       return (
         <Link to={this.props.location.pathname}>
-          <button className="btn-modal-submit" onClick={this.props.onHide}>
+          <button className="btn-modal-action" onClick={this.props.onHide}>
             got it
           </button>
         </Link>
@@ -148,7 +148,7 @@ class Subscribe extends Reflux.Component {
     if (!this.state.hasToken) {
       return (
         <button
-          className="btn-modal-submit"
+          className="btn-modal-action"
           onClick={userActions.toggle.bind(this, 'loginModal')}>
           sign in to follow
         </button>


### PR DESCRIPTION
fixes #563 

- updates location for each confirmation / positive action button within the 'modals'
- fixes the following pages - 
  * snapshot
  * publish
  * jobs
  * subscribe
  * share