### PR TITLE
Misc CLI improvements

### DIFF
--- a/packages/openneuro-cli/src/__tests__/datasets.spec.js
+++ b/packages/openneuro-cli/src/__tests__/datasets.spec.js
@@ -12,12 +12,18 @@ describe('datasets.js', () => {
         .then(() => expect(client.mutate).toHaveBeenCalledTimes(1))
         .then(done)
     })
-    it('does not call createDataset when passed a dataset id', done => {
-      const client = { mutate: jest.fn() }
+    it('queries for a dataset when passed a dataset id', done => {
+      const client = {
+        mutate: jest.fn(),
+        query: jest.fn(() =>
+          Promise.resolve({ data: { createDataset: { id: 'testid' } } }),
+        ),
+      }
       getOrCreateDataset(client, 'test dataset', 'ds42')
         .then(dsId => {
           expect(dsId).toBe('ds42')
           expect(client.mutate).not.toHaveBeenCalled()
+          expect(client.query).toHaveBeenCalled()
         })
         .then(done)
     })

--- a/packages/openneuro-cli/src/__tests__/files.spec.js
+++ b/packages/openneuro-cli/src/__tests__/files.spec.js
@@ -10,7 +10,7 @@ jest.mock('fs', () => new (require('metro-memory-fs'))())
 describe('files.js', () => {
   describe('getFileTree', () => {
     beforeEach(() => {
-      require('fs').reset()
+      fs.reset()
       tmpPath = '/testing'
       // Some directory complexity to test against
       fs.mkdirSync(tmpPath)
@@ -30,7 +30,7 @@ describe('files.js', () => {
     })
     it('should return a tree', done => {
       files
-        .getFileTree(tmpPath, tmpPath)
+        .getFileTree(tmpPath, tmpPath, false)
         .then(tree => {
           expect(tree).toHaveProperty('files')
           expect(tree.files).toHaveLength(2)
@@ -43,7 +43,7 @@ describe('files.js', () => {
     })
     it('should include relative directory names at each node', done => {
       files
-        .getFileTree(tmpPath, tmpPath)
+        .getFileTree(tmpPath, tmpPath, false)
         .then(tree => {
           expect(tree).toHaveProperty('name')
           expect(tree.name).toBe('')

--- a/packages/openneuro-cli/src/__tests__/files.spec.js
+++ b/packages/openneuro-cli/src/__tests__/files.spec.js
@@ -7,28 +7,27 @@ let tmpPath
 // Must be require for Jest's implementation
 jest.mock('fs', () => new (require('metro-memory-fs'))())
 
-beforeEach(() => {
-  require('fs').reset()
-  tmpPath = '/testing'
-  // Some directory complexity to test against
-  fs.mkdirSync(tmpPath)
-  fs.mkdirSync(path.join(tmpPath, 'dir'))
-  fs.mkdirSync(path.join(tmpPath, 'dir/dir2'))
-  fs.mkdirSync(path.join(tmpPath, 'dir3'))
-  const testFiles = [
-    'test',
-    'test2',
-    'dir/test3',
-    'dir/dir2/test4',
-    'dir3/test5',
-  ]
-  for (const filePath of testFiles) {
-    fs.writeFileSync(path.join(tmpPath, filePath), filePath)
-  }
-})
-
 describe('files.js', () => {
   describe('getFileTree', () => {
+    beforeEach(() => {
+      require('fs').reset()
+      tmpPath = '/testing'
+      // Some directory complexity to test against
+      fs.mkdirSync(tmpPath)
+      fs.mkdirSync(path.join(tmpPath, 'dir'))
+      fs.mkdirSync(path.join(tmpPath, 'dir/dir2'))
+      fs.mkdirSync(path.join(tmpPath, 'dir3'))
+      const testFiles = [
+        'test',
+        'test2',
+        'dir/test3',
+        'dir/dir2/test4',
+        'dir3/test5',
+      ]
+      for (const filePath of testFiles) {
+        fs.writeFileSync(path.join(tmpPath, filePath), filePath)
+      }
+    })
     it('should return a tree', done => {
       files
         .getFileTree(tmpPath, tmpPath)
@@ -51,6 +50,39 @@ describe('files.js', () => {
           expect(tree.directories[0].name).toBe('dir')
         })
         .then(done)
+    })
+  })
+  describe('fileProgress', () => {
+    it('returns a valid percentage', () => {
+      const progress = files.fileProgress(
+        { log: jest.fn() },
+        'test',
+        { bytesRead: 100 },
+        200,
+      )()
+      expect(progress.percentage).toBe(50)
+    })
+    it('returns a correct remainingBytes', () => {
+      const progress = files.fileProgress(
+        { log: jest.fn() },
+        'test',
+        { bytesRead: 100 },
+        200,
+      )()
+      expect(progress.remainingBytes).toBe(100)
+    })
+    it('formats status with all values', () => {
+      const mockConsole = { log: jest.fn() }
+      const progress = files.fileProgress(
+        mockConsole,
+        'test',
+        { bytesRead: 100 },
+        200,
+      )()
+      expect(mockConsole.log).toHaveBeenCalled()
+      expect(mockConsole.log).toHaveBeenCalledWith(
+        'Transferring "test" - 50% complete (100 Bytes) remaining)',
+      )
     })
   })
 })

--- a/packages/openneuro-cli/src/__tests__/files.spec.js
+++ b/packages/openneuro-cli/src/__tests__/files.spec.js
@@ -73,12 +73,7 @@ describe('files.js', () => {
     })
     it('formats status with all values', () => {
       const mockConsole = { log: jest.fn() }
-      const progress = files.fileProgress(
-        mockConsole,
-        'test',
-        { bytesRead: 100 },
-        200,
-      )()
+      files.fileProgress(mockConsole, 'test', { bytesRead: 100 }, 200)()
       expect(mockConsole.log).toHaveBeenCalled()
       expect(mockConsole.log).toHaveBeenCalledWith(
         'Transferring "test" - 50% complete (100 Bytes) remaining)',

--- a/packages/openneuro-cli/src/__tests__/utils.spec.js
+++ b/packages/openneuro-cli/src/__tests__/utils.spec.js
@@ -1,0 +1,15 @@
+import { debounce } from '../utils'
+
+describe('cli utils', () => {
+  describe('debounce', () => {
+    it('should debounce functions', () => {
+      jest.useFakeTimers()
+      const mockFn = jest.fn()
+      const debounced = debounce(mockFn, 1000)
+      debounced()
+      debounced()
+      jest.runAllTimers()
+      expect(mockFn).toHaveBeenCalledTimes(1)
+    })
+  })
+})

--- a/packages/openneuro-cli/src/actions.js
+++ b/packages/openneuro-cli/src/actions.js
@@ -48,7 +48,11 @@ export const upload = (dir, cmd) => {
     // TODO - This URL (at least the hostname) should be configurable
     const client = createClient('http://localhost:9876/crn/graphql')
     return getOrCreateDataset(client, dir, cmd.datasetId).then(
-      validateAndUpload(client, dir),
+      validateAndUpload(client, dir, {
+        ignoreWarnings: cmd.ignoreWarnings,
+        ignoreNiftiHeaders: cmd.ignoreNiftiHeaders,
+        verbose: cmd.verbose,
+      }),
     )
   } catch (e) {
     // eslint-disable-next-line no-console

--- a/packages/openneuro-cli/src/actions.js
+++ b/packages/openneuro-cli/src/actions.js
@@ -56,8 +56,8 @@ export const upload = (dir, cmd) => {
       ignoreNiftiHeaders: cmd.ignoreNiftiHeaders,
       verbose: cmd.verbose,
     }
-    // eslint-disable-next-line no-console
     if (cmd.dataset) {
+      // eslint-disable-next-line no-console
       console.log(`Adding files to "${cmd.dataset}"`)
       uploadDataset(dir, cmd.dataset, validatorOptions)
     } else {

--- a/packages/openneuro-cli/src/actions.js
+++ b/packages/openneuro-cli/src/actions.js
@@ -58,7 +58,7 @@ export const upload = (dir, cmd) => {
     }
     // eslint-disable-next-line no-console
     if (cmd.dataset) {
-      console.log(`Updating ${cmd.dataset}`)
+      console.log(`Adding files to "${cmd.dataset}"`)
       uploadDataset(dir, cmd.dataset, validatorOptions)
     } else {
       inquirer

--- a/packages/openneuro-cli/src/cli.js
+++ b/packages/openneuro-cli/src/cli.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import commander from 'commander'
+import colors from 'colors'
 import packageJson from '../package.json'
 import { login, upload } from './actions.js'
 
@@ -20,3 +21,11 @@ commander
   .action(upload)
 
 commander.parse(process.argv)
+
+if (!process.argv.slice(2).length) {
+  commander.outputHelp(make_red)
+}
+
+function make_red(txt) {
+  return colors.red(txt) //display the help text in red on the console
+}

--- a/packages/openneuro-cli/src/cli.js
+++ b/packages/openneuro-cli/src/cli.js
@@ -18,6 +18,12 @@ commander
   .alias('sync')
   .description('Upload or sync a dataset (if a accession number is provided)')
   .option('-d, --dataset [dsId]', 'Specify the dataset to update')
+  .option('-i, --ignoreWarnings', 'Ignore validation warnings when uploading')
+  .option(
+    '-n, --ignoreNiftiHeaders',
+    'Disregard NIfTI header content during validation',
+  )
+  .option('-v, --verbose', 'Verbose output')
   .action(upload)
 
 commander.parse(process.argv)

--- a/packages/openneuro-cli/src/datasets.js
+++ b/packages/openneuro-cli/src/datasets.js
@@ -7,7 +7,12 @@ import { datasets } from 'openneuro-client'
 export const getOrCreateDataset = (client, dir, datasetId) => {
   const label = path.basename(dir)
   if (datasetId) {
-    return Promise.resolve(datasetId)
+    return client
+      .query({
+        query: datasets.getDataset,
+        variables: { id: datasetId },
+      })
+      .then(() => datasetId)
   } else {
     return client
       .mutate({

--- a/packages/openneuro-cli/src/files.js
+++ b/packages/openneuro-cli/src/files.js
@@ -1,10 +1,31 @@
 import fs from 'fs'
 import path from 'path'
 import { promisify } from 'util'
+import { debounce } from './utils'
 
 const readdir = promisify(fs.readdir)
 
-export const getFileTree = (basepath, root) => {
+const bytesToSize = bytes => {
+  const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB']
+  if (bytes === 0) return 'n/a'
+  const i = parseInt(String(Math.floor(Math.log(bytes) / Math.log(1024))), 10)
+  if (i === 0) return `${bytes} ${sizes[i]})`
+  return `${(bytes / 1024 ** i).toFixed(1)} ${sizes[i]}`
+}
+
+export const fileProgress = (console, filename, stream, size) => () => {
+  const percentage = Math.round(100 * (stream.bytesRead / size))
+  const remainingBytes = size - stream.bytesRead
+  const remaining = remainingBytes
+    ? `(${bytesToSize(remainingBytes)} remaining)`
+    : ''
+  console.log(
+    `Transferring "${filename}" - ${percentage}% complete ${remaining}`,
+  )
+  return { percentage, remainingBytes }
+}
+
+export const getFileTree = (basepath, root, logging = true) => {
   return readdir(root).then(async contents => {
     // Run stat for each file
     const stats = contents.map(filePath => ({
@@ -18,7 +39,16 @@ export const getFileTree = (basepath, root) => {
       name: path.relative(basepath, root),
       files: stats
         .filter(({ stat }) => stat.isFile())
-        .map(({ filePath }) => fs.createReadStream(filePath)),
+        .map(({ stat, filePath }) => {
+          const stream = fs.createReadStream(filePath)
+          if (logging) {
+            stream.on(
+              'data',
+              debounce(fileProgress(console, filePath, stream, stat.size), 500),
+            )
+          }
+          return stream
+        }),
       directories: await Promise.all(
         // This is an array of each promise related to the next level in the tree
         stats

--- a/packages/openneuro-cli/src/files.js
+++ b/packages/openneuro-cli/src/files.js
@@ -53,7 +53,7 @@ export const getFileTree = (basepath, root, logging = true) => {
         // This is an array of each promise related to the next level in the tree
         stats
           .filter(({ stat }) => stat.isDirectory())
-          .map(({ filePath }) => getFileTree(basepath, filePath)),
+          .map(({ filePath }) => getFileTree(basepath, filePath, logging)),
       ),
     }
   })

--- a/packages/openneuro-cli/src/upload.js
+++ b/packages/openneuro-cli/src/upload.js
@@ -34,8 +34,12 @@ const fatalError = err => {
  * @param {string} dir - Directory to upload
  * @param {string} datasetId - Optionally update an existing dataset
  */
-export const validateAndUpload = (client, dir) => datasetId => {
-  return validatePromise(dir)
+export const validateAndUpload = (
+  client,
+  dir,
+  validatorOptions,
+) => datasetId => {
+  return validatePromise(dir, validatorOptions)
     .catch(fatalError)
     .then(() => datasetUpload(client, dir, datasetId))
     .catch(fatalError)

--- a/packages/openneuro-cli/src/utils.js
+++ b/packages/openneuro-cli/src/utils.js
@@ -1,0 +1,10 @@
+export const debounce = (fn, time) => {
+  let timeout
+
+  return () => {
+    const functionCall = () => fn.apply(this, arguments)
+
+    clearTimeout(timeout)
+    timeout = setTimeout(functionCall, time)
+  }
+}


### PR DESCRIPTION
A bunch of small fixes and improvements to the CLI.

* Shows help text when run without arguments
* Displays upload progress per file (at least once per file, at most twice per second)
* Asks for confirmation when creating a new dataset.
* Allows you to add files to datasets specified with the --dataset option.
* Warns you when you try to upload to a dataset that does not exist (though this feature depends on fixes in the API that are not in this branch).