### PR TITLE
App container build paths fix

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -29,7 +29,7 @@ deployment:
     commands:
       - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
       - docker build --pull -t openneuro/server packages/openneuro-server
-      - docker build --pull -t openneuro/app packages/openneuro-app
+      - docker build --pull -t openneuro/app -f packages/openneuro-app/Dockerfile .
       # Update latest tag
       - docker tag -f openneuro/server openneuro/server:latest
       - docker tag -f openneuro/app openneuro/app:latest
@@ -40,7 +40,7 @@ deployment:
     commands:
       - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
       - docker build --pull -t openneuro/server packages/openneuro-server
-      - docker build --pull -t openneuro/app packages/openneuro-app
+      - docker build --pull -t openneuro/app -f packages/openneuro-app/Dockerfile .
       # Update latest tag
       - docker tag -f openneuro/server openneuro/server:$CIRCLE_BRANCH
       - docker tag -f openneuro/app openneuro/app:$CIRCLE_BRANCH
@@ -51,7 +51,7 @@ deployment:
     commands:
       - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
       - docker build --pull -t openneuro/server packages/openneuro-server
-      - docker build --pull -t openneuro/app packages/openneuro-app
+      - docker build --pull -t openneuro/app -f packages/openneuro-app/Dockerfile .
       - docker tag openneuro/server openneuro/server:$CIRCLE_TAG
       - docker tag openneuro/app openneuro/app:$CIRCLE_TAG
       - docker push openneuro/server:$CIRCLE_TAG

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -10,12 +10,14 @@ services:
   # web app bundle build
   app:
     build:
-      context: ./packages/openneuro-app
-    command: sh -c "yarn install --pure-lockfile && yarn start --watch --watch-poll ${WEBPACK_POLL_INTERVAL}"
+      context: .
+      dockerfile: ./packages/openneuro-app/Dockerfile
+    working_dir: /srv/packages/openneuro-app
+    command: sh -c "yarn install && yarn start --watch"
     volumes:
-      - ./packages/openneuro-app:/srv
+      - .:/srv
       - yarn_cache:/root/.cache
-      - project:/srv/dist
+      - project:/srv/packages/openneuro-app/dist
     tmpfs:
       - /srv/node_modules:exec
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -20,6 +20,7 @@ services:
       - project:/srv/packages/openneuro-app/dist
     tmpfs:
       - /srv/node_modules:exec
+      - /srv/packages/openneuro-app/node_modules:exec
 
   # crn core (bids-core)
   core:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
   app:
     image: openneuro/app:${CRN_APP_TAG}
     volumes:
-      - project:/srv/dist
+      - project:/srv/packages/openneuro-app/dist
     env_file: ./config.env
 
   # crn core (bids-core)

--- a/packages/openneuro-app/Dockerfile
+++ b/packages/openneuro-app/Dockerfile
@@ -5,9 +5,9 @@ RUN apk --no-cache --update add git
 ADD . /srv
 
 # setup app directory
-WORKDIR /srv
+WORKDIR /srv/packages/openneuro-app
 
 # Build the frontend
-RUN npm install -g yarn && yarn install --pure-lockfile
+RUN npm install -g yarn && yarn install --pure-lockfile && yarn bootstrap
 
 CMD yarn build

--- a/packages/openneuro-app/Dockerfile
+++ b/packages/openneuro-app/Dockerfile
@@ -5,9 +5,11 @@ RUN apk --no-cache --update add git
 ADD . /srv
 
 # setup app directory
-WORKDIR /srv/packages/openneuro-app
+WORKDIR /srv
 
 # Build the frontend
 RUN npm install -g yarn && yarn install --pure-lockfile && yarn bootstrap
+
+WORKDIR /srv/packages/openneuro-app
 
 CMD yarn build

--- a/packages/openneuro-app/package.json
+++ b/packages/openneuro-app/package.json
@@ -30,6 +30,7 @@
     "load-google-api": "^0.1.3",
     "loadable-components": "^0.4.0",
     "moment": "^2.10.3",
+    "openneuro-client": "^1.12.0",
     "pluralize": "^7.0.0",
     "prismjs": "^1.10.0",
     "prop-types": "^15.6.0",
@@ -92,14 +93,11 @@
     "webpack-visualizer-plugin": "^0.1.11"
   },
   "jest": {
-    "setupFiles": [
-      "./jestsetup.js"
-    ],
-    "snapshotSerializers": [
-      "enzyme-to-json/serializer"
-    ],
+    "setupFiles": ["./jestsetup.js"],
+    "snapshotSerializers": ["enzyme-to-json/serializer"],
     "moduleNameMapper": {
-      "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/__mocks__/fileMock.js",
+      "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$":
+        "<rootDir>/__mocks__/fileMock.js",
       "\\.(css|less)$": "<rootDir>/__mocks__/styleMock.js"
     },
     "collectCoverageFrom": [

--- a/packages/openneuro-client/package.json
+++ b/packages/openneuro-client/package.json
@@ -3,13 +3,15 @@
   "version": "1.12.0",
   "description": "OpenNeuro shared client library.",
   "main": "src/index.js",
+  "browser": "src/client.js",
   "repository": "git@github.com:OpenNeuroOrg/openneuro.git",
   "author": "Squishymedia",
   "license": "MIT",
   "dependencies": {
     "apollo-boost": "^0.1.4",
     "apollo-link": "^1.2.1",
-    "apollo-upload-client": "https://github.com/danielmeneses/apollo-upload-client.git",
+    "apollo-upload-client":
+      "https://github.com/danielmeneses/apollo-upload-client.git",
     "esm": "^3.0.16",
     "form-data": "^2.3.2",
     "graphql": "^0.13.2",


### PR DESCRIPTION
This fixes the repo internal imports made from webpack. This bloats the image but is needed because Docker does not follow the symlinks made in the node_modules directory. With this change you can import sibling dependencies in the docker-compose environment without having to publish on every change.