### PR TITLE
Add a catch to revalidate and clear validating tag

### DIFF
--- a/packages/openneuro-app/src/scripts/dataset/dataset.store.js
+++ b/packages/openneuro-app/src/scripts/dataset/dataset.store.js
@@ -1277,21 +1277,30 @@ let datasetStore = Reflux.createStore({
    */
   revalidate() {
     let dataset = this.data.dataset
-    scitran.addTag('projects', dataset._id, 'validating').then(() => {
-      dataset.status.validating = true
-      this.update({ dataset })
-      crn.validate(dataset._id).then(res => {
-        let validation = res.body.validation
-        dataset.status.validating = false
-        dataset.validation = validation
-        dataset.summary = res.body.summary
-        dataset.status.invalid =
-          validation.errors &&
-          (validation.errors == 'Invalid' || validation.errors.length > 0)
+    scitran
+      .addTag('projects', dataset._id, 'validating')
+      .then(() => {
+        dataset.status.validating = true
         this.update({ dataset })
-        this.updateModified()
+        return crn.validate(dataset._id).then(res => {
+          let validation = res.body && res.body.validation
+          dataset.status.validating = false
+          dataset.validation = validation
+          dataset.summary = res.body && res.body.summary
+          dataset.status.invalid =
+            validation.errors &&
+            (validation.errors == 'Invalid' || validation.errors.length > 0)
+          this.update({ dataset })
+          this.updateModified()
+        })
       })
-    })
+      .catch(e => {
+        if (dataset.status.validating) {
+          scitran.removeTag('projects', dataset._id, 'validating')
+          dataset.status.validating = false
+          this.update({ dataset })
+        }
+      })
   },
 
   /**

--- a/packages/openneuro-app/src/scripts/dataset/dataset.store.js
+++ b/packages/openneuro-app/src/scripts/dataset/dataset.store.js
@@ -1288,6 +1288,7 @@ let datasetStore = Reflux.createStore({
           dataset.validation = validation
           dataset.summary = res.body && res.body.summary
           dataset.status.invalid =
+            validation &&
             validation.errors &&
             (validation.errors == 'Invalid' || validation.errors.length > 0)
           this.update({ dataset })

--- a/packages/openneuro-app/src/scripts/dataset/dataset.store.js
+++ b/packages/openneuro-app/src/scripts/dataset/dataset.store.js
@@ -1294,7 +1294,7 @@ let datasetStore = Reflux.createStore({
           this.updateModified()
         })
       })
-      .catch(e => {
+      .catch(() => {
         if (dataset.status.validating) {
           scitran.removeTag('projects', dataset._id, 'validating')
           dataset.status.validating = false


### PR DESCRIPTION
There was no error handling client side for validation http errors (different than validation failures). This adds a catch to clear the validation flag if there is an error from validation request.