### PR TITLE
updateREADME alters the modified date in scitran

### DIFF
--- a/packages/openneuro-app/src/scripts/dataset/dataset.store.js
+++ b/packages/openneuro-app/src/scripts/dataset/dataset.store.js
@@ -805,7 +805,7 @@ let datasetStore = Reflux.createStore({
         [],
       )
       .then(res => {
-        scitran.updateModified(dataset._id).then(() => {
+        scitran.updateProject(dataset._id, {}).then(() => {
           callback(null, res)
           dataset.README = value
           this.update({ dataset })

--- a/packages/openneuro-app/src/scripts/dataset/dataset.store.js
+++ b/packages/openneuro-app/src/scripts/dataset/dataset.store.js
@@ -805,10 +805,12 @@ let datasetStore = Reflux.createStore({
         [],
       )
       .then(res => {
-        callback(null, res)
-        dataset.README = value
-        this.update({ dataset })
-        this.updateModified()
+        scitran.updateModified(dataset._id).then(() => {
+          callback(null, res)
+          dataset.README = value
+          this.update({ dataset })
+          this.updateModified()
+        })
       })
   },
 


### PR DESCRIPTION
fixes #612

updating the readme via the ui changed the modified date for the dataset store only, and did not actually update the modified date on the scitran project. This pr fixes that.