### PR TITLE
Updating validator (after fixing deployment issue)

### DIFF
--- a/packages/openneuro-app/package.json
+++ b/packages/openneuro-app/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "async": "^2.6.0",
     "babel-runtime": "^6.26.0",
-    "bids-validator": "^0.26.6",
+    "bids-validator": "^0.26.10",
     "bowser": "^1.7.3",
     "bytes": "^3.0.0",
     "codecov": "^3.0.0",

--- a/packages/openneuro-cli/package.json
+++ b/packages/openneuro-cli/package.json
@@ -10,7 +10,7 @@
     "openneuro": "./src/index.js"
   },
   "dependencies": {
-    "bids-validator": "^0.26.6",
+    "bids-validator": "^0.26.10",
     "commander": "^2.15.1",
     "esm": "^3.0.16",
     "find-config": "^1.0.0",

--- a/packages/openneuro-server/package.json
+++ b/packages/openneuro-server/package.json
@@ -25,7 +25,7 @@
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "base64url": "^2.0.0",
     "bcrypt": "^2.0.1",
-    "bids-validator": "^0.26.6",
+    "bids-validator": "^0.26.10",
     "body-parser": "^1.18.2",
     "cron": "^1.1.0",
     "draft-js": "^0.10.5",


### PR DESCRIPTION
There was a bug in the circle deployment code for the bids validator causing the last 3-4 versions to be identical. This update brings the latest (this time for real!) version of the validator.