### PR TITLE
Upload deadlock fix and better CLI progress

### DIFF
--- a/packages/openneuro-cli/src/files.js
+++ b/packages/openneuro-cli/src/files.js
@@ -41,6 +41,7 @@ export const getFileTree = (basepath, root, logging = true) => {
         .filter(({ stat }) => stat.isFile())
         .map(({ stat, filePath }) => {
           const stream = fs.createReadStream(filePath)
+          stream.pause()
           if (logging) {
             stream.on(
               'data',

--- a/packages/openneuro-cli/src/files.js
+++ b/packages/openneuro-cli/src/files.js
@@ -43,7 +43,7 @@ export const getFileTree = (basepath, root, logging = true) => {
           const stream = fs.createReadStream(filePath)
           if (logging) {
             stream.on(
-              'readable',
+              'data',
               debounce(fileProgress(console, filePath, stream, stat.size), 500),
             )
           }

--- a/packages/openneuro-server/datalad/dataset.js
+++ b/packages/openneuro-server/datalad/dataset.js
@@ -108,16 +108,21 @@ const fileUrl = (datasetId, path, filename) => {
 /**
  * Add files to a dataset
  */
-export const addFile = async (datasetId, path, { filename, stream }) => {
+export const addFile = (datasetId, path, file) => {
   // Cannot use superagent 'request' due to inability to post streams
-  return stream
-    .pipe(requestNode.post(fileUrl(datasetId, path, filename)))
-    .on('close', () => {
-      // eslint-disable-next-line no-console
-      console.warn(
-        `A client hung up the connection - ${datasetId}:${path}:${filename}`,
-      )
-    })
+  return new Promise(async (resolve, reject) => {
+    const { filename, stream, mimetype } = await file
+    stream.pipe(
+      requestNode(
+        {
+          url: fileUrl(datasetId, path, filename),
+          method: 'post',
+          headers: { 'Content-Type': mimetype },
+        },
+        err => (err ? reject(err) : resolve()),
+      ),
+    )
+  })
 }
 
 /**

--- a/packages/openneuro-server/graphql/resolvers/dataset.js
+++ b/packages/openneuro-server/graphql/resolvers/dataset.js
@@ -47,6 +47,5 @@ export const updateFilesTree = (datasetId, fileTree) => {
     datalad.addFile(datasetId, name, file),
   )
   const dirPromises = directories.map(tree => updateFilesTree(datasetId, tree))
-  console.log(filesPromises)
   return filesPromises.concat(...dirPromises)
 }


### PR DESCRIPTION
This prevents a deadlock in file uploads caused by chaining Promise.all. Instead, the entire tree is hoisted to updateFiles and Promise.all is called once.

Progress is also more reliable with large single files.