### PR TITLE
Don't display deleted draft info when not an owner

### DIFF
--- a/packages/openneuro-app/src/scripts/dataset/dataset.store.js
+++ b/packages/openneuro-app/src/scripts/dataset/dataset.store.js
@@ -1983,7 +1983,14 @@ let datasetStore = Reflux.createStore({
       }
 
       // add draft is available
-      if (dataset && dataset.permissions && !dataset.permissions.length) {
+      if (
+        dataset &&
+        this.data.currentUser &&
+        this.data.currentUser.profile &&
+        dataset.user._id === this.data.currentUser.profile._id &&
+        dataset.permissions &&
+        !dataset.permissions.length
+      ) {
         snapshots.unshift({
           orphaned: true,
         })


### PR DESCRIPTION
Closes #579 

Logged owner of deleted dataset
<img width="547" alt="screenshot_73" src="https://user-images.githubusercontent.com/238759/39669522-0d482250-50a3-11e8-8c9e-02398207c3d9.png">

Logged owner of a normal dataset
<img width="550" alt="screenshot_74" src="https://user-images.githubusercontent.com/238759/39669523-1a59d7ea-50a3-11e8-86c0-e643d0df0e99.png">

Guest - deleted dataset
<img width="561" alt="screenshot_75" src="https://user-images.githubusercontent.com/238759/39669526-2ea3e4de-50a3-11e8-8f1f-e58142a8bace.png">

Guest - normal dataset
<img width="520" alt="screenshot_76" src="https://user-images.githubusercontent.com/238759/39669528-47bd7962-50a3-11e8-8a96-eda4c2be2950.png">
