### PR TITLE
Flower container for monitoring Celery tasks

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -80,6 +80,18 @@ services:
     restart: always
     env_file: ./config.env
 
+  flower:
+    image: openneuro/datalad-service:${DATALAD_SERVICE_TAG}
+    command:
+      - flower
+      - -A
+      - datalad_service.worker
+      - --broker
+      - redis://redis
+    env_file: ./config.env
+    restart: always
+    ports:
+      - "5555:5555"
 
   # nginx - static file serving and service proxy
   nginx:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,6 +76,7 @@ services:
       - "1"
     volumes:
       - ${PERSISTENT_DIR}/datalad:/datalad
+      - ./datalad-key:/datalad-key
     restart: always
     env_file: ./config.env
 


### PR DESCRIPTION
This adds [Flower](http://flower.readthedocs.io/en/latest/) support and fixes a missing ssh key in the celery workers.