### PR TITLE
Datalad datasets page

### DIFF
--- a/packages/openneuro-app/config.js
+++ b/packages/openneuro-app/config.js
@@ -64,5 +64,6 @@ export default {
 
   datalad: {
     enabled: process.env.CRN_SERVER_DATALAD,
+    uri: 'datalad:9877'
   },
 }

--- a/packages/openneuro-app/package.json
+++ b/packages/openneuro-app/package.json
@@ -29,6 +29,7 @@
     "jszip": "^3.1.5",
     "load-google-api": "^0.1.3",
     "loadable-components": "^0.4.0",
+    "lodash.clonedeep": "^4.5.0",
     "moment": "^2.10.3",
     "openneuro-client": "^1.13.0",
     "pluralize": "^7.0.0",

--- a/packages/openneuro-app/src/scripts/common/forms/click-to-edit.jsx
+++ b/packages/openneuro-app/src/scripts/common/forms/click-to-edit.jsx
@@ -93,8 +93,7 @@ class ClickToEdit extends React.Component {
         input = (
           <ArrayInput
             model={[
-              { id: 'name', placeholder: 'Name', required: true },
-              { id: 'ORCIDID', placeholder: 'ORCID ID' },
+              { id: 'name', placeholder: 'Name', required: true }
             ]}
             value={value}
             onChange={this._handleChange.bind(this, type)}
@@ -125,9 +124,9 @@ class ClickToEdit extends React.Component {
         input = (
           <FileArrayInput
             value={this.props.value}
-            onChange={this._handleFile}
-            onDelete={this._handleDelete}
-            onFileClick={this._download}
+            onChange={this._handleFile.bind(this)}
+            onDelete={this._handleDelete.bind(this)}
+            onFileClick={this._download.bind(this)}
           />
         )
         display = (
@@ -161,7 +160,7 @@ class ClickToEdit extends React.Component {
       return (
         <div className="fade-in" key={index}>
           <span>
-            {item.name} {item.ORCIDID ? '-' : null} {item.ORCIDID}
+            {item}
           </span>
         </div>
       )

--- a/packages/openneuro-app/src/scripts/common/partials/file-tree.jsx
+++ b/packages/openneuro-app/src/scripts/common/partials/file-tree.jsx
@@ -6,6 +6,7 @@ import WarnButton from '../forms/warn-button.jsx'
 import Spinner from './spinner.jsx'
 import files from '../../utils/files'
 import config from '../../../../config'
+import datalad from '../../utils/datalad'
 import datasetStore from '../../dataset/dataset.store.js'
 import { refluxConnect } from '../../utils/reflux'
 import { Link } from 'react-router-dom'
@@ -178,13 +179,12 @@ class FileTree extends Reflux.Component {
 
     let downloadFile
     if (!item.children) {
+      let link = 'http://localhost:9876/crn/datasets/' + bids.decodeId(this.data.dataset._id) + '/files/' + datalad.encodeFilePath(file.name)
       downloadFile = (
         <span className="download-file">
-          <WarnButton
-            icon="fa-download"
-            message="Download"
-            prepDownload={this.props.getFileDownloadTicket.bind(this, item)}
-          />
+          <a href={link} download>
+            <i className="fa fa-download" /> DOWNLOAD
+          </a>
         </span>
       )
     }
@@ -249,12 +249,12 @@ class FileTree extends Reflux.Component {
           itemUrl =
             this.state.datasets.datasetUrl +
             '/results/' +
-            encodeURIComponent(item.path)
+            datalad.encodeFilePath(item.path)
         } else {
           itemUrl =
             this.state.datasets.datasetUrl +
             '/file-display/' +
-            encodeURIComponent(item.name)
+            datalad.encodeFilePath(item.name)
         }
 
         displayBtn = (

--- a/packages/openneuro-app/src/scripts/common/partials/file-tree.jsx
+++ b/packages/openneuro-app/src/scripts/common/partials/file-tree.jsx
@@ -8,6 +8,7 @@ import files from '../../utils/files'
 import config from '../../../../config'
 import datalad from '../../utils/datalad'
 import datasetStore from '../../dataset/dataset.store.js'
+import actions from '../../dataset/dataset.actions.js'
 import { refluxConnect } from '../../utils/reflux'
 import { Link } from 'react-router-dom'
 
@@ -179,26 +180,35 @@ class FileTree extends Reflux.Component {
 
     let downloadFile
     if (!item.children) {
-      let link = 'http://localhost:9876/crn/datasets/' + bids.decodeId(this.data.dataset._id) + '/files/' + datalad.encodeFilePath(file.name)
+      let link = actions.getFileURL(this.state.datasets.dataset._id, item.name)
       downloadFile = (
         <span className="download-file">
-          <a href={link} download>
-            <i className="fa fa-download" /> DOWNLOAD
-          </a>
+          <span>
+            <a className="btn-warn-component warning" href={link} download>
+              <i className="fa fa-download" /> DOWNLOAD
+            </a>
+          </span>
         </span>
       )
     }
 
     if (!item.children) {
       if (this.props.editable && files.hasExtension(item.name, ['.json'])) {
+        let itemUrl =
+        this.state.datasets.datasetUrl +
+        '/file-edit/' +
+        datalad.encodeFilePath(item.name)
+
         editFile = (
           <span className="view-file">
-            <WarnButton
-              icon="fa-pencil"
-              warn={false}
-              message=" Edit"
-              action={this.props.editFile.bind(this, item)}
-            />
+            <Link to={itemUrl}>
+              <WarnButton
+                icon="fa-pencil"
+                warn={false}
+                message=" Edit"
+                action={() => null}
+              />
+            </Link>
           </span>
         )
       }

--- a/packages/openneuro-app/src/scripts/datalad/dataset-page.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/dataset-page.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import LeftSidebar from './left-sidebar.jsx'
 import LeftSidebarButton from './left-sidebar-button.jsx'
 import DatasetMain from './dataset-main.jsx'
+import Tools from './fragments/tools/dataset-toolbar.jsx'
 
 export default class DatasetPage extends React.Component {
   constructor(props) {
@@ -32,6 +33,7 @@ export default class DatasetPage extends React.Component {
             sidebar={this.state.sidebar}
             toggle={this.toggleSidebar}
           />
+          <Tools dataset={this.props.dataset}/>
           <div className="fade-in inner-route dataset-route light">
             <div className="clearfix dataset-wrap">
               <div className="dataset-animation">

--- a/packages/openneuro-app/src/scripts/datalad/fragments/tools/dataset-toolbar.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/fragments/tools/dataset-toolbar.jsx
@@ -1,0 +1,349 @@
+// dependencies -------------------------------------------------------
+
+import React from 'react'
+import Reflux from 'reflux'
+import PropTypes from 'prop-types'
+import { withRouter } from 'react-router-dom'
+import moment from 'moment'
+import WarnButton from '../../../common/forms/warn-button.jsx'
+import userStore from '../../../user/user.store.js'
+import actions from '../../../dataset/dataset.actions.js'
+import datasetStore from '../../../dataset/dataset.store.js'
+import { refluxConnect } from '../../../utils/reflux'
+
+class Tools extends Reflux.Component {
+  constructor() {
+    super()
+    refluxConnect(this, datasetStore, 'datasets')
+  }
+
+  // life cycle events --------------------------------------------------
+
+  componentDidMount() {
+    // let dataset = this.state.datasets.dataset
+
+    // if (dataset && (dataset.access === 'rw' || dataset.access == 'admin')) {
+    //   actions.loadUsers()
+    // }
+  }
+
+  render() {
+    let dataset = this.props.dataset
+    let datasets = this.state.datasets
+    let datasetUrl = '/datasets/' + dataset.id
+    console.log('dataset:', dataset)
+    console.log('datasets:', datasets)
+    console.log('datasetUrl:', datasetUrl)
+
+    // let dataset = datasets ? datasets.dataset : null,
+    let snapshots = dataset ? dataset.snapshots : null
+    console.log('user:', userStore)
+    console.log('location:', this.props.location)
+    if (!dataset) {
+      return null
+    }
+
+    // let datasetHasJobs = !!dataset.jobs.length
+    // // permission check shorthands
+    // let isAdmin = dataset.access === 'admin',
+    let isAdmin = !!userStore.isRoot(),
+      isSignedIn = !!userStore.hasToken(),
+      isPublic = !!dataset.public,
+      isIncomplete = !!(dataset.status && dataset.status.incomplete),
+    //   isInvalid = !!dataset.status.invalid,
+      isSnapshot = !!(this.props.location.pathname.indexOf('versions') == -1),
+      isSubscribed = !!dataset.subscribed
+    //   hasUserStar = !!dataset.hasUserStar,
+    //   hasDoi =
+    //     dataset.description.DatasetDOI &&
+    //     dataset.description.DatasetDOI.toLowerCase().indexOf('openneuro') >= 0,
+    //   isSuperuser =
+    //     window.localStorage.scitran && JSON.parse(window.localStorage.scitran)
+    //       ? JSON.parse(window.localStorage.scitran).root
+    //       : null
+
+    // let displayDelete = this._deleteDataset(
+    //   isAdmin,
+    //   isPublic,
+    //   isSuperuser,
+    //   datasetHasJobs,
+    // )
+
+    let tools = [
+      {
+        tooltip: 'Download Dataset',
+        icon: 'fa-download',
+        prepDownload: actions.getDatasetDownloadTicket.bind(this),
+        action: actions.confirmDatasetDownload.bind(this, this.props.history),
+        display: !isIncomplete,
+        warn: true,
+        modalLink: datasetUrl + '/subscribe',
+        validations: [
+          {
+            check: datasets.uploading && !isSnapshot,
+            message: 'Files are currently uploading',
+            timeout: 5000,
+            type: 'Error',
+          },
+        ],
+      },
+      {
+        tooltip: 'Publish Dataset',
+        icon: 'fa-globe icon-plus',
+        action: actions.showDatasetComponent.bind(
+          this,
+          'publish',
+          this.props.history,
+        ),
+        display: isAdmin 
+        && !isPublic, 
+        // && !isIncomplete,
+        warn: false,
+        modalLink: datasetUrl + '/publish',
+        // validations: [
+        //   {
+        //     check: datasets.uploading && !isSnapshot,
+        //     message: 'Files are currently uploading',
+        //     timeout: 5000,
+        //     type: 'Error',
+        //   },
+        // ],
+      },
+    //   {
+    //     tooltip: 'Unpublish Dataset',
+    //     icon: 'fa-globe icon-ban',
+    //     action: actions.publish.bind(
+    //       this,
+    //       dataset._id,
+    //       false,
+    //       this.props.history,
+    //     ),
+    //     display: isPublic && isSuperuser,
+    //     warn: true,
+    //     validations: [
+    //       {
+    //         check: datasets.uploading && !isSnapshot,
+    //         message: 'Files are currently uploading',
+    //         timeout: 5000,
+    //         type: 'Error',
+    //       },
+    //     ],
+    //   },
+    //   {
+    //     tooltip: isSnapshot ? 'Delete Snapshot' : 'Delete Dataset',
+    //     icon: 'fa-trash',
+    //     action: actions.deleteDataset.bind(
+    //       this,
+    //       dataset._id,
+    //       this.props.history,
+    //     ),
+    //     display: displayDelete,
+    //     warn: true,
+    //     validations: [
+    //       {
+    //         check: datasets.uploading && !isSnapshot,
+    //         message: 'Files are currently uploading',
+    //         timeout: 5000,
+    //         type: 'Error',
+    //       },
+    //     ],
+    //   },
+    //   {
+    //     tooltip: 'Share Dataset',
+    //     icon: 'fa-user icon-plus',
+    //     action: actions.showDatasetComponent.bind(
+    //       this,
+    //       'share',
+    //       this.props.history,
+    //     ),
+    //     display: isAdmin && !isSnapshot && !isIncomplete,
+    //     warn: false,
+    //     modalLink: datasetUrl + '/share',
+    //     validations: [
+    //       {
+    //         check: datasets.uploading && !isSnapshot,
+    //         message: 'Files are currently uploading',
+    //         timeout: 5000,
+    //         type: 'Error',
+    //       },
+    //     ],
+    //   },
+    //   {
+    //     tooltip: 'Create Snapshot',
+    //     icon: 'fa-camera-retro icon-plus',
+    //     action: actions.showDatasetComponent.bind(
+    //       this,
+    //       'create-snapshot',
+    //       this.props.history,
+    //     ),
+    //     display: isAdmin && !isSnapshot && !isIncomplete,
+    //     warn: false,
+    //     modalLink: datasetUrl + '/create-snapshot',
+    //     validations: [
+    //       {
+    //         check: isInvalid,
+    //         message:
+    //           'You cannot snapshot an invalid dataset. Please fix the errors and try again.',
+    //         timeout: 5000,
+    //         type: 'Error',
+    //       },
+    //       {
+    //         check:
+    //           snapshots.length > 1 &&
+    //           moment(dataset.modified).diff(moment(snapshots[1].modified)) <= 0,
+    //         message:
+    //           'No modifications have been made since the last snapshot was created. Please use the most recent snapshot.',
+    //         timeout: 6000,
+    //         type: 'Error',
+    //       },
+    //       {
+    //         check: datasets.uploading && !isSnapshot,
+    //         message: 'Files are currently uploading',
+    //         timeout: 5000,
+    //         type: 'Error',
+    //       },
+    //     ],
+    //   },
+    //   {
+    //     tooltip: 'Run Analysis',
+    //     icon: 'fa-area-chart icon-plus',
+    //     action: actions.showDatasetComponent.bind(
+    //       this,
+    //       'jobs',
+    //       this.props.history,
+    //     ),
+    //     display: isSignedIn && !isIncomplete,
+    //     warn: false,
+    //     modalLink: datasetUrl + '/jobs',
+    //     validations: [
+    //       {
+    //         check: datasets.uploading && !isSnapshot,
+    //         message: 'Files are currently uploading',
+    //         timeout: 5000,
+    //         type: 'Error',
+    //       },
+    //     ],
+    //   },
+      {
+        tooltip: 'Follow Dataset',
+        icon: 'fa-tag icon-plus',
+        action: actions.createSubscription.bind(this),
+        display: isSignedIn && !isSubscribed,
+        warn: false,
+        validations: [
+          {
+            check: datasets.uploading && !isSnapshot,
+            message: 'You are about to follow a dataset',
+            timeout: 5000,
+            type: 'Error',
+          },
+        ],
+      },
+    //   {
+    //     tooltip: 'Unfollow Dataset',
+    //     icon: 'fa-tag icon-minus',
+    //     action: actions.deleteSubscription.bind(this),
+    //     display: isSignedIn && isSubscribed,
+    //     warn: true,
+    //   },
+    //   {
+    //     tooltip: 'Star Dataset',
+    //     icon: 'fa-star icon-plus',
+    //     action: actions.addStar.bind(this),
+    //     display: isSignedIn && !hasUserStar,
+    //     warn: false,
+    //   },
+    //   {
+    //     tooltip: 'Unstar Dataset',
+    //     icon: 'fa-star-o icon-minus',
+    //     action: actions.removeStar.bind(this),
+    //     display: isSignedIn && hasUserStar,
+    //     warn: true,
+    //   },
+    //   {
+    //     tooltip: 'Generate DOI',
+    //     icon: 'fa-gavel icon-plus',
+    //     action: actions.registerDoi.bind(this),
+    //     display: isAdmin && isPublic && !hasDoi,
+    //     warn: true,
+    //   },
+    ]
+
+    if (dataset && !dataset.loading) {
+      return (
+        <div className="col-xs-12 dataset-tools-wrap">
+          <div className="tools clearfix">
+            {this._snapshotLabel(dataset)}
+            {this._tools(tools)}
+          </div>
+        </div>
+      )
+    } else {
+      return null
+    }
+  }
+
+  // template methods ---------------------------------------------------
+
+  _snapshotLabel(dataset) {
+    return (
+      <div className="snapshot-select-label">
+        <div
+          className={!dataset.original ? 'draft' : 'snapshot'}
+          onClick={actions.toggleSidebar}>
+          {!dataset.original
+            ? 'Draft'
+            : 'Snapshot v' + dataset.snapshot_version}
+        </div>
+      </div>
+    )
+  }
+
+  _tools(toolConfig) {
+    let tools = toolConfig.map((tool, index) => {
+      if (tool.display) {
+        return (
+          <div role="presentation" className="tool" key={index}>
+            <WarnButton
+              tooltip={tool.tooltip}
+              icon={tool.icon}
+              prepDownload={tool.prepDownload}
+              action={tool.action}
+              warn={tool.warn}
+              link={tool.link}
+              modalLink={tool.modalLink}
+              validations={tool.validations}
+            />
+          </div>
+        )
+      }
+    })
+    return tools
+  }
+
+  _deleteDataset(isAdmin, isPublic, isSuperuser, datasetHasJobs) {
+    //CRN admin can delete any dataset
+    if (isSuperuser) {
+      return true
+    }
+    // If user is not a CRN admin and the dataset has jobs associated with it, don't allow deletion.
+    if (datasetHasJobs) {
+      return false
+    }
+    // If user is not a CRN admin, there are no jobs associated with dataset and the dataset is not public,
+    // and the user has been given admin access (this is different than CRN admin) to the shared dataset
+    // allow deletion
+    if (isAdmin && !isPublic) {
+      return true
+    }
+    //otherwise don't allow deletion
+    return false
+  }
+}
+
+Tools.propTypes = {
+  history: PropTypes.object,
+  location: PropTypes.object,
+}
+
+export default withRouter(Tools)

--- a/packages/openneuro-app/src/scripts/datalad/fragments/tools/dataset-toolbar.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/fragments/tools/dataset-toolbar.jsx
@@ -4,7 +4,6 @@ import React from 'react'
 import Reflux from 'reflux'
 import PropTypes from 'prop-types'
 import { withRouter } from 'react-router-dom'
-import moment from 'moment'
 import WarnButton from '../../../common/forms/warn-button.jsx'
 import userStore from '../../../user/user.store.js'
 import actions from '../../../dataset/dataset.actions.js'
@@ -31,14 +30,8 @@ class Tools extends Reflux.Component {
     let dataset = this.props.dataset
     let datasets = this.state.datasets
     let datasetUrl = '/datasets/' + dataset.id
-    console.log('dataset:', dataset)
-    console.log('datasets:', datasets)
-    console.log('datasetUrl:', datasetUrl)
 
     // let dataset = datasets ? datasets.dataset : null,
-    let snapshots = dataset ? dataset.snapshots : null
-    console.log('user:', userStore)
-    console.log('location:', this.props.location)
     if (!dataset) {
       return null
     }

--- a/packages/openneuro-app/src/scripts/dataset/dataset.actions.js
+++ b/packages/openneuro-app/src/scripts/dataset/dataset.actions.js
@@ -30,6 +30,7 @@ var Actions = Reflux.createActions([
   'getAttachmentDownloadTicket',
   'getDatasetDownloadTicket',
   'getFileDownloadTicket',
+  'getFileURL',
   'getResultDownloadTicket',
   'getJobLogs',
   'getLogstream',

--- a/packages/openneuro-app/src/scripts/dataset/dataset.content.jsx
+++ b/packages/openneuro-app/src/scripts/dataset/dataset.content.jsx
@@ -221,7 +221,7 @@ class DatasetContent extends Reflux.Component {
       let authorString = 'authored by '
       for (let i = 0; i < authors.length; i++) {
         let author = authors[i]
-        authorString += author.name
+        authorString += author
         if (authors.length > 1) {
           if (i < authors.length - 2) {
             authorString += ', '

--- a/packages/openneuro-app/src/scripts/dataset/dataset.content.jsx
+++ b/packages/openneuro-app/src/scripts/dataset/dataset.content.jsx
@@ -204,7 +204,7 @@ class DatasetContent extends Reflux.Component {
         message="The dataset has failed to load in time. Please check your network connection."
         className="col-xs-12 dataset-inner dataset-route dataset-wrap inner-route light text-center">
         {this.state.datasets.loading ? (
-          <Timeout timeout={30000}>
+          <Timeout timeout={100000}>
             <Spinner active={true} text={loadingText} />
           </Timeout>
         ) : (

--- a/packages/openneuro-app/src/scripts/dataset/dataset.content.jsx
+++ b/packages/openneuro-app/src/scripts/dataset/dataset.content.jsx
@@ -204,7 +204,7 @@ class DatasetContent extends Reflux.Component {
         message="The dataset has failed to load in time. Please check your network connection."
         className="col-xs-12 dataset-inner dataset-route dataset-wrap inner-route light text-center">
         {this.state.datasets.loading ? (
-          <Timeout timeout={20000}>
+          <Timeout timeout={30000}>
             <Spinner active={true} text={loadingText} />
           </Timeout>
         ) : (

--- a/packages/openneuro-app/src/scripts/dataset/dataset.file-display.jsx
+++ b/packages/openneuro-app/src/scripts/dataset/dataset.file-display.jsx
@@ -5,6 +5,7 @@
 import React from 'react'
 import Reflux from 'reflux'
 import PropTypes from 'prop-types'
+import datalad from '../utils/datalad'
 import datasetStore from './dataset.store'
 import actions from './dataset.actions'
 import FileView from '../common/partials/file-view.jsx'
@@ -49,16 +50,17 @@ class FileContent extends Reflux.Component {
     const fileName = file ? file.name : null
 
     if (!fileName) {
-      let fileName = decodeURIComponent(this.props.match.params.fileName)
+      let fileName = this.props.match.params.fileName
       if (
         fileName &&
         datasets &&
         datasets.dataset &&
         !this.state.fileRequested
       ) {
+        let decodedName = datalad.decodeFilePath(fileName)
         this.setState({ fileRequested: true })
         let displayFile = {
-          name: fileName,
+          name: decodedName,
           history: this.props.history,
         }
         actions.displayFile(null, null, displayFile, null)

--- a/packages/openneuro-app/src/scripts/dataset/dataset.metadata.jsx
+++ b/packages/openneuro-app/src/scripts/dataset/dataset.metadata.jsx
@@ -69,15 +69,15 @@ export default class MetaData extends React.Component {
           'referencesAndLinks',
         ),
       },
-      {
-        key: 'DigitalDocuments',
-        label: 'Digital Documents',
-        type: 'fileArray',
-        value: dataset.attachments,
-        onChange: actions.uploadAttachment,
-        onDelete: actions.deleteAttachment,
-        onFileClick: actions.getAttachmentDownloadTicket,
-      },
+      // {
+      //   key: 'DigitalDocuments',
+      //   label: 'Digital Documents',
+      //   type: 'fileArray',
+      //   value: dataset.attachments,
+      //   onChange: actions.uploadAttachment,
+      //   onDelete: actions.deleteAttachment,
+      //   onFileClick: actions.getAttachmentDownloadTicket,
+      // },
     ]
 
     let fields = metadata.map(item => {

--- a/packages/openneuro-app/src/scripts/dataset/dataset.routes.jsx
+++ b/packages/openneuro-app/src/scripts/dataset/dataset.routes.jsx
@@ -92,7 +92,7 @@ export default class DatasetRoutes extends React.Component {
           <Route
             name="fileEdit"
             exact
-            path="/datasets/:datasetId/file-edit"
+            path="/datasets/:datasetId/file-edit/:fileName"
             component={FileEdit}
           />
           <Route

--- a/packages/openneuro-app/src/scripts/dataset/dataset.snapshot-loader.jsx
+++ b/packages/openneuro-app/src/scripts/dataset/dataset.snapshot-loader.jsx
@@ -34,7 +34,7 @@ class SnapshotLoader extends Reflux.Component {
       let datasetId = props.match.params.datasetId
       const snapshotId = props.match.params.snapshotId
       if (snapshotId && this.state.datasets) {
-        const datasetUrl = bids.encodeId(datasetId, snapshotId)
+        const datasetUrl = [datasetId, snapshotId].join(':')
         if (
           !this.state.datasets.loading &&
           datasetUrl !== this.state.datasets.loadedUrl
@@ -46,7 +46,7 @@ class SnapshotLoader extends Reflux.Component {
       if (reload) {
         if (snapshotId) {
           const query = new URLSearchParams(props.location.search)
-          const snapshotUrl = bids.encodeId(datasetId, snapshotId)
+          const snapshotUrl = [datasetId, snapshotId].join(':')
           const app = query.get('app')
           const version = query.get('version')
           const job = query.get('job')
@@ -56,7 +56,7 @@ class SnapshotLoader extends Reflux.Component {
             app: app,
             version: version,
             job: job,
-            datasetId: bids.encodeId(datasetId),
+            datasetId: datasetId,
             tag: snapshotId
           })
         }

--- a/packages/openneuro-app/src/scripts/dataset/dataset.snapshot-loader.jsx
+++ b/packages/openneuro-app/src/scripts/dataset/dataset.snapshot-loader.jsx
@@ -2,7 +2,6 @@ import Reflux from 'reflux'
 import { withRouter } from 'react-router-dom'
 import datasetStore from './dataset.store'
 import actions from './dataset.actions'
-import bids from '../utils/bids'
 import { refluxConnect } from '../utils/reflux'
 
 class SnapshotLoader extends Reflux.Component {

--- a/packages/openneuro-app/src/scripts/dataset/dataset.snapshot-loader.jsx
+++ b/packages/openneuro-app/src/scripts/dataset/dataset.snapshot-loader.jsx
@@ -57,6 +57,7 @@ class SnapshotLoader extends Reflux.Component {
             version: version,
             job: job,
             datasetId: bids.encodeId(datasetId),
+            tag: snapshotId
           })
         }
       }

--- a/packages/openneuro-app/src/scripts/dataset/dataset.store.js
+++ b/packages/openneuro-app/src/scripts/dataset/dataset.store.js
@@ -14,7 +14,6 @@ import userActions from '../user/user.actions'
 import upload from '../utils/upload'
 import config from '../../../config'
 import files from '../utils/files'
-import request from '../utils/request'
 import moment from 'moment'
 import { stringify as querystring } from 'urlite/querystring'
 
@@ -184,7 +183,6 @@ let datasetStore = Reflux.createStore({
           let selectedSnapshot = this.data.selectedSnapshot
           if (!selectedSnapshot || selectedSnapshot === datasetId) {
             let dataset = res
-            console.log('dataset:', dataset)
             let originalId = dataset.original ? dataset.original : datasetId
             this.update(
               {
@@ -199,7 +197,6 @@ let datasetStore = Reflux.createStore({
                 loading: false,
               })
               this.loadSnapshots(dataset, [], () => {
-                console.log('this.data.dataset:', this.data.dataset)
                 this.loadComments(originalId)
                 this.getDatasetStars()
                 this.checkSubscriptionFollowers(() => {
@@ -1113,7 +1110,8 @@ let datasetStore = Reflux.createStore({
         action: () => {
           datalad
           .deleteDirectory(bids.decodeId(this.data.dataset._id), dirTree.dirPath)
-          .then(res => {
+          .then(() => {
+            // TODO: ADD FUNCTIONALITY FOR HANDLING SUCCESSFUL DATASET DIRECTORY DELETION
             // this.loadDataset(bids.decodeId(this.data.dataset._id), undefined, true) // reload dataset
           })
         },
@@ -1764,9 +1762,9 @@ let datasetStore = Reflux.createStore({
                   this.showDatasetComponent(displayUrl, file.history)
             })
           })
-        .catch(err => {
-          console.log(err)
-        })
+        // .catch(err => {
+        //   console.log(err)
+        // })
       }
     } else {
       callback()
@@ -1796,9 +1794,9 @@ let datasetStore = Reflux.createStore({
             this.showDatasetComponent('file-edit', file.history)
           })
           })
-        .catch(err => {
-          console.log(err)
-        })
+        // .catch(err => {
+        //   console.log(err)
+        // })
       }
   },
 

--- a/packages/openneuro-app/src/scripts/dataset/dataset.store.js
+++ b/packages/openneuro-app/src/scripts/dataset/dataset.store.js
@@ -194,27 +194,28 @@ let datasetStore = Reflux.createStore({
                     children: dataset.children,
                   },
                 ],
+                loading: false,
               },
-              this.loadJobs(
-                datasetId,
-                snapshot,
-                originalId,
-                options,
-                (err, jobs) => {
-                  this.loadSnapshots(dataset, jobs, () => {
-                    this.loadComments(originalId)
-                    this.getDatasetStars()
-                    this.checkSubscriptionFollowers(() => {
-                      let datasetUrl = this.constructDatasetUrl(dataset)
-                      this.update({
-                        loading: false,
-                        snapshot: snapshot,
-                        datasetUrl: datasetUrl,
-                      })
-                    })
-                  })
-                },
-              ),
+              // this.loadJobs(
+              //   datasetId,
+              //   snapshot,
+              //   originalId,
+              //   options,
+              //   (err, jobs) => {
+              //     this.loadSnapshots(dataset, jobs, () => {
+              //       this.loadComments(originalId)
+              //       this.getDatasetStars()
+              //       this.checkSubscriptionFollowers(() => {
+              //         let datasetUrl = this.constructDatasetUrl(dataset)
+              //         this.update({
+              //           loading: false,
+              //           snapshot: snapshot,
+              //           datasetUrl: datasetUrl,
+              //         })
+              //       })
+              //     })
+              //   },
+              // ),
             )
 
             if (

--- a/packages/openneuro-app/src/scripts/dataset/tools/index.js
+++ b/packages/openneuro-app/src/scripts/dataset/tools/index.js
@@ -36,7 +36,7 @@ class Tools extends Reflux.Component {
       return null
     }
 
-    let datasetHasJobs = !!dataset.jobs.length
+    let datasetHasJobs = dataset.jobs ? !!dataset.jobs.length : false
 
     // permission check shorthands
     let isAdmin = dataset.access === 'admin',

--- a/packages/openneuro-app/src/scripts/dataset/tools/json/jsoneditor.store.js
+++ b/packages/openneuro-app/src/scripts/dataset/tools/json/jsoneditor.store.js
@@ -110,7 +110,11 @@ let JsonEditorStore = Reflux.createStore({
           let file = new File([jsonContent], fileName, {
             type: 'application/json',
           })
-          file.parentId = this.data.originalFile.parentId
+          let hasParentId = this.data.originalFile.parentId
+          let parentId = hasParentId ? this.data.originalFile.parentId : 'root'
+          this.data.originalFile.parentId = parentId
+          file.parentId = parentId
+          
 
           this.data.onSave(this.data.originalFile, file)
 

--- a/packages/openneuro-app/src/scripts/dataset/tools/publish.jsx
+++ b/packages/openneuro-app/src/scripts/dataset/tools/publish.jsx
@@ -26,24 +26,6 @@ class Publish extends Reflux.Component {
     }
   }
 
-  componentWillReceiveProps() {
-    let snapshots = this.state.datasets.snapshots
-    let dataset = this.state.datasets.dataset
-
-    if (snapshots && dataset) {
-      snapshots.map(snapshot => {
-        if (snapshot._id == dataset._id) {
-          if (snapshot.original) {
-            this.setState({ selectedSnapshot: snapshot._id })
-          } else if (snapshots.length > 1) {
-            this.setState({ selectedSnapshot: snapshots[1]._id })
-          }
-          return
-        }
-      })
-    }
-  }
-
   _datasetLink() {
     if (this.state.datasets.datasetUrl) {
       return (
@@ -60,18 +42,13 @@ class Publish extends Reflux.Component {
 
   _submitButton() {
     let snapshots = this.state.datasets.snapshots
-    if (snapshots) {
-      let selectedSnapshot = snapshots.filter(snapshot => {
-        return snapshot._id === this.state.selectedSnapshot
-      })
-      if (selectedSnapshot && selectedSnapshot.length) {
-        return selectedSnapshot[0].public ? null : (
-          <div className="dataset-form-controls col-xs-12">
-            {this._submit()}
-          </div>
+    if (snapshots && snapshots.length) {
+      return (
+            <div className="dataset-form-controls col-xs-12">
+              {this._submit()}
+            </div>
         )
       }
-    }
     return null
   }
 
@@ -96,18 +73,22 @@ class Publish extends Reflux.Component {
     let form = (
       <div className="dataset-form-body col-xs-12">
         <div className="dataset-form-content col-xs-12">
-          {this._snapshots()}
+          {/* {this._snapshots()} */}
           <p className="text-danger">
-            This snapshot will be released publicly under a
+            All existing and future snapshots of this dataset will be released publicly under a
             <a
               href="https://wiki.creativecommons.org/wiki/CC0"
               target="_blank"
               rel="noopener noreferrer">
               {' '}
               CC0 license
-            </a>. This operation cannot be undone.
+            </a>. 
+            {/* TODO: can this operation REALLY not be undone? */}
+            {/* This operation cannot be undone. */}
           </p>
         </div>
+        {/* TODO: add create snapshot function if there is ever a case where a snapshot will not exist */}
+        {/* {this._createNewSnapshot()} */}
         {this._submitButton()}
       </div>
     )
@@ -204,8 +185,8 @@ class Publish extends Reflux.Component {
     let dataset = datasetStore.data.dataset
     let snapshots = datasetStore.data.snapshots
     let modified = !(
-      snapshots.length > 1 &&
-      moment(dataset.modified).diff(moment(snapshots[1].modified)) <= 0
+      snapshots.length > 0 &&
+      moment(dataset.modified).diff(moment(snapshots[0].modified)) <= 0
     )
     if (modified && this.state.datasets.datasetUrl) {
       let to = {
@@ -226,7 +207,7 @@ class Publish extends Reflux.Component {
 
   _submit() {
     let submitButton
-    if (this.state.selectedSnapshot) {
+    if (this.state.datasets.snapshots && this.state.datasets.snapshots.length) {
       submitButton = (
         <button className="btn-modal-action" onClick={this._publish.bind(this)}>
           Publish

--- a/packages/openneuro-app/src/scripts/dataset/tools/snapshot.jsx
+++ b/packages/openneuro-app/src/scripts/dataset/tools/snapshot.jsx
@@ -102,7 +102,7 @@ class Snapshot extends Reflux.Component {
       const app = query.get('app')
       const version = query.get('version')
       const job = query.get('job')
-      const snapshotUrl = bids.encodeId(datasetId, snapshotId)
+      const snapshotUrl = datasetId.join(snapshotId, ':')
       actions.trackView(snapshotUrl)
       actions.loadDataset(snapshotUrl, {
         snapshot: true,
@@ -168,7 +168,7 @@ class Snapshot extends Reflux.Component {
           <h4>Snapshot Version: {this._versionString()}</h4>
         </div>
 
-        {/* <div className="snapshot-version-major form-group col-xs-4">
+        <div className="snapshot-version-major form-group col-xs-4">
           <label htmlFor="major" className="control-label">
             Major
           </label>
@@ -177,7 +177,6 @@ class Snapshot extends Reflux.Component {
             type="number"
             step="1"
             min={this.state.newSnapshotVersion}
-            max={this.state.newSnapshotVersion}
             value={this.state.currentVersion.major}
             onChange={this._handleVersion}
             name="major"
@@ -198,7 +197,6 @@ class Snapshot extends Reflux.Component {
             name="minor"
             title="minor"
             className="form-control"
-            disabled={true}
           />
         </div>
         <div className="snapshot-version-point form-group col-xs-4">
@@ -214,9 +212,8 @@ class Snapshot extends Reflux.Component {
             name="point"
             title="point"
             className="form-control"
-            disabled={true}
           />
-        </div> */}
+        </div>
       </div>
     )
   }
@@ -323,7 +320,7 @@ class Snapshot extends Reflux.Component {
       this.state.changes,
       this.state.datasets.dataset.CHANGES,
     )
-    actions.createSnapshot(changes, this.props.history, res => {
+    actions.createSnapshot(changes, this._versionString(), this.props.history, res => {
       if (res && res.error) {
         this.setState({
           changes: [],

--- a/packages/openneuro-app/src/scripts/routes.jsx
+++ b/packages/openneuro-app/src/scripts/routes.jsx
@@ -7,7 +7,8 @@ import requireAuth from './utils/requireAuth'
 import Dataset from './dataset/dataset.jsx'
 import DataLad from './datalad/datalad.jsx'
 
-const datasetComponent = config.datalad.enabled ? DataLad : Dataset
+// const datasetComponent = config.datalad.enabled ? DataLad : Dataset
+const datasetComponent = Dataset
 
 // wrap with loadable HOC
 const FrontPage = loadable(() => import('./front-page/front-page.jsx'))

--- a/packages/openneuro-app/src/scripts/routes.jsx
+++ b/packages/openneuro-app/src/scripts/routes.jsx
@@ -1,11 +1,9 @@
 // dependencies ----------------------------------------------------------
-import config from '../../config'
 import React from 'react'
 import { Route, Switch } from 'react-router-dom'
 import loadable from 'loadable-components'
 import requireAuth from './utils/requireAuth'
 import Dataset from './dataset/dataset.jsx'
-import DataLad from './datalad/datalad.jsx'
 
 // const datasetComponent = config.datalad.enabled ? DataLad : Dataset
 const datasetComponent = Dataset

--- a/packages/openneuro-app/src/scripts/utils/bids.js
+++ b/packages/openneuro-app/src/scripts/utils/bids.js
@@ -162,9 +162,10 @@ export default {
         // }
         const data = projectRes ? projectRes.data : null
         if (data) {
-          let project = data.dataset
-          let draft = project ? project.draft : null
-          let tempFiles = draft.files ? this._formatFiles(draft.files) : null
+          // get snapshot or draft, depending on results
+          let project = !options.snapshot ? data.dataset : data.snapshot
+          let draft = !options.snapshot ? project.draft : null
+          let tempFiles = draft ? this._formatFiles(draft.files) : this._formatFiles(project.files)
           this.getMetadata(
             project,
             metadata => {

--- a/packages/openneuro-app/src/scripts/utils/bids.js
+++ b/packages/openneuro-app/src/scripts/utils/bids.js
@@ -182,7 +182,7 @@ export default {
                   return callback(dataset)
                 })
                 .catch(err => {
-                  console.log('error getting jobs:', err)
+                  // console.log('error getting jobs:', err)
                   return callback(dataset)
                 })
               })

--- a/packages/openneuro-app/src/scripts/utils/bids.js
+++ b/packages/openneuro-app/src/scripts/utils/bids.js
@@ -457,7 +457,7 @@ export default {
       label: project.label,
       group: project.uploader ? project.uploader.id : null,
       created: project.created,
-      modified: project.modified,
+      modified: project.draft ? project.draft.modified : null,
       permissions: project.permissions,
       public: !!project.public,
       downloads: project.downloads,

--- a/packages/openneuro-app/src/scripts/utils/bids.js
+++ b/packages/openneuro-app/src/scripts/utils/bids.js
@@ -33,7 +33,7 @@ export default {
   ) {
     const res = (await datalad
       .getDatasets({
-        authenticate: isAdmin || !isPublic,
+        public: isPublic,
         snapshot: false,
         metadata: metadata,
       })).data
@@ -41,7 +41,6 @@ export default {
       return callback([])
     }
     const projects = res.datasets ? res.datasets : []
-    console.log('projects:', projects)
     const users = isSignedOut ? null : (await scitran.getUsers()).body
     const stars = (await crn.getStars()).body
     const followers = (await crn.getSubscriptions()).body
@@ -459,7 +458,7 @@ export default {
       created: project.created,
       modified: project.modified,
       permissions: project.permissions,
-      public: project.public,
+      public: !!project.public,
       downloads: project.downloads,
       views: project.views,
 

--- a/packages/openneuro-app/src/scripts/utils/bids.js
+++ b/packages/openneuro-app/src/scripts/utils/bids.js
@@ -36,6 +36,7 @@ export default {
         authenticate: isAdmin || !isPublic,
         snapshot: false,
         metadata: metadata,
+        isPublic: isPublic
       })).data
     if (!res) {
       return callback([])

--- a/packages/openneuro-app/src/scripts/utils/bids.js
+++ b/packages/openneuro-app/src/scripts/utils/bids.js
@@ -183,7 +183,7 @@ export default {
                 })
                 .catch(err => {
                   // console.log('error getting jobs:', err)
-                  return callback(dataset)
+                  return callback(dataset, err)
                 })
               })
               

--- a/packages/openneuro-app/src/scripts/utils/bids.js
+++ b/packages/openneuro-app/src/scripts/utils/bids.js
@@ -33,7 +33,7 @@ export default {
   ) {
     const res = (await datalad
       .getDatasets({
-        public: isPublic,
+        authenticate: isAdmin || !isPublic,
         snapshot: false,
         metadata: metadata,
       })).data
@@ -66,7 +66,7 @@ export default {
           (existing.hasOwnProperty('original') &&
             existing.snapshot_version < project.snapshot_version)
         ) {
-          if (isAdmin || isPublic || this.userAccess(project)) {
+          if (isAdmin || project.public || this.userAccess(project)) {
             resultDict[datasetId] = dataset
           }
         }
@@ -169,7 +169,7 @@ export default {
               dataset.CHANGES = metadata.CHANGES
               dataset.children = tempFiles
               dataset.showChildren = true
-
+              dataset.snapshots = project.snapshots
               // get dataset usage stats
               this.usage(projectId, usage => {
                 if (usage) {

--- a/packages/openneuro-app/src/scripts/utils/bids.js
+++ b/packages/openneuro-app/src/scripts/utils/bids.js
@@ -107,8 +107,8 @@ export default {
     async.each(
       metadataFiles,
       (filename, cb) => {
-        scitran
-          .getFile('projects', project._id, filename, options)
+        datalad
+          .getFile(project._id, filename, options)
           .then(file => {
             let contents
             try {

--- a/packages/openneuro-app/src/scripts/utils/datalad.js
+++ b/packages/openneuro-app/src/scripts/utils/datalad.js
@@ -1,53 +1,111 @@
 import getClient from 'openneuro-client'
 import gql from 'graphql-tag'
+import bids from './bids'
 
 const client = getClient('/crn/graphql')
 export default {
     getDataset(datasetId, options, callback) {
-        client.query({
-            query: gql`
-            {
-              dataset(id: "ds001098") {
+      if (!options.snapshot) {
+        this.queryDataset(datasetId, (data) => {
+          callback(data)
+        })
+      } else {
+        this.querySnapshot(options.datasetId, options.tag, (data) => {
+          console.log('getDataset options:', options)
+          callback(data)
+        })
+      }
+    },
+    queryDataset(datasetId, callback) {
+      console.log('datasetId in graphql query:', bids.decodeId(datasetId))
+
+      const query = gql`
+        query ds ($datasetId: ID!) {
+          dataset (id: $datasetId) {
+            id
+            label
+            created
+            public
+            uploader {
+              id
+              firstName
+              lastName
+              email
+            }
+            draft {
+              modified
+              files {
                 id
-                label
-                created
-                public
-                uploader {
-                  id
-                  firstName
-                  lastName
-                  email
-                }
-                draft {
-                  modified
-                  files {
-                    id
-                    filename
-                    size
-                  }
-                  summary {
-                    modalities
-                    sessions
-                    subjects
-                    tasks
-                    size
-                    totalFiles
-                  }
-                }
-                snapshots {
-                  id
-                  tag
-                }
+                filename
+                size
+              }
+              summary {
+                modalities
+                sessions
+                subjects
+                tasks
+                size
+                totalFiles
               }
             }
-          `,
-          variables: {
-              datasetId: datasetId
+            snapshots {
+              id
+              tag
+            }
           }
-        })
-        .then(data => {
-            console.log('apollo data:', data)
-            return callback(data)
-        })
-    }
+        }
+      `
+      client.query({
+        query: query,
+        variables: {
+            datasetId: bids.decodeId(datasetId)
+        }
+      })
+      .then(data => {
+          console.log('apollo data:', data)
+          return callback(data)
+      })
+      .catch(err => {
+        console.log(err)
+        return callback()
+      })
+    },
+    querySnapshot(datasetId, tag, callback) {
+      client.query({
+        query: gql`
+          query getSnapshot ($datasetId: ID!, $tag: String!) {
+            snapshot(datasetId: $datasetId, tag: $tag) {
+              id
+              tag
+              created
+              authors {
+                ORCID
+                name
+              }
+              summary {
+                size
+                totalFiles
+              }
+              files {
+                id
+                filename
+                size
+              }
+            }
+          }
+        `,
+        variables: {
+          datasetId: bids.decodeId(datasetId),
+          tag: tag
+        }
+      })
+      .then(data => {
+        console.log('apollo data:', data)
+        return callback(data)
+      })
+      .catch(err => {
+        console.log('error in snapshot query:', err) 
+        return callback(err)
+      })
+  }
 }

--- a/packages/openneuro-app/src/scripts/utils/datalad.js
+++ b/packages/openneuro-app/src/scripts/utils/datalad.js
@@ -4,6 +4,33 @@ import bids from './bids'
 
 const client = getClient('/crn/graphql')
 export default {
+    getDatasets(callback) {
+      const query = gql`
+      query {
+        datasets {
+          id
+          created
+          label
+          uploader {
+            id
+          }
+          public
+        }
+      }
+      `
+      client.query({
+        query: query
+      })
+      .then(data => {
+          console.log('apollo data:', data)
+          return callback(data)
+      })
+      .catch(err => {
+        console.log(err)
+        return callback()
+      })
+    },
+
     getDataset(datasetId, options, callback) {
       if (!options.snapshot) {
         this.queryDataset(datasetId, (data) => {

--- a/packages/openneuro-app/src/scripts/utils/datalad.js
+++ b/packages/openneuro-app/src/scripts/utils/datalad.js
@@ -58,6 +58,7 @@ export default {
         query ds ($datasetId: ID!) {
           dataset (id: $datasetId) {
             id
+            _id: id
             label
             created
             public
@@ -85,6 +86,7 @@ export default {
             }
             snapshots {
               id
+              _id: id
               tag
             }
           }
@@ -111,6 +113,7 @@ export default {
           query getSnapshot ($datasetId: ID!, $tag: String!) {
             snapshot(datasetId: $datasetId, tag: $tag) {
               id
+              _id: id
               tag
               created
               authors {
@@ -123,6 +126,8 @@ export default {
               }
               files {
                 id
+                _id: id
+                name: filename
                 filename
                 size
               }

--- a/packages/openneuro-app/src/scripts/utils/datalad.js
+++ b/packages/openneuro-app/src/scripts/utils/datalad.js
@@ -169,6 +169,8 @@ export default {
 
     },
     
+    // FILE OPERATIONS
+
     getFile(datasetId, filename, options) {
       filename = this.encodeFilePath(filename)
       const uri = `/crn/datasets/${datasetId}/files/${filename}`
@@ -188,7 +190,50 @@ export default {
             console.log('error in getFile:', err)
             reject(err)
           })
-    })
+      })
+    },
+
+    deleteFiles(datasetId, fileTree, options) {
+      let mutation = files.deleteFiles
+
+      return new Promise((resolve, reject) => {
+        client.mutate({
+          mutation: mutation,
+          variables: {
+            datasetId: bids.decodeId(datasetId),
+            files: fileTree
+          }
+        })
+        .then(data => {
+          console.log('response from deleteFiles:', data)
+          resolve(data)
+        })
+        .catch(err => {
+          console.log(err)
+          reject(err)
+        })
+      })
+    },
+
+    deleteFile(datasetId, file, options) {
+      // get the file path from the file object
+      let filePath = file.modifiedName ? this.encodeFilePath(file.modifiedName) : this.encodeFilePath(file.name)
+
+      // shape the file into the same shape as accepted by deleteFiles
+      let fileTree = this.constructFileTree(file, filePath)
+
+      // call updateFiles
+      return this.deleteFiles(datasetId, fileTree, {})
+    },
+
+    deleteDirectory(datasetId, pathname, options) {
+      let path = this.encodeFilePath(pathname)
+      let fileTree = {
+        name: path,
+        files: [],
+        directories: []
+      }
+      return this.deleteFiles(datasetId, fileTree, {})
     },
 
     updateFiles(datasetId, fileTree, options) {

--- a/packages/openneuro-app/src/scripts/utils/datalad.js
+++ b/packages/openneuro-app/src/scripts/utils/datalad.js
@@ -1,0 +1,53 @@
+import getClient from 'openneuro-client'
+import gql from 'graphql-tag'
+
+const client = getClient('/crn/graphql')
+export default {
+    getDataset(datasetId, options, callback) {
+        client.query({
+            query: gql`
+            {
+              dataset(id: "ds001098") {
+                id
+                label
+                created
+                public
+                uploader {
+                  id
+                  firstName
+                  lastName
+                  email
+                }
+                draft {
+                  modified
+                  files {
+                    id
+                    filename
+                    size
+                  }
+                  summary {
+                    modalities
+                    sessions
+                    subjects
+                    tasks
+                    size
+                    totalFiles
+                  }
+                }
+                snapshots {
+                  id
+                  tag
+                }
+              }
+            }
+          `,
+          variables: {
+              datasetId: datasetId
+          }
+        })
+        .then(data => {
+            console.log('apollo data:', data)
+            return callback(data)
+        })
+    }
+}

--- a/packages/openneuro-app/src/scripts/utils/datalad.js
+++ b/packages/openneuro-app/src/scripts/utils/datalad.js
@@ -166,6 +166,29 @@ export default {
           reject(err)
         })
       })
+
+    },
+    
+    getFile(datasetId, filename, options) {
+      filename = this.encodeFilePath(filename)
+      const uri = `/crn/datasets/${datasetId}/files/${filename}`
+      return new Promise((resolve, reject) => {
+        request
+          .get(uri, {
+            headers: {
+              'Content-Type': 'application/*'
+            }
+          })
+          .then((res) => {
+            console.log('res from getFile:', res)
+            let file = res.body
+            resolve(res)
+          })
+          .catch((err) => {
+            console.log('error in getFile:', err)
+            reject(err)
+          })
+    })
     },
 
     updateFiles(datasetId, fileTree, options) {
@@ -221,28 +244,6 @@ export default {
         }
         return fileTree
       }
-    },
-    
-    getFile(datasetId, filename, options) {
-      filename = this.encodeFilePath(filename)
-      const uri = `/crn/datasets/${datasetId}/files/${filename}`
-      return new Promise((resolve, reject) => {
-        request
-          .get(uri, {
-            headers: {
-              'Content-Type': 'application/*'
-            }
-          })
-          .then((res) => {
-            console.log('res from getFile:', res)
-            let file = res.body
-            resolve(res)
-          })
-          .catch((err) => {
-            console.log('error in getFile:', err)
-            reject(err)
-          })
-    })
   },
 
   encodeFilePath(path) {

--- a/packages/openneuro-app/src/scripts/utils/datalad.js
+++ b/packages/openneuro-app/src/scripts/utils/datalad.js
@@ -4,10 +4,6 @@ import gql from 'graphql-tag'
 import bids from './bids'
 import clone from 'lodash.clonedeep'
 import request from './request'
-import config from '../../../config'
-import userStore from '../user/user.store'
-
-const URI = config.datalad.uri
 
 function getToken() {
   let credentials = JSON.parse(window.localStorage.token)
@@ -34,7 +30,7 @@ export default {
             resolve(data)
         })
         .catch(err => {
-          console.log('error in getDatasets:', err)
+          // console.log('error in getDatasets:', err)
           reject(err)
         })
       })
@@ -72,8 +68,8 @@ export default {
           return callback(data)
       })
       .catch(err => {
-        console.log('error in datasetQuery:', err)
-        return callback()
+        // console.log('error in datasetQuery:', err)
+        return callback(err)
       })
     },
 
@@ -110,16 +106,15 @@ export default {
         }
       })
       .then(data => {
-        console.log('apollo data:', data)
         return callback(data)
       })
       .catch(err => {
-        console.log('error in snapshot query:', err) 
+        // console.log('error in snapshot query:', err) 
         return callback(err)
       })
     },
 
-    deleteDataset(datasetId, options) {
+    deleteDataset(datasetId) {
       let mutation = datasets.deleteDataset
       return new Promise((resolve, reject) => {
         client.mutate({
@@ -151,7 +146,7 @@ export default {
           resolve(data)
         })
         .catch(err => {
-          console.log('error in updatePublic:', err)
+          // console.log('error in updatePublic:', err)
           reject(err)
         })
       })
@@ -179,7 +174,7 @@ export default {
           resolve(data)
         })
         .catch(err => {
-          console.log('error in createSnapshot:', err)
+          // console.log('error in createSnapshot:', err)
           reject(err)
         })
       })
@@ -202,17 +197,16 @@ export default {
             }
           })
           .then((res) => {
-            let file = res.body
             resolve(res)
           })
           .catch((err) => {
-            console.log('error in getFile:', err)
+            // console.log('error in getFile:', err)
             reject(err)
           })
       })
     },
 
-    deleteFiles(datasetId, fileTree, options) {
+    deleteFiles(datasetId, fileTree) {
       let mutation = files.deleteFiles
 
       return new Promise((resolve, reject) => {
@@ -227,13 +221,13 @@ export default {
           resolve(data)
         })
         .catch(err => {
-          console.log('error in deleteFiles:', err)
+          // console.log('error in deleteFiles:', err)
           reject(err)
         })
       })
     },
 
-    deleteFile(datasetId, file, options) {
+    deleteFile(datasetId, file) {
       // get the file path from the file object
       let filePath = file.modifiedName ? this.encodeFilePath(file.modifiedName) : this.encodeFilePath(file.name)
 
@@ -241,20 +235,20 @@ export default {
       let fileTree = this.constructFileTree(file, filePath)
 
       // call updateFiles
-      return this.deleteFiles(datasetId, fileTree, {})
+      return this.deleteFiles(datasetId, fileTree)
     },
 
-    deleteDirectory(datasetId, pathname, options) {
+    deleteDirectory(datasetId, pathname) {
       let path = this.encodeFilePath(pathname)
       let fileTree = {
         name: path,
         files: [],
         directories: []
       }
-      return this.deleteFiles(datasetId, fileTree, {})
+      return this.deleteFiles(datasetId, fileTree)
     },
 
-    updateFiles(datasetId, fileTree, options) {
+    updateFiles(datasetId, fileTree) {
       let mutation = files.updateFiles
 
       return new Promise((resolve, reject) => {
@@ -269,13 +263,13 @@ export default {
           resolve(data)
         })
         .catch(err => {
-          console.log('error in updateFiles:', err)
+          // console.log('error in updateFiles:', err)
           reject(err)
         })
       })
     },
 
-    updateFile(datasetId, file, options) {
+    updateFile(datasetId, file) {
       // get the file path from the file object
       let filePath = file.modifiedName ? this.encodeFilePath(file.modifiedName) : this.encodeFilePath(file.name)
 
@@ -283,7 +277,7 @@ export default {
       let fileTree = this.constructFileTree(file, filePath)
 
       // call updateFiles
-      return this.updateFiles(datasetId, fileTree, {})
+      return this.updateFiles(datasetId, fileTree)
     },
 
     updateFileFromString(datasetId, filename, value, type) {

--- a/packages/openneuro-app/src/scripts/utils/datalad.js
+++ b/packages/openneuro-app/src/scripts/utils/datalad.js
@@ -4,30 +4,33 @@ import bids from './bids'
 
 const client = getClient('/crn/graphql')
 export default {
-    getDatasets(callback) {
+    async getDatasets(options) {
       const query = gql`
-      query {
-        datasets {
-          id
-          created
-          label
-          uploader {
+        query {
+          datasets {
             id
+            _id: id
+            created
+            label
+            uploader {
+              id
+            }
+            public
           }
-          public
         }
-      }
       `
-      client.query({
-        query: query
-      })
-      .then(data => {
-          console.log('apollo data:', data)
-          return callback(data)
-      })
-      .catch(err => {
-        console.log(err)
-        return callback()
+      return new Promise((resolve, reject) => {
+        client.query({
+          query: query
+        })
+        .then(data => {
+            console.log('apollo data:', data)
+            resolve(data)
+        })
+        .catch(err => {
+          console.log(err)
+          reject()
+        })
       })
     },
 

--- a/packages/openneuro-app/src/scripts/utils/datalad.js
+++ b/packages/openneuro-app/src/scripts/utils/datalad.js
@@ -25,6 +25,11 @@ export default {
         })
         .then(data => {
             console.log('apollo data:', data)
+            if (options.public) {
+              data = data.data.datasets.filter((dataset) => {
+                return dataset.public
+              })
+            }
             resolve(data)
         })
         .catch(err => {

--- a/packages/openneuro-app/src/scripts/utils/json-ld.js
+++ b/packages/openneuro-app/src/scripts/utils/json-ld.js
@@ -39,7 +39,7 @@ const formatAuthors = authorList => {
   if (authorList.length) {
     let authorsArray = []
     for (let author of authorList) {
-      let nameParts = author.name ? author.name.split(' ') : []
+      let nameParts = author? author.split(' ') : []
       let familyName = nameParts.length ? nameParts[nameParts.length - 1] : null
       nameParts.pop()
       let givenName = nameParts.length ? nameParts.join(' ') : null

--- a/packages/openneuro-client/src/__mocks__/client.js
+++ b/packages/openneuro-client/src/__mocks__/client.js
@@ -2,7 +2,6 @@ import ApolloClient from 'apollo-client'
 import { SchemaLink } from 'apollo-link-schema'
 import { InMemoryCache } from 'apollo-cache-inmemory'
 import { addMockFunctionsToSchema } from 'graphql-tools'
-import {GraphQLDateTime} from 'graphql-iso-date'
 import schema from 'openneuro-server/graphql/schema'
 
 /**

--- a/packages/openneuro-client/src/__mocks__/client.js
+++ b/packages/openneuro-client/src/__mocks__/client.js
@@ -2,6 +2,7 @@ import ApolloClient from 'apollo-client'
 import { SchemaLink } from 'apollo-link-schema'
 import { InMemoryCache } from 'apollo-cache-inmemory'
 import { addMockFunctionsToSchema } from 'graphql-tools'
+import {GraphQLDateTime} from 'graphql-iso-date'
 import schema from 'openneuro-server/graphql/schema'
 
 /**
@@ -28,6 +29,7 @@ addMockFunctionsToSchema({
       created: testTime,
       modified: testTime,
     }),
+    DateTime: () => {return testTime}
   },
 })
 

--- a/packages/openneuro-client/src/__tests__/datasets.spec.js
+++ b/packages/openneuro-client/src/__tests__/datasets.spec.js
@@ -1,5 +1,5 @@
 import createClient from '../client'
-import { testDsId } from '../client'
+import { testDsId} from '../client'
 import { getDataset, getDatasets, createDataset } from '../datasets'
 
 jest.mock('../client')
@@ -13,14 +13,6 @@ describe('datasets.js', () => {
         .query({ query: getDataset, variables: { id: testDsId } })
         .then(({ data: { dataset } }) => {
           expect(dataset.id).toBe(testDsId)
-        })
-        .then(done)
-    })
-    it('does not return extra data', done => {
-      gqlClient
-        .query({ query: getDataset, variables: { id: testDsId } })
-        .then(({ data: { dataset } }) => {
-          expect(dataset.created).toBeUndefined()
         })
         .then(done)
     })

--- a/packages/openneuro-client/src/client.js
+++ b/packages/openneuro-client/src/client.js
@@ -23,10 +23,19 @@ const authLink = getAuthorization =>
   setContext((_, { headers }) => {
     // Passthrough any headers but add in authorization if set
     const token = getAuthorization ? getAuthorization() : false
+    let tokenString = ''
+    if (token) {
+      if (typeof(window) !== 'undefined' && window.localStorage && window.localStorage.token) {
+        tokenString = `${token}`
+      } else {
+        tokenString = `Bearer ${token}`
+      }
+    }
+    
     return {
       headers: Object.assign(
         {
-          authorization: token ? `Bearer ${token}` : '',
+          authorization: tokenString,
         },
         headers,
       ),

--- a/packages/openneuro-client/src/client.js
+++ b/packages/openneuro-client/src/client.js
@@ -9,6 +9,7 @@ import * as datasets from './datasets'
 
 const cache = new InMemoryCache()
 
+/* global window */
 /**
  * Setup a client for working with the OpenNeuro API
  *

--- a/packages/openneuro-client/src/datasets.js
+++ b/packages/openneuro-client/src/datasets.js
@@ -34,6 +34,7 @@ export const getDataset = gql`
         id
         _id: id
         tag
+        created
         snapshot_version: tag
       }
     }
@@ -60,6 +61,14 @@ export const createDataset = gql`
     createDataset(label: $label) {
       id
       label
+    }
+  }
+`
+
+export const deleteDataset = gql`
+  mutation deleteDataset($label: String!) {
+    deleteDataset(label: $label) {
+      id
     }
   }
 `

--- a/packages/openneuro-client/src/datasets.js
+++ b/packages/openneuro-client/src/datasets.js
@@ -4,7 +4,38 @@ export const getDataset = gql`
   query dataset($id: ID!) {
     dataset(id: $id) {
       id
+      _id: id
       label
+      created
+      public
+      uploader {
+        id
+        firstName
+        lastName
+        email
+      }
+      draft {
+        modified
+        files {
+          id
+          filename
+          size
+        }
+        summary {
+          modalities
+          sessions
+          subjects
+          tasks
+          size
+          totalFiles
+        }
+      }
+      snapshots {
+        id
+        _id: id
+        tag
+        snapshot_version: tag
+      }
     }
   }
 `
@@ -13,7 +44,13 @@ export const getDatasets = gql`
   query {
     datasets {
       id
+      _id: id
+      created
       label
+      uploader {
+        id
+      }
+      public
     }
   }
 `
@@ -24,5 +61,11 @@ export const createDataset = gql`
       id
       label
     }
+  }
+`
+
+export const updatePublic = gql`
+  mutation ($id: ID!, $publicFlag: Boolean!) {
+    updatePublic(datasetId: $id, publicFlag: $publicFlag)
   }
 `

--- a/packages/openneuro-client/src/files.js
+++ b/packages/openneuro-client/src/files.js
@@ -19,3 +19,13 @@ export const updateFiles = gql`
     }
   }
 `
+
+export const deleteFiles = gql`
+  mutation deleteFiles($datasetId: ID!, $files: FileTree!) {
+    deleteFiles(datasetId: $datasetId, files: $files) {
+      dataset {
+        id
+      }
+    }
+  }
+`

--- a/packages/openneuro-server/config.js
+++ b/packages/openneuro-server/config.js
@@ -84,7 +84,7 @@ let config = {
     ENVIRONMENT: process.env.ENVIRONMENT,
   },
   datalad: {
-    enabled: false,
+    enabled: true,
     uri: 'datalad:9877',
   },
   doi: {

--- a/packages/openneuro-server/datalad/dataset.js
+++ b/packages/openneuro-server/datalad/dataset.js
@@ -77,6 +77,17 @@ export const getDataset = id => {
 }
 
 /**
+ * Delete dataset and associated documents
+ */
+export const deleteDataset= (id, user, userInfo) => {
+  let deleteURI = `${uri}/datasets/${id}`
+  request.del(deleteURI)
+    .then(res => {
+      return c.crn.datasets.deleteOne({ id })
+    })
+}
+
+/**
  * Fetch all datasets
  *
  * TODO - Support cursor pagination

--- a/packages/openneuro-server/datalad/dataset.js
+++ b/packages/openneuro-server/datalad/dataset.js
@@ -165,3 +165,18 @@ export const commitFiles = (datasetId, name, email) => {
   setCommitInfo(req, name, email)
   return req
 }
+/**
+ * Update public state
+ */
+export const updatePublic = (datasetId, publicFlag) => {
+  console.log('updating crn dataset', datasetId, 'with publicFlag:', publicFlag)
+  // update mongo
+  return c.crn.datasets.updateOne({id: datasetId}, {$set: {public: publicFlag}}, {upsert: true})
+  
+  // TODO: send request to backend to initiate uplaod to s3 bucket
+  // const url = `${uri}/datasets/${datasetId}/updatePublic/${publicFlag}`
+  // return request
+  //   .post(url)
+  //   .set('Accept', 'application/json')
+  //   .then(({ body }) => body)
+}

--- a/packages/openneuro-server/datalad/dataset.js
+++ b/packages/openneuro-server/datalad/dataset.js
@@ -116,7 +116,7 @@ const encodeFilePath = path => {
 const fileUrl = (datasetId, path, filename) => {
   // If path is provided, this is a subdirectory, otherwise a root level file.
   const filePath = path ? [path, filename].join('/') : filename
-  const fileName = encodeFilePath(filePath)
+  const fileName = filename ? encodeFilePath(filePath) : encodeFilePath(path)
   const url = `http://${uri}/datasets/${datasetId}/files/${fileName}`
   return url
 }
@@ -170,6 +170,16 @@ export const commitFiles = (datasetId, name, email) => {
   setCommitInfo(req, name, email)
   return req
 }
+/** 
+ * Delete an existing file in a dataset
+ */
+export const deleteFile = (datasetId, path, file) => {
+  // Cannot use superagent 'request' due to inability to post streams
+  let url = fileUrl(datasetId, path, file.name)
+  console.log('sending deleteFile request to datalad path:', url)
+  return request.del(url)
+}
+
 /**
  * Update public state
  */

--- a/packages/openneuro-server/datalad/dataset.js
+++ b/packages/openneuro-server/datalad/dataset.js
@@ -187,7 +187,6 @@ export const commitFiles = (datasetId, name, email) => {
 export const deleteFile = (datasetId, path, file) => {
   // Cannot use superagent 'request' due to inability to post streams
   let url = fileUrl(datasetId, path, file.name)
-  console.log('sending deleteFile request to datalad path:', url)
   return request.del(url)
 }
 

--- a/packages/openneuro-server/datalad/dataset.js
+++ b/packages/openneuro-server/datalad/dataset.js
@@ -79,10 +79,10 @@ export const getDataset = id => {
 /**
  * Delete dataset and associated documents
  */
-export const deleteDataset= (id, user, userInfo) => {
+export const deleteDataset= (id) => {
   let deleteURI = `${uri}/datasets/${id}`
   request.del(deleteURI)
-    .then(res => {
+    .then(() => {
       return c.crn.datasets.deleteOne({ id })
     })
 }

--- a/packages/openneuro-server/graphql/resolvers/dataset.js
+++ b/packages/openneuro-server/graphql/resolvers/dataset.js
@@ -63,6 +63,39 @@ export const updateFilesTree = (datasetId, fileTree) => {
 }
 
 /**
+ * Delete files from a draft
+ */
+export const deleteFiles = (obj, { datasetId, files: fileTree }) => {
+  // TODO - The id returned here is a placeholder
+  const promises = deleteFilesTree(datasetId, fileTree)
+  return Promise.all(promises).then(() => ({
+    id: new Date(),
+  }))
+}
+
+/**
+ * Recursively walk a delete tree and return an array of
+ * promises for each forwarded request.
+ *
+ * @param {string} datasetId
+ * @param {object} fileTree
+ */
+export const deleteFilesTree = (datasetId, fileTree) => {
+  // drafts just need something to invalidate client cache
+  const { name, files, directories } = fileTree
+  if (files.length) {
+    const filesPromises = files.map(file =>
+      datalad.deleteFile(datasetId, name, file),
+    )
+    const dirPromises = directories.map(tree => deleteFilesTree(datasetId, tree))
+    return filesPromises.concat(...dirPromises)
+  } else {
+    return [datalad.deleteFile(datasetId, name, {name: ''})]
+  }
+  
+}
+
+/**
  * Update the dataset Public status
  */
 export const updatePublic = (obj, { datasetId, publicFlag}) => {

--- a/packages/openneuro-server/graphql/resolvers/dataset.js
+++ b/packages/openneuro-server/graphql/resolvers/dataset.js
@@ -16,6 +16,13 @@ export const createDataset = (obj, { label }, { user, userInfo }) => {
 }
 
 /**
+ * Delete an existing dataset, as well as all snapshots
+ */
+export const deleteDataset = (obj, { label }, { user, userInfo }) => {
+  return datalad.deleteDataset(label, user, userInfo)
+}
+
+/**
  * Tag the working tree for a dataset
  */
 export const createSnapshot = (obj, { datasetId, tag }) => {
@@ -25,15 +32,11 @@ export const createSnapshot = (obj, { datasetId, tag }) => {
 /**
  * Add files to a draft
  */
-<<<<<<< HEAD
 export const updateFiles = (
   obj,
   { datasetId, files: fileTree },
   { userInfo: { firstname, lastname, email } },
 ) => {
-=======
-export const updateFiles = (obj, { datasetId, files: fileTree }) => {
->>>>>>> f726408d... remove some debug code from gql dataset resolver
   // TODO - The id returned here is a placeholder
   const promises = updateFilesTree(datasetId, fileTree)
   return Promise.all(promises)
@@ -56,7 +59,7 @@ export const updateFilesTree = (datasetId, fileTree) => {
   // drafts just need something to invalidate client cache
   const { name, files, directories } = fileTree
   const filesPromises = files.map(file =>
-    datalad.updateFile(datasetId, name, file),
+    datalad.addFile(datasetId, name, file),
   )
   const dirPromises = directories.map(tree => updateFilesTree(datasetId, tree))
   return filesPromises.concat(...dirPromises)

--- a/packages/openneuro-server/graphql/resolvers/dataset.js
+++ b/packages/openneuro-server/graphql/resolvers/dataset.js
@@ -57,3 +57,11 @@ export const updateFilesTree = (datasetId, fileTree) => {
   const dirPromises = directories.map(tree => updateFilesTree(datasetId, tree))
   return filesPromises.concat(...dirPromises)
 }
+
+/**
+ * Update the dataset Public status
+ */
+export const updatePublic = (obj, { datasetId, publicFlag}) => {
+  console.log('hit the updatePublic resolver!')
+  return datalad.updatePublic(datasetId, publicFlag)
+}

--- a/packages/openneuro-server/graphql/resolvers/dataset.js
+++ b/packages/openneuro-server/graphql/resolvers/dataset.js
@@ -52,11 +52,13 @@ export const updateFilesTree = (datasetId, fileTree) => {
   // drafts just need something to invalidate client cache
   const { name, files, directories } = fileTree
   const filesPromises = files.map(file =>
-    datalad.addFile(datasetId, name, file),
+    datalad.updateFile(datasetId, name, file),
   )
   const dirPromises = directories.map(tree => updateFilesTree(datasetId, tree))
   return filesPromises.concat(...dirPromises)
 }
+
+
 
 /**
  * Update the dataset Public status

--- a/packages/openneuro-server/graphql/resolvers/dataset.js
+++ b/packages/openneuro-server/graphql/resolvers/dataset.js
@@ -25,11 +25,15 @@ export const createSnapshot = (obj, { datasetId, tag }) => {
 /**
  * Add files to a draft
  */
+<<<<<<< HEAD
 export const updateFiles = (
   obj,
   { datasetId, files: fileTree },
   { userInfo: { firstname, lastname, email } },
 ) => {
+=======
+export const updateFiles = (obj, { datasetId, files: fileTree }) => {
+>>>>>>> f726408d... remove some debug code from gql dataset resolver
   // TODO - The id returned here is a placeholder
   const promises = updateFilesTree(datasetId, fileTree)
   return Promise.all(promises)
@@ -58,12 +62,9 @@ export const updateFilesTree = (datasetId, fileTree) => {
   return filesPromises.concat(...dirPromises)
 }
 
-
-
 /**
  * Update the dataset Public status
  */
 export const updatePublic = (obj, { datasetId, publicFlag}) => {
-  console.log('hit the updatePublic resolver!')
   return datalad.updatePublic(datasetId, publicFlag)
 }

--- a/packages/openneuro-server/graphql/resolvers/index.js
+++ b/packages/openneuro-server/graphql/resolvers/index.js
@@ -4,6 +4,7 @@ import {
   dataset,
   datasets,
   createDataset,
+  deleteDataset,
   createSnapshot,
   updatePublic,
   updateFiles,
@@ -28,6 +29,7 @@ export default {
   Mutation: {
     createDataset,
     updateFiles,
+    deleteDataset,
     deleteFiles,
     createSnapshot,
     updatePublic

--- a/packages/openneuro-server/graphql/resolvers/index.js
+++ b/packages/openneuro-server/graphql/resolvers/index.js
@@ -5,6 +5,7 @@ import {
   datasets,
   createDataset,
   createSnapshot,
+  updatePublic,
   updateFiles,
 } from './dataset.js'
 import { draft, snapshot, snapshots } from './datalad.js'
@@ -27,6 +28,7 @@ export default {
     createDataset,
     updateFiles,
     createSnapshot,
+    updatePublic
   },
   User: user,
   Dataset: {

--- a/packages/openneuro-server/graphql/resolvers/index.js
+++ b/packages/openneuro-server/graphql/resolvers/index.js
@@ -7,6 +7,7 @@ import {
   createSnapshot,
   updatePublic,
   updateFiles,
+  deleteFiles,
 } from './dataset.js'
 import { draft, snapshot, snapshots } from './datalad.js'
 import { whoami, user, users } from './user.js'
@@ -27,6 +28,7 @@ export default {
   Mutation: {
     createDataset,
     updateFiles,
+    deleteFiles,
     createSnapshot,
     updatePublic
   },

--- a/packages/openneuro-server/graphql/schema.js
+++ b/packages/openneuro-server/graphql/schema.js
@@ -29,6 +29,8 @@ const typeDefs = `
     createSnapshot(datasetId: ID!, tag: String!): Snapshot
     # Add or update files in a draft - returns a new Draft
     updateFiles(datasetId: ID!, files: FileTree!): Draft
+    # Add or remove the public flag from a dataset
+    updatePublic(datasetId: ID!, publicFlag: Boolean!): Boolean!
   }
 
   # File tree

--- a/packages/openneuro-server/graphql/schema.js
+++ b/packages/openneuro-server/graphql/schema.js
@@ -29,6 +29,8 @@ const typeDefs = `
     createSnapshot(datasetId: ID!, tag: String!): Snapshot
     # Add or update files in a draft - returns a new Draft
     updateFiles(datasetId: ID!, files: FileTree!): Draft
+    # delete files in a draft - returns a new Draft
+    deleteFiles(datasetId: ID!, files: FileTree!): Draft
     # Add or remove the public flag from a dataset
     updatePublic(datasetId: ID!, publicFlag: Boolean!): Boolean!
   }

--- a/packages/openneuro-server/graphql/schema.js
+++ b/packages/openneuro-server/graphql/schema.js
@@ -25,6 +25,8 @@ const typeDefs = `
   type Mutation {
     # Create a new dataset container and repository
     createDataset(label: String!): Dataset
+    # Deletes a dataset and all associated snapshots
+    deleteDataset(label: String!): Dataset
     # Tag the current draft
     createSnapshot(datasetId: ID!, tag: String!): Snapshot
     # Add or update files in a draft - returns a new Draft

--- a/packages/openneuro-server/handlers/datalad.js
+++ b/packages/openneuro-server/handlers/datalad.js
@@ -43,3 +43,22 @@ export const createSnapshot = (req, res) => {
     res.send()
   })
 }
+
+/**
+ * Get a file from a dataset
+ */
+export const getFile = (req, res) => {
+  console.log('************ SERVER: HIT GETFILE')
+  const datasetId = req.params.datasetId
+  const filename = req.params.filename
+  res.set('Content-Type', 'application/*')
+  const uri = `${URI}/datasets/${datasetId}/files/${filename}`
+  return request.get(uri)
+    .pipe(res)
+    // .then((file) => {
+    //   res.send(file)
+    // })
+    // .catch((err) => {
+    //   res.send(err)
+    // })
+}

--- a/packages/openneuro-server/handlers/datalad.js
+++ b/packages/openneuro-server/handlers/datalad.js
@@ -48,17 +48,10 @@ export const createSnapshot = (req, res) => {
  * Get a file from a dataset
  */
 export const getFile = (req, res) => {
-  console.log('************ SERVER: HIT GETFILE')
   const datasetId = req.params.datasetId
   const filename = req.params.filename
   res.set('Content-Type', 'application/*')
   const uri = `${URI}/datasets/${datasetId}/files/${filename}`
   return request.get(uri)
     .pipe(res)
-    // .then((file) => {
-    //   res.send(file)
-    // })
-    // .catch((err) => {
-    //   res.send(err)
-    // })
 }

--- a/packages/openneuro-server/libs/auth.js
+++ b/packages/openneuro-server/libs/auth.js
@@ -87,8 +87,15 @@ let auth = {
     } else {
       scitran.getUserByToken(req.headers.authorization, (err, resp) => {
         if (resp.body && resp.body._id) {
-          req.user = resp.body._id
-          req.isSuperUser = resp.body.root
+          let scitranUser = resp.body
+          req.user = scitranUser._id
+          req.userInfo = {
+            id: req.user,
+            firstname: scitranUser.firstname,
+            lastname: scitranUser.lastname,
+            email: scitranUser.email,
+          }
+          req.isSuperUser = scitranUser.root
         }
         return next()
       })

--- a/packages/openneuro-server/routes.js
+++ b/packages/openneuro-server/routes.js
@@ -354,6 +354,13 @@ const dataladRoutes = [
     url: '/openfmri/dataset/api/:datasetId',
     handler: openfmri.getDataset,
   },
+
+  // file routes
+  {
+    method: 'get',
+    url: '/datasets/:datasetId/files/:filename',
+    handler: datalad.getFile,
+  },
 ]
 
 // initialize routes -------------------------------


### PR DESCRIPTION
ties the datalad backend into the majority of the front-end functionality, including:

dashboard page:
- my datasets, public datasets, and admin datasets

datasets page:
- publish dataset
- file previews
- file-tree operations
-- add, update, delete, edit, view
- comments
- stars
- follow
- create snapshot (note that viewing a snapshot is still in progress)
- dataset summary stats (followers, views, downloads, etc)
- dataset description
- dataset description edits (label change not yet functional)