### PR TITLE
Save validation data from datalad-service

### DIFF
--- a/packages/openneuro-server/graphql/resolvers/index.js
+++ b/packages/openneuro-server/graphql/resolvers/index.js
@@ -7,6 +7,7 @@ import {
   createSnapshot,
   updateFiles,
 } from './dataset.js'
+import { updateValidation } from './validation.js'
 import { draft, snapshot, snapshots } from './datalad.js'
 import { whoami, user, users } from './user.js'
 
@@ -27,6 +28,7 @@ export default {
     createDataset,
     updateFiles,
     createSnapshot,
+    updateValidation,
   },
   User: user,
   Dataset: {

--- a/packages/openneuro-server/graphql/resolvers/index.js
+++ b/packages/openneuro-server/graphql/resolvers/index.js
@@ -7,7 +7,7 @@ import {
   createSnapshot,
   updateFiles,
 } from './dataset.js'
-import { updateValidation } from './validation.js'
+import { updateSummary, updateValidation } from './validation.js'
 import { draft, snapshot, snapshots } from './datalad.js'
 import { whoami, user, users } from './user.js'
 
@@ -28,6 +28,7 @@ export default {
     createDataset,
     updateFiles,
     createSnapshot,
+    updateSummary,
     updateValidation,
   },
   User: user,

--- a/packages/openneuro-server/graphql/resolvers/summary.js
+++ b/packages/openneuro-server/graphql/resolvers/summary.js
@@ -1,3 +1,4 @@
+import mongo from '../../libs/mongo.js'
 /**
  * Summary resolver
  *
@@ -8,6 +9,7 @@ export const summary = () => {
   // This needs the remote validator work completed
   // These will be retrieved by index in mongodb after that
   return {
+    id: 'notarealid',
     modalities: ['bold', 'inplaneT2', 'T1w'],
     sessions: ['anat'],
     subjects: ['sub-01', 'sub-02', 'sub-03'],

--- a/packages/openneuro-server/graphql/resolvers/summary.js
+++ b/packages/openneuro-server/graphql/resolvers/summary.js
@@ -1,4 +1,3 @@
-import mongo from '../../libs/mongo.js'
 /**
  * Summary resolver
  *

--- a/packages/openneuro-server/graphql/resolvers/validation.js
+++ b/packages/openneuro-server/graphql/resolvers/validation.js
@@ -1,17 +1,37 @@
 import mongo from '../../libs/mongo.js'
 
 /**
- * Save validation data returned by the datalad service
+ * Save summary data returned by the datalad service
+ *
+ * Returns the saved summary if successful
+ */
+export const updateSummary = (obj, args) => {
+  const summaries = mongo.collections.crn.summaries
+  return summaries
+    .update(
+      { id: args.summary.id, datasetId: args.summary.datasetId },
+      args.summary,
+      {
+        upsert: true,
+      },
+    )
+    .then(() => args.summary)
+}
+
+/**
+ * Save issues data returned by the datalad service
  *
  * Returns only a boolean if successful or not
- *
- * updateValidation(datasetId: ID!, ref: String!, summary: Summary, issues: [ValidationIssue])
  */
 export const updateValidation = (obj, args) => {
-  const validations = mongo.collections.crn.draftValidations
-  return validations
-    .update({ datasetId: args.datasetId, ref: args.ref }, args, {
-      upsert: true,
-    })
+  const issues = mongo.collections.crn.issues
+  return issues
+    .update(
+      { id: args.validation.id, datasetId: args.validation.datasetId },
+      args.validation,
+      {
+        upsert: true,
+      },
+    )
     .then(() => true)
 }

--- a/packages/openneuro-server/graphql/resolvers/validation.js
+++ b/packages/openneuro-server/graphql/resolvers/validation.js
@@ -1,0 +1,17 @@
+import mongo from '../../libs/mongo.js'
+
+/**
+ * Save validation data returned by the datalad service
+ *
+ * Returns only a boolean if successful or not
+ *
+ * updateValidation(datasetId: ID!, ref: String!, summary: Summary, issues: [ValidationIssue])
+ */
+export const updateValidation = (obj, args) => {
+  const validations = mongo.collections.crn.draftValidations
+  return validations
+    .update({ datasetId: args.datasetId, ref: args.ref }, args, {
+      upsert: true,
+    })
+    .then(() => true)
+}

--- a/packages/openneuro-server/graphql/schema.js
+++ b/packages/openneuro-server/graphql/schema.js
@@ -29,6 +29,8 @@ const typeDefs = `
     createSnapshot(datasetId: ID!, tag: String!): Snapshot
     # Add or update files in a draft - returns a new Draft
     updateFiles(datasetId: ID!, files: FileTree!): Draft
+    # Update a draft with validation results
+    updateValidation(datasetId: ID!, ref: String!, summary: Summary, issues: [ValidationIssue]): Boolean
   }
 
   # File tree
@@ -76,6 +78,7 @@ const typeDefs = `
     modified: DateTime!
     authors: [Author]
     summary: Summary
+    issues: [ValidationIssue]
     files: [DatasetFile]
   }
 
@@ -102,8 +105,39 @@ const typeDefs = `
     sessions: [String]
     subjects: [String]
     tasks: [String]
-    size: Int
-    totalFiles: Int
+    size: Int!
+    totalFiles: Int!
+  }
+
+  enum Severity {
+    error
+    warning
+  }
+
+  type ValidationIssue {
+    severity: Severity!
+    key: String!
+    code: Int!
+    reason: String!
+    files: [ValidationFileIssue]
+    additionalFileCount: Int
+  }
+
+  type ValidationIssueFile {
+    key: String!
+    code: Int!
+    file: ValidationFileDetail
+    evidence: String
+    line: Int
+    character: Int
+    severity: Severity!
+    reason: String
+  }
+
+  type ValidationFileDetail {
+    name: String!
+    path: String!
+    relativePath: String!
   }
 
   # File metadata and link to contents

--- a/packages/openneuro-server/graphql/schema.js
+++ b/packages/openneuro-server/graphql/schema.js
@@ -29,8 +29,26 @@ const typeDefs = `
     createSnapshot(datasetId: ID!, tag: String!): Snapshot
     # Add or update files in a draft - returns a new Draft
     updateFiles(datasetId: ID!, files: FileTree!): Draft
+    # Update a draft summary
+    updateSummary(summary: SummaryInput!): Summary
     # Update a draft with validation results
-    updateValidation(datasetId: ID!, ref: String!, summary: Summary, issues: [ValidationIssue]): Boolean
+    updateValidation(validation: ValidationInput!): Boolean
+  }
+
+  input SummaryInput {
+    datasetId: ID!
+    modalities: [String]
+    sessions: [String]
+    subjects: [String]
+    tasks: [String]
+    size: Int!
+    totalFiles: Int!
+  }
+
+  input ValidationInput {
+    datasetId: ID!
+    ref: String!
+    issues: [ValidationIssueInput]!
   }
 
   # File tree
@@ -123,10 +141,21 @@ const typeDefs = `
     additionalFileCount: Int
   }
 
+  input ValidationIssueInput {
+    severity: Severity!
+    key: String!
+    code: Int!
+    reason: String!
+    files: [ValidationIssueFileInput]
+    additionalFileCount: Int
+  }
+
   type ValidationIssueFile {
     key: String!
     code: Int!
-    file: ValidationFileDetail
+    filename: String
+    path: String
+    relativePath: String
     evidence: String
     line: Int
     character: Int
@@ -134,10 +163,17 @@ const typeDefs = `
     reason: String
   }
 
-  type ValidationFileDetail {
-    name: String!
-    path: String!
-    relativePath: String!
+  input ValidationIssueFileInput {
+    key: String!
+    code: Int!
+    filename: String
+    path: String
+    relativePath: String
+    evidence: String
+    line: Int
+    character: Int
+    severity: Severity!
+    reason: String
   }
 
   # File metadata and link to contents

--- a/packages/openneuro-server/graphql/schema.js
+++ b/packages/openneuro-server/graphql/schema.js
@@ -119,7 +119,7 @@ const typeDefs = `
     key: String!
     code: Int!
     reason: String!
-    files: [ValidationFileIssue]
+    files: [ValidationIssueFile]
     additionalFileCount: Int
   }
 

--- a/packages/openneuro-server/graphql/schema.js
+++ b/packages/openneuro-server/graphql/schema.js
@@ -36,6 +36,7 @@ const typeDefs = `
   }
 
   input SummaryInput {
+    id: ID! # Git reference for this summary
     datasetId: ID!
     modalities: [String]
     sessions: [String]
@@ -46,8 +47,8 @@ const typeDefs = `
   }
 
   input ValidationInput {
+    id: ID! # Git reference for this validation
     datasetId: ID!
-    ref: String!
     issues: [ValidationIssueInput]!
   }
 
@@ -119,6 +120,7 @@ const typeDefs = `
 
   # Validator summary from bids-validator
   type Summary {
+    id: ID!
     modalities: [String]
     sessions: [String]
     subjects: [String]

--- a/packages/openneuro-server/libs/mongo.js
+++ b/packages/openneuro-server/libs/mongo.js
@@ -27,8 +27,6 @@ export default {
   collections: {
     crn: {
       blacklist: null,
-      draftValidations: null,
-      snapshotValidations: null,
       jobs: null,
       jobDefinitions: null,
       tickets: null,
@@ -40,6 +38,8 @@ export default {
       comments: null,
       subscriptions: null,
       datasets: null,
+      summaries: null,
+      issues: null,
       snapshots: null,
       stars: null,
       dois: null,

--- a/packages/openneuro-server/libs/mongo.js
+++ b/packages/openneuro-server/libs/mongo.js
@@ -27,7 +27,8 @@ export default {
   collections: {
     crn: {
       blacklist: null,
-      validationQueue: null,
+      draftValidations: null,
+      snapshotValidations: null,
       jobs: null,
       jobDefinitions: null,
       tickets: null,


### PR DESCRIPTION
This implements the hook to receive validation data from the [datalad backend](https://github.com/openneuroorg/datalad-service).

Fixes #603 