### PR TITLE
Add revision field to datasets

### DIFF
--- a/packages/openneuro-client/src/__mocks__/client.js
+++ b/packages/openneuro-client/src/__mocks__/client.js
@@ -28,7 +28,12 @@ addMockFunctionsToSchema({
       created: testTime,
       modified: testTime,
     }),
-    DateTime: () => {return testTime}
+    DateTime: () => {
+      return testTime
+    },
+    BigInt: () => {
+      return 8589934592
+    },
   },
 })
 

--- a/packages/openneuro-server/datalad/dataset.js
+++ b/packages/openneuro-server/datalad/dataset.js
@@ -59,12 +59,14 @@ export const createDataset = (label, uploader, userInfo) => {
  */
 export const createDatasetModel = (id, label, uploader) => {
   const creationTime = new Date()
+  const revision = null // Empty repo has no hash yet
   const datasetObj = {
     id,
     label,
     created: creationTime,
     modified: creationTime,
     uploader,
+    revision,
   }
   return c.crn.datasets.insertOne(datasetObj)
 }
@@ -79,12 +81,11 @@ export const getDataset = id => {
 /**
  * Delete dataset and associated documents
  */
-export const deleteDataset= (id) => {
+export const deleteDataset = id => {
   let deleteURI = `${uri}/datasets/${id}`
-  request.del(deleteURI)
-    .then(() => {
-      return c.crn.datasets.deleteOne({ id })
-    })
+  request.del(deleteURI).then(() => {
+    return c.crn.datasets.deleteOne({ id })
+  })
 }
 
 /**
@@ -181,7 +182,8 @@ export const commitFiles = (datasetId, name, email) => {
   setCommitInfo(req, name, email)
   return req
 }
-/** 
+
+/**
  * Delete an existing file in a dataset
  */
 export const deleteFile = (datasetId, path, file) => {
@@ -195,8 +197,12 @@ export const deleteFile = (datasetId, path, file) => {
  */
 export const updatePublic = (datasetId, publicFlag) => {
   // update mongo
-  return c.crn.datasets.updateOne({id: datasetId}, {$set: {public: publicFlag}}, {upsert: true})
-  
+  return c.crn.datasets.updateOne(
+    { id: datasetId },
+    { $set: { public: publicFlag } },
+    { upsert: true },
+  )
+
   // TODO: send request to backend to initiate uplaod to s3 bucket
   // const url = `${uri}/datasets/${datasetId}/updatePublic/${publicFlag}`
   // return request

--- a/packages/openneuro-server/datalad/draft.js
+++ b/packages/openneuro-server/datalad/draft.js
@@ -2,6 +2,7 @@
  * Manage serving a Draft object based on DataLad working trees
  */
 import request from 'superagent'
+import mongo from '../libs/mongo.js'
 import config from '../config.js'
 
 const uri = config.datalad.uri
@@ -12,4 +13,14 @@ export const getDraftFiles = datasetId => {
     .get(filesUrl)
     .set('Accept', 'application/json')
     .then(({ body: { files } }) => files)
+}
+
+export const updateDatasetRevision = datasetId => gitRef => {
+  /**
+   * Update the revision pointer in a draft on changes
+   */
+  return mongo.collections.crn.datasets.update(
+    { id: datasetId },
+    { $set: { revision: gitRef } },
+  )
 }

--- a/packages/openneuro-server/graphql/resolvers/datalad.js
+++ b/packages/openneuro-server/graphql/resolvers/datalad.js
@@ -8,7 +8,7 @@ import { getSnapshot, getSnapshots } from '../../datalad/snapshots.js'
 export const draft = obj => {
   return getDraftFiles(obj.id).then(files => ({
     files,
-    summary,
+    summary: () => summary(obj),
     modified: new Date(), // TODO - Return cache age here
   }))
 }

--- a/packages/openneuro-server/graphql/resolvers/datalad.js
+++ b/packages/openneuro-server/graphql/resolvers/datalad.js
@@ -7,6 +7,7 @@ import { getSnapshot, getSnapshots } from '../../datalad/snapshots.js'
  */
 export const draft = obj => {
   return getDraftFiles(obj.id).then(files => ({
+    id: obj.revision,
     files,
     summary: () => summary(obj),
     modified: new Date(), // TODO - Return cache age here

--- a/packages/openneuro-server/graphql/resolvers/index.js
+++ b/packages/openneuro-server/graphql/resolvers/index.js
@@ -1,5 +1,6 @@
 import { GraphQLDate, GraphQLTime, GraphQLDateTime } from 'graphql-iso-date'
 import { GraphQLUpload } from 'apollo-upload-server'
+import GraphQLBigInt from 'graphql-bigint'
 import {
   dataset,
   datasets,
@@ -19,6 +20,7 @@ export default {
   Time: GraphQLTime,
   DateTime: GraphQLDateTime,
   Upload: GraphQLUpload,
+  BigInt: GraphQLBigInt,
   Query: {
     dataset,
     datasets,

--- a/packages/openneuro-server/graphql/resolvers/summary.js
+++ b/packages/openneuro-server/graphql/resolvers/summary.js
@@ -1,19 +1,11 @@
+import mongo from '../../libs/mongo.js'
+
 /**
  * Summary resolver
- *
- * Triggers validation if a summary is invalid or null
  */
-export const summary = () => {
-  // Stub summary for now
-  // This needs the remote validator work completed
-  // These will be retrieved by index in mongodb after that
-  return {
-    id: 'notarealid',
-    modalities: ['bold', 'inplaneT2', 'T1w'],
-    sessions: ['anat'],
-    subjects: ['sub-01', 'sub-02', 'sub-03'],
-    tasks: ['balloon analog risk task'],
-    size: 65536,
-    totalFiles: 10,
-  }
+export const summary = dataset => {
+  return mongo.collections.crn.summaries.findOne({
+    id: dataset.revision,
+    datasetId: dataset.id,
+  })
 }

--- a/packages/openneuro-server/graphql/schema.js
+++ b/packages/openneuro-server/graphql/schema.js
@@ -6,6 +6,7 @@ const typeDefs = `
   scalar DateTime
   scalar Time
   scalar Upload
+  scalar BigInt
 
   type Query {
     # One dataset
@@ -48,7 +49,7 @@ const typeDefs = `
     sessions: [String]
     subjects: [String]
     tasks: [String]
-    size: Int!
+    size: BigInt!
     totalFiles: Int!
   }
 
@@ -131,7 +132,7 @@ const typeDefs = `
     sessions: [String]
     subjects: [String]
     tasks: [String]
-    size: Int!
+    size: BigInt!
     totalFiles: Int!
   }
 
@@ -188,7 +189,7 @@ const typeDefs = `
   type DatasetFile {
     id: ID!
     filename: String!
-    size: Int
+    size: BigInt
     urls: [String]
   }
 `

--- a/packages/openneuro-server/package.json
+++ b/packages/openneuro-server/package.json
@@ -33,6 +33,7 @@
     "express": "^4.13.3",
     "express-fileupload": "^0.1.4",
     "graphql": "^0.13.2",
+    "graphql-bigint": "^1.0.0",
     "graphql-iso-date": "^3.5.0",
     "graphql-tag": "^2.8.0",
     "graphql-tools": "^2.21.0",
@@ -51,7 +52,8 @@
     "react-dom": "^16.2.0",
     "redis": "^2.8.0",
     "request": "^2.83.0",
-    "s3-stream-download": "https://github.com/OpenNeuroOrg/s3-stream-download.git",
+    "s3-stream-download":
+      "https://github.com/OpenNeuroOrg/s3-stream-download.git",
     "superagent": "^3.8.2",
     "tar-fs": "^1.9.0",
     "underscore": "^1.8.3",

--- a/packages/openneuro-server/yarn.lock
+++ b/packages/openneuro-server/yarn.lock
@@ -2760,6 +2760,10 @@ graphql-anywhere@^4.1.9:
   dependencies:
     apollo-utilities "^1.0.12"
 
+graphql-bigint@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/graphql-bigint/-/graphql-bigint-1.0.0.tgz#b2909be9c9970a9a7697273c27d0ea47a146a19c"
+
 graphql-extensions@^0.0.x, graphql-extensions@~0.0.9:
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/graphql-extensions/-/graphql-extensions-0.0.10.tgz#34bdb2546d43f6a5bc89ab23c295ec0466c6843d"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4790,6 +4790,10 @@ graphql-anywhere@^4.1.0-alpha.0, graphql-anywhere@^4.1.8:
   dependencies:
     apollo-utilities "^1.0.11"
 
+graphql-bigint@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/graphql-bigint/-/graphql-bigint-1.0.0.tgz#b2909be9c9970a9a7697273c27d0ea47a146a19c"
+
 graphql-extensions@^0.0.x, graphql-extensions@~0.0.9:
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/graphql-extensions/-/graphql-extensions-0.0.10.tgz#34bdb2546d43f6a5bc89ab23c295ec0466c6843d"


### PR DESCRIPTION
This tracks the dataset revision value after commits to support looking up validation data by (datasetId, gitRef) pairs.

Fixes a bug with datasets larger than 2^32nd bytes.

Implements a real summary resolver.