### PR TITLE
CLI: Specify nodejs version and supported OSes.

### DIFF
--- a/packages/openneuro-cli/package.json
+++ b/packages/openneuro-cli/package.json
@@ -4,6 +4,8 @@
   "description": "OpenNeuro command line uploader / editor.",
   "main": "index.js",
   "repository": "git@github.com:OpenNeuroOrg/openneuro.git",
+  "engines": { "node": ">=8.0.0" },
+  "os": ["!win32"],
   "author": "Squishymedia",
   "license": "MIT",
   "bin": {


### PR DESCRIPTION
Fixes #656 by warning on unsupported NodeJS versions and Win32 (due to known issues in #646).