### PR TITLE
Datalad permissions

### DIFF
--- a/packages/openneuro-app/src/scripts/dataset/tools/share.jsx
+++ b/packages/openneuro-app/src/scripts/dataset/tools/share.jsx
@@ -249,17 +249,17 @@ class Share extends Reflux.Component {
   }
 
   _removeUser(userId) {
-    // datalad.removePermission(this.state.datasets.dataset._id, userId).then(() => {
-    //   let index
-    //   let permissions = this.state.permissions
-    //   for (let i = 0; i < permissions.length; i++) {
-    //     if (permissions[i]._id === userId) {
-    //       index = i
-    //     }
-    //   }
-    //   permissions.splice(index, 1)
-    //   this.setState({ permissions })
-    // })
+    datalad.removePermissions(this.state.datasets.dataset._id, userId).then(() => {
+      let index
+      let permissions = this.state.permissions
+      for (let i = 0; i < permissions.length; i++) {
+        if (permissions[i]._id === userId) {
+          index = i
+        }
+      }
+      permissions.splice(index, 1)
+      this.setState({ permissions })
+    })
   }
 }
 

--- a/packages/openneuro-app/src/scripts/dataset/tools/share.jsx
+++ b/packages/openneuro-app/src/scripts/dataset/tools/share.jsx
@@ -6,7 +6,7 @@ import React from 'react'
 import Reflux from 'reflux'
 import PropTypes from 'prop-types'
 import { Link, withRouter } from 'react-router-dom'
-import bids from '../../utils/bids'
+import datalad from '../../utils/datalad'
 import Input from '../../common/forms/input.jsx'
 import WarnButton from '../../common/forms/warn-button.jsx'
 import Spinner from '../../common/partials/spinner.jsx'
@@ -190,10 +190,12 @@ class Share extends Reflux.Component {
   }
 
   _addUser() {
+    let userId = this.state.input
+    let level = this.state.select
     this.setState({ error: null })
 
     // check name and access level are selected
-    if (this.state.input.length < 1 || this.state.select.length < 1) {
+    if (userId.length < 1 || level.length < 1) {
       this.setState({
         error:
           'You must enter a valid email address and select an access level',
@@ -204,7 +206,7 @@ class Share extends Reflux.Component {
     // check if user is already a member
     let isMember = false
     for (let user of this.state.permissions) {
-      if (this.state.input === user._id) {
+      if (userId === user._id) {
         isMember = true
       }
     }
@@ -216,7 +218,7 @@ class Share extends Reflux.Component {
     // check if user exists
     let userExists = false
     for (let user of this.state.users) {
-      if (this.state.input === user._id) {
+      if (userId === user._id) {
         userExists = true
       }
     }
@@ -230,10 +232,11 @@ class Share extends Reflux.Component {
 
     // add member
     let role = {
-      _id: this.state.input,
-      access: this.state.select,
+      _id: userId,
+      access: level,
     }
-    bids.addPermission(this.state.datasets.dataset._id, role).then(() => {
+
+    datalad.updatePermissions(this.state.datasets.dataset._id, userId, level).then(() => {
       let permissions = this.state.permissions
       permissions.push(role)
       this.setState({
@@ -246,17 +249,17 @@ class Share extends Reflux.Component {
   }
 
   _removeUser(userId) {
-    bids.removePermission(this.state.datasets.dataset._id, userId).then(() => {
-      let index
-      let permissions = this.state.permissions
-      for (let i = 0; i < permissions.length; i++) {
-        if (permissions[i]._id === userId) {
-          index = i
-        }
-      }
-      permissions.splice(index, 1)
-      this.setState({ permissions })
-    })
+    // datalad.removePermission(this.state.datasets.dataset._id, userId).then(() => {
+    //   let index
+    //   let permissions = this.state.permissions
+    //   for (let i = 0; i < permissions.length; i++) {
+    //     if (permissions[i]._id === userId) {
+    //       index = i
+    //     }
+    //   }
+    //   permissions.splice(index, 1)
+    //   this.setState({ permissions })
+    // })
   }
 }
 

--- a/packages/openneuro-app/src/scripts/utils/bids.js
+++ b/packages/openneuro-app/src/scripts/utils/bids.js
@@ -549,6 +549,7 @@ export default {
     let validationIssues = project.draft ? project.draft.issues : []
     let tags = project.tags ? project.tags : []
     let currentUser = userStore.data.scitran
+    let uploader = project.uploader ? project.uploader.id : null
     let userId = currentUser ? currentUser._id : null
     let hasRoot = currentUser ? currentUser.root : null
     let permissions = project.permissions ? project.permissions : []
@@ -565,7 +566,7 @@ export default {
       hasPublic: tags.indexOf('hasPublic') > -1,
       shared:
         userStore.data.scitran &&
-        project.group != userStore.data.scitran._id &&
+        uploader != userStore.data.scitran._id &&
         !!userAccess &&
         !adminOnlyAccess,
     }

--- a/packages/openneuro-app/src/scripts/utils/datalad.js
+++ b/packages/openneuro-app/src/scripts/utils/datalad.js
@@ -349,6 +349,25 @@ export default {
   
   decodeFilePath(path) {
     return path.replace(new RegExp(':', 'g'), '/')
-  }
+  },
 
+
+  // PERMISSIONS OPERATIONS
+  updatePermissions(datasetId, userId, level) {
+    let mutation = datasets.updatePermissions
+    datasetId = bids.decodeId(datasetId)
+    return new Promise((resolve, reject) => {
+      client.mutate({
+        mutation: mutation,
+        variables: {
+          datasetId, userId, level
+        }
+      }).then(() => {
+        resolve()
+      })
+      .catch(err => {
+        reject(err)
+      })
+    })
+  },
 }

--- a/packages/openneuro-app/src/scripts/utils/datalad.js
+++ b/packages/openneuro-app/src/scripts/utils/datalad.js
@@ -1,5 +1,5 @@
 import getClient from 'openneuro-client'
-import {datasets, files} from 'openneuro-client'
+import { datasets, files } from 'openneuro-client'
 import gql from 'graphql-tag'
 import bids from './bids'
 import clone from 'lodash.clonedeep'
@@ -12,80 +12,80 @@ function getToken() {
 
 const client = getClient('/crn/graphql', getToken)
 export default {
-    async getDatasets(options) {
-      const query = datasets.getDatasets
-      return new Promise((resolve, reject) => {
-        client.query({
-          query: query
-        })
+  async getDatasets(options) {
+    const query = datasets.getDatasets
+    return new Promise((resolve, reject) => {
+      client.query({
+        query: query
+      })
         .then(data => {
-            data = clone(data)
-            let datasets = data.data.datasets
-            if (options.isPublic) {
-              datasets = data.data.datasets.filter((dataset) => {
-                return dataset.public
-              })
-            }
-            data.data.datasets = datasets
-            resolve(data)
+          data = clone(data)
+          let datasets = data.data.datasets
+          if (options.isPublic) {
+            datasets = data.data.datasets.filter((dataset) => {
+              return dataset.public
+            })
+          }
+          data.data.datasets = datasets
+          resolve(data)
         })
         .catch(err => {
           // console.log('error in getDatasets:', err)
           reject(err)
         })
-      })
-    },
+    })
+  },
 
-    async getDataset(datasetId) {
-      return new Promise((resolve, reject) => {
-        this.queryDataset(datasetId, (err, data) => {
-          if (err) reject(err)
-          resolve(data)
-        })
+  async getDataset(datasetId) {
+    return new Promise((resolve, reject) => {
+      this.queryDataset(datasetId, (err, data) => {
+        if (err) reject(err)
+        resolve(data)
       })
-       
-    },
+    })
 
-    async getSnapshot(datasetId, options) {
-      return new Promise((resolve, reject) => {
-        this.querySnapshot(datasetId, options.tag, (err, data) => {
-          if (err) reject(err)
-          data = clone(data)
-          data.data.snapshot._id = options.datasetId
-          resolve(data)
-        })
-      })
-      
-    },
+  },
 
-    queryDataset(datasetId, callback) {
-      const query = datasets.getDataset
-      client.query({
-        query: query,
-        variables: {
-            id: bids.decodeId(datasetId)
-        }
+  async getSnapshot(datasetId, options) {
+    return new Promise((resolve, reject) => {
+      this.querySnapshot(datasetId, options.tag, (err, data) => {
+        if (err) reject(err)
+        data = clone(data)
+        data.data.snapshot._id = options.datasetId
+        resolve(data)
       })
+    })
+
+  },
+
+  queryDataset(datasetId, callback) {
+    const query = datasets.getDataset
+    client.query({
+      query: query,
+      variables: {
+        id: bids.decodeId(datasetId)
+      }
+    })
       .then(data => {
-          data = clone(data)
-          let snapshots = data.data.dataset.snapshots.slice(0)
-          for (let snapshot of snapshots) {
-              let splitId = snapshot.id.split(':')
-              snapshot._id = splitId[splitId.length -1]
-              snapshot.original = splitId[0]
-          }
-          data.data.dataset.files = data.data.dataset.draft ? data.data.dataset.draft.files : []
-          return callback(null, data)
+        data = clone(data)
+        let snapshots = data.data.dataset.snapshots.slice(0)
+        for (let snapshot of snapshots) {
+          let splitId = snapshot.id.split(':')
+          snapshot._id = splitId[splitId.length - 1]
+          snapshot.original = splitId[0]
+        }
+        data.data.dataset.files = data.data.dataset.draft ? data.data.dataset.draft.files : []
+        return callback(null, data)
       })
       .catch(err => {
         // console.log('error in datasetQuery:', err)
         return callback(err, null)
       })
-    },
+  },
 
-    querySnapshot(datasetId, tag, callback) {
-      client.query({
-        query: gql`
+  querySnapshot(datasetId, tag, callback) {
+    client.query({
+      query: gql`
           query getSnapshot ($datasetId: ID!, $tag: String!) {
             snapshot(datasetId: $datasetId, tag: $tag) {
               id
@@ -110,11 +110,11 @@ export default {
             }
           }
         `,
-        variables: {
-          datasetId: bids.decodeId(datasetId),
-          tag: tag
-        }
-      })
+      variables: {
+        datasetId: bids.decodeId(datasetId),
+        tag: tag
+      }
+    })
       .then(data => {
         return callback(null, data)
       })
@@ -122,80 +122,80 @@ export default {
         // console.log('error in snapshot query:', err) 
         return callback(err, null)
       })
-    },
+  },
 
-    deleteDataset(datasetId, options) {
-      if (options.snapshot && options.tag) {
-        let mutation = datasets.deleteSnapshot
-        return new Promise((resolve, reject) => {
-          client.mutate({
-            mutation: mutation,
-            variables: {
-              datasetId: bids.decodeId(datasetId),
-              tag: options.tag
-            }
-          })
-          .then(data => {
-            resolve(data)
-          })
-          .catch(err => {
-            reject(err)
-          })
-        })
-      } else {
-        let mutation = datasets.deleteDataset
-        return new Promise((resolve, reject) => {
-          client.mutate({
-            mutation: mutation,
-            variables: {
-              label: bids.decodeId(datasetId)
-            }
-          })
-          .then(data => {
-            resolve(data)
-          })
-          .catch(err => {
-            reject(err)
-          })
-        })
-      }
-    },
-
-    updatePublic(datasetId, publicFlag) {
-      datasetId = bids.decodeId(datasetId)
-      const mutation = datasets.updatePublic
+  deleteDataset(datasetId, options) {
+    if (options.snapshot && options.tag) {
+      let mutation = datasets.deleteSnapshot
       return new Promise((resolve, reject) => {
         client.mutate({
           mutation: mutation,
           variables: {
-            id: bids.decodeId(datasetId),
-            publicFlag: publicFlag
+            datasetId: bids.decodeId(datasetId),
+            tag: options.tag
           }
         })
+          .then(data => {
+            resolve(data)
+          })
+          .catch(err => {
+            reject(err)
+          })
+      })
+    } else {
+      let mutation = datasets.deleteDataset
+      return new Promise((resolve, reject) => {
+        client.mutate({
+          mutation: mutation,
+          variables: {
+            label: bids.decodeId(datasetId)
+          }
+        })
+          .then(data => {
+            resolve(data)
+          })
+          .catch(err => {
+            reject(err)
+          })
+      })
+    }
+  },
+
+  updatePublic(datasetId, publicFlag) {
+    datasetId = bids.decodeId(datasetId)
+    const mutation = datasets.updatePublic
+    return new Promise((resolve, reject) => {
+      client.mutate({
+        mutation: mutation,
+        variables: {
+          id: bids.decodeId(datasetId),
+          publicFlag: publicFlag
+        }
+      })
         .then(data => {
           let uri = `/crn/datasets/${datasetId}/publish`
           // if now public, initialize migration to a public s3 bucket
           // otherwise, initialize migration to a private s3 bucket          
           if (publicFlag) {
             request.post(uri)
-            .then(() => resolve(data))
-            .catch(err => reject(err))
+              .then(() => resolve(data))
+              .catch(err => reject(err))
           } else {
             request.del(uri)
-            .then(() => resolve(data))
-            .catch(err => reject(err))
+              .then(() => resolve(data))
+              .catch(err => reject(err))
           }
         })
         .catch(err => {
           // console.log('error in updatePublic:', err)
           reject(err)
         })
-      })
-      
-    },
+    })
 
-    createSnapshot(datasetId, tag) {
-      const mutation = gql`
+  },
+
+  createSnapshot(datasetId, tag) {
+    const mutation = gql`
         mutation ($datasetId: ID!, $tag: String!) {
           createSnapshot(datasetId: $datasetId, tag: $tag) {
             id
@@ -203,14 +203,14 @@ export default {
           }
         }
       `
-      return new Promise((resolve, reject) => {
-        client.mutate({
-          mutation: mutation,
-          variables: {
-            datasetId: bids.decodeId(datasetId),
-            tag: tag
-          }
-        })
+    return new Promise((resolve, reject) => {
+      client.mutate({
+        mutation: mutation,
+        variables: {
+          datasetId: bids.decodeId(datasetId),
+          tag: tag
+        }
+      })
         .then(data => {
           resolve(data)
         })
@@ -218,46 +218,46 @@ export default {
           // console.log('error in createSnapshot:', err)
           reject(err)
         })
-      })
+    })
 
-    },
-    
-    // FILE OPERATIONS
+  },
 
-    getFile(datasetId, filename, options) {
-      filename = this.encodeFilePath(filename)
-      let uri = `/crn/datasets/${datasetId}/files/${filename}`
-      if (options && options.snapshot) {
-        uri = `/crn/datasets/${datasetId}/snapshots/${options.tag}/files/${filename}`
-      }
-      return new Promise((resolve, reject) => {
-        request
-          .get(uri, {
-            headers: {
-              'Content-Type': 'application/*'
-            }
-          })
-          .then((res) => {
-            resolve(res)
-          })
-          .catch((err) => {
-            // console.log('error in getFile:', err)
-            reject(err)
-          })
-      })
-    },
+  // FILE OPERATIONS
 
-    deleteFiles(datasetId, fileTree) {
-      let mutation = files.deleteFiles
-
-      return new Promise((resolve, reject) => {
-        client.mutate({
-          mutation: mutation,
-          variables: {
-            datasetId: bids.decodeId(datasetId),
-            files: fileTree
+  getFile(datasetId, filename, options) {
+    filename = this.encodeFilePath(filename)
+    let uri = `/crn/datasets/${datasetId}/files/${filename}`
+    if (options && options.snapshot) {
+      uri = `/crn/datasets/${datasetId}/snapshots/${options.tag}/files/${filename}`
+    }
+    return new Promise((resolve, reject) => {
+      request
+        .get(uri, {
+          headers: {
+            'Content-Type': 'application/*'
           }
         })
+        .then((res) => {
+          resolve(res)
+        })
+        .catch((err) => {
+          // console.log('error in getFile:', err)
+          reject(err)
+        })
+    })
+  },
+
+  deleteFiles(datasetId, fileTree) {
+    let mutation = files.deleteFiles
+
+    return new Promise((resolve, reject) => {
+      client.mutate({
+        mutation: mutation,
+        variables: {
+          datasetId: bids.decodeId(datasetId),
+          files: fileTree
+        }
+      })
         .then(data => {
           resolve(data)
         })
@@ -265,41 +265,41 @@ export default {
           // console.log('error in deleteFiles:', err)
           reject(err)
         })
+    })
+  },
+
+  deleteFile(datasetId, file) {
+    // get the file path from the file object
+    let filePath = file.modifiedName ? this.encodeFilePath(file.modifiedName) : this.encodeFilePath(file.name)
+
+    // shape the file into the same shape as accepted by deleteFiles
+    let fileTree = this.constructFileTree(file, filePath)
+
+    // call updateFiles
+    return this.deleteFiles(datasetId, fileTree)
+  },
+
+  deleteDirectory(datasetId, pathname) {
+    let path = this.encodeFilePath(pathname)
+    let fileTree = {
+      name: path,
+      files: [],
+      directories: []
+    }
+    return this.deleteFiles(datasetId, fileTree)
+  },
+
+  updateFiles(datasetId, fileTree) {
+    let mutation = files.updateFiles
+
+    return new Promise((resolve, reject) => {
+      client.mutate({
+        mutation: mutation,
+        variables: {
+          datasetId: bids.decodeId(datasetId),
+          files: fileTree
+        }
       })
-    },
-
-    deleteFile(datasetId, file) {
-      // get the file path from the file object
-      let filePath = file.modifiedName ? this.encodeFilePath(file.modifiedName) : this.encodeFilePath(file.name)
-
-      // shape the file into the same shape as accepted by deleteFiles
-      let fileTree = this.constructFileTree(file, filePath)
-
-      // call updateFiles
-      return this.deleteFiles(datasetId, fileTree)
-    },
-
-    deleteDirectory(datasetId, pathname) {
-      let path = this.encodeFilePath(pathname)
-      let fileTree = {
-        name: path,
-        files: [],
-        directories: []
-      }
-      return this.deleteFiles(datasetId, fileTree)
-    },
-
-    updateFiles(datasetId, fileTree) {
-      let mutation = files.updateFiles
-
-      return new Promise((resolve, reject) => {
-        client.mutate({
-          mutation: mutation,
-          variables: {
-            datasetId: bids.decodeId(datasetId),
-            files: fileTree
-          }
-        })
         .then(data => {
           resolve(data)
         })
@@ -307,52 +307,61 @@ export default {
           // console.log('error in updateFiles:', err)
           reject(err)
         })
-      })
-    },
+    })
+  },
 
-    updateFile(datasetId, file) {
-      // get the file path from the file object
-      let filePath = file.modifiedName ? this.encodeFilePath(file.modifiedName) : this.encodeFilePath(file.name)
+  updateFile(datasetId, file) {
+    // get the file path from the file object
+    let filePath = file.modifiedName ? this.encodeFilePath(file.modifiedName) : this.encodeFilePath(file.name)
 
-      // shape the file into the same shape as accepted by updateFiles
-      let fileTree = this.constructFileTree(file, filePath)
+    // shape the file into the same shape as accepted by updateFiles
+    let fileTree = this.constructFileTree(file, filePath)
 
-      // call updateFiles
-      return this.updateFiles(datasetId, fileTree)
-    },
+    // call updateFiles
+    return this.updateFiles(datasetId, fileTree)
+  },
 
-    updateFileFromString(datasetId, filename, value, type) {
-      let file = new File([value], filename, { type: type })
-      return this.updateFile(datasetId, file)
-    },
+  updateFileFromString(datasetId, filename, value, type) {
+    let file = new File([value], filename, { type: type })
+    return this.updateFile(datasetId, file)
+  },
 
-    constructFileTree(file, filePath) {
-      let fileName = filePath.split(':').slice(-1)[0]
-      if (filePath.split(':').length > 0) {
-        let pathComponents = filePath.split(':')
-        let newNode = pathComponents.slice(-1)[0]
-        let newPath = pathComponents.reverse().slice(1).reverse().join(':')
-        let files = (newNode === fileName) ? [file] : []
-        let directories = (newNode === fileName) ? [] : this.constructFileTree(file, newPath)
-        let fileTree = {
-          name: newPath,
-          files: files,
-          directories: directories
-        }
-        return fileTree
+  constructFileTree(file, filePath) {
+    let fileName = filePath.split(':').slice(-1)[0]
+    if (filePath.split(':').length > 0) {
+      let pathComponents = filePath.split(':')
+      let newNode = pathComponents.slice(-1)[0]
+      let newPath = pathComponents.reverse().slice(1).reverse().join(':')
+      let files = (newNode === fileName) ? [file] : []
+      let directories = (newNode === fileName) ? [] : this.constructFileTree(file, newPath)
+      let fileTree = {
+        name: newPath,
+        files: files,
+        directories: directories
       }
+      return fileTree
+    }
   },
 
   encodeFilePath(path) {
     return path.replace(new RegExp('/', 'g'), ':')
   },
-  
+
   decodeFilePath(path) {
     return path.replace(new RegExp(':', 'g'), '/')
   },
 
 
   // PERMISSIONS OPERATIONS
+
+  /**
+   * Update Permissions
+   * 
+   * adds / updates a user's role on a dataset
+   * @param {*} datasetId id of dataset that requires permissions update
+   * @param {*} userId permissions will be changed for user with this id
+   * @param {*} level the access level we wish to grant the user, 'r' = read, 'rw' = read / write, 'admin' = all access
+   */
   updatePermissions(datasetId, userId, level) {
     let mutation = datasets.updatePermissions
     datasetId = bids.decodeId(datasetId)
@@ -362,12 +371,29 @@ export default {
         variables: {
           datasetId, userId, level
         }
-      }).then(() => {
-        resolve()
-      })
-      .catch(err => {
-        reject(err)
-      })
+      }).then(() => resolve())
+        .catch(err => reject(err))
     })
   },
+
+  /**
+   * Remove Permissions
+   * 
+   * removes a user's role on a dataset
+   * @param {*} datasetId id of dataset that requires permission removal
+   * @param {*} userId permissions will be removed for the user with this id
+   */
+  removePermissions(datasetId, userId) {
+    let mutation = datasets.removePermissions
+    datasetId = bids.decodeId(datasetId)
+    return new Promise((resolve, reject) => {
+      client.mutate({
+        mutation: mutation,
+        variables: {
+          datasetId, userId
+        }
+      }).then(() => resolve())
+        .catch(err => reject(err))
+    })
+  }
 }

--- a/packages/openneuro-client/src/datasets.js
+++ b/packages/openneuro-client/src/datasets.js
@@ -42,6 +42,12 @@ export const getDataset = gql`
         created
         snapshot_version: tag
       }
+      permissions {
+        userId
+        _id: userId
+        level
+        access: level
+      }
     }
   }
 `
@@ -57,6 +63,12 @@ export const getDatasets = gql`
         id
       }
       public
+      permissions {
+        userId
+        _id: userId
+        level
+        access: level
+      }
     }
   }
 `
@@ -87,5 +99,11 @@ export const deleteSnapshot = gql`
 export const updatePublic = gql`
   mutation ($id: ID!, $publicFlag: Boolean!) {
     updatePublic(datasetId: $id, publicFlag: $publicFlag)
+  }
+`
+
+export const updatePermissions = gql`
+  mutation ($datasetId: ID!, $userId: String!, $level: String) {
+    updatePermissions(datasetId: $datasetId, userId: $userId, level: $level)
   }
 `

--- a/packages/openneuro-client/src/datasets.js
+++ b/packages/openneuro-client/src/datasets.js
@@ -107,3 +107,9 @@ export const updatePermissions = gql`
     updatePermissions(datasetId: $datasetId, userId: $userId, level: $level)
   }
 `
+
+export const removePermissions = gql`
+  mutation ($datasetId: ID!, $userId: String!) {
+    removePermissions(datasetId: $datasetId, userId: $userId)
+  }
+`

--- a/packages/openneuro-server/datalad/dataset.js
+++ b/packages/openneuro-server/datalad/dataset.js
@@ -75,7 +75,7 @@ export const createDatasetModel = (id, label, uploader) => {
 export const giveUploaderPermission = (id, uploader) => {
   const datasetId = id
   const userId = uploader
-  const level = 'rw'
+  const level = 'admin'
   return c.crn.permissions.insertOne({datasetId, userId, level})
 }
 

--- a/packages/openneuro-server/datalad/dataset.js
+++ b/packages/openneuro-server/datalad/dataset.js
@@ -34,6 +34,7 @@ export const createDataset = (label, uploader, userInfo) => {
   return new Promise(async (resolve, reject) => {
     const datasetId = await getAccessionNumber()
     const dsObj = await createDatasetModel(datasetId, label, uploader)
+    await giveUploaderPermission(datasetId, uploader)
     // If successful, create the repo
     const url = `${uri}/datasets/${datasetId}`
     if (dsObj) {
@@ -69,6 +70,13 @@ export const createDatasetModel = (id, label, uploader) => {
     revision,
   }
   return c.crn.datasets.insertOne(datasetObj)
+}
+
+export const giveUploaderPermission = (id, uploader) => {
+  const datasetId = id
+  const userId = uploader
+  const level = 'rw'
+  return c.crn.permissions.insertOne({datasetId, userId, level})
 }
 
 /**

--- a/packages/openneuro-server/graphql/resolvers/index.js
+++ b/packages/openneuro-server/graphql/resolvers/index.js
@@ -16,7 +16,7 @@ import {
 import { updateSummary, updateValidation } from './validation.js'
 import { draft, snapshot, snapshots } from './datalad.js'
 import { whoami, user, users } from './user.js'
-import { permissions, updatePermissions } from './permissions.js'
+import { permissions, updatePermissions, removePermissions } from './permissions.js'
 
 export default {
   Date: GraphQLDate,
@@ -44,6 +44,7 @@ export default {
     updateSnapshotFileUrls,
     updatePublic,
     updatePermissions,
+    removePermissions,
   },
   User: user,
   Dataset: {

--- a/packages/openneuro-server/graphql/resolvers/index.js
+++ b/packages/openneuro-server/graphql/resolvers/index.js
@@ -16,6 +16,7 @@ import {
 import { updateSummary, updateValidation } from './validation.js'
 import { draft, snapshot, snapshots } from './datalad.js'
 import { whoami, user, users } from './user.js'
+import { permissions, updatePermissions } from './permissions.js'
 
 export default {
   Date: GraphQLDate,
@@ -42,11 +43,13 @@ export default {
     updateValidation,
     updateSnapshotFileUrls,
     updatePublic,
+    updatePermissions,
   },
   User: user,
   Dataset: {
     uploader: ds => user(ds, { id: ds.uploader }),
     draft,
     snapshots,
+    permissions: ds => permissions(ds)
   },
 }

--- a/packages/openneuro-server/graphql/resolvers/permissions.js
+++ b/packages/openneuro-server/graphql/resolvers/permissions.js
@@ -2,7 +2,9 @@ import mongo from '../../libs/mongo.js'
 
 export const permissions = obj => {
   let datasetId = obj.id
-  return mongo.collections.crn.permissions.find({ datasetId: datasetId }).toArray()
+  return mongo.collections.crn.permissions
+    .find({ datasetId: datasetId })
+    .toArray()
 }
 
 /**
@@ -23,4 +25,14 @@ export const updatePermissions = (obj, args) => {
     },
     { upsert: true },
   )
+}
+
+/**
+ * Remove user permissions on a dataset
+ */
+export const removePermissions = (obj, args) => {
+  return mongo.collections.crn.permissions.remove({
+    datasetId: args.datasetId,
+    userId: args.userId,
+  })
 }

--- a/packages/openneuro-server/graphql/resolvers/permissions.js
+++ b/packages/openneuro-server/graphql/resolvers/permissions.js
@@ -1,0 +1,26 @@
+import mongo from '../../libs/mongo.js'
+
+export const permissions = obj => {
+  let datasetId = obj.id
+  return mongo.collections.crn.permissions.find({ datasetId: datasetId }).toArray()
+}
+
+/**
+ * Update user permissions on a dataset
+ */
+export const updatePermissions = (obj, args) => {
+  return mongo.collections.crn.permissions.updateOne(
+    {
+      datasetId: args.datasetId,
+      userId: args.userId,
+    },
+    {
+      $set: {
+        datasetId: args.datasetId,
+        userId: args.userId,
+        level: args.level,
+      },
+    },
+    { upsert: true },
+  )
+}

--- a/packages/openneuro-server/graphql/schema.js
+++ b/packages/openneuro-server/graphql/schema.js
@@ -44,6 +44,8 @@ const typeDefs = `
     updateValidation(validation: ValidationInput!): Boolean
     # Update a snapshot with a list of file urls
     updateSnapshotFileUrls(fileUrls: FileUrls!): Boolean
+    # Update a users's permissions on a dataset
+    updatePermissions(datasetId: ID!, userId: String!, level: String): Boolean
   }
 
   input SummaryInput {
@@ -105,6 +107,7 @@ const typeDefs = `
     public: Boolean
     draft: Draft
     snapshots: [Snapshot]
+    permissions: [Permission]
   }
 
   # Ephemeral draft or working tree for a dataset
@@ -130,6 +133,13 @@ const typeDefs = `
     summary: Summary
     issues: [ValidationIssue]
     files: [DatasetFile]
+  }
+
+  #User permissions on a dataset
+  type Permission {
+    datasetId: ID!
+    userId: String!
+    level: String!
   }
 
   # Authors of a dataset
@@ -219,6 +229,7 @@ const typeDefs = `
     filename: String!
     urls: [String]
   }
+
 `
 
 export default makeExecutableSchema({

--- a/packages/openneuro-server/graphql/schema.js
+++ b/packages/openneuro-server/graphql/schema.js
@@ -46,6 +46,8 @@ const typeDefs = `
     updateSnapshotFileUrls(fileUrls: FileUrls!): Boolean
     # Update a users's permissions on a dataset
     updatePermissions(datasetId: ID!, userId: String!, level: String): Boolean
+    # Remove a users's permissions on a dataset
+    removePermissions(datasetId: ID!, userId: String!): Boolean
   }
 
   input SummaryInput {

--- a/packages/openneuro-server/libs/mongo.js
+++ b/packages/openneuro-server/libs/mongo.js
@@ -45,6 +45,7 @@ export default {
       dois: null,
       keys: null,
       files: null,
+      permissions: null,
     },
     scitran: {
       projects: null,


### PR DESCRIPTION
fixes #668 
fixes #660 
fixes #675 

implements permissions model for the datalad backend via gql. 

* updatePermissions - changes the permissions of a user on a dataset
* removePermissions - removes the permissions of a user on a dataset
* datasets / dataset queries now return the permissions objects as an array
* permissions collection added to mongo
* share.jsx screen now uses the datalad permissions functions (replacing the bids functions)
