### PR TITLE
allow for null dataset responses from dataset queries

### DIFF
--- a/packages/openneuro-app/src/scripts/utils/bids.js
+++ b/packages/openneuro-app/src/scripts/utils/bids.js
@@ -153,8 +153,9 @@ export default {
         if (data) {
           // get snapshot or draft, depending on results
           let project = data.dataset
-          let draft = project.draft
-          let snapshot = options.snapshot ? (await datalad.getSnapshot(projectId, options)).data.snapshot : null
+          let draft = project ? project.draft : null
+          let snapshotQuery = options.snapshot ? (await datalad.getSnapshot(projectId, options)).data : null
+          let snapshot = snapshotQuery ? snapshotQuery.dataset : null
           let tempFiles = !snapshot ? this._formatFiles(draft.files) : this._formatFiles(snapshot.files)
           project.snapshot_version = snapshot ? snapshot.tag : null
           this.getMetadata(

--- a/packages/openneuro-app/src/scripts/utils/datalad.js
+++ b/packages/openneuro-app/src/scripts/utils/datalad.js
@@ -68,13 +68,16 @@ export default {
       })
       .then(data => {
           data = clone(data)
-          let snapshots = data.data.dataset.snapshots.slice(0)
-          for (let snapshot of snapshots) {
-              let splitId = snapshot.id.split(':')
-              snapshot._id = splitId[splitId.length -1]
-              snapshot.original = splitId[0]
+          if (data.data.dataset) {
+            let snapshots = data.data.dataset.snapshots ? data.data.dataset.snapshots.slice(0) : []
+            for (let snapshot of snapshots) {
+                let splitId = snapshot.id.split(':')
+                snapshot._id = splitId[splitId.length -1]
+                snapshot.original = splitId[0]
+            }
+            data.data.dataset.files = data.data.dataset.draft ? data.data.dataset.draft.files : []
           }
-          data.data.dataset.files = data.data.dataset.draft ? data.data.dataset.draft.files : []
+          
           return callback(null, data)
       })
       .catch(err => {


### PR DESCRIPTION
fixes #628 

null results from gql dataset queries were throwing an error when trying to access the snapshot field (because it didn't exist!). this fixes that problem. 