### PR TITLE
Client side streaming downloads for DataLad backend

### DIFF
--- a/packages/openneuro-app/src/scripts/datalad/download/download-link.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/download/download-link.jsx
@@ -26,8 +26,10 @@ const downloadClick = (datasetId, snapshotTag) => callback => {
     } else {
       // Something has gone wrong with the service worker
       // or the browser does not support it
-      console.log('An unexpected issue occurred downloading.')
-      console.log(serviceWorker)
+      console.error('An unexpected issue occurred downloading.', serviceWorker)
+      global.alert(
+        'Download failed to start. Please wait a few moments and try again.',
+      )
       // TODO Maybe re-register here?
     }
   }

--- a/packages/openneuro-app/src/scripts/datalad/download/download-link.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/download/download-link.jsx
@@ -24,6 +24,12 @@ const downloadClick = (datasetId, snapshotTag) => callback => {
       'Your browser is out of date, please upgrade to a newer supported browser to download.',
     )
     callback()
+  } else if (typeof global.ReadableStream === 'undefined') {
+    // This is likely Firefox with flags disabled
+    global.alert(
+      'Web streams are required to download. Try a recent version of Chrome or enable "dom.streams.enabled" and "javascript.options.streams" in Firefox about:config',
+    )
+    callback()
   } else {
     // Check for a running service worker
     global.navigator.serviceWorker.getRegistration().then(registration => {

--- a/packages/openneuro-app/src/scripts/datalad/download/download-link.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/download/download-link.jsx
@@ -27,7 +27,7 @@ const downloadClick = (datasetId, snapshotTag) => callback => {
   } else if (typeof global.ReadableStream === 'undefined') {
     // This is likely Firefox with flags disabled
     global.alert(
-      'Web streams are required to download. Try a recent version of Chrome or enable "dom.streams.enabled",  "javascript.options.streams", and "dom.ipc.multiOptOut" in Firefox about:config',
+      'Web streams are required to download. Try a recent version of Chrome or see the FAQ for how to enable these features on Firefox.',
     )
     callback()
   } else {

--- a/packages/openneuro-app/src/scripts/datalad/download/download-link.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/download/download-link.jsx
@@ -14,15 +14,21 @@ const downloadClick = (datasetId, snapshotTag) => callback => {
     ? `${config.crn.url}datasets/${datasetId}/snapshots/${snapshotTag}/download`
     : `${config.crn.url}datasets/${datasetId}/download`
   // Check that a service worker is registered
-  const serviceWorker = global.navigator.serviceWorker.controller
-  if (serviceWorker && serviceWorker.scriptURL.startsWith(config.url)) {
-    global.open(uri, `${datasetId} download`)
-  } else {
-    // Something has gone wrong with the service worker
-    // or the browser does not support it
+  if (!global.navigator.serviceWorker) {
     global.alert(
-      'An error was encountered with this download. Please try again or upgrade to a newer supported browser.',
+      'Your browser is out of date, please upgrade to a newer supported browser to download.',
     )
+  } else {
+    const serviceWorker = global.navigator.serviceWorker.controller
+    if (serviceWorker && serviceWorker.scriptURL.startsWith(config.url)) {
+      global.open(uri, `${datasetId} download`)
+    } else {
+      // Something has gone wrong with the service worker
+      // or the browser does not support it
+      console.log('An unexpected issue occurred downloading.')
+      console.log(serviceWorker)
+      // TODO Maybe re-register here?
+    }
   }
   // Finish the WarnButton loading state.
   callback()

--- a/packages/openneuro-app/src/scripts/datalad/download/download-link.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/download/download-link.jsx
@@ -1,0 +1,50 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import WarnButton from '../../common/forms/warn-button.jsx'
+import config from '../../../../config.js'
+
+/**
+ * Event handler for initiating dataset or snapshot downloads
+ * @param {string} datasetId Accession number string for a dataset
+ */
+const downloadClick = (datasetId, snapshotTag) => callback => {
+  // This can't be a GraphQL query since it is intercepted
+  // by the service worker
+  const uri = snapshotTag
+    ? `${config.crn.url}datasets/${datasetId}/snapshots/${snapshotTag}/download`
+    : `${config.crn.url}datasets/${datasetId}/download`
+  // Check that a service worker is registered
+  const serviceWorker = global.navigator.serviceWorker.controller
+  if (serviceWorker && serviceWorker.scriptURL.startsWith(config.crn.url)) {
+    global.open(uri, `${datasetId} download`)
+  } else {
+    // Something has gone wrong with the service worker
+    // or the browser does not support it
+    global.alert(
+      'An error was encountered with this download. Please try again or upgrade to a newer supported browser.',
+    )
+  }
+  // Finish the WarnButton loading state.
+  callback()
+}
+
+/**
+ * Generate a magic bundle link for this dataset
+ */
+const DownloadLink = ({ datasetId, snapshotTag }) => (
+  <div role="presentation" className="tool">
+    <WarnButton
+      tooltip="Download"
+      icon="fa-download"
+      warn={false}
+      action={downloadClick(datasetId, snapshotTag)}
+    />
+  </div>
+)
+
+DownloadLink.propTypes = {
+  datasetId: PropTypes.string.isRequired,
+  snapshotTag: PropTypes.string,
+}
+
+export default DownloadLink

--- a/packages/openneuro-app/src/scripts/datalad/download/download-link.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/download/download-link.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import React from 'react'
 import PropTypes from 'prop-types'
 import WarnButton from '../../common/forms/warn-button.jsx'

--- a/packages/openneuro-app/src/scripts/datalad/download/download-link.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/download/download-link.jsx
@@ -40,14 +40,21 @@ const downloadClick = (datasetId, snapshotTag) => callback => {
       } else {
         // Waiting on the service worker
         if (registration.installing || registration.waiting) {
-          serviceWorker.addEventListener('statechange', function(e) {
-            if (e.target.state === 'active') {
-              // Worker ready, start downloading
-              serviceWorker.removeEventListener('statechange', this, true)
-              startDownload(uri, datasetId)
-              callback()
-            }
-          })
+          global.navigator.serviceWorker.addEventListener(
+            'statechange',
+            function(e) {
+              if (e.target.state === 'active') {
+                // Worker ready, start downloading
+                global.navigator.serviceWorker.removeEventListener(
+                  'statechange',
+                  this,
+                  true,
+                )
+                startDownload(uri, datasetId)
+                callback()
+              }
+            },
+          )
         } else {
           global.alert(
             'Download failed, please refresh and try again in a few moments.',

--- a/packages/openneuro-app/src/scripts/datalad/download/download-link.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/download/download-link.jsx
@@ -27,7 +27,7 @@ const downloadClick = (datasetId, snapshotTag) => callback => {
   } else if (typeof global.ReadableStream === 'undefined') {
     // This is likely Firefox with flags disabled
     global.alert(
-      'Web streams are required to download. Try a recent version of Chrome or enable "dom.streams.enabled" and "javascript.options.streams" in Firefox about:config',
+      'Web streams are required to download. Try a recent version of Chrome or enable "dom.streams.enabled",  "javascript.options.streams", and "dom.ipc.multiOptOut" in Firefox about:config',
     )
     callback()
   } else {

--- a/packages/openneuro-app/src/scripts/datalad/download/download-link.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/download/download-link.jsx
@@ -15,7 +15,7 @@ const downloadClick = (datasetId, snapshotTag) => callback => {
     : `${config.crn.url}datasets/${datasetId}/download`
   // Check that a service worker is registered
   const serviceWorker = global.navigator.serviceWorker.controller
-  if (serviceWorker && serviceWorker.scriptURL.startsWith(config.crn.url)) {
+  if (serviceWorker && serviceWorker.scriptURL.startsWith(config.url)) {
     global.open(uri, `${datasetId} download`)
   } else {
     // Something has gone wrong with the service worker

--- a/packages/openneuro-app/src/scripts/dataset/tools/index.js
+++ b/packages/openneuro-app/src/scripts/dataset/tools/index.js
@@ -5,6 +5,7 @@ import Reflux from 'reflux'
 import PropTypes from 'prop-types'
 import { withRouter } from 'react-router-dom'
 import moment from 'moment'
+import DownloadLink from '../../datalad/download/download-link.jsx'
 import WarnButton from '../../common/forms/warn-button.jsx'
 import userStore from '../../user/user.store.js'
 import actions from '../dataset.actions.js'
@@ -65,23 +66,6 @@ class Tools extends Reflux.Component {
     )
 
     let tools = [
-      {
-        tooltip: 'Download Dataset',
-        icon: 'fa-download',
-        prepDownload: actions.getDatasetDownloadTicket.bind(this),
-        action: actions.confirmDatasetDownload.bind(this, this.props.history),
-        display: !isIncomplete,
-        warn: true,
-        modalLink: datasets.datasetUrl + '/subscribe',
-        validations: [
-          {
-            check: datasets.uploading && !isSnapshot,
-            message: 'Files are currently uploading',
-            timeout: 5000,
-            type: 'Error',
-          },
-        ],
-      },
       {
         tooltip: 'Publish Dataset',
         icon: 'fa-globe icon-plus',
@@ -181,7 +165,7 @@ class Tools extends Reflux.Component {
             type: 'Error',
           },
           {
-            check: 
+            check:
               snapshots.length > 1 &&
               moment(dataset.modified).diff(moment(snapshots[1].created)) <= 0,
             message:
@@ -267,6 +251,14 @@ class Tools extends Reflux.Component {
         <div className="col-xs-12 dataset-tools-wrap">
           <div className="tools clearfix">
             {this._snapshotLabel(dataset)}
+            {isSnapshot ? (
+              <DownloadLink
+                datasetId={dataset.linkID}
+                snapshotTag={dataset.snapshot_version}
+              />
+            ) : (
+              <DownloadLink datasetId={dataset.linkID} />
+            )}
             {this._tools(tools)}
           </div>
         </div>

--- a/packages/openneuro-app/src/scripts/faq/__tests__/__snapshots__/faq.spec.jsx.snap
+++ b/packages/openneuro-app/src/scripts/faq/__tests__/__snapshots__/faq.spec.jsx.snap
@@ -211,7 +211,7 @@ exports[`faq/faq/Faq renders successfully 1`] = `
       className="panel-heading"
     >
       <span>
-        I'm having trouble downloading with Firefox, what can I do?
+        I am having trouble downloading with Firefox, what can I do?
       </span>
     </div>
     <div

--- a/packages/openneuro-app/src/scripts/faq/__tests__/__snapshots__/faq.spec.jsx.snap
+++ b/packages/openneuro-app/src/scripts/faq/__tests__/__snapshots__/faq.spec.jsx.snap
@@ -203,5 +203,51 @@ exports[`faq/faq/Faq renders successfully 1`] = `
       </span>
     </div>
   </div>
+  <div
+    className="panel"
+    key="8"
+  >
+    <div
+      className="panel-heading"
+    >
+      <span>
+        I'm having trouble downloading with Firefox, what can I do?
+      </span>
+    </div>
+    <div
+      className="panel-body"
+    >
+      <span>
+        <p>
+          Firefox is working to support the APIs used by downloads but as of Firefox 60, these features are hidden behind experimental configuration flags. Chrome is recommended for dataset or snapshot downloads, but you can try out Firefox support by enabling three
+           
+          <q>
+            about:config
+          </q>
+           flags.
+        </p>
+        <ul>
+          <li>
+            dom.streams.enabled - enables web streams.
+          </li>
+          <li>
+            javascript.options.streams - allows Javascript to use the API.
+          </li>
+          <li>
+            dom.ipc.multiOptOut - works around thread bugs, this may not be needed but improves reliablity on some platforms.
+          </li>
+        </ul>
+        <p>
+          You can find out more about
+           
+          <a
+            href="https://developer.mozilla.org/en-US/docs/Web/API/Streams_API"
+          >
+            web streams on MDN.
+          </a>
+        </p>
+      </span>
+    </div>
+  </div>
 </div>
 `;

--- a/packages/openneuro-app/src/scripts/faq/faq.jsx
+++ b/packages/openneuro-app/src/scripts/faq/faq.jsx
@@ -111,8 +111,8 @@ class Faq extends React.Component {
               target="_blank"
               rel="noopener noreferrer">
               bids.neuroimaging.io
-            </a>.
-            If you have any questions about organizing your data please post them at
+            </a>. If you have any questions about organizing your data please
+            post them at
             <a
               href="https://neurostars.org/tags/bids"
               target="_blank"
@@ -137,10 +137,43 @@ class Faq extends React.Component {
               target="_blank"
               rel="noopener noreferrer">
               pydeface
-            </a>. 
-            Defacing is strongly preffered over skullstripping, because 
-            the process is more robust and yields lower chance of 
-            accidentally removing brain tissue.
+            </a>. Defacing is strongly preffered over skullstripping, because
+            the process is more robust and yields lower chance of accidentally
+            removing brain tissue.
+          </span>
+        ),
+      },
+      {
+        faq: (
+          <span>
+            I'm having trouble downloading with Firefox, what can I do?
+          </span>
+        ),
+        faq_answer: (
+          <span>
+            <p>
+              Firefox is working to support the APIs used by downloads but as of
+              Firefox 60, these features are hidden behind experimental
+              configuration flags. Chrome is recommended for dataset or snapshot
+              downloads, but you can try out Firefox support by enabling three{' '}
+              <q>about:config</q> flags.
+            </p>
+            <ul>
+              <li>dom.streams.enabled - enables web streams.</li>
+              <li>
+                javascript.options.streams - allows Javascript to use the API.
+              </li>
+              <li>
+                dom.ipc.multiOptOut - works around thread bugs, this may not be
+                needed but improves reliablity on some platforms.
+              </li>
+            </ul>
+            <p>
+              You can find out more about{' '}
+              <a href="https://developer.mozilla.org/en-US/docs/Web/API/Streams_API">
+                web streams on MDN.
+              </a>
+            </p>
           </span>
         ),
       },

--- a/packages/openneuro-app/src/scripts/faq/faq.jsx
+++ b/packages/openneuro-app/src/scripts/faq/faq.jsx
@@ -146,7 +146,7 @@ class Faq extends React.Component {
       {
         faq: (
           <span>
-            I'm having trouble downloading with Firefox, what can I do?
+            I am having trouble downloading with Firefox, what can I do?
           </span>
         ),
         faq_answer: (

--- a/packages/openneuro-app/src/scripts/serviceworker/dataset.js
+++ b/packages/openneuro-app/src/scripts/serviceworker/dataset.js
@@ -63,21 +63,25 @@ const fetchAlternates = urls => {
  * @param {URL} index The URL for a file index (s3 and other files)
  */
 export const bundleResponse = async index => {
-  let filename = 'archive.zip'
+  let filename = 'archive'
   const tokens = index.pathname.split('/')
+  const tl = tokens.length
   // If this is a draft download
-  if (tokens[-3] === 'dataset') {
+  if (tokens[tl - 3] === 'datasets') {
     // Set filename to the accession number
-    filename = tokens[-2]
+    filename = tokens[tl - 2]
+  } else if (tokens[tl - 3] === 'snapshots') {
+    // Accession number + snapshot
+    filename = `${tokens[tl - 4]}-${tokens[tl - 2]}`
   }
-  const header = {
+  const headers = {
     'Content-Type': 'application/zip',
-    'Content-Disposition': `attachment; filename=${filename}.zip`,
+    'Content-Disposition': `attachment; filename="${filename}.zip"`,
   }
   return new Response(
     await fetch(index)
       .then(resp => resp.json())
       .then(zipFiles),
-    header,
+    { headers },
   )
 }

--- a/packages/openneuro-app/src/scripts/serviceworker/dataset.js
+++ b/packages/openneuro-app/src/scripts/serviceworker/dataset.js
@@ -34,6 +34,7 @@ export const zipFiles = ({ files }) => {
           controller.enqueue(data)
         })
         .on('error', err => {
+          // eslint-disable-next-line no-console
           console.log(err)
         })
         .on('end', () => controller.close())

--- a/packages/openneuro-app/src/scripts/serviceworker/dataset.js
+++ b/packages/openneuro-app/src/scripts/serviceworker/dataset.js
@@ -50,7 +50,9 @@ export const zipFiles = ({ files }) => {
 const fetchAlternates = urls => {
   if (urls.length > 0) {
     const fileUrl = urls.shift()
-    return fetch(fileUrl).catch(() => fetchAlternates(urls))
+    return fetch(fileUrl, { method: 'HEAD' }).then(
+      response => (response.ok ? fetch(fileUrl) : fetchAlternates(urls)),
+    )
   } else {
     throw new Error('All file URLs failed.')
   }

--- a/packages/openneuro-app/src/scripts/serviceworker/dataset.js
+++ b/packages/openneuro-app/src/scripts/serviceworker/dataset.js
@@ -1,0 +1,80 @@
+import { Readable } from 'stream'
+import JSZip from 'jszip'
+
+/**
+ * Return a streaming zip from array of file objects
+ * @param {Array} files Array of files to fetch
+ */
+export const zipFiles = ({ files }) => {
+  const zip = new JSZip()
+
+  // Start getting files, in order
+  for (const { filename, urls } of files) {
+    const readStream = new Readable()
+    let reader
+    readStream._read = () => {
+      reader = reader || fetchAlternates(urls).then(res => res.body.getReader())
+      reader.then(reader =>
+        reader
+          .read()
+          .then(({ value, done }) =>
+            readStream.push(done ? null : new Buffer(value)),
+          ),
+      )
+    }
+    zip.file(filename, readStream)
+  }
+
+  // Build a ReadableStream for fetch
+  return new ReadableStream({
+    start(controller) {
+      zip
+        .generateInternalStream({ type: 'uint8array', streamFiles: true })
+        .on('data', data => {
+          controller.enqueue(data)
+        })
+        .on('error', err => {
+          console.log(err)
+        })
+        .on('end', () => controller.close())
+        .resume()
+    },
+  })
+}
+
+/**
+ * Check each URL provided
+ * @param {Array} urls
+ */
+const fetchAlternates = urls => {
+  if (urls.length > 0) {
+    const fileUrl = urls.shift()
+    return fetch(fileUrl).catch(() => fetchAlternates(urls))
+  } else {
+    throw new Error('All file URLs failed.')
+  }
+}
+
+/**
+ * Create a zipped response for an Dataset FetchEvent
+ * @param {URL} index The URL for a file index (s3 and other files)
+ */
+export const bundleResponse = async index => {
+  let filename = 'archive.zip'
+  const tokens = index.pathname.split('/')
+  // If this is a draft download
+  if (tokens[-3] === 'dataset') {
+    // Set filename to the accession number
+    filename = tokens[-2]
+  }
+  const header = {
+    'Content-Type': 'application/zip',
+    'Content-Disposition': `attachment; filename=${filename}.zip`,
+  }
+  return new Response(
+    await fetch(index)
+      .then(resp => resp.json())
+      .then(zipFiles),
+    header,
+  )
+}

--- a/packages/openneuro-app/src/scripts/sw.js
+++ b/packages/openneuro-app/src/scripts/sw.js
@@ -19,6 +19,10 @@ self.addEventListener('install', event => {
   )
 })
 
+self.addEventListener('activate', event => {
+  event.waitUntil(self.clients.claim())
+})
+
 self.addEventListener('fetch', event => {
   // Let the browser do its default thing
   // for non-GET requests.

--- a/packages/openneuro-app/src/scripts/sw.js
+++ b/packages/openneuro-app/src/scripts/sw.js
@@ -3,8 +3,9 @@
  *
  * Be careful to only include necessary dependencies here
  */
-import { zipResponse } from './serviceworker/s3'
-import config from '../../config'
+import { zipResponse } from './serviceworker/s3.js'
+import { bundleResponse } from './serviceworker/dataset.js'
+import config from '../../config.js'
 
 const CACHE_NAME = 'openneuro'
 const CACHE_PATHS = serviceWorkerOption.assets
@@ -30,6 +31,9 @@ self.addEventListener('fetch', event => {
       const hostname = url.hostname
       const prefix = url.pathname.slice(1)
       return event.respondWith(zipResponse(hostname, prefix))
+    } else if (url.pathname.endsWith('download')) {
+      // Catch any aggregate download requests
+      return event.respondWith(bundleResponse(url))
     } else {
       // Skip serving from cache for cross origin 'only-if-cached' requests
       if (

--- a/packages/openneuro-server/datalad/dataset.js
+++ b/packages/openneuro-server/datalad/dataset.js
@@ -78,7 +78,7 @@ export const giveUploaderPermission = (id, uploader) => {
   const datasetId = id
   const userId = uploader
   const level = 'admin'
-  return c.crn.permissions.insertOne({datasetId, userId, level})
+  return c.crn.permissions.insertOne({ datasetId, userId, level })
 }
 
 /**
@@ -212,24 +212,4 @@ export const updatePublic = (datasetId, publicFlag) => {
   //   .post(url)
   //   .set('Accept', 'application/json')
   //   .then(({ body }) => body)
-}
-
-export const updateSnapshotFileUrls = (datasetId, snapshotTag, files) => {
-  //insert the file url data into mongo
-  return c.crn.files.updateOne(
-    {
-      datasetId: datasetId,
-      tag: snapshotTag,
-    },
-    {
-      $set: {
-        datasetId: datasetId,
-        tag: snapshotTag,
-        files: files,
-      },
-    },
-    {
-      upsert: true,
-    },
-  )
 }

--- a/packages/openneuro-server/datalad/draft.js
+++ b/packages/openneuro-server/datalad/draft.js
@@ -12,6 +12,15 @@ const draftFilesKey = (datasetId, revision) => {
   return `openneuro:draftFiles:${datasetId}:${revision}`
 }
 
+const addFileUrl = datasetId => file => {
+  // This is a draft, files are local
+  const filePath = file.filename.replace(/\//g, ':')
+  const fileUrl = `${config.url}${
+    config.apiPrefix
+  }datasets/${datasetId}/files/${filePath}`
+  return { ...file, urls: [fileUrl] }
+}
+
 export const getDraftFiles = (datasetId, revision) => {
   const filesUrl = `${uri}/datasets/${datasetId}/files`
   const key = draftFilesKey(datasetId, revision)
@@ -22,8 +31,9 @@ export const getDraftFiles = (datasetId, revision) => {
         .get(filesUrl)
         .set('Accept', 'application/json')
         .then(({ body: { files } }) => {
-          redis.set(key, JSON.stringify(files))
-          return files
+          const filesWithUrls = files.map(addFileUrl(datasetId))
+          redis.set(key, JSON.stringify(filesWithUrls))
+          return filesWithUrls
         })
   })
 }

--- a/packages/openneuro-server/datalad/draft.js
+++ b/packages/openneuro-server/datalad/draft.js
@@ -5,20 +5,12 @@ import request from 'superagent'
 import mongo from '../libs/mongo.js'
 import { redis } from '../libs/redis.js'
 import config from '../config.js'
+import { addFileUrl } from './utils.js'
 
 const uri = config.datalad.uri
 
 const draftFilesKey = (datasetId, revision) => {
   return `openneuro:draftFiles:${datasetId}:${revision}`
-}
-
-const addFileUrl = datasetId => file => {
-  // This is a draft, files are local
-  const filePath = file.filename.replace(/\//g, ':')
-  const fileUrl = `${config.url}${
-    config.apiPrefix
-  }datasets/${datasetId}/files/${filePath}`
-  return { ...file, urls: [fileUrl] }
 }
 
 export const getDraftFiles = (datasetId, revision) => {

--- a/packages/openneuro-server/datalad/snapshots.js
+++ b/packages/openneuro-server/datalad/snapshots.js
@@ -154,9 +154,18 @@ export const getSnapshot = (datasetId, tag) => {
         .get(url)
         .set('Accept', 'application/json')
         .then(async ({ body }) => {
-          const externalFiles = await c.crn.files
-            .findOne({ datasetId, tag }, { files: true })
-            .then(result => result.files)
+          // Only add S3 URLs for public datasets
+          const dataset = await c.crn.datasets.findOne(
+            { id: datasetId },
+            { public: true },
+          )
+          let externalFiles
+          if (dataset.public) {
+            externalFiles = await c.crn.files
+              .findOne({ datasetId, tag }, { files: true })
+              .then(result => result.files)
+          }
+          // If not public, fallback URLs are used
           const filesWithUrls = body.files.map(
             addFileUrl(datasetId, tag, externalFiles),
           )

--- a/packages/openneuro-server/datalad/snapshots.js
+++ b/packages/openneuro-server/datalad/snapshots.js
@@ -5,6 +5,7 @@ import request from 'superagent'
 import mongo from '../libs/mongo'
 import { redis } from '../libs/redis.js'
 import config from '../config.js'
+import { addFileUrl } from './utils.js'
 
 const c = mongo.collections
 const uri = config.datalad.uri
@@ -21,22 +22,28 @@ const snapshotIndexKey = datasetId => {
 
 const createSnapshotMetadata = (datasetId, tag, hexsha, created) => {
   return c.crn.snapshots.update(
-    {datasetId: datasetId, tag: tag}, 
-    {$set: 
-      {datasetId: datasetId, tag: tag, hexsha: hexsha, created: created}
-    }, 
-    {upsert: true}
+    { datasetId: datasetId, tag: tag },
+    {
+      $set: {
+        datasetId: datasetId,
+        tag: tag,
+        hexsha: hexsha,
+        created: created,
+      },
+    },
+    { upsert: true },
   )
 }
 
 const getSnapshotMetadata = (datasetId, snapshots) => {
   let tags = snapshots.map(s => s.tag)
   return new Promise((resolve, reject) => {
-    c.crn.snapshots.find({datasetId: datasetId, tag: {$in: tags}})
+    c.crn.snapshots
+      .find({ datasetId: datasetId, tag: { $in: tags } })
       .toArray((err, metadata) => {
         if (err) reject(err)
         snapshots = snapshots.map(s => {
-          const match_metadata = metadata.find(m => (m.tag == s.tag))
+          const match_metadata = metadata.find(m => m.tag == s.tag)
           s.created = match_metadata ? match_metadata.created : null
           return s
         })
@@ -64,12 +71,19 @@ export const createSnapshot = async (datasetId, tag) => {
         body.created = new Date()
         // Eager caching for snapshots
         // Set the key and after resolve to body
-        return redis.set(sKey, JSON.stringify(body))
-          // Metadata for snapshots
-          .then(() =>
-            createSnapshotMetadata(datasetId, tag, body.hexsha, body.created)
-              .then(() => body)
-          )
+        return (
+          redis
+            .set(sKey, JSON.stringify(body))
+            // Metadata for snapshots
+            .then(() =>
+              createSnapshotMetadata(
+                datasetId,
+                tag,
+                body.hexsha,
+                body.created,
+              ).then(() => body),
+            )
+        )
       }),
   )
 }
@@ -81,9 +95,12 @@ export const deleteSnapshot = (datasetId, tag) => {
   const indexKey = snapshotIndexKey(datasetId)
   const sKey = snapshotKey(datasetId, tag)
 
-  return request.del(url).then(({body}) => 
-    redis.del(indexKey).then(() => 
-      redis.del(sKey)).then(() => body))
+  return request.del(url).then(({ body }) =>
+    redis
+      .del(indexKey)
+      .then(() => redis.del(sKey))
+      .then(() => body),
+  )
 }
 
 /**
@@ -103,7 +120,7 @@ export const getSnapshots = datasetId => {
         .get(url)
         .set('Accept', 'application/json')
         .then(async ({ body: { snapshots } }) => {
-          snapshots = (await getSnapshotMetadata(datasetId, snapshots))
+          snapshots = await getSnapshotMetadata(datasetId, snapshots)
           redis.set(key, JSON.stringify(snapshots))
           return snapshots
         })
@@ -136,9 +153,41 @@ export const getSnapshot = (datasetId, tag) => {
       return request
         .get(url)
         .set('Accept', 'application/json')
-        .then(({ body }) => {
-          redis.set(key, JSON.stringify(body))
-          return body
+        .then(async ({ body }) => {
+          const externalFiles = await c.crn.files
+            .findOne({ datasetId, tag }, { files: true })
+            .then(result => result.files)
+          const filesWithUrls = body.files.map(
+            addFileUrl(datasetId, tag, externalFiles),
+          )
+          const snapshot = { ...body, files: filesWithUrls }
+          redis.set(key, JSON.stringify(snapshot))
+          return snapshot
         })
   })
+}
+
+export const updateSnapshotFileUrls = (datasetId, snapshotTag, files) => {
+  //insert the file url data into mongo
+  return c.crn.files
+    .updateOne(
+      {
+        datasetId: datasetId,
+        tag: snapshotTag,
+      },
+      {
+        $set: {
+          datasetId: datasetId,
+          tag: snapshotTag,
+          files: files,
+        },
+      },
+      {
+        upsert: true,
+      },
+    )
+    .then(data => {
+      // Clear snapshot cache when we get new URLs
+      return redis.del(snapshotKey(datasetId, snapshotTag)).then(() => data)
+    })
 }

--- a/packages/openneuro-server/datalad/utils.js
+++ b/packages/openneuro-server/datalad/utils.js
@@ -1,0 +1,33 @@
+import config from '../config.js'
+
+export const addFileUrl = (datasetId, tag, externalFiles) => file => {
+  // This is a draft, files are local
+  const filePath = file.filename.replace(/\//g, ':')
+  if (tag) {
+    // Snapshot
+    const urls = []
+
+    // Published snapshot S3 URL
+    if (externalFiles) {
+      const match = externalFiles.filter(
+        fileObj => fileObj.filename === file.filename,
+      )
+      const matchedFile = match ? match.pop() : null
+      // If any matches are found, merge in the urls
+      if (matchedFile) urls.push(...matchedFile.urls)
+    } else {
+      // Backup URL for direct access
+      const fileUrl = `${config.url}${
+        config.apiPrefix
+      }datasets/${datasetId}/snapshots/${tag}/files/${filePath}`
+      urls.push(fileUrl)
+    }
+    return { ...file, urls }
+  } else {
+    // Dataset draft
+    const fileUrl = `${config.url}${
+      config.apiPrefix
+    }datasets/${datasetId}/files/${filePath}`
+    return { ...file, urls: [fileUrl] }
+  }
+}

--- a/packages/openneuro-server/graphql/resolvers/datalad.js
+++ b/packages/openneuro-server/graphql/resolvers/datalad.js
@@ -2,6 +2,7 @@ import { summary } from './summary.js'
 import { issues } from './issues.js'
 import { getDraftFiles, getPartialStatus } from '../../datalad/draft.js'
 import { getSnapshot, getSnapshots } from '../../datalad/snapshots.js'
+import { dataset } from './dataset.js'
 
 /**
  * Resolvers for state held by the datalad service
@@ -26,5 +27,8 @@ export const snapshots = obj => {
 }
 
 export const snapshot = (obj, { datasetId, tag }) => {
-  return getSnapshot(datasetId, tag)
+  return getSnapshot(datasetId, tag).then(snapshot => ({
+    ...snapshot,
+    dataset: () => dataset(snapshot, { id: datasetId }),
+  }))
 }

--- a/packages/openneuro-server/graphql/resolvers/dataset.js
+++ b/packages/openneuro-server/graphql/resolvers/dataset.js
@@ -25,7 +25,7 @@ export const createDataset = (obj, { label }, { user, userInfo }) => {
  */
 export const deleteDataset = (obj, { label }) => {
   return datalad.deleteDataset(label).then(deleted => {
-    pubsub.publish('datasetDeleted', {id: label})
+    pubsub.publish('datasetDeleted', { id: label })
     return deleted
   })
 }
@@ -40,7 +40,7 @@ export const createSnapshot = (obj, { datasetId, tag }) => {
 /**
  * Remove a tag from a dataset
  */
-export const deleteSnapshot = (obj, {datasetId, tag}) => {
+export const deleteSnapshot = (obj, { datasetId, tag }) => {
   return snapshots.deleteSnapshot(datasetId, tag)
 }
 
@@ -86,9 +86,11 @@ export const updateFilesTree = (datasetId, fileTree) => {
 /**
  * Delete files from a draft
  */
-export const deleteFiles = (obj, 
+export const deleteFiles = (
+  obj,
   { datasetId, files: fileTree },
-  {userInfo: {firstname, lastname, email}}) => {
+  { userInfo: { firstname, lastname, email } },
+) => {
   // TODO - The id returned here is a placeholder
   const promises = deleteFilesTree(datasetId, fileTree)
   return Promise.all(promises)
@@ -97,7 +99,8 @@ export const deleteFiles = (obj,
         .commitFiles(datasetId, `${firstname} ${lastname}`, email)
         .then(res => res.body.ref)
         .then(updateDatasetRevision(datasetId)),
-    ).then(() => ({
+    )
+    .then(() => ({
       id: new Date(),
     }))
 }
@@ -136,8 +139,8 @@ export const updatePublic = (obj, { datasetId, publicFlag }) => {
  * Update the file urls within a snapshot
  */
 export const updateSnapshotFileUrls = (obj, { fileUrls }) => {
-  let datasetId = fileUrls.datasetId
-  let snapshotTag = fileUrls.tag
-  let files = fileUrls.files
-  return datalad.updateSnapshotFileUrls(datasetId, snapshotTag, files)
+  const datasetId = fileUrls.datasetId
+  const snapshotTag = fileUrls.tag
+  const files = fileUrls.files
+  return snapshots.updateSnapshotFileUrls(datasetId, snapshotTag, files)
 }

--- a/packages/openneuro-server/handlers/download.js
+++ b/packages/openneuro-server/handlers/download.js
@@ -1,0 +1,34 @@
+import { graphql } from 'graphql'
+import schema from '../graphql/schema.js'
+
+const DRAFT_FILES = `
+  query dataset($datasetId: ID!) {
+    dataset(id: $datasetId) {
+      id
+      draft {
+        id
+        files {
+          id
+          filename
+          size
+          urls
+        }
+      }
+    }
+  }
+`
+
+export const datasetDownload = (req, res) => {
+  const datasetId = req.params.datasetId
+  graphql(schema, DRAFT_FILES, null, null, { datasetId })
+    .then(({ data }) => {
+      res.send({ files: data.dataset.draft.files, datasetId })
+    })
+    .catch(err => {
+      console.log(err)
+      res.status(500)
+      res.send(err)
+    })
+}
+
+export const snapshotDownload = (req, res) => {}

--- a/packages/openneuro-server/handlers/download.js
+++ b/packages/openneuro-server/handlers/download.js
@@ -39,7 +39,6 @@ export const datasetDownload = (req, res) => {
       res.send({ files: data.dataset.draft.files, datasetId })
     })
     .catch(err => {
-      console.log(err)
       res.status(500)
       res.send(err)
     })
@@ -53,7 +52,6 @@ export const snapshotDownload = (req, res) => {
       res.send({ files: data.snapshot.files, datasetId, tag })
     })
     .catch(err => {
-      console.log(err)
       res.status(500)
       res.send(err)
     })

--- a/packages/openneuro-server/handlers/download.js
+++ b/packages/openneuro-server/handlers/download.js
@@ -18,6 +18,20 @@ const DRAFT_FILES = `
   }
 `
 
+const SNAPSHOT_FILES = `
+  query snapshot($datasetId: ID!, $tag: String!) {
+    snapshot(id: $datasetId) {
+      id
+      files {
+        id
+        filename
+        size
+        urls
+      }
+    }
+  }
+`
+
 export const datasetDownload = (req, res) => {
   const datasetId = req.params.datasetId
   graphql(schema, DRAFT_FILES, null, null, { datasetId })
@@ -31,4 +45,16 @@ export const datasetDownload = (req, res) => {
     })
 }
 
-export const snapshotDownload = (req, res) => {}
+export const snapshotDownload = (req, res) => {
+  const datasetId = req.params.datasetId
+  const tag = req.params.snapshotId
+  graphql(schema, SNAPSHOT_FILES, null, null, { datasetId, tag })
+    .then(({ data }) => {
+      res.send({ files: data.snapshot.files, datasetId, tag })
+    })
+    .catch(err => {
+      console.log(err)
+      res.status(500)
+      res.send(err)
+    })
+}

--- a/packages/openneuro-server/handlers/download.js
+++ b/packages/openneuro-server/handlers/download.js
@@ -20,7 +20,7 @@ const DRAFT_FILES = `
 
 const SNAPSHOT_FILES = `
   query snapshot($datasetId: ID!, $tag: String!) {
-    snapshot(id: $datasetId) {
+    snapshot(datasetId: $datasetId, tag: $tag) {
       id
       files {
         id

--- a/packages/openneuro-server/routes.js
+++ b/packages/openneuro-server/routes.js
@@ -10,6 +10,7 @@ import datasets from './handlers/datasets'
 import stars from './handlers/stars'
 import * as datalad from './handlers/datalad'
 import * as openfmri from './handlers/openfmri'
+import * as download from './handlers/download.js'
 import comments from './handlers/comments'
 import subscriptions from './handlers/subscriptions'
 import auth from './libs/auth'
@@ -376,6 +377,18 @@ const dataladRoutes = [
     method: 'get',
     url: '/datasets/:datasetId/snapshots/:snapshotId/files/:filename',
     handler: datalad.getFile,
+  },
+
+  // Download routes
+  {
+    method: 'get',
+    url: '/datasets/:datasetId/download',
+    handler: download.datasetDownload,
+  },
+  {
+    method: 'get',
+    url: '/datasets/:datasetId/snapshots/:snapshotId/download',
+    handler: download.datasetDownload,
   },
 ]
 

--- a/packages/openneuro-server/routes.js
+++ b/packages/openneuro-server/routes.js
@@ -388,7 +388,7 @@ const dataladRoutes = [
   {
     method: 'get',
     url: '/datasets/:datasetId/snapshots/:snapshotId/download',
-    handler: download.datasetDownload,
+    handler: download.snapshotDownload,
   },
 ]
 


### PR DESCRIPTION
This implements all the changes to enable downloading from the new backend.

Requires a cache clear, so remove the Redis container before testing.

* Drafts and private datasets are always streamed via OpenNeuro itself.
* Public snapshots are streamed from S3 once published (as long as S3 is reachable).
* Adds a metadata endpoint that the CLI can use to implement downloads later.

Fixes #395

One optimization that is not included here is draft files that are available on S3 still always come from OpenNeuro itself.