### PR TITLE
Synchronous file access

### DIFF
--- a/packages/openneuro-client/src/datasets.js
+++ b/packages/openneuro-client/src/datasets.js
@@ -21,6 +21,7 @@ export const getDataset = gql`
           id
           filename
           size
+          objectpath
         }
         summary {
           modalities

--- a/packages/openneuro-server/datalad/dataset.js
+++ b/packages/openneuro-server/datalad/dataset.js
@@ -118,8 +118,16 @@ export const getDatasets = () => {
  * Convert to URL compatible path
  * @param {String} path
  */
-const encodeFilePath = path => {
+export const encodeFilePath = path => {
   return path.replace(new RegExp('/', 'g'), ':')
+}
+
+/**
+ * Convert to from URL compatible path fo filepath
+ * @param {String} path
+ */
+export const decodeFilePath = path => {
+  return path.replace(new RegExp(':', 'g'), '/')
 }
 
 /**

--- a/packages/openneuro-server/datalad/draft.js
+++ b/packages/openneuro-server/datalad/draft.js
@@ -13,7 +13,7 @@ const draftFilesKey = (datasetId, revision) => {
   return `openneuro:draftFiles:${datasetId}:${revision}`
 }
 
-export const getDraftFiles = (datasetId, revision) => {
+export const getDraftFiles = async (datasetId, revision) => {
   const filesUrl = `${uri}/datasets/${datasetId}/files`
   const key = draftFilesKey(datasetId, revision)
   return redis.get(key).then(data => {
@@ -42,6 +42,18 @@ export const updateDatasetRevision = datasetId => gitRef => {
 
 export const draftPartialKey = datasetId => {
   return `openneuro:partialDraft:${datasetId}`
+}
+
+export const getDatasetRevision = async datasetId => {
+  return new Promise((resolve, reject) => {
+    mongo.collections.crn.datasets.findOne({ id: datasetId }).then(obj => {
+      if (obj) {
+        resolve(obj.revision)
+      } else {
+        reject(null)
+      }
+    })
+  })
 }
 
 export const getPartialStatus = datasetId => {

--- a/packages/openneuro-server/datalad/snapshots.js
+++ b/packages/openneuro-server/datalad/snapshots.js
@@ -151,7 +151,7 @@ const snapshotKey = (datasetId, tag) => {
  * @param {string} datasetId Dataset accession number
  * @param {string} tag Tag name to retrieve
  */
-export const getSnapshot = (datasetId, tag) => {
+export const getSnapshot = async (datasetId, tag) => {
   const url = `${uri}/datasets/${datasetId}/snapshots/${tag}`
   const key = snapshotKey(datasetId, tag)
   return redis.get(key).then(data => {

--- a/packages/openneuro-server/graphql/schema.js
+++ b/packages/openneuro-server/graphql/schema.js
@@ -237,6 +237,7 @@ const typeDefs = `
     filename: String!
     size: BigInt
     urls: [String]
+    objectpath: String
   }
 
   # Update file object

--- a/packages/openneuro-server/handlers/datalad.js
+++ b/packages/openneuro-server/handlers/datalad.js
@@ -87,11 +87,8 @@ export const getFile = async (req, res) => {
   let file = fileList.find(f => {
     return f.filename == decodedFilename
   })
-  let filepath = file ? encodeFilePath(file.objectpath) : null
+  let filepath = file ? encodeFilePath(file.id) : null
   res.set('Content-Type', 'application/*')
-  let uri = `${URI}/datasets/${datasetId}/files/${filepath}`
-  if (snapshotId) {
-    uri = `${URI}/datasets/${datasetId}/snapshots/${snapshotId}/files/${filepath}`
-  }
+  let uri = `${URI}/datasets/${datasetId}/objects/${filepath}`
   return request.get(uri).pipe(res)
 }

--- a/packages/openneuro-server/handlers/datalad.js
+++ b/packages/openneuro-server/handlers/datalad.js
@@ -1,6 +1,9 @@
 import config from '../config'
 import request from 'superagent'
 import { getAccessionNumber } from '../libs/dataset'
+import { getDraftFiles, getDatasetRevision } from '../datalad/draft'
+import { getSnapshot } from '../datalad/snapshots'
+import { encodeFilePath, decodeFilePath } from '../datalad/dataset.js'
 
 /**
  * Handlers for datalad dataset manipulation
@@ -65,16 +68,30 @@ export const unpublishDataset = (req, res) => {
 /**
  * Get a file from a dataset
  */
-export const getFile = (req, res) => {
+export const getFile = async (req, res) => {
   const datasetId = req.params.datasetId
   const snapshotId = req.params.snapshotId
   const filename = req.params.filename
-  res.set('Content-Type', 'application/*')
-  let uri = `${URI}/datasets/${datasetId}/files/${filename}`
+  const decodedFilename = decodeFilePath(filename)
+  let fileList = []
+  let data
   if (snapshotId) {
-    uri = `${URI}/datasets/${datasetId}/snapshots/${snapshotId}/files/${filename}`
+    data = await getSnapshot(datasetId, snapshotId)
+    fileList = data ? data.files : []
+  } else {
+    let currentRevision = await getDatasetRevision(datasetId)
+    if (currentRevision) {
+      fileList = await getDraftFiles(datasetId, currentRevision)
+    }
   }
-  
-  return request.get(uri)
-    .pipe(res)
+  let file = fileList.find(f => {
+    return f.filename == decodedFilename
+  })
+  let filepath = file ? encodeFilePath(file.objectpath) : null
+  res.set('Content-Type', 'application/*')
+  let uri = `${URI}/datasets/${datasetId}/files/${filepath}`
+  if (snapshotId) {
+    uri = `${URI}/datasets/${datasetId}/snapshots/${snapshotId}/files/${filepath}`
+  }
+  return request.get(uri).pipe(res)
 }


### PR DESCRIPTION
depends on https://github.com/OpenNeuroOrg/datalad-service/pull/35
fixes #697 
fixes #696 

allows users to access files inside of datalad synchronously, cache-first, via the annex objectID and / or git hex stored in the file object's 'id' field.

additionally implements eager cacheing on newly created datasets before publishing snapshots