### PR TITLE
Datalad uploaders follow datasets

### DIFF
--- a/packages/openneuro-app/src/scripts/dataset/dataset.store.js
+++ b/packages/openneuro-app/src/scripts/dataset/dataset.store.js
@@ -1928,7 +1928,7 @@ let datasetStore = Reflux.createStore({
   // Comments  ----------------------------------------------------------------
 
   loadComments(datasetId) {
-    crn.getComments(datasetId).then(res => {
+    crn.getComments(bids.decodeId(datasetId)).then(res => {
       if (res && (res.status === 404 || res.status === 403)) {
         this.update({
           commentTree: [],
@@ -1956,7 +1956,7 @@ let datasetStore = Reflux.createStore({
     const parentId = typeof parent === 'undefined' ? null : parent
 
     const comment = {
-      datasetId: datasetId,
+      datasetId: bids.decodeId(datasetId),
       datasetLabel: datasetLabel,
       parentId: parentId,
       text: content,
@@ -1964,10 +1964,10 @@ let datasetStore = Reflux.createStore({
       createDate: moment().format(),
     }
 
-    crn.createComment(datasetId, comment).then(res => {
+    crn.createComment(bids.decodeId(datasetId), comment).then(res => {
       if (res) {
         if (res.status === 200 && res.ok) {
-          this.loadComments(datasetId)
+          this.loadComments(bids.decodeId(datasetId))
         }
       }
     })
@@ -1982,13 +1982,15 @@ let datasetStore = Reflux.createStore({
       commentId: commentId,
       text: content,
     }
-    crn.updateComment(datasetId, commentId, comment).then(res => {
-      if (res) {
-        if (res.status === 200 && res.ok) {
-          this.loadComments(datasetId)
+    crn
+      .updateComment(bids.decodeId(datasetId), commentId, comment)
+      .then(res => {
+        if (res) {
+          if (res.status === 200 && res.ok) {
+            this.loadComments(datasetId)
+          }
         }
-      }
-    })
+      })
   },
 
   deleteComment(commentId, parent, callback) {
@@ -2005,7 +2007,7 @@ let datasetStore = Reflux.createStore({
     crn.deleteComment(comment).then(res => {
       if (res) {
         if (res.status === 200 && res.ok) {
-          this.loadComments(datasetId)
+          this.loadComments(bids.decodeId(datasetId))
           if (callback) {
             callback()
           }
@@ -2067,7 +2069,7 @@ let datasetStore = Reflux.createStore({
       this.data.currentUser && this.data.currentUser.profile
         ? this.data.currentUser.profile._id
         : null
-    crn.createSubscription(datasetId, userId).then(res => {
+    crn.createSubscription(bids.decodeId(datasetId), userId).then(res => {
       if (res && res.status !== 200) {
         callback({ error: 'There was an error while following this dataset.' })
       } else {
@@ -2086,7 +2088,7 @@ let datasetStore = Reflux.createStore({
       this.data.currentUser && this.data.currentUser.profile
         ? this.data.currentUser.profile._id
         : null
-    crn.deleteSubscription(datasetId, userId).then(res => {
+    crn.deleteSubscription(bids.decodeId(datasetId), userId).then(res => {
       if (res && res.status !== 200) {
         callback({
           error: 'There was an error while unfollowing this dataset.',
@@ -2126,7 +2128,7 @@ let datasetStore = Reflux.createStore({
     let datasetId = this.data.dataset.original
       ? this.data.dataset.original
       : this.data.dataset._id
-    crn.getSubscriptions(datasetId).then(res => {
+    crn.getSubscriptions(bids.decodeId(datasetId)).then(res => {
       dataset.followersList = res.body || []
       dataset.followers = res.body ? res.body.length : '0'
       this.update(
@@ -2147,7 +2149,7 @@ let datasetStore = Reflux.createStore({
       this.data.currentUser && this.data.currentUser.profile
         ? this.data.currentUser.profile._id
         : null
-    crn.addStar(datasetId, userId).then(res => {
+    crn.addStar(bids.decodeId(datasetId), userId).then(res => {
       if (res && res.status !== 200) {
         callback({
           error: 'There was an error while adding a star to this dataset.',
@@ -2168,7 +2170,7 @@ let datasetStore = Reflux.createStore({
       this.data.currentUser && this.data.currentUser.profile
         ? this.data.currentUser.profile._id
         : null
-    crn.removeStar(datasetId, userId).then(res => {
+    crn.removeStar(bids.decodeId(datasetId), userId).then(res => {
       if (res && res.status !== 200) {
         callback({
           error: 'There was an error while removing a star from this dataset.',
@@ -2190,7 +2192,7 @@ let datasetStore = Reflux.createStore({
       this.data.currentUser && this.data.currentUser.profile
         ? this.data.currentUser.profile._id
         : null
-    crn.getStars(datasetId).then(res => {
+    crn.getStars(bids.decodeId(datasetId)).then(res => {
       if (res && res.status !== 200) {
         let dataset = this.data.dataset
         dataset.stars = []

--- a/packages/openneuro-app/src/scripts/utils/bids.js
+++ b/packages/openneuro-app/src/scripts/utils/bids.js
@@ -344,7 +344,7 @@ export default {
     if (stars) {
       let datasetId = dataset.original ? dataset.original : dataset._id
       let associatedStars = stars.filter(star => {
-        return star.datasetId === datasetId
+        return star.datasetId === this.decodeId(datasetId)
       })
       if (associatedStars.length) {
         return associatedStars
@@ -366,7 +366,7 @@ export default {
     if (followers) {
       let datasetId = dataset.original ? dataset.original : dataset._id
       let subscriptions = followers.filter(follower => {
-        return follower.datasetId === datasetId
+        return follower.datasetId === this.decodeId(datasetId)
       })
       return subscriptions
     } else {
@@ -383,7 +383,7 @@ export default {
     if (usage) {
       let datasetId = dataset._id
       let matches = usage.filter(entry => {
-        return entry._id == datasetId
+        return entry._id == this.decodeId(datasetId)
       })
       const downloads = matches.length ? '' + matches[0].downloads : '0'
       return downloads
@@ -401,7 +401,7 @@ export default {
     if (usage) {
       let datasetId = dataset._id
       let matches = usage.filter(entry => {
-        return entry._id == datasetId
+        return entry._id == this.decodeId(datasetId)
       })
       const views = matches.length ? '' + matches[0].views : '0'
       return views

--- a/packages/openneuro-server/datalad/dataset.js
+++ b/packages/openneuro-server/datalad/dataset.js
@@ -8,6 +8,7 @@ import requestNode from 'request'
 import config from '../config'
 import mongo from '../libs/mongo'
 import pubsub from '../graphql/pubsub.js'
+import subscriptions from '../handlers/subscriptions.js'
 import { redis } from '../libs/redis.js'
 import { getAccessionNumber } from '../libs/dataset'
 import { draftPartialKey } from './draft.js'
@@ -50,7 +51,11 @@ export const createDataset = (label, uploader, userInfo) => {
         )
       await req
       pubsub.publish('datasetAdded', { id: datasetId })
-      resolve({ id: datasetId, label })
+      subscriptions
+        .subscribe(datasetId, uploader)
+        .then(() => resolve({ id: datasetId, label }))
+        .catch(err => reject(err))
+      // resolve({ id: datasetId, label })
     } else {
       reject(Error(`Failed to create ${datasetId} - "${label}"`))
     }

--- a/packages/openneuro-server/handlers/subscriptions.js
+++ b/packages/openneuro-server/handlers/subscriptions.js
@@ -20,25 +20,31 @@ export default {
    *
    * Creates an entry in the c.crn.subscriptions database
    */
-
   create(req, res, next) {
     let data = req.body
     let datasetId = data.datasetId
     let userId = data.userId
 
-    c.crn.subscriptions.insertOne(
-      {
-        datasetId: datasetId,
-        userId: userId,
-      },
-      (err, response) => {
-        if (err) {
-          return next(err)
-        } else {
-          return res.send(response.ops)
-        }
-      },
-    )
+    this.subscribe(datasetId, userId)
+      .then(response => res.send(response.ops))
+      .catch(err => next(err))
+  },
+
+  subscribe(datasetId, userId) {
+    return new Promise((resolve, reject) => {
+      c.crn.subscriptions.insertOne(
+        {
+          datasetId: datasetId,
+          userId: userId,
+        },
+        (err, response) => {
+          if (err) {
+            reject(err)
+          }
+          resolve(response)
+        },
+      )
+    })
   },
 
   /**


### PR DESCRIPTION
fixes #649 

* uploaders now automatically follow datasets that are uploaded via cli or app
* uses accession numbers to access star, follower, and subscription counts on dashboard and dataset pages