### PR TITLE
Toggleable analysis

### DIFF
--- a/config.env.example
+++ b/config.env.example
@@ -63,4 +63,4 @@ ENVIRONMENT=
 
 # client -----------------------------------------------------------------------
 
-ENABLE_ANALYSIS=true
+ANALYSIS_ENABLED=true

--- a/config.env.example
+++ b/config.env.example
@@ -60,3 +60,7 @@ DOI_URL=
 
 SENTRY_DSN=
 ENVIRONMENT=
+
+# client -----------------------------------------------------------------------
+
+ENABLE_ANALYSIS=true

--- a/packages/openneuro-app/config.js
+++ b/packages/openneuro-app/config.js
@@ -69,5 +69,7 @@ export default {
     uri: 'datalad:9877',
   },
 
-  analysis: process.env.ENABLE_ANALYSIS,
+  analysis: {
+    enabled: process.env.ANALYSIS_ENABLED,
+  },
 }

--- a/packages/openneuro-app/config.js
+++ b/packages/openneuro-app/config.js
@@ -66,6 +66,8 @@ export default {
 
   datalad: {
     enabled: process.env.CRN_SERVER_DATALAD,
-    uri: 'datalad:9877'
+    uri: 'datalad:9877',
   },
+
+  analysis: process.env.ENABLE_ANALYSIS,
 }

--- a/packages/openneuro-app/src/scripts/admin/admin.jsx
+++ b/packages/openneuro-app/src/scripts/admin/admin.jsx
@@ -12,6 +12,14 @@ import Jobs from '../dashboard/dashboard.jobs.jsx'
 
 import BlacklistModal from './admin.blacklist.modal.jsx'
 import actions from './admin.actions'
+import config from '../../../config'
+import {
+  AdminJobLink,
+  JobStatsLink,
+  JobAppDefinitionsLink,
+} from '../common/partials/jobs.jsx'
+
+const analysisEnabled = config.analysis.enabled
 
 class Dashboard extends React.Component {
   // life cycle events --------------------------------------------------
@@ -40,9 +48,7 @@ class Dashboard extends React.Component {
                 </NavLink>
               </li>
               <li>
-                <NavLink to="/admin/app-definitions" className="btn-tab">
-                  App Definitions
-                </NavLink>
+                <JobAppDefinitionsLink enabled={analysisEnabled} />
               </li>
               <li>
                 <NavLink to="/admin/event-logs" className="btn-tab">
@@ -55,14 +61,10 @@ class Dashboard extends React.Component {
                 </NavLink>
               </li>
               <li>
-                <NavLink to="/admin/jobs" className="btn-tab">
-                  All Jobs
-                </NavLink>
+                <AdminJobLink enabled={analysisEnabled} />
               </li>
               <li>
-                <NavLink to="/admin/job-statistics" className="btn-tab">
-                  Job Stats
-                </NavLink>
+                <JobStatsLink enabled={analysisEnabled} />
               </li>
             </ul>
             <Switch>

--- a/packages/openneuro-app/src/scripts/common/partials/jobs.jsx
+++ b/packages/openneuro-app/src/scripts/common/partials/jobs.jsx
@@ -1,0 +1,97 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { Route, NavLink } from 'react-router-dom'
+
+class JobLink extends React.Component {
+  render() {
+    if (this.props.enabled) {
+      return (
+        <NavLink to={this.props.prefix + '/jobs'} className="btn-tab">
+          {this.props.isPublic ? 'Public' : 'My'} Analyses
+        </NavLink>
+      )
+    } else {
+      return null
+    }
+  }
+}
+
+JobLink.propTypes = {
+  prefix: PropTypes.string,
+  isPublic: PropTypes.bool,
+  enabled: PropTypes.bool,
+}
+
+class AdminJobLink extends React.Component {
+  render() {
+    if (this.props.enabled) {
+      return (
+        <NavLink to="/admin/jobs" className="btn-tab">
+          All Jobs
+        </NavLink>
+      )
+    } else {
+      return null
+    }
+  }
+}
+
+AdminJobLink.propTypes = {
+  enabled: PropTypes.bool,
+}
+
+class JobStatsLink extends React.Component {
+  render() {
+    if (this.props.enabled) {
+      return (
+        <NavLink to="/admin/job-statistics" className="btn-tab">
+          Job Stats
+        </NavLink>
+      )
+    } else {
+      return null
+    }
+  }
+}
+
+JobStatsLink.propTypes = {
+  enabled: PropTypes.bool,
+}
+
+class JobAppDefinitionsLink extends React.Component {
+  render() {
+    if (this.props.enabled) {
+      return (
+        <NavLink to="/admin/app-definitions" className="btn-tab">
+          App Definitions
+        </NavLink>
+      )
+    } else {
+      return null
+    }
+  }
+}
+
+JobAppDefinitionsLink.propTypes = {
+  enabled: PropTypes.bool,
+}
+
+class JobRoute extends React.Component {
+  render() {
+    if (this.props.enabled) {
+      return (
+        <Route component={this.props.jobs} path={this.props.prefix + '/jobs'} />
+      )
+    } else {
+      return null
+    }
+  }
+}
+
+JobRoute.propTypes = {
+  prefix: PropTypes.string,
+  jobs: PropTypes.func,
+  enabled: PropTypes.bool,
+}
+
+export { JobLink, JobRoute, AdminJobLink, JobStatsLink, JobAppDefinitionsLink }

--- a/packages/openneuro-app/src/scripts/dashboard/dashboard.jsx
+++ b/packages/openneuro-app/src/scripts/dashboard/dashboard.jsx
@@ -4,7 +4,11 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { Switch, Route, NavLink, Redirect } from 'react-router-dom'
 import Datasets from './dashboard.datasets.jsx'
+import { JobLink, JobRoute } from '../common/partials/jobs.jsx'
 import Jobs from './dashboard.jobs.jsx'
+import config from '../../../config'
+
+const analysisEnabled = config.analysis.enabled
 
 const publicDatasets = () => <Datasets public />
 const publicJobs = () => <Jobs public />
@@ -32,15 +36,17 @@ class Dashboard extends React.Component {
                 </NavLink>
               </li>
               <li>
-                <NavLink to={prefix + '/jobs'} className="btn-tab">
-                  {isPublic ? 'Public' : 'My'} Analyses
-                </NavLink>
+                <JobLink
+                  prefix={prefix}
+                  isPublic={isPublic}
+                  enabled={analysisEnabled}
+                />
               </li>
             </ul>
             <Switch>
               <Redirect path={prefix} to={prefix + '/datasets'} exact />
               <Route component={datasets} path={prefix + '/datasets'} />
-              <Route component={jobs} path={prefix + '/jobs'} />
+              <JobRoute prefix={prefix} jobs={jobs} enabled={analysisEnabled} />
             </Switch>
           </div>
         </div>

--- a/packages/openneuro-app/src/scripts/dataset/dataset.store.js
+++ b/packages/openneuro-app/src/scripts/dataset/dataset.store.js
@@ -179,39 +179,26 @@ let datasetStore = Reflux.createStore({
               ],
               loading: false,
             })
-            this.loadSnapshots(dataset, [], () => {
-              this.loadComments(datasetId)
-              this.getDatasetStars()
-              this.checkSubscriptionFollowers(() => {
-                let datasetUrl = this.constructDatasetUrl(dataset)
-                this.update({
-                  loading: false,
-                  snapshot: snapshot,
-                  datasetUrl: datasetUrl,
+            this.loadJobs(
+              bids.decodeId(datasetId),
+              selectedSnapshot,
+              bids.decodeId(datasetId),
+              options,
+              (err, jobs) => {
+                this.loadSnapshots(dataset, jobs, () => {
+                  this.loadComments(datasetId)
+                  this.getDatasetStars()
+                  this.checkSubscriptionFollowers(() => {
+                    let datasetUrl = this.constructDatasetUrl(dataset)
+                    this.update({
+                      loading: false,
+                      snapshot: snapshot,
+                      datasetUrl: datasetUrl,
+                    })
+                  })
                 })
-              })
-            })
-
-            // this.loadJobs(
-            //   datasetId,
-            //   snapshot,
-            //   originalId,
-            //   options,
-            //   (err, jobs) => {
-            //     this.loadSnapshots(dataset, jobs, () => {
-            //       this.loadComments(originalId)
-            //       this.getDatasetStars()
-            //       this.checkSubscriptionFollowers(() => {
-            //         let datasetUrl = this.constructDatasetUrl(dataset)
-            //         this.update({
-            //           loading: false,
-            //           snapshot: snapshot,
-            //           datasetUrl: datasetUrl,
-            //         })
-            //       })
-            //     })
-            //   },
-            // ),
+              },
+            )
 
             if (
               forceReload ||
@@ -1327,6 +1314,9 @@ let datasetStore = Reflux.createStore({
    * Load Jobs
    */
   loadJobs(projectId, snapshot, originalId, options, callback) {
+    if (!config.analysis.enabled) {
+      return callback(null, [])
+    }
     let jobId = options.job
     this.update({ loadingJobs: true })
     crn

--- a/packages/openneuro-app/src/scripts/dataset/tools/index.js
+++ b/packages/openneuro-app/src/scripts/dataset/tools/index.js
@@ -181,26 +181,27 @@ class Tools extends Reflux.Component {
           },
         ],
       },
-      {
-        tooltip: 'Run Analysis',
-        icon: 'fa-area-chart icon-plus',
-        action: actions.showDatasetComponent.bind(
-          this,
-          'jobs',
-          this.props.history,
-        ),
-        display: isSignedIn && !isIncomplete,
-        warn: false,
-        modalLink: datasets.datasetUrl + '/jobs',
-        validations: [
-          {
-            check: datasets.uploading && !isSnapshot,
-            message: 'Files are currently uploading',
-            timeout: 5000,
-            type: 'Error',
-          },
-        ],
-      },
+      // TODO: TURN THIS BACK ON WHEN WE WANT TO ENABLE ANALYSES
+      // {
+      //   tooltip: 'Run Analysis',
+      //   icon: 'fa-area-chart icon-plus',
+      //   action: actions.showDatasetComponent.bind(
+      //     this,
+      //     'jobs',
+      //     this.props.history,
+      //   ),
+      //   display: isSignedIn && !isIncomplete,
+      //   warn: false,
+      //   modalLink: datasets.datasetUrl + '/jobs',
+      //   validations: [
+      //     {
+      //       check: datasets.uploading && !isSnapshot,
+      //       message: 'Files are currently uploading',
+      //       timeout: 5000,
+      //       type: 'Error',
+      //     },
+      //   ],
+      // },
       {
         tooltip: 'Follow Dataset',
         icon: 'fa-tag icon-plus',

--- a/packages/openneuro-app/src/scripts/front-page/front-page.pipelines.jsx
+++ b/packages/openneuro-app/src/scripts/front-page/front-page.pipelines.jsx
@@ -15,6 +15,7 @@ import Spinner from '../common/partials/spinner.jsx'
 import markdown from '../utils/markdown'
 import bids from '../utils/bids'
 import { refluxConnect } from '../utils/reflux'
+import config from '../../../config'
 
 // component setup ----------------------------------------------------
 
@@ -26,22 +27,26 @@ class Pipelines extends Reflux.Component {
   // life cycle events --------------------------------------------------
 
   render() {
-    return (
-      <span>
-        <div className="browse-pipelines">
-          <h3 className="browse-pipeline-header">Check Out Our Pipelines</h3>
-          <div className="container">{this._pipelines()}</div>
-        </div>
-        {!this.state.frontpage.selectedPipeline.jobDefinitionName
-          ? null
-          : this._pipelineDetail(this.state.frontpage.selectedPipeline)}
-        <FileDisplay
-          file={this.state.frontpage.displayFile}
-          show={this.state.frontpage.displayFile.show}
-          onHide={FPActions.hideFileDisplay}
-        />
-      </span>
-    )
+    if (config.analysis.enabled) {
+      return (
+        <span>
+          <div className="browse-pipelines">
+            <h3 className="browse-pipeline-header">Check Out Our Pipelines</h3>
+            <div className="container">{this._pipelines()}</div>
+          </div>
+          {!this.state.frontpage.selectedPipeline.jobDefinitionName
+            ? null
+            : this._pipelineDetail(this.state.frontpage.selectedPipeline)}
+          <FileDisplay
+            file={this.state.frontpage.displayFile}
+            show={this.state.frontpage.displayFile.show}
+            onHide={FPActions.hideFileDisplay}
+          />
+        </span>
+      )
+    } else {
+      return null
+    }
   }
 
   // template methods ---------------------------------------------------

--- a/packages/openneuro-app/src/scripts/utils/bids.js
+++ b/packages/openneuro-app/src/scripts/utils/bids.js
@@ -5,6 +5,7 @@ import userStore from '../user/user.store'
 import fileUtils from './files'
 import hex from './hex'
 import datalad from './datalad'
+import config from '../../../config.js'
 
 /**
  * BIDS
@@ -182,16 +183,21 @@ export default {
                   dataset.views = this.views(dataset, usage)
                   dataset.downloads = this.downloads(dataset, usage)
                 }
-                crn
-                  .getDatasetJobs(projectId, options)
-                  .then(res => {
-                    dataset.jobs = res.body
-                    return callback(dataset)
-                  })
-                  .catch(err => {
-                    // console.log('error getting jobs:', err)
-                    return callback(dataset, err)
-                  })
+                if (config.analysis.enabled) {
+                  crn
+                    .getDatasetJobs(projectId, options)
+                    .then(res => {
+                      dataset.jobs = res.body
+                      return callback(dataset)
+                    })
+                    .catch(err => {
+                      // console.log('error getting jobs:', err)
+                      return callback(dataset, err)
+                    })
+                } else {
+                  dataset.jobs = []
+                  return callback(dataset)
+                }
               })
             },
             options,

--- a/packages/openneuro-app/webpack.common.js
+++ b/packages/openneuro-app/webpack.common.js
@@ -16,7 +16,8 @@ const env = {
   SCITRAN_AUTH_ORCID_URI: JSON.stringify(process.env.SCITRAN_AUTH_ORCID_URI),
   AWS_S3_ANALYSIS_BUCKET: JSON.stringify(process.env.AWS_S3_ANALYSIS_BUCKET),
   AWS_S3_DATASET_BUCKET: JSON.stringify(process.env.AWS_S3_DATASET_BUCKET),
-  CRN_SERVER_DATALAD: JSON.stringify(process.env.CRN_SERVER_DATALAD)
+  CRN_SERVER_DATALAD: JSON.stringify(process.env.CRN_SERVER_DATALAD) == 'true',
+  ANALYSIS_ENABLED: JSON.stringify(process.env.ANALYSIS_ENABLED) == 'true',
 }
 
 module.exports = {

--- a/packages/openneuro-app/webpack.common.js
+++ b/packages/openneuro-app/webpack.common.js
@@ -16,8 +16,8 @@ const env = {
   SCITRAN_AUTH_ORCID_URI: JSON.stringify(process.env.SCITRAN_AUTH_ORCID_URI),
   AWS_S3_ANALYSIS_BUCKET: JSON.stringify(process.env.AWS_S3_ANALYSIS_BUCKET),
   AWS_S3_DATASET_BUCKET: JSON.stringify(process.env.AWS_S3_DATASET_BUCKET),
-  CRN_SERVER_DATALAD: JSON.stringify(process.env.CRN_SERVER_DATALAD) == 'true',
-  ANALYSIS_ENABLED: JSON.stringify(process.env.ANALYSIS_ENABLED) == 'true',
+  CRN_SERVER_DATALAD: JSON.stringify(process.env.CRN_SERVER_DATALAD) == '"true"',
+  ANALYSIS_ENABLED: JSON.stringify(process.env.ANALYSIS_ENABLED) == '"true"',
 }
 
 module.exports = {


### PR DESCRIPTION
fixes #596 

allows for a site admin to toggle analysis features on / off by setting the ANALYSIS_ENABLED config parameter to a boolean. 

ANALYSIS_ENABLED=true -> analysis features are shown. 
ANALYSIS_ENABLED=anything_other_than_true -> analysis features are disabled

* dashboard 'my / public analyses' tab is toggleable
* admin 'all jobs', 'app definitions', and 'job stats' tabs + panels toggleable
* datasets page -> job panel is toggleable

disables the 'run analysis' button for datasets page, regardless of ANALYSIS_ENABLED config, until it is refactored to work with scitran.

fixes bug where boolean params were not being set to the right truthy value