### PR TITLE
DataLad migration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 # docker compose versions
-version: '2'
+version: '2.2'
 
 # shared volumes
 volumes:
@@ -67,6 +67,7 @@ services:
     depends_on:
       - celery
     restart: always
+    init: true
   
   # celery Python backend
   celery:
@@ -87,6 +88,7 @@ services:
       - ./datalad-key:/datalad-key
     restart: always
     env_file: ./config.env
+    init: true
 
   flower:
     image: openneuro/datalad-service:${DATALAD_SERVICE_TAG}

--- a/packages/openneuro-server/datalad/migration.js
+++ b/packages/openneuro-server/datalad/migration.js
@@ -1,0 +1,92 @@
+import fs from 'fs'
+import path from 'path'
+import mongo from '../libs/mongo.js'
+import scitran from '../libs/scitran.js'
+import * as dataset from '../datalad/dataset.js'
+import * as snapshots from '../datalad/snapshots.js'
+import bids from '../libs/bidsId.js'
+import config from '../config.js'
+import files from '../libs/files.js'
+
+const DRY_RUN = false
+
+const migrateAll = () => {
+  const c = mongo.collections
+  c.scitran.projects
+    .find({})
+    .toArray()
+    .then(async projects => {
+      for (const dataset of projects) {
+        await migrate(
+          bids.decodeId(dataset._id),
+          dataset.group,
+          dataset.label,
+          dataset.created,
+        )
+      }
+    })
+}
+
+const migrate = (datasetId, uploader, label, created) => {
+  return new Promise((resolve, reject) => {
+    console.log(
+      `Dataset "${datasetId}"/"${label}" uploaded by "${uploader}" on ${created}`,
+    )
+    scitran.getProjectSnapshots(datasetId, async (err, snapshots) => {
+      console.log(`Found ${snapshots.body.length} snapshots.`)
+      if (snapshots.body.length === 0) {
+        console.log(`WARNING: ${datasetId} has no snapshots`)
+      }
+      try {
+        if (!DRY_RUN) dataset.createDatasetModel(datasetId, label, uploader)
+        for (const snapshot of snapshots.body) {
+          const snapshotId = bids.decodeId(snapshot._id)
+          console.log(`Migrating snapshot "${snapshotId}"`)
+          await migrateSnapshot(datasetId, snapshotId)
+        }
+      } catch {
+        console.log(`"${datasetId}" has been imported, skipping`)
+      }
+    })
+  })
+}
+
+const migrateSnapshot = async (datasetId, snapshotId) => {
+  console.log(`Snapshot migration of "${datasetId}-${snapshotId}"`)
+  if (!DRY_RUN) {
+    return new Promise((resolve, reject) => {
+      scitran.downloadSymlinkDataset(
+        bids.encodeId(snapshotId),
+        (err, hash) => {
+          const snapshotDir = config.location + '/persistent/datasets/' + hash
+          uploadSnapshotContent(datasetId, snapshotId, snapshotDir).then(() =>
+            resolve(),
+          )
+        },
+        { snapshot: true },
+      )
+    })
+  }
+}
+
+const uploadSnapshotContent = async (datasetId, snapshotId, snapshotDir) => {
+  files.getFiles(snapshotDir, async snapshotFiles => {
+    for (const filePath of snapshotFiles) {
+      const file = fs.createReadStream(filePath)
+      const relativePath = path.relative(snapshotDir, filePath)
+      await dataset.updateFile(datasetId, relativePath, file)
+    }
+  })
+  console.log(`Files for "${datasetId}-${snapshotId}" transferred.`)
+  await dataset.commitFiles(
+    datasetId,
+    'DataLad Importer',
+    'no-reply@openneuro.org',
+  )
+  await snapshots.createSnapshot(datasetId, snapshotId)
+  console.log(`Snapshot "${snapshotId}" created.`)
+}
+
+mongo.connect(config.mongo.url).then(() => {
+  migrateAll()
+})

--- a/packages/openneuro-server/datalad/migration.js
+++ b/packages/openneuro-server/datalad/migration.js
@@ -1,3 +1,4 @@
+/* eslint-disable */
 import fs from 'fs'
 import path from 'path'
 import mongo from '../libs/mongo.js'

--- a/packages/openneuro-server/datalad/migration.js
+++ b/packages/openneuro-server/datalad/migration.js
@@ -112,9 +112,17 @@ const migrate = (datasetId, uploader, label, created) => {
 const migrateSnapshot = (datasetId, snapshotId) => {
   console.log(`Snapshot migration of "${datasetId}-${snapshotId}"`)
   return new Promise((resolve, reject) => {
+    const scitranSnapshotId =
+      snapshotId.length === 5
+        ? bids.encodeId(`${datasetId.slice(2)}-${snapshotId}`)
+        : snapshotId
+    console.log(`Getting files for snapshot: "${scitranSnapshotId}"`)
     scitran.downloadSymlinkDataset(
-      bids.encodeId(snapshotId),
+      bids.encodeId(scitranSnapshotId),
       (err, hash) => {
+        if (err) {
+          console.log(err)
+        }
         const snapshotDir = config.location + '/persistent/datasets/' + hash
         uploadSnapshotContent(datasetId, snapshotId, snapshotDir).then(() =>
           resolve(),

--- a/packages/openneuro-server/datalad/migration.js
+++ b/packages/openneuro-server/datalad/migration.js
@@ -77,6 +77,7 @@ const migrate = (datasetId, uploader, label, created) => {
         await createScitranSnapshot(datasetId)
         console.log(`${datasetId} snapshot created - rerunning migration`)
         await migrate(datasetId, uploader, label, created)
+        resolve()
       } else {
         try {
           // This will throw an exception for a dataset that already exists

--- a/packages/openneuro-server/datalad/migration.js
+++ b/packages/openneuro-server/datalad/migration.js
@@ -57,10 +57,9 @@ const migrate = (datasetId, uploader, label, created) => {
         )
         for (const snapshot of chronological) {
           const snapshotId = bids.decodeId(snapshot._id)
-          console.log(`Migrating snapshot "${snapshotId}"`)
           await migrateSnapshot(datasetId, snapshotId)
-          resolve()
         }
+        resolve()
       } catch (e) {
         console.log(e)
         console.log(`"${datasetId}" has been imported, skipping`)

--- a/packages/openneuro-server/datalad/migration.js
+++ b/packages/openneuro-server/datalad/migration.js
@@ -17,6 +17,7 @@ process.on('unhandledRejection', error => {
   console.log('unhandledRejection', error)
 })
 
+// Setup a migration of all SciTran datasets
 const migrateAll = () => {
   const c = mongo.collections
   c.scitran.projects
@@ -40,6 +41,7 @@ const migrateAll = () => {
     })
 }
 
+// Promise wrapper for SciTran project snapshots request
 const createScitranSnapshot = datasetId => {
   return new Promise((resolve, reject) => {
     request.post(
@@ -59,6 +61,7 @@ const createScitranSnapshot = datasetId => {
   })
 }
 
+// Migrate a dataset to the new backend
 const migrate = (datasetId, uploader, label, created) => {
   return new Promise((resolve, reject) => {
     console.log(
@@ -67,12 +70,13 @@ const migrate = (datasetId, uploader, label, created) => {
     scitran.getProjectSnapshots(datasetId, async (err, snapshots) => {
       console.log(`Found ${snapshots.body.length} snapshots.`)
       if (snapshots.body.length === 0) {
+        // Create at least one private snapshot if none exist
         console.log(
           `WARNING: ${datasetId} has no snapshots - creating SciTran snapshot`,
         )
         await createScitranSnapshot(datasetId)
         console.log(`${datasetId} snapshot created - rerunning migration`)
-        migrate(datasetId, uploader, label, created)
+        await migrate(datasetId, uploader, label, created)
       } else {
         try {
           // This will throw an exception for a dataset that already exists

--- a/packages/openneuro-server/datalad/migration.js
+++ b/packages/openneuro-server/datalad/migration.js
@@ -82,6 +82,10 @@ const migrate = (datasetId, uploader, label, created) => {
             .set('Accept', 'application/json')
             .set('From', '"OpenNeuro Importer" <no-reply@openneuro.org>')
           await dataset.createDatasetModel(datasetId, label, uploader)
+          // If all snapshots are public, the dataset is now public
+          if (snapshots.body.filter(snapshot => snapshot.public).length > 0) {
+            await dataset.updatePublic(datasetId, true)
+          }
           const chronological = snapshots.body.sort(
             (a, b) => new Date(b.created) - new Date(a.created),
           )

--- a/packages/openneuro-server/migration.js
+++ b/packages/openneuro-server/migration.js
@@ -1,0 +1,2 @@
+require('babel-core/register')
+require('./datalad/migration.js')


### PR DESCRIPTION
This migrates all datasets to DataLad and saves dataset metadata from SciTran.

Everything happens linearly (despite somewhat complicated order of promises) just for ease of debugging in the case of failure. This makes it fairly slow but deterministic.

One piece is excluded from this script, dataset permissions, since that migration can run after this (it only moves Mongo fields).

Runs with `node migration.js` within the updated server container.