### PR TITLE
google passport auth uses email as id

### DIFF
--- a/packages/openneuro-server/libs/authentication/passport.js
+++ b/packages/openneuro-server/libs/authentication/passport.js
@@ -93,7 +93,7 @@ const loadProfile = profile => {
       .filter(email => email.type === 'account')
       .shift()
     return {
-      id: profile.id,
+      id: primaryEmail.value,
       email: primaryEmail.value,
       name: profile.displayName,
       provider: profile.provider,


### PR DESCRIPTION
fixes #740 