### PR TITLE
MongoDB migrations for DataLad + new auth system

### DIFF
--- a/packages/openneuro-server/datalad-migration.js
+++ b/packages/openneuro-server/datalad-migration.js
@@ -1,0 +1,3 @@
+// This migrates datasets from SciTran to DataLad service backend
+require('babel-core/register')
+require('./datalad/migration.js')

--- a/packages/openneuro-server/migration.js
+++ b/packages/openneuro-server/migration.js
@@ -1,2 +1,0 @@
-require('babel-core/register')
-require('./datalad/migration.js')

--- a/packages/openneuro-server/migrations/01-scitranUser.js
+++ b/packages/openneuro-server/migrations/01-scitranUser.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 /**
  * Migration from old SciTran user format to our own user database
  */

--- a/packages/openneuro-server/migrations/01-scitranUser.js
+++ b/packages/openneuro-server/migrations/01-scitranUser.js
@@ -1,0 +1,65 @@
+/**
+ * Migration from old SciTran user format to our own user database
+ */
+import path from 'path'
+import User from '../models/user.js'
+import mongo from '../libs/mongo.js'
+
+const scitran = mongo.collections.scitran
+
+export default {
+  id: path.basename(module.filename),
+  update: async () => {
+    await scitran.users
+      .find()
+      .toArray()
+      .then(async scitranUsers => {
+        //throw new Error(util.inspect(scitranUsers))
+        for (const oldUser of scitranUsers) {
+          let newUser
+          if (oldUser._id.indexOf('@') !== -1) {
+            // This is a legacy Google user
+            newUser = await User.findOneAndUpdate(
+              {
+                provider: 'google',
+                providerId: oldUser._id,
+              },
+              {
+                provider: 'google',
+                providerId: oldUser._id,
+                email: oldUser.email,
+                admin: oldUser.root,
+                name: `${oldUser.firstname} ${oldUser.lastname}`,
+                created: oldUser.created,
+                lastLogin: oldUser.lastlogin,
+              },
+              { upsert: true, new: true, setDefaultsOnInsert: true },
+            )
+          } else {
+            // This is a legacy ORCID user
+            newUser = await User.findOneAndUpdate(
+              {
+                provider: 'orcid',
+                providerId: oldUser._id,
+              },
+              {
+                provider: 'orcid',
+                providerId: oldUser._id,
+                email: oldUser.email,
+                admin: oldUser.root,
+                name: `${oldUser.firstname} ${oldUser.lastname}`,
+                created: oldUser.created,
+                lastLogin: oldUser.lastlogin,
+              },
+              { upsert: true, new: true, setDefaultsOnInsert: true },
+            )
+          }
+          console.log(
+            `User "${oldUser._id}" ->"${newUser.id}" + "${
+              newUser.providerId
+            }" migrated to new auth format.`,
+          )
+        }
+      })
+  },
+}

--- a/packages/openneuro-server/migrations/02-scitranPermission.js
+++ b/packages/openneuro-server/migrations/02-scitranPermission.js
@@ -1,0 +1,9 @@
+/**
+ * Migration from old SciTran user format to our own user database
+ */
+import path from 'path'
+
+export default {
+  id: path.basename(module.filename),
+  update: async () => {},
+}

--- a/packages/openneuro-server/migrations/02-scitranPermission.js
+++ b/packages/openneuro-server/migrations/02-scitranPermission.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 /**
  * Migrate permissions from SciTran datasets to new db
  */

--- a/packages/openneuro-server/migrations/02-scitranPermission.js
+++ b/packages/openneuro-server/migrations/02-scitranPermission.js
@@ -1,9 +1,43 @@
 /**
- * Migration from old SciTran user format to our own user database
+ * Migrate permissions from SciTran datasets to new db
  */
 import path from 'path'
+import bidsId from '../libs/bidsId.js'
+import mongo from '../libs/mongo.js'
+import User from '../models/user.js'
+import Permission from '../models/permission.js'
+
+const scitran = mongo.collections.scitran
 
 export default {
   id: path.basename(module.filename),
-  update: async () => {},
+  update: async () => {
+    const projectPermissions = await scitran.projects
+      .find({}, { permissions: true })
+      .toArray()
+    const newPermissions = []
+    for (const project of projectPermissions) {
+      for (const permission of project.permissions) {
+        const datasetId = bidsId.decodeId(project._id)
+        if (datasetId && typeof datasetId === 'string') {
+          // Check for datasetId basic assumptions
+          if (datasetId.slice(0, 3) !== 'ds0') {
+            throw new Error(`Invalid id "${datasetId}"`)
+          }
+          const providerId = permission._id
+          const user = await User.findOne({ providerId })
+          newPermissions.push({
+            datasetId,
+            userId: user.id,
+            level: permission.access,
+          })
+        } else {
+          console.log(`Skipping invalid dataset ${project._id}`)
+        }
+      }
+    }
+    Permission.collection.insert(newPermissions).catch(e => {
+      throw e
+    })
+  },
 }

--- a/packages/openneuro-server/migrations/03-genericAccounts.js
+++ b/packages/openneuro-server/migrations/03-genericAccounts.js
@@ -1,9 +1,40 @@
 /**
- * Migrate all users to generic user ids
+ * Migrate all user content to generic user ids
+ *
+ * These items are migrated here:
+ * Comments, Datasets, Jobs, Stars, Subscriptions
  */
 import path from 'path'
+import mongo from '../libs/mongo.js'
+import User from '../models/user.js'
+
+const c = mongo.collections
 
 export default {
   id: path.basename(module.filename),
-  update: async () => {},
+  update: async () => {
+    const users = await User.find()
+    for (const user of users) {
+      c.crn.comments.updateMany(
+        { 'user._id': user.providerId },
+        { $set: { 'user._id': user.id } },
+      )
+      c.crn.datasets.updateMany(
+        { uploader: user.providerId },
+        { $set: { uploader: user.id } },
+      )
+      c.crn.jobs.updateMany(
+        { userId: user.providerId },
+        { $set: { userId: user.id } },
+      )
+      c.crn.stars.updateMany(
+        { userId: user.providerId },
+        { $set: { userId: user.id } },
+      )
+      c.crn.subscriptions.updateMany(
+        { userId: user.providerId },
+        { $set: { userId: user.id } },
+      )
+    }
+  },
 }

--- a/packages/openneuro-server/migrations/03-genericAccounts.js
+++ b/packages/openneuro-server/migrations/03-genericAccounts.js
@@ -1,0 +1,9 @@
+/**
+ * Migrate all users to generic user ids
+ */
+import path from 'path'
+
+export default {
+  id: path.basename(module.filename),
+  update: async () => {},
+}

--- a/packages/openneuro-server/migrations/index.js
+++ b/packages/openneuro-server/migrations/index.js
@@ -1,0 +1,1 @@
+export default []

--- a/packages/openneuro-server/migrations/index.js
+++ b/packages/openneuro-server/migrations/index.js
@@ -1,1 +1,5 @@
-export default []
+import scitranUser from './01-scitranUser.js'
+import scitranPermission from './02-scitranPermission.js'
+import genericAccounts from './03-genericAccounts.js'
+
+export default [scitranUser, scitranPermission, genericAccounts]

--- a/packages/openneuro-server/migrations/index.js
+++ b/packages/openneuro-server/migrations/index.js
@@ -2,4 +2,5 @@ import scitranUser from './01-scitranUser.js'
 import scitranPermission from './02-scitranPermission.js'
 import genericAccounts from './03-genericAccounts.js'
 
+// Ordered list should match a sort of the filenames
 export default [scitranUser, scitranPermission, genericAccounts]

--- a/packages/openneuro-server/migrations/upgrade.js
+++ b/packages/openneuro-server/migrations/upgrade.js
@@ -1,4 +1,4 @@
-/*eslint no-console: "error"*/
+/* eslint-disable no-console */
 // Run all pending migrations
 import config from '../config.js'
 import mongo from '../libs/mongo.js'

--- a/packages/openneuro-server/migrations/upgrade.js
+++ b/packages/openneuro-server/migrations/upgrade.js
@@ -1,0 +1,51 @@
+/*eslint no-console: "error"*/
+// Run all pending migrations
+import config from '../config.js'
+import mongo from '../libs/mongo.js'
+import mongoose from 'mongoose'
+import Migration from '../models/migration.js'
+import migrations from './index.js'
+
+// Setup Mongoose
+mongoose.connect(`${config.mongo.url}crn`)
+
+/**
+ * This is a basic migration system, runs any unapplied updates in order
+ * from the index provided in index.js
+ *
+ * Will yell at you if there are errors.
+ *
+ * Runs manually for now but could run at startup.
+ */
+const upgradeAll = async () => {
+  // Connect to old database(s)
+  await mongo.connect(config.mongo.url)
+  for (const migrationDefinition of migrations) {
+    const key = migrationDefinition.id
+    const migrate = await Migration.findOneAndUpdate(
+      { id: key },
+      {},
+      { upsert: true, new: true, setDefaultsOnInsert: true },
+    )
+    try {
+      if (migrate.complete) {
+        console.log(`${key} has already run - continuing`)
+      } else {
+        await migrationDefinition.update()
+        console.log(`${key} migration complete`)
+        migrate.complete = true
+        await migrate.save()
+      }
+    } catch (e) {
+      console.log(`${key} failed to execute - exiting`)
+      throw e
+    }
+  }
+}
+
+// Entrypoint
+upgradeAll().then(() => {
+  mongo.dbs.scitran.close()
+  mongo.dbs.crn.close()
+  mongoose.connection.close()
+})

--- a/packages/openneuro-server/models/migration.js
+++ b/packages/openneuro-server/models/migration.js
@@ -1,0 +1,10 @@
+import mongoose from 'mongoose'
+
+const migrationSchema = new mongoose.Schema({
+  id: String,
+  complete: { type: Boolean, default: false },
+})
+
+const Migration = mongoose.model('Migration', migrationSchema)
+
+export default Migration

--- a/packages/openneuro-server/models/permission.js
+++ b/packages/openneuro-server/models/permission.js
@@ -1,0 +1,11 @@
+import mongoose from 'mongoose'
+
+const permissionSchema = new mongoose.Schema({
+  datasetId: { type: String, required: true },
+  userId: { type: String, required: true },
+  level: { type: String, required: true, enum: ['ro', 'rw', 'admin'] },
+})
+
+const Permission = mongoose.model('Permission', permissionSchema)
+
+export default Permission

--- a/packages/openneuro-server/models/user.js
+++ b/packages/openneuro-server/models/user.js
@@ -1,12 +1,16 @@
+import uuid from 'uuid'
 import mongoose from 'mongoose'
 
 const userSchema = new mongoose.Schema({
-  id: String,
+  id: { type: String, default: uuid.v4 }, // OpenNeuro id
   email: String,
   name: String,
   provider: String, // Login provider
+  providerId: String, // Login provider unique id
   admin: { type: Boolean, default: false },
   blacklist: { type: Boolean, default: false },
+  created: { type: Date, default: Date.now },
+  lastSeen: { type: Date, default: Date.now },
 })
 
 userSchema.index({ id: 1, provider: 1 }, { unique: true })

--- a/packages/openneuro-server/upgrade.js
+++ b/packages/openneuro-server/upgrade.js
@@ -1,0 +1,3 @@
+// Run any pending MongoDB migrations
+require('babel-core/register')
+require('./migrations/upgrade.js')


### PR DESCRIPTION
This adds the missing migrations for #738, #739, and #740 

Migrations do not run on server startup in this implementation because I think there's an open question about how to decide if a database with no migration history requires updates or not. For now, they are manually run with `node upgrade.js`.