### PR TITLE
Dataset added subscription bug

### DIFF
--- a/packages/openneuro-app/src/scripts/dashboard/dashboard.datasets.jsx
+++ b/packages/openneuro-app/src/scripts/dashboard/dashboard.datasets.jsx
@@ -62,7 +62,7 @@ class Datasets extends Reflux.Component {
     this.props.datasetsQuery.subscribeToMore({
       document: gql`
         subscription {
-          datasetAdded {
+          draftFilesUpdated {
             id
           }
         }

--- a/packages/openneuro-server/datalad/dataset.js
+++ b/packages/openneuro-server/datalad/dataset.js
@@ -7,7 +7,6 @@ import request from 'superagent'
 import requestNode from 'request'
 import config from '../config'
 import mongo from '../libs/mongo'
-import pubsub from '../graphql/pubsub.js'
 import * as subscriptions from '../handlers/subscriptions.js'
 import { generateDataladCookie } from '../libs/authentication/jwt'
 import { redis } from '../libs/redis.js'
@@ -38,7 +37,6 @@ export const createDataset = (label, uploader, userInfo) => {
         .set('Accept', 'application/json')
         .set('Cookie', generateDataladCookie(config)(userInfo))
       await req
-      pubsub.publish('datasetAdded', { id: datasetId })
       subscriptions
         .subscribe(datasetId, uploader)
         .then(() => resolve({ id: datasetId, label }))

--- a/packages/openneuro-server/graphql/resolvers/index.js
+++ b/packages/openneuro-server/graphql/resolvers/index.js
@@ -22,7 +22,6 @@ import {
   removePermissions,
 } from './permissions.js'
 import {
-  datasetAdded,
   datasetDeleted,
   datasetValidationUpdated,
   draftFilesUpdated,
@@ -63,7 +62,6 @@ export default {
     setAdmin,
   },
   Subscription: {
-    datasetAdded,
     datasetDeleted,
     datasetValidationUpdated,
     draftFilesUpdated,

--- a/packages/openneuro-server/graphql/resolvers/subscriptions.js
+++ b/packages/openneuro-server/graphql/resolvers/subscriptions.js
@@ -1,9 +1,5 @@
 import pubsub from '../pubsub.js'
 
-export const datasetAdded = {
-  subscribe: () => pubsub.asyncIterator('datasetAdded'),
-}
-
 export const datasetDeleted = {
   subscribe: () => pubsub.asyncIterator('datasetDeleted'),
 }

--- a/packages/openneuro-server/graphql/schema.js
+++ b/packages/openneuro-server/graphql/schema.js
@@ -58,7 +58,6 @@ const typeDefs = `
 
   type Subscription {
     # Publishes when the set of datasets changes
-    datasetAdded: Dataset
     datasetDeleted: ID
     snapshotAdded: ID
     snapshotDeleted: ID


### PR DESCRIPTION
gets rid of the datasetAdded subscription, and replaces it with draftFilesUpdated subscription on the dataset dashboard to fix a bug where datasets were getting cached (as incomplete) before they had finished uploading. 