### PR TITLE
Graphql analytics

### DIFF
--- a/packages/openneuro-app/src/scripts/datalad/download/download-link.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/download/download-link.jsx
@@ -3,9 +3,17 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import WarnButton from '../../common/forms/warn-button.jsx'
 import config from '../../../../config.js'
+import datalad from '../../utils/datalad'
 
 const startDownload = uri => {
   global.location.assign(uri)
+}
+const trackDownload = (datasetId, snapshotTag) => {
+  datalad.trackAnalytics(datasetId, {
+    snapshot: true,
+    tag: snapshotTag,
+    type: 'download',
+  })
 }
 
 /**
@@ -36,6 +44,7 @@ const downloadClick = (datasetId, snapshotTag) => callback => {
       if (registration.active) {
         // Service worker is already running as expected
         startDownload(uri)
+        trackDownload(datasetId, snapshotTag)
         callback()
       } else {
         // Waiting on the service worker
@@ -51,6 +60,7 @@ const downloadClick = (datasetId, snapshotTag) => callback => {
                   true,
                 )
                 startDownload(uri)
+                trackDownload(datasetId, snapshotTag)
                 callback()
               }
             },

--- a/packages/openneuro-app/src/scripts/dataset/dataset.metrics.jsx
+++ b/packages/openneuro-app/src/scripts/dataset/dataset.metrics.jsx
@@ -15,7 +15,7 @@ class Metrics extends React.Component {
     let followers = dataset.followers ? '' + dataset.followers : '0'
     let displayStars = fromDashboard ? (stars !== '0' ? true : false) : true
     let hasDownloads = downloads !== '0'
-    let isSnapshot = dataset.hasOwnProperty('original')
+    let isSnapshot = dataset.hasOwnProperty('snapshot_version')
     let displayDownloads = fromDashboard
       ? hasDownloads ? true : false // don't display downloads on dash if the count is 0
       : isSnapshot ? true : false // down't display downloads on dataset page if the dataset is a draft
@@ -25,7 +25,6 @@ class Metrics extends React.Component {
     let displayViews = fromDashboard
       ? dataset.views !== '0' ? true : false // don't display views on dash if the count is 0
       : isSnapshot ? true : false // don't display views on the dataset draft page
-
     return (
       <span className="metrics-wrap">
         <Metric type="stars" value={stars} display={displayStars} />

--- a/packages/openneuro-app/src/scripts/dataset/dataset.snapshot-loader.jsx
+++ b/packages/openneuro-app/src/scripts/dataset/dataset.snapshot-loader.jsx
@@ -1,6 +1,7 @@
 import Reflux from 'reflux'
 import { withRouter } from 'react-router-dom'
 import datasetStore from './dataset.store'
+import bids from '../utils/bids'
 import actions from './dataset.actions'
 import { refluxConnect } from '../utils/reflux'
 
@@ -45,18 +46,17 @@ class SnapshotLoader extends Reflux.Component {
       if (reload) {
         if (snapshotId) {
           const query = new URLSearchParams(props.location.search)
-          const snapshotUrl = [datasetId, snapshotId].join(':')
           const app = query.get('app')
           const version = query.get('version')
           const job = query.get('job')
-          actions.trackView(snapshotUrl)
+          actions.trackView(bids.decodeId(datasetId), bids.decodeId(snapshotId))
           actions.loadDataset(datasetId, {
             snapshot: true,
             app: app,
             version: version,
             job: job,
             datasetId: datasetId,
-            tag: snapshotId
+            tag: snapshotId,
           })
         }
       }

--- a/packages/openneuro-app/src/scripts/dataset/dataset.store.js
+++ b/packages/openneuro-app/src/scripts/dataset/dataset.store.js
@@ -430,14 +430,17 @@ let datasetStore = Reflux.createStore({
    * download feedback.
    */
   trackDownload(callback) {
-    scitran
-      .trackUsage(this.data.dataset._id, 'download', { snapshot: true })
-      .then(() => {
-        let dataset = this.data.dataset
-        dataset.downloads++
-        this.update({ dataset })
-        callback()
-      })
+    let options = {
+      snapshot: true,
+      tag: this.data.dataset.tag,
+      type: 'download',
+    }
+    datalad.trackAnalytics(this.data.dataset._id, options).then(() => {
+      let dataset = this.data.dataset
+      dataset.downloads++
+      this.update({ dataset })
+      callback()
+    })
   },
 
   /**
@@ -1724,8 +1727,9 @@ let datasetStore = Reflux.createStore({
 
   // usage analytics ---------------------------------------------------------------
 
-  trackView(snapshotId) {
-    scitran.trackUsage(snapshotId, 'view', { snapshot: true })
+  trackView(datasetId, tag) {
+    let options = { snapshot: true, tag: tag, type: 'view' }
+    datalad.trackAnalytics(datasetId, options)
   },
 
   toggleSidebar(value) {

--- a/packages/openneuro-app/src/scripts/dataset/tools/snapshot.jsx
+++ b/packages/openneuro-app/src/scripts/dataset/tools/snapshot.jsx
@@ -103,7 +103,7 @@ class Snapshot extends Reflux.Component {
       const version = query.get('version')
       const job = query.get('job')
       const snapshotUrl = datasetId.join(snapshotId, ':')
-      actions.trackView(snapshotUrl)
+      actions.trackView(bids.decodeId(datasetId), bids.decodeId(snapshotId))
       actions.loadDataset(snapshotUrl, {
         snapshot: true,
         app: app,

--- a/packages/openneuro-app/src/scripts/utils/bids.js
+++ b/packages/openneuro-app/src/scripts/utils/bids.js
@@ -394,7 +394,7 @@ export default {
    * a formatted top level container of a
    * BIDS dataset.
    */
-  formatDataset(project, description, users, stars, followers, usage) {
+  formatDataset(project, description, users, stars, followers) {
     let files = project.files
 
     let dataset = {

--- a/packages/openneuro-app/src/scripts/utils/bids.js
+++ b/packages/openneuro-app/src/scripts/utils/bids.js
@@ -44,40 +44,31 @@ export default {
     const users = isSignedOut ? null : await datalad.getUsers()
     const stars = (await crn.getStars()).body
     const followers = (await crn.getSubscriptions()).body
-    this.usage(null, usage => {
-      let resultDict = {}
-      for (let project of projects) {
-        let dataset = this.formatDataset(
-          project,
-          null,
-          users,
-          stars,
-          followers,
-          usage,
-        )
-        let datasetId = dataset.hasOwnProperty('original')
-          ? dataset.original
-          : dataset._id
-        let existing = resultDict[datasetId]
-        if (
-          !existing ||
-          (existing.hasOwnProperty('original') &&
-            !dataset.hasOwnProperty('original')) ||
-          (existing.hasOwnProperty('original') &&
-            existing.snapshot_version < project.snapshot_version)
-        ) {
-          if (isAdmin || project.public || this.userAccess(project)) {
-            resultDict[datasetId] = dataset
-          }
+    let resultDict = {}
+    for (let project of projects) {
+      let dataset = this.formatDataset(project, null, users, stars, followers)
+      let datasetId = dataset.hasOwnProperty('original')
+        ? dataset.original
+        : dataset._id
+      let existing = resultDict[datasetId]
+      if (
+        !existing ||
+        (existing.hasOwnProperty('original') &&
+          !dataset.hasOwnProperty('original')) ||
+        (existing.hasOwnProperty('original') &&
+          existing.snapshot_version < project.snapshot_version)
+      ) {
+        if (isAdmin || project.public || this.userAccess(project)) {
+          resultDict[datasetId] = dataset
         }
       }
+    }
 
-      let results = []
-      for (let key in resultDict) {
-        results.push(resultDict[key])
-      }
-      callback(results)
-    })
+    let results = []
+    for (let key in resultDict) {
+      results.push(resultDict[key])
+    }
+    callback(results)
   },
 
   /**
@@ -117,10 +108,10 @@ export default {
             } finally {
               metadata[filename] = contents
             }
-            cb()
+            return cb()
           })
           .catch(() => {
-            cb()
+            return cb()
           })
       },
       () => {
@@ -163,6 +154,7 @@ export default {
             ? this._formatFiles(draftFiles)
             : this._formatFiles(snapshotFiles)
           project.snapshot_version = snapshot ? snapshot.tag : null
+          project.analytics = snapshot ? snapshot.analytics : project.analytics
           this.getMetadata(
             project,
             metadata => {
@@ -176,28 +168,20 @@ export default {
               dataset.children = tempFiles
               dataset.showChildren = true
               dataset.snapshots = project.snapshots
-              // get dataset usage stats
-              this.usage(projectId, usage => {
-                if (usage) {
-                  dataset.views = this.views(dataset, usage)
-                  dataset.downloads = this.downloads(dataset, usage)
-                }
-                if (config.analysis.enabled) {
-                  crn
-                    .getDatasetJobs(projectId, options)
-                    .then(res => {
-                      dataset.jobs = res.body
-                      return callback(dataset)
-                    })
-                    .catch(err => {
-                      // console.log('error getting jobs:', err)
-                      return callback(dataset, err)
-                    })
-                } else {
-                  dataset.jobs = []
-                  return callback(dataset)
-                }
-              })
+              if (config.analysis.enabled) {
+                crn
+                  .getDatasetJobs(projectId, options)
+                  .then(res => {
+                    dataset.jobs = res.body
+                    return callback(dataset)
+                  })
+                  .catch(err => {
+                    return callback(dataset, err)
+                  })
+              } else {
+                dataset.jobs = []
+                return callback(dataset)
+              }
             },
             options,
           )
@@ -360,17 +344,10 @@ export default {
    *
    * Takes a dataset and usage array and returns the download count of the dataset
    */
-  downloads(dataset, usage) {
-    if (usage) {
-      let datasetId = dataset._id
-      let matches = usage.filter(entry => {
-        return entry._id == this.decodeId(datasetId)
-      })
-      const downloads = matches.length ? '' + matches[0].downloads : '0'
-      return downloads
-    } else {
-      return '0'
-    }
+  downloads(dataset) {
+    return dataset.analytics && dataset.analytics.downloads
+      ? '' + dataset.analytics.downloads
+      : '0'
   },
 
   /**
@@ -378,17 +355,10 @@ export default {
    *
    * Takes a dataset and usage array and returns the view count of the dataset
    */
-  views(dataset, usage) {
-    if (usage) {
-      let datasetId = dataset._id
-      let matches = usage.filter(entry => {
-        return entry._id == this.decodeId(datasetId)
-      })
-      const views = matches.length ? '' + matches[0].views : '0'
-      return views
-    } else {
-      return '0'
-    }
+  views(dataset) {
+    return dataset.analytics && dataset.analytics.views
+      ? '' + dataset.analytics.views
+      : '0'
   },
 
   /**
@@ -438,8 +408,8 @@ export default {
         project.draft && project.draft.modified ? project.draft.modified : null,
       permissions: project.permissions,
       public: !!project.public,
-      downloads: project.downloads,
-      views: project.views,
+      downloads: this.downloads(project),
+      views: this.views(project),
 
       /** modified for BIDS **/
       validation:
@@ -478,8 +448,6 @@ export default {
     dataset.stars = this.stars(dataset, stars)
     dataset.starCount = dataset.stars ? '' + dataset.stars.length : '0'
     dataset.followersList = this.followers(dataset, followers)
-    dataset.downloads = this.downloads(dataset, usage)
-    dataset.views = this.views(dataset, usage)
     dataset.followers = '' + dataset.followersList.length
     return dataset
   },
@@ -591,18 +559,6 @@ export default {
       return false
     }
     return project.uploader ? project.uploader.id === userProfile.sub : false
-  },
-
-  /**
-   * Usage
-   * Takes a snapshotId and snapshot boolean and
-   * callsback view and download counts for snapshots.
-   */
-  usage(datasetId, callback) {
-    crn.getAnalytics(datasetId).then(res => {
-      let usage = res ? res.body : null
-      return callback(usage)
-    })
   },
 
   /**

--- a/packages/openneuro-app/src/scripts/utils/datalad.js
+++ b/packages/openneuro-app/src/scripts/utils/datalad.js
@@ -1,6 +1,6 @@
 import getClient from 'openneuro-client'
 import config from '../../../config'
-import { datasets, files, users } from 'openneuro-client'
+import { datasets, files, users, snapshots } from 'openneuro-client'
 import gql from 'graphql-tag'
 import bids from './bids'
 import clone from 'lodash.clonedeep'
@@ -127,31 +127,7 @@ export default {
   querySnapshot(datasetId, tag, callback) {
     client
       .query({
-        query: gql`
-          query getSnapshot($datasetId: ID!, $tag: String!) {
-            snapshot(datasetId: $datasetId, tag: $tag) {
-              id
-              _id: id
-              tag
-              created
-              authors {
-                ORCID
-                name
-              }
-              summary {
-                size
-                totalFiles
-              }
-              files {
-                id
-                _id: id
-                name: filename
-                filename
-                size
-              }
-            }
-          }
-        `,
+        query: snapshots.getSnapshot,
         variables: {
           datasetId: bids.decodeId(datasetId),
           tag: tag,
@@ -574,6 +550,24 @@ export default {
       variables: {
         id: id,
         admin: admin,
+      },
+    })
+  },
+
+  //Analytics
+  /**
+   * Track Analytics
+   *
+   * Adds a 'view' or 'download' type entry to the analytics for a specific dataset
+   */
+  trackAnalytics(datasetId, options) {
+    options = options || {}
+    return client.mutate({
+      mutation: datasets.trackAnalytics,
+      variables: {
+        datasetId: datasetId,
+        tag: options.tag,
+        type: options.type,
       },
     })
   },

--- a/packages/openneuro-app/src/scripts/utils/scitran.js
+++ b/packages/openneuro-app/src/scripts/utils/scitran.js
@@ -392,37 +392,4 @@ export default {
       },
     )
   },
-
-  // usage analytics ------------------------------------------------------------------------
-
-  /**
-   * Track Usage
-   *
-   * - type ('view' or 'download')
-   */
-  trackUsage(snapshotId, type, options) {
-    options.query = { type }
-    return request.post(
-      config.scitran.url + 'projects/' + snapshotId + '/analytics',
-      options,
-    )
-  },
-
-  /**
-   * Get Usage Analytics
-   *
-   * options
-   * - type       ('view' or 'download')
-   * - user_id    (string)
-   * - start_date (date) year-month-day
-   * - end_date   (date) year-month-day
-   * - count      (boolean)
-   * - limit      (integer)
-   */
-  getUsage(snapshotId, options) {
-    return request.get(
-      config.scitran.url + 'projects/' + snapshotId + '/analytics',
-      options,
-    )
-  },
 }

--- a/packages/openneuro-client/src/datasets.js
+++ b/packages/openneuro-client/src/datasets.js
@@ -86,6 +86,10 @@ export const getDatasets = gql`
         id
         partial
       }
+      analytics {
+        views
+        downloads
+      }
     }
   }
 `
@@ -194,5 +198,11 @@ export const removePermissions = gql`
 export const checkPartial = gql`
   query partial($datasetId: ID!) {
     partial(datasetId: $datasetId)
+  }
+`
+
+export const trackAnalytics = gql`
+  mutation($datasetId: ID!, $tag: String, $type: AnalyticTypes!) {
+    trackAnalytics(datasetId: $datasetId, tag: $tag, type: $type)
   }
 `

--- a/packages/openneuro-client/src/snapshots.js
+++ b/packages/openneuro-client/src/snapshots.js
@@ -1,10 +1,40 @@
 import gql from 'graphql-tag'
 
 export const createSnapshot = gql`
-        mutation ($datasetId: ID!, $tag: String!) {
-          createSnapshot(datasetId: $datasetId, tag: $tag) {
-            id
-            tag
-          }
-        }
-      `
+  mutation($datasetId: ID!, $tag: String!) {
+    createSnapshot(datasetId: $datasetId, tag: $tag) {
+      id
+      tag
+    }
+  }
+`
+
+export const getSnapshot = gql`
+  query getSnapshot($datasetId: ID!, $tag: String!) {
+    snapshot(datasetId: $datasetId, tag: $tag) {
+      id
+      _id: id
+      tag
+      created
+      authors {
+        ORCID
+        name
+      }
+      summary {
+        size
+        totalFiles
+      }
+      files {
+        id
+        _id: id
+        name: filename
+        filename
+        size
+      }
+      analytics {
+        views
+        downloads
+      }
+    }
+  }
+`

--- a/packages/openneuro-server/datalad/dataset.js
+++ b/packages/openneuro-server/datalad/dataset.js
@@ -254,3 +254,57 @@ export const updatePublic = (datasetId, publicFlag) => {
   //   .set('Accept', 'application/json')
   //   .then(({ body }) => body)
 }
+
+export const getDatasetAnalytics = (datasetId, tag) => {
+  return new Promise((resolve, reject) => {
+    let datasetQuery = tag
+      ? { datasetId: datasetId, tag: tag }
+      : { datasetId: datasetId }
+    c.crn.analytics
+      .aggregate([
+        {
+          $match: datasetQuery,
+        },
+        {
+          $group: {
+            _id: '$datasetId',
+            tag: { $first: '$tag' },
+            views: {
+              $sum: {
+                $cond: [{ $eq: ['$type', 'view'] }, 1, 0],
+              },
+            },
+            downloads: {
+              $sum: {
+                $cond: [{ $eq: ['$type', 'download'] }, 1, 0],
+              },
+            },
+          },
+        },
+        {
+          $project: {
+            _id: 0,
+            datasetId: '$_id',
+            tag: 1,
+            views: 1,
+            downloads: 1,
+          },
+        },
+      ])
+      .toArray((err, results) => {
+        if (err) {
+          return reject(err)
+        }
+        results = results.length ? results[0] : {}
+        return resolve(results)
+      })
+  })
+}
+
+export const trackAnalytics = (datasetId, tag, type) => {
+  return c.crn.analytics.insertOne({
+    datasetId: datasetId,
+    tag: tag,
+    type: type,
+  })
+}

--- a/packages/openneuro-server/graphql/resolvers/dataset.js
+++ b/packages/openneuro-server/graphql/resolvers/dataset.js
@@ -149,3 +149,24 @@ export const updateSnapshotFileUrls = (obj, { fileUrls }) => {
 export const partial = (obj, { datasetId }) => {
   return getPartialStatus(datasetId)
 }
+
+/**
+ * Get analytics for a dataset or snapshot
+ */
+export const analytics = async obj => {
+  // if the dataset field exists, the request is from a snapshot, and
+  // we resolve the datasetId from the dataset snapshot field of context.
+  // otherwise, just use the id field because the object is a dataset
+  const datasetId = obj && obj.dataset ? (await obj.dataset()).id : obj.id
+
+  // if the object is a snapshot, grab the tag. otherwise, tag is null
+  const tag = obj && obj.tag ? obj.tag : null
+  return datalad.getDatasetAnalytics(datasetId, tag)
+}
+
+/**
+ * Track analytic of type 'view' or 'download' for a dataset / snapshot
+ */
+export const trackAnalytics = (obj, { datasetId, tag, type }) => {
+  return datalad.trackAnalytics(datasetId, tag, type)
+}

--- a/packages/openneuro-server/graphql/resolvers/index.js
+++ b/packages/openneuro-server/graphql/resolvers/index.js
@@ -12,6 +12,8 @@ import {
   updateFiles,
   deleteFiles,
   updateSnapshotFileUrls,
+  analytics,
+  trackAnalytics,
 } from './dataset.js'
 import { updateSummary, updateValidation } from './validation.js'
 import { draft, snapshot, snapshots, partial } from './datalad.js'
@@ -61,6 +63,7 @@ export default {
     removePermissions,
     removeUser,
     setAdmin,
+    trackAnalytics,
   },
   Subscription: {
     datasetAdded,
@@ -76,6 +79,7 @@ export default {
     uploader: ds => user(ds, { id: ds.uploader }),
     draft,
     snapshots,
+    analytics: ds => analytics(ds),
     permissions: ds =>
       permissions(ds).then(p =>
         p.map(permission =>
@@ -84,5 +88,8 @@ export default {
           }),
         ),
       ),
+  },
+  Snapshot: {
+    analytics: snapshot => analytics(snapshot),
   },
 }

--- a/packages/openneuro-server/graphql/schema.js
+++ b/packages/openneuro-server/graphql/schema.js
@@ -54,6 +54,8 @@ const typeDefs = `
     removeUser(id: ID!): Boolean
     # Sets a users admin status
     setAdmin(id: ID!, admin: Boolean!): Boolean
+    # Tracks a view or download for a dataset
+    trackAnalytics(datasetId: ID!, tag: String, type: AnalyticTypes): Boolean
   }
 
   type Subscription {
@@ -128,6 +130,7 @@ const typeDefs = `
     draft: Draft
     snapshots: [Snapshot]
     permissions: [Permission]
+    analytics: Analytic
   }
 
   # Ephemeral draft or working tree for a dataset
@@ -153,6 +156,7 @@ const typeDefs = `
     summary: Summary
     issues: [ValidationIssue]
     files: [DatasetFile]
+    analytics: Analytic
   }
 
   #User permissions on a dataset
@@ -251,6 +255,20 @@ const typeDefs = `
   input UpdateFileUrlInput {
     filename: String!
     urls: [String]
+  }
+
+  # Analytics for a dataset
+  type Analytic {
+    datasetId: ID!
+    tag: String
+    views: Int
+    downloads: Int
+  }
+
+  # Types of analytics
+  enum AnalyticTypes {
+    download
+    view
   }
 
 `

--- a/packages/openneuro-server/libs/bidsId.js
+++ b/packages/openneuro-server/libs/bidsId.js
@@ -41,4 +41,28 @@ export default {
     }
     return id
   },
+
+  decode(id) {
+    let decodedId = this.hexToASCII(id)
+    let datasetId = null
+    let tag = null
+    // decodes the two different formats of storing dataset + snapshot tag
+    if (/\s{4}ds\d{6}/.test(decodedId)) {
+      datasetId = decodedId.slice(4)
+    } else if (/\d{6}-\d{5}/.test(decodedId)) {
+      tag = decodedId.slice(7)
+      datasetId = 'ds' + decodedId.slice(0, 6)
+    } else {
+      // handles all these old dataset ids that start with 57 or 58
+      if (id.startsWith('57') || id.startsWith('58')) {
+        datasetId = id
+      } else {
+        // if the id is of the proper length but has no ds, add ds.
+        // otherwise, add it is short and needs a 0 as well
+        const beginning = id.length == 6 ? 'ds' : 'ds0'
+        datasetId = beginning + id
+      }
+    }
+    return { datasetId, tag }
+  },
 }

--- a/packages/openneuro-server/libs/mongo.js
+++ b/packages/openneuro-server/libs/mongo.js
@@ -47,12 +47,12 @@ export default {
       files: null,
       permissions: null,
       users: null,
+      analytics: null,
     },
     scitran: {
       projects: null,
       project_snapshots: null,
       users: null,
-      analytics: null,
     },
   },
 

--- a/packages/openneuro-server/libs/mongo.js
+++ b/packages/openneuro-server/libs/mongo.js
@@ -53,6 +53,7 @@ export default {
       projects: null,
       project_snapshots: null,
       users: null,
+      analytics: null,
     },
   },
 

--- a/packages/openneuro-server/migrations/04-scitranAnalytics.js
+++ b/packages/openneuro-server/migrations/04-scitranAnalytics.js
@@ -1,0 +1,30 @@
+/* eslint-disable no-console */
+/**
+ * Migrate permissions from SciTran datasets to new db
+ */
+import path from 'path'
+import bidsId from '../libs/bidsId.js'
+import mongo from '../libs/mongo.js'
+import Analytics from '../models/analytics.js'
+
+const scitran = mongo.collections.scitran
+
+export default {
+  id: path.basename(module.filename),
+  update: async () => {
+    const analytics = await scitran.analytics.find({}).toArray()
+    // console.log('analytics:', analytics)
+    const newAnalytics = []
+    for (const analytic of analytics) {
+      let { datasetId, tag } = bidsId.decode(analytic.container_id)
+      newAnalytics.push({
+        datasetId,
+        tag,
+        type: analytic.analytics_type,
+      })
+    }
+    Analytics.collection.insert(newAnalytics).catch(e => {
+      throw e
+    })
+  },
+}

--- a/packages/openneuro-server/migrations/index.js
+++ b/packages/openneuro-server/migrations/index.js
@@ -1,6 +1,12 @@
 import scitranUser from './01-scitranUser.js'
 import scitranPermission from './02-scitranPermission.js'
 import genericAccounts from './03-genericAccounts.js'
+import scitranAnalytics from './04-scitranAnalytics.js'
 
 // Ordered list should match a sort of the filenames
-export default [scitranUser, scitranPermission, genericAccounts]
+export default [
+  scitranUser,
+  scitranPermission,
+  genericAccounts,
+  scitranAnalytics,
+]

--- a/packages/openneuro-server/models/analytics.js
+++ b/packages/openneuro-server/models/analytics.js
@@ -1,0 +1,11 @@
+import mongoose from 'mongoose'
+
+const analyticsSchema = new mongoose.Schema({
+  datasetId: { type: String, required: true },
+  tag: { type: String, required: false },
+  type: { type: String, required: true },
+})
+
+const Analytics = mongoose.model('Analytics', analyticsSchema)
+
+export default Analytics


### PR DESCRIPTION
fixes #750 

* moves the analytics counters (views and downloads) from scitran into graphql.
* includes a script for the analytics migration from scitran to gql.
* updates the corresponding front-end components to use the new methods