### PR TITLE
Analytics becomes counter

### DIFF
--- a/packages/openneuro-app/src/scripts/datalad/download/download-link.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/download/download-link.jsx
@@ -12,7 +12,7 @@ const trackDownload = (datasetId, snapshotTag) => {
   datalad.trackAnalytics(datasetId, {
     snapshot: true,
     tag: snapshotTag,
-    type: 'download',
+    type: 'downloads',
   })
 }
 

--- a/packages/openneuro-app/src/scripts/dataset/dataset.store.js
+++ b/packages/openneuro-app/src/scripts/dataset/dataset.store.js
@@ -433,7 +433,7 @@ let datasetStore = Reflux.createStore({
     let options = {
       snapshot: true,
       tag: this.data.dataset.tag,
-      type: 'download',
+      type: 'downloads',
     }
     datalad.trackAnalytics(this.data.dataset._id, options).then(() => {
       let dataset = this.data.dataset
@@ -1728,7 +1728,7 @@ let datasetStore = Reflux.createStore({
   // usage analytics ---------------------------------------------------------------
 
   trackView(datasetId, tag) {
-    let options = { snapshot: true, tag: tag, type: 'view' }
+    let options = { snapshot: true, tag: tag, type: 'views' }
     datalad.trackAnalytics(datasetId, options)
   },
 

--- a/packages/openneuro-server/datalad/dataset.js
+++ b/packages/openneuro-server/datalad/dataset.js
@@ -268,14 +268,10 @@ export const getDatasetAnalytics = (datasetId, tag) => {
             _id: '$datasetId',
             tag: { $first: '$tag' },
             views: {
-              $sum: {
-                $cond: [{ $eq: ['$type', 'view'] }, 1, 0],
-              },
+              $sum: '$views',
             },
             downloads: {
-              $sum: {
-                $cond: [{ $eq: ['$type', 'download'] }, 1, 0],
-              },
+              $sum: '$downloads',
             },
           },
         },
@@ -300,9 +296,18 @@ export const getDatasetAnalytics = (datasetId, tag) => {
 }
 
 export const trackAnalytics = (datasetId, tag, type) => {
-  return c.crn.analytics.insertOne({
-    datasetId: datasetId,
-    tag: tag,
-    type: type,
-  })
+  return c.crn.analytics.updateOne(
+    {
+      datasetId: datasetId,
+      tag: tag,
+    },
+    {
+      $inc: {
+        [type]: 1,
+      },
+    },
+    {
+      upsert: true,
+    },
+  )
 }

--- a/packages/openneuro-server/graphql/schema.js
+++ b/packages/openneuro-server/graphql/schema.js
@@ -266,8 +266,8 @@ const typeDefs = `
 
   # Types of analytics
   enum AnalyticTypes {
-    download
-    view
+    downloads
+    views
   }
 
 `

--- a/packages/openneuro-server/migrations/04-scitranAnalytics.js
+++ b/packages/openneuro-server/migrations/04-scitranAnalytics.js
@@ -14,17 +14,25 @@ export default {
   update: async () => {
     const analytics = await scitran.analytics.find({}).toArray()
     // console.log('analytics:', analytics)
-    const newAnalytics = []
     for (const analytic of analytics) {
       let { datasetId, tag } = bidsId.decode(analytic.container_id)
-      newAnalytics.push({
-        datasetId,
-        tag,
-        type: analytic.analytics_type,
-      })
+      let type = analytic.analytics_type + 's' //convert 'view' -> 'views' and 'download' -> 'downloads'
+      try {
+        await Analytics.collection.updateOne(
+          {
+            datasetId,
+            tag,
+          },
+          {
+            $inc: { [type]: 1 },
+          },
+          {
+            upsert: true,
+          },
+        )
+      } catch (e) {
+        throw e
+      }
     }
-    Analytics.collection.insert(newAnalytics).catch(e => {
-      throw e
-    })
   },
 }

--- a/packages/openneuro-server/migrations/04-scitranAnalytics.js
+++ b/packages/openneuro-server/migrations/04-scitranAnalytics.js
@@ -17,22 +17,18 @@ export default {
     for (const analytic of analytics) {
       let { datasetId, tag } = bidsId.decode(analytic.container_id)
       let type = analytic.analytics_type + 's' //convert 'view' -> 'views' and 'download' -> 'downloads'
-      try {
-        await Analytics.collection.updateOne(
-          {
-            datasetId,
-            tag,
-          },
-          {
-            $inc: { [type]: 1 },
-          },
-          {
-            upsert: true,
-          },
-        )
-      } catch (e) {
-        throw e
-      }
+      await Analytics.collection.updateOne(
+        {
+          datasetId,
+          tag,
+        },
+        {
+          $inc: { [type]: 1 },
+        },
+        {
+          upsert: true,
+        },
+      )
     }
   },
 }


### PR DESCRIPTION
fixes #764 

the analytics database was previously designed poorly, in that each view or download had its own object in the analytics collection. 

now each dataset or snapshot has its own object, and those objects have counter fields 'views' and 'downloads'. tracking mutations and queries have been updated accordingly.