### PR TITLE
Restore blacklist functionality and ignore git and DataLad metadata.

### DIFF
--- a/packages/openneuro-server/datalad/dataset.js
+++ b/packages/openneuro-server/datalad/dataset.js
@@ -139,6 +139,9 @@ const fileUrl = (datasetId, path, filename) => {
   return url
 }
 
+// Files to skip in uploads
+const blacklist = ['.DS_Store', 'Icon\r', '.git', '.gitattributes', '.datalad']
+
 /**
  * Add files to a dataset
  */
@@ -147,6 +150,10 @@ export const addFile = (datasetId, path, file) => {
   return new Promise((resolve, reject) =>
     file
       .then(({ filename, stream, mimetype }) => {
+        // Skip any blacklisted files
+        if (blacklist.includes(filename)) {
+          return resolve()
+        }
         stream
           .on('error', err => {
             if (err.constructor.name === 'FileStreamDisconnectUploadError') {


### PR DESCRIPTION
Fixes #731 and some related issues when users attempt to upload git or datalad metadata as part of their dataset. Later we'll support some kind of push mechanism but for now we filter out these files.