### PR TITLE
Resolver permissions fix

### DIFF
--- a/packages/openneuro-server/datalad/dataset.js
+++ b/packages/openneuro-server/datalad/dataset.js
@@ -105,10 +105,10 @@ export const deleteDataset = id => {
  *
  * TODO - Support cursor pagination
  */
-export const getDatasets = ({ userId }) => {
-  if (userId) {
+export const getDatasets = options => {
+  if (options && 'userId' in options) {
     return c.crn.permissions
-      .find({ userId })
+      .find({ userId: options.userId })
       .toArray()
       .then(datasetsAllowed => {
         const datasetIds = datasetsAllowed.map(

--- a/packages/openneuro-server/datalad/dataset.js
+++ b/packages/openneuro-server/datalad/dataset.js
@@ -105,8 +105,22 @@ export const deleteDataset = id => {
  *
  * TODO - Support cursor pagination
  */
-export const getDatasets = () => {
-  return c.crn.datasets.find().toArray()
+export const getDatasets = ({ userId }) => {
+  if (userId) {
+    return c.crn.permissions
+      .find({ userId })
+      .toArray()
+      .then(datasetsAllowed => {
+        const datasetIds = datasetsAllowed.map(
+          permission => permission.datasetId,
+        )
+        return c.crn.datasets
+          .find({ $or: [{ id: { $in: datasetIds } }, { public: true }] })
+          .toArray()
+      })
+  } else {
+    return c.crn.datasets.find({ public: true }).toArray()
+  }
 }
 
 /**

--- a/packages/openneuro-server/datalad/dataset.js
+++ b/packages/openneuro-server/datalad/dataset.js
@@ -106,6 +106,10 @@ export const deleteDataset = id => {
  * TODO - Support cursor pagination
  */
 export const getDatasets = options => {
+  if (options && 'admin' in options) {
+    // Admins can see all datasets
+    return c.crn.datasets.find().toArray()
+  }
   if (options && 'userId' in options) {
     return c.crn.permissions
       .find({ userId: options.userId })

--- a/packages/openneuro-server/graphql/permissions.js
+++ b/packages/openneuro-server/graphql/permissions.js
@@ -28,10 +28,14 @@ export const checkDatasetRead = (datasetId, userId) => {
 
 const writeErrorMessage = 'You do not have access to modify this dataset.'
 
-export const checkDatasetWrite = (datasetId, userId) => {
+export const checkDatasetWrite = (datasetId, userId, userInfo) => {
   if (!userId) {
     // Quick path for anonymous writes
     return Promise.reject(writeErrorMessage)
+  }
+  if (userId && userInfo.admin) {
+    // Always allow admins
+    return Promise.resolve(true)
   }
   return Permission.findOne({ datasetId, userId }).then(permission => {
     if (

--- a/packages/openneuro-server/graphql/permissions.js
+++ b/packages/openneuro-server/graphql/permissions.js
@@ -4,27 +4,28 @@ import mongo from '../libs/mongo.js'
 const c = mongo.collections
 
 export const checkDatasetRead = (datasetId, userId, userInfo) => {
-  const publicOnly = userInfo.admin ? false : true
-  return c.crn.datasets
-    .findOne({ id: datasetId, public: publicOnly })
-    .then(datasetFound => {
-      if (datasetFound) {
-        return true
-      } else {
-        return Permission.findOne({ datasetId, userId }).then(permission => {
-          if (
-            permission &&
-            (permission.level === 'admin' ||
-              permission.level === 'rw' ||
-              permission.level === 'ro')
-          ) {
-            return true
-          } else {
-            throw new Error('You do not have access to read this dataset.')
-          }
-        })
-      }
-    })
+  const query = { id: datasetId }
+  if (!userInfo.admin) {
+    query.public = true
+  }
+  return c.crn.datasets.findOne(query).then(datasetFound => {
+    if (datasetFound) {
+      return true
+    } else {
+      return Permission.findOne({ datasetId, userId }).then(permission => {
+        if (
+          permission &&
+          (permission.level === 'admin' ||
+            permission.level === 'rw' ||
+            permission.level === 'ro')
+        ) {
+          return true
+        } else {
+          throw new Error('You do not have access to read this dataset.')
+        }
+      })
+    }
+  })
 }
 
 const writeErrorMessage = 'You do not have access to modify this dataset.'

--- a/packages/openneuro-server/graphql/permissions.js
+++ b/packages/openneuro-server/graphql/permissions.js
@@ -1,0 +1,42 @@
+import Permission from './../models/permission'
+import mongo from '../libs/mongo.js'
+
+const c = mongo.collections
+
+export const checkDatasetRead = (datasetId, userId) => {
+  return c.crn.datasets
+    .findOne({ id: datasetId, public: true })
+    .then(datasetFound => {
+      if (datasetFound) {
+        return true
+      } else {
+        return Permission.findOne({ datasetId, userId }).then(permission => {
+          if (
+            permission.level === 'admin' ||
+            permission.level === 'rw' ||
+            permission.level === 'ro'
+          ) {
+            return true
+          } else {
+            throw new Error('You do not have access to read this dataset.')
+          }
+        })
+      }
+    })
+}
+
+const writeErrorMessage = 'You do not have access to modify this dataset.'
+
+export const checkDatasetWrite = (datasetId, userId) => {
+  if (!userId) {
+    // Quick path for anonymous writes
+    return Promise.reject(writeErrorMessage)
+  }
+  return Permission.findOne({ datasetId, userId }).then(permission => {
+    if (permission.level === 'admin' || permission.level === 'rw') {
+      return true
+    } else {
+      throw new Error(writeErrorMessage)
+    }
+  })
+}

--- a/packages/openneuro-server/graphql/permissions.js
+++ b/packages/openneuro-server/graphql/permissions.js
@@ -12,9 +12,10 @@ export const checkDatasetRead = (datasetId, userId) => {
       } else {
         return Permission.findOne({ datasetId, userId }).then(permission => {
           if (
-            permission.level === 'admin' ||
-            permission.level === 'rw' ||
-            permission.level === 'ro'
+            permission &&
+            (permission.level === 'admin' ||
+              permission.level === 'rw' ||
+              permission.level === 'ro')
           ) {
             return true
           } else {
@@ -33,7 +34,10 @@ export const checkDatasetWrite = (datasetId, userId) => {
     return Promise.reject(writeErrorMessage)
   }
   return Permission.findOne({ datasetId, userId }).then(permission => {
-    if (permission.level === 'admin' || permission.level === 'rw') {
+    if (
+      permission &&
+      (permission.level === 'admin' || permission.level === 'rw')
+    ) {
       return true
     } else {
       throw new Error(writeErrorMessage)

--- a/packages/openneuro-server/graphql/permissions.js
+++ b/packages/openneuro-server/graphql/permissions.js
@@ -3,9 +3,10 @@ import mongo from '../libs/mongo.js'
 
 const c = mongo.collections
 
-export const checkDatasetRead = (datasetId, userId) => {
+export const checkDatasetRead = (datasetId, userId, userInfo) => {
+  const publicOnly = userInfo.admin ? false : true
   return c.crn.datasets
-    .findOne({ id: datasetId, public: true })
+    .findOne({ id: datasetId, public: publicOnly })
     .then(datasetFound => {
       if (datasetFound) {
         return true

--- a/packages/openneuro-server/graphql/resolvers/dataset.js
+++ b/packages/openneuro-server/graphql/resolvers/dataset.js
@@ -4,8 +4,8 @@ import pubsub from '../pubsub.js'
 import { checkDatasetRead, checkDatasetWrite } from '../permissions.js'
 import { getPartialStatus } from '../../datalad/draft.js'
 
-export const dataset = (obj, { id }, { user }) => {
-  return checkDatasetRead(id, user).then(() => {
+export const dataset = (obj, { id }, { user, userInfo }) => {
+  return checkDatasetRead(id, user, userInfo).then(() => {
     return datalad.getDataset(id)
   })
 }
@@ -33,8 +33,8 @@ export const createDataset = (obj, { label }, { user, userInfo }) => {
 /**
  * Delete an existing dataset, as well as all snapshots
  */
-export const deleteDataset = (obj, { label }, { user }) => {
-  return checkDatasetWrite(obj.id, user).then(() => {
+export const deleteDataset = (obj, { label }, { user, userInfo }) => {
+  return checkDatasetWrite(obj.id, user, userInfo).then(() => {
     return datalad.deleteDataset(label).then(deleted => {
       pubsub.publish('datasetDeleted', { id: label })
       return deleted
@@ -46,7 +46,7 @@ export const deleteDataset = (obj, { label }, { user }) => {
  * Tag the working tree for a dataset
  */
 export const createSnapshot = (obj, { datasetId, tag }, { user, userInfo }) => {
-  return checkDatasetWrite(datasetId, user).then(() => {
+  return checkDatasetWrite(datasetId, user, userInfo).then(() => {
     return snapshots.createSnapshot(datasetId, tag, userInfo)
   })
 }
@@ -55,7 +55,7 @@ export const createSnapshot = (obj, { datasetId, tag }, { user, userInfo }) => {
  * Remove a tag from a dataset
  */
 export const deleteSnapshot = (obj, { datasetId, tag }, { user }) => {
-  return checkDatasetWrite(datasetId, user).then(() => {
+  return checkDatasetWrite(datasetId, user, userInfo).then(() => {
     return snapshots.deleteSnapshot(datasetId, tag)
   })
 }
@@ -68,7 +68,7 @@ export const updateFiles = (
   { datasetId, files: fileTree },
   { user, userInfo },
 ) => {
-  return checkDatasetWrite(datasetId, user).then(() => {
+  return checkDatasetWrite(datasetId, user, userInfo).then(() => {
     const promises = updateFilesTree(datasetId, fileTree)
     return Promise.all(promises)
       .then(() =>
@@ -107,7 +107,7 @@ export const deleteFiles = (
   { datasetId, files: fileTree },
   { user, userInfo },
 ) => {
-  return checkDatasetWrite(datasetId, user).then(() => {
+  return checkDatasetWrite(datasetId, user, userInfo).then(() => {
     // TODO - The id returned here is a placeholder
     const promises = deleteFilesTree(datasetId, fileTree)
     return Promise.all(promises)
@@ -148,8 +148,12 @@ export const deleteFilesTree = (datasetId, fileTree) => {
 /**
  * Update the dataset Public status
  */
-export const updatePublic = (obj, { datasetId, publicFlag }, { user }) => {
-  return checkDatasetWrite(datasetId, user).then(() => {
+export const updatePublic = (
+  obj,
+  { datasetId, publicFlag },
+  { user, userInfo },
+) => {
+  return checkDatasetWrite(datasetId, user, userInfo).then(() => {
     return datalad.updatePublic(datasetId, publicFlag)
   })
 }

--- a/packages/openneuro-server/graphql/resolvers/dataset.js
+++ b/packages/openneuro-server/graphql/resolvers/dataset.js
@@ -54,7 +54,7 @@ export const createSnapshot = (obj, { datasetId, tag }, { user, userInfo }) => {
 /**
  * Remove a tag from a dataset
  */
-export const deleteSnapshot = (obj, { datasetId, tag }, { user }) => {
+export const deleteSnapshot = (obj, { datasetId, tag }, { user, userInfo }) => {
   return checkDatasetWrite(datasetId, user, userInfo).then(() => {
     return snapshots.deleteSnapshot(datasetId, tag)
   })

--- a/packages/openneuro-server/graphql/resolvers/dataset.js
+++ b/packages/openneuro-server/graphql/resolvers/dataset.js
@@ -10,9 +10,9 @@ export const dataset = (obj, { id }, { user, userInfo }) => {
   })
 }
 
-export const datasets = (parent, args, { user }) => {
+export const datasets = (parent, args, { user, userInfo }) => {
   if (user) {
-    return datalad.getDatasets({ userId: user })
+    return datalad.getDatasets({ userId: user, admin: userInfo.admin })
   } else {
     return datalad.getDatasets()
   }

--- a/packages/openneuro-server/graphql/resolvers/dataset.js
+++ b/packages/openneuro-server/graphql/resolvers/dataset.js
@@ -5,13 +5,17 @@ import { checkDatasetRead, checkDatasetWrite } from '../permissions.js'
 import { getPartialStatus } from '../../datalad/draft.js'
 
 export const dataset = (obj, { id }, { user }) => {
-  return checkDatasetRead(obj.id, user).then(() => {
+  return checkDatasetRead(id, user).then(() => {
     return datalad.getDataset(id)
   })
 }
 
-export const datasets = () => {
-  return datalad.getDatasets()
+export const datasets = (parent, args, { user }) => {
+  if (user) {
+    return datalad.getDatasets({ userId: user })
+  } else {
+    return datalad.getDatasets()
+  }
 }
 
 /**


### PR DESCRIPTION
This catches an error for anonymous users trying to upload a dataset and gives them at least an API error message. Also checks permissions more carefully for all of the writable resolvers and the get datasets aggregate.