### PR TITLE
fix broken example pipeline analysis links

### DIFF
--- a/packages/openneuro-app/src/scripts/common/partials/file-tree.jsx
+++ b/packages/openneuro-app/src/scripts/common/partials/file-tree.jsx
@@ -178,11 +178,14 @@ class FileTree extends Reflux.Component {
     }
 
     let downloadFile
-    if (!item.children) {
+    if (!item.children && this.state.datasets.dataset) {
       downloadFile = (
         <span className="download-file">
           <span>
-            <a className="btn-warn-component warning" href={files.getFileURL(this.state.datasets.dataset, item.name)} download>
+            <a
+              className="btn-warn-component warning"
+              href={files.getFileURL(this.state.datasets.dataset, item.name)}
+              download>
               <i className="fa fa-download" /> DOWNLOAD
             </a>
           </span>
@@ -190,12 +193,12 @@ class FileTree extends Reflux.Component {
       )
     }
 
-    if (!item.children) {
+    if (!item.children && this.state.datasets.dataset) {
       if (this.props.editable && files.hasExtension(item.name, ['.json'])) {
         let itemUrl =
-        this.state.datasets.datasetUrl +
-        '/file-edit/' +
-        datalad.encodeFilePath(item.name)
+          this.state.datasets.datasetUrl +
+          '/file-edit/' +
+          datalad.encodeFilePath(item.name)
 
         editFile = (
           <span className="view-file">
@@ -237,6 +240,7 @@ class FileTree extends Reflux.Component {
 
     if (
       !item.children &&
+      this.state.datasets._id &&
       this.props.displayFile &&
       files.hasExtension(item.name, allowedFiles)
     ) {

--- a/packages/openneuro-app/src/scripts/dataset/run/index.js
+++ b/packages/openneuro-app/src/scripts/dataset/run/index.js
@@ -308,7 +308,14 @@ class JobAccordion extends React.Component {
           }
 
           let logstreamUrl = 'logs/' + encodeURIComponent(logstream.name)
-          return (
+          return this.props.fromPipelines ? (
+            <span className="job-log" key={label}>
+              <span>{label}</span>
+              {exitCode != undefined ? (
+                <span className={exitCodeClass}>{exitCodeStatus}</span>
+              ) : null}
+            </span>
+          ) : (
             <span className="job-log" key={label}>
               <WarnButton
                 icon="fa-eye"
@@ -416,6 +423,7 @@ JobAccordion.propTypes = {
   support: PropTypes.string,
   currentUser: PropTypes.object,
   history: PropTypes.object,
+  fromPipelines: PropTypes.bool,
 }
 
 export default withRouter(JobAccordion)

--- a/packages/openneuro-app/src/scripts/front-page/front-page.pipelines.jsx
+++ b/packages/openneuro-app/src/scripts/front-page/front-page.pipelines.jsx
@@ -210,11 +210,9 @@ class Pipelines extends Reflux.Component {
     let analysisLink = (
       <span>
         <Link
-          to="snapshot"
-          params={{
-            datasetId: bids.decodeId(exampleJob.datasetId),
-            snapshotId: exampleJob.snapshotId,
-          }}
+          to={`datasets/${bids.decodeId(
+            exampleJob.datasetId,
+          )}/version/${bids.decodeId(exampleJob.snapshotId)}`}
           query={{
             app: exampleJob.appLabel,
             version: exampleJob.appVersion,
@@ -234,7 +232,7 @@ class Pipelines extends Reflux.Component {
           </div>
           <div className="col-sm-6 ">
             <Link
-              to="publicJobs"
+              to="public/jobs"
               className="explore-more pull-right"
               query={{ pipeline: exampleJob.appLabel }}>
               <i className="fa fa-area-chart" /> Explore More
@@ -247,6 +245,7 @@ class Pipelines extends Reflux.Component {
           eventKey={exampleJob.appId}>
           <Run
             run={exampleJob}
+            fromPipelines={true}
             toggleFolder={FPActions.toggleFolder}
             displayFile={FPActions.displayFile}
           />


### PR DESCRIPTION
fixes #765 

* file display + individual file downloads are disabled for the pipeline example job log preview
* the link to public jobs has been updated to be accurate
* fixed broken link to the dataset that contains the example job