### PR TITLE
Enable hot module reloading and name chunks nicely with Webpack 4

### DIFF
--- a/packages/openneuro-app/.babelrc
+++ b/packages/openneuro-app/.babelrc
@@ -1,5 +1,5 @@
 {
-  "plugins": ["transform-object-rest-spread", "transform-runtime", "syntax-dynamic-import"],
+  "plugins": ["loadable-components/babel", "transform-object-rest-spread", "transform-runtime", "syntax-dynamic-import"],
   "presets": [
     "react",
     [

--- a/packages/openneuro-app/package.json
+++ b/packages/openneuro-app/package.json
@@ -49,6 +49,7 @@
     "react-helmet": "^5.2.0",
     "react-markdown": "^3.3.4",
     "react-router": "4",
+    "react-router-dom": "^4.3.1",
     "react-select": "^1.0.0-rc.5",
     "react-table": "^6.7.6",
     "reflux": "6.4.1",
@@ -65,7 +66,7 @@
     "xmldoc": "^1.1.0"
   },
   "devDependencies": {
-    "babel": "6.23.0",
+    "babel-core": "^6.26.3",
     "babel-jest": "^22.1.0",
     "babel-loader": "^7.1.5",
     "babel-plugin-syntax-dynamic-import": "^6.18.0",
@@ -75,7 +76,7 @@
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-react": "^6.24.1",
     "cache-loader": "^1.2.2",
-    "clean-webpack-plugin": "^0.1.16",
+    "clean-webpack-plugin": "^0.1.19",
     "compression-webpack-plugin": "^1.0.0",
     "connect-history-api-fallback": "^1.5.0",
     "copy-webpack-plugin": "^4.5.2",
@@ -91,7 +92,6 @@
     "moment-timezone": "^0.5.13",
     "node-sass": "^4.5.3",
     "react-addons-test-utils": "^15.6.2",
-    "react-router-dom": "^4.2.2",
     "react-test-renderer": "^16.0.0",
     "sass-loader": "^6.0.6",
     "style-loader": "^0.19.1",

--- a/packages/openneuro-app/src/scripts/client.jsx
+++ b/packages/openneuro-app/src/scripts/client.jsx
@@ -10,6 +10,8 @@ import packageJson from '../../package.json'
 import { loadConfig } from './config.js'
 import GoogleAnalytics from 'react-ga'
 
+if (module.hot) module.hot.accept()
+
 loadConfig().then(config => {
   GoogleAnalytics.initialize(config.analytics.trackingId)
 

--- a/packages/openneuro-app/src/scripts/dataset/run/__tests__/__snapshots__/download-all.spec.jsx.snap
+++ b/packages/openneuro-app/src/scripts/dataset/run/__tests__/__snapshots__/download-all.spec.jsx.snap
@@ -1,16 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`dataset/dataset/run/JobAccordion renders a failed run 1`] = `
-<Route
-  render={[Function]}
-/>
-`;
+exports[`dataset/dataset/run/JobAccordion renders a failed run 1`] = `<Route />`;
 
-exports[`dataset/dataset/run/JobAccordion renders a successful run 1`] = `
-<Route
-  render={[Function]}
-/>
-`;
+exports[`dataset/dataset/run/JobAccordion renders a successful run 1`] = `<Route />`;
 
 exports[`dataset/run/DownloadAll should render something 1`] = `
 <span

--- a/packages/openneuro-app/src/scripts/dataset/run/__tests__/__snapshots__/index.spec.js.snap
+++ b/packages/openneuro-app/src/scripts/dataset/run/__tests__/__snapshots__/index.spec.js.snap
@@ -1,13 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`dataset/dataset/run/JobAccordion renders a failed run 1`] = `
-<Route
-  render={[Function]}
-/>
-`;
+exports[`dataset/dataset/run/JobAccordion renders a failed run 1`] = `<Route />`;
 
-exports[`dataset/dataset/run/JobAccordion renders a successful run 1`] = `
-<Route
-  render={[Function]}
-/>
-`;
+exports[`dataset/dataset/run/JobAccordion renders a successful run 1`] = `<Route />`;

--- a/packages/openneuro-app/src/scripts/routes.jsx
+++ b/packages/openneuro-app/src/scripts/routes.jsx
@@ -4,15 +4,27 @@ import { Route, Switch } from 'react-router-dom'
 import loadable from 'loadable-components'
 
 // wrap with loadable HOC
-const Dataset = loadable(() => import('./dataset/dataset.jsx'))
-const FrontPage = loadable(() => import('./front-page/front-page.jsx'))
-const Admin = loadable(() => import('./admin/admin.jsx'))
-const Dashboard = loadable(() => import('./dashboard/dashboard.jsx'))
-const Faq = loadable(() => import('./faq/faq.jsx'))
-const SearchResults = loadable(() =>
-  import('./dashboard/dashboard.searchresults.jsx'),
+const Dataset = loadable(() =>
+  import(/* webpackChunkName: 'Dataset' */ './dataset/dataset.jsx'),
 )
-const APIKey = loadable(() => import('./user/api.jsx'))
+const FrontPage = loadable(() =>
+  import(/* webpackChunkName: 'FrontPage' */ './front-page/front-page.jsx'),
+)
+const Admin = loadable(() =>
+  import(/* webpackChunkName: 'Admin' */ './admin/admin.jsx'),
+)
+const Dashboard = loadable(() =>
+  import(/* webpackChunkName: 'Dashboard' */ './dashboard/dashboard.jsx'),
+)
+const Faq = loadable(() =>
+  import(/* webpackChunkName: 'Faq' */ './faq/faq.jsx'),
+)
+const SearchResults = loadable(() =>
+  import(/* webpackChunkName: 'SearchResults' */ './dashboard/dashboard.searchresults.jsx'),
+)
+const APIKey = loadable(() =>
+  import(/* webpackChunkName: 'APIKey' */ './user/api.jsx'),
+)
 
 // routes ----------------------------------------------------------------
 

--- a/packages/openneuro-app/webpack.common.js
+++ b/packages/openneuro-app/webpack.common.js
@@ -11,16 +11,6 @@ module.exports = {
   entry: {
     app: './scripts/client.jsx',
     css: './sass/main.scss',
-    vendor: [
-      'es6-shim',
-      'react',
-      'react-dom',
-      'react-router-dom',
-      'react-select',
-      'react-bootstrap',
-      'moment',
-      'remarkable',
-    ],
   },
   output: {
     path: path.resolve(__dirname, 'dist'),
@@ -28,8 +18,18 @@ module.exports = {
   },
   optimization: {
     splitChunks: {
-      name: 'vendor',
       minChunks: Infinity,
+      cacheGroups: {
+        vendors: {
+          test: /[\\/]node_modules[\\/]/,
+          priority: -10,
+        },
+        default: {
+          minChunks: Infinity,
+          priority: -20,
+          reuseExistingChunk: true,
+        },
+      },
     },
   },
   plugins: [

--- a/packages/openneuro-app/webpack.dev.js
+++ b/packages/openneuro-app/webpack.dev.js
@@ -9,7 +9,10 @@ module.exports = merge(common, {
   mode: 'development',
   devtool: 'inline-source-map',
   serve: {
-    hotClient: false,
+    hotClient: {
+      host: { client: 'localhost', server: '0.0.0.0' },
+      port: 8145,
+    },
     content: path.join(__dirname, 'dist'),
     host: '0.0.0.0',
     port: 9876,

--- a/yarn.lock
+++ b/yarn.lock
@@ -893,6 +893,30 @@ babel-core@^6.0.0, babel-core@^6.26.0:
     slash "^1.0.0"
     source-map "^0.5.6"
 
+babel-core@^6.26.3:
+  version "6.26.3"
+  resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-6.26.3.tgz#b2e2f09e342d0f0c88e2f02e067794125e75c207"
+  dependencies:
+    babel-code-frame "^6.26.0"
+    babel-generator "^6.26.0"
+    babel-helpers "^6.24.1"
+    babel-messages "^6.23.0"
+    babel-register "^6.26.0"
+    babel-runtime "^6.26.0"
+    babel-template "^6.26.0"
+    babel-traverse "^6.26.0"
+    babel-types "^6.26.0"
+    babylon "^6.18.0"
+    convert-source-map "^1.5.1"
+    debug "^2.6.9"
+    json5 "^0.5.1"
+    lodash "^4.17.4"
+    minimatch "^3.0.4"
+    path-is-absolute "^1.0.1"
+    private "^0.1.8"
+    slash "^1.0.0"
+    source-map "^0.5.7"
+
 babel-eslint@8.2.2, babel-eslint@^8.0.0:
   version "8.2.2"
   resolved "http://registry.npmjs.org/babel-eslint/-/babel-eslint-8.2.2.tgz#1102273354c6f0b29b4ea28a65f97d122296b68b"
@@ -1530,10 +1554,6 @@ babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.24.1, babel-types@^6.26
     esutils "^2.0.2"
     lodash "^4.17.4"
     to-fast-properties "^1.0.3"
-
-babel@6.23.0:
-  version "6.23.0"
-  resolved "https://registry.yarnpkg.com/babel/-/babel-6.23.0.tgz#d0d1e7d803e974765beea3232d4e153c0efb90f4"
 
 babylon@7.0.0-beta.43, babylon@^7.0.0-beta.40:
   version "7.0.0-beta.43"
@@ -2182,7 +2202,7 @@ clean-css@4.1.x:
   dependencies:
     source-map "0.5.x"
 
-clean-webpack-plugin@^0.1.16:
+clean-webpack-plugin@^0.1.19:
   version "0.1.19"
   resolved "https://registry.yarnpkg.com/clean-webpack-plugin/-/clean-webpack-plugin-0.1.19.tgz#ceda8bb96b00fe168e9b080272960d20fdcadd6d"
   dependencies:
@@ -2653,7 +2673,7 @@ conventional-recommended-bump@^1.2.1:
     meow "^3.3.0"
     object-assign "^4.0.1"
 
-convert-source-map@^1.4.0, convert-source-map@^1.5.0:
+convert-source-map@^1.4.0, convert-source-map@^1.5.0, convert-source-map@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.5.1.tgz#b8278097b9bc229365de5c62cf5fcaed8b5599e5"
 
@@ -5062,7 +5082,7 @@ inquirer@^5.2.0:
     strip-ansi "^4.0.0"
     through "^2.3.6"
 
-invariant@^2.1.0, invariant@^2.2.0, invariant@^2.2.1, invariant@^2.2.2:
+invariant@^2.1.0, invariant@^2.2.0, invariant@^2.2.1, invariant@^2.2.2, invariant@^2.2.4:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
   dependencies:
@@ -8153,7 +8173,7 @@ prismjs@^1.10.0:
   optionalDependencies:
     clipboard "^2.0.0"
 
-private@^0.1.6, private@^0.1.7, private@~0.1.5:
+private@^0.1.6, private@^0.1.7, private@^0.1.8, private@~0.1.5:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.8.tgz#2381edb3689f7a53d653190060fcf822d2f368ff"
 
@@ -8487,18 +8507,18 @@ react-reconciler@^0.7.0:
     object-assign "^4.1.1"
     prop-types "^15.6.0"
 
-react-router-dom@^4.2.2:
-  version "4.2.2"
-  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-4.2.2.tgz#c8a81df3adc58bba8a76782e946cbd4eae649b8d"
+react-router-dom@^4.3.1:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-4.3.1.tgz#4c2619fc24c4fa87c9fd18f4fb4a43fe63fbd5c6"
   dependencies:
     history "^4.7.2"
-    invariant "^2.2.2"
+    invariant "^2.2.4"
     loose-envify "^1.3.1"
-    prop-types "^15.5.4"
-    react-router "^4.2.0"
-    warning "^3.0.0"
+    prop-types "^15.6.1"
+    react-router "^4.3.1"
+    warning "^4.0.1"
 
-react-router@4, react-router@^4.2.0:
+react-router@4:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/react-router/-/react-router-4.2.0.tgz#61f7b3e3770daeb24062dae3eedef1b054155986"
   dependencies:
@@ -8509,6 +8529,18 @@ react-router@4, react-router@^4.2.0:
     path-to-regexp "^1.7.0"
     prop-types "^15.5.4"
     warning "^3.0.0"
+
+react-router@^4.3.1:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-4.3.1.tgz#aada4aef14c809cb2e686b05cee4742234506c4e"
+  dependencies:
+    history "^4.7.2"
+    hoist-non-react-statics "^2.5.0"
+    invariant "^2.2.4"
+    loose-envify "^1.3.1"
+    path-to-regexp "^1.7.0"
+    prop-types "^15.6.1"
+    warning "^4.0.1"
 
 react-select@^1.0.0-rc.5:
   version "1.2.1"
@@ -10567,6 +10599,12 @@ walker@~1.0.5:
 warning@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/warning/-/warning-3.0.0.tgz#32e5377cb572de4ab04753bdf8821c01ed605b7c"
+  dependencies:
+    loose-envify "^1.0.0"
+
+warning@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/warning/-/warning-4.0.1.tgz#66ce376b7fbfe8a887c22bdf0e7349d73d397745"
   dependencies:
     loose-envify "^1.0.0"
 


### PR DESCRIPTION
Follow up fixes for #812 - turns out HMR can be turned on and chunks were not built properly. This fixes the chunking configuration and gives the dynamic chunks useful names.