### PR TITLE
Always provide default metadata values

### DIFF
--- a/packages/openneuro-app/src/scripts/utils/bids.js
+++ b/packages/openneuro-app/src/scripts/utils/bids.js
@@ -475,7 +475,7 @@ export default {
       ReferencesAndLinks: [],
       DatasetDOI: '',
     }
-    description = description ? description : defaultDescription
+    description = Object.assign(defaultDescription, description)
 
     if (metadata && metadata.authors) {
       description.Authors = metadata.authors

--- a/packages/openneuro-app/src/scripts/utils/bids.js
+++ b/packages/openneuro-app/src/scripts/utils/bids.js
@@ -435,8 +435,8 @@ export default {
           ? project.metadata.summary
           : null,
     }
-    ;(dataset.status = this.formatStatus(project, dataset.access)),
-      (dataset.authors = dataset.description.Authors)
+    dataset.status = this.formatStatus(project, dataset.access)
+    dataset.authors = dataset.description.Authors
     dataset.referencesAndLinks = dataset.description.ReferencesAndLinks
 
     dataset.user = this.user(dataset, users)


### PR DESCRIPTION
This fixes #786 by always providing some sane default values for metadata fields such as authors. Some of these fields are optional or dataset_description.json might not have been uploaded yet.