### PR TITLE
Add untracked flag to draft files resolver

### DIFF
--- a/packages/openneuro-server/graphql/resolvers/dataset.js
+++ b/packages/openneuro-server/graphql/resolvers/dataset.js
@@ -2,7 +2,6 @@ import * as datalad from '../../datalad/dataset.js'
 import * as snapshots from '../../datalad/snapshots.js'
 import pubsub from '../pubsub.js'
 import { checkDatasetRead, checkDatasetWrite } from '../permissions.js'
-import { getPartialStatus } from '../../datalad/draft.js'
 
 export const dataset = (obj, { id }, { user, userInfo }) => {
   return checkDatasetRead(id, user, userInfo).then(() => {
@@ -166,13 +165,6 @@ export const updateSnapshotFileUrls = (obj, { fileUrls }) => {
   const snapshotTag = fileUrls.tag
   const files = fileUrls.files
   return snapshots.updateSnapshotFileUrls(datasetId, snapshotTag, files)
-}
-
-/**
- * Check if a dataset draft is partially uploaded
- */
-export const partial = (obj, { datasetId }) => {
-  return getPartialStatus(datasetId)
 }
 
 /**

--- a/packages/openneuro-server/graphql/resolvers/draft.js
+++ b/packages/openneuro-server/graphql/resolvers/draft.js
@@ -2,9 +2,13 @@ import { summary } from './summary.js'
 import { issues } from './issues.js'
 import { getDraftFiles, getPartialStatus } from '../../datalad/draft.js'
 
+// A draft must have a dataset parent
+const draftFiles = dataset => (_, { untracked }) =>
+  getDraftFiles(dataset.id, dataset.revision, { untracked })
+
 export const draft = obj => ({
   id: obj.revision,
-  files: () => getDraftFiles(obj.id, obj.revision),
+  files: draftFiles(obj),
   summary: () => summary(obj),
   issues: () => issues(obj),
   modified: obj.modified,

--- a/packages/openneuro-server/graphql/resolvers/draft.js
+++ b/packages/openneuro-server/graphql/resolvers/draft.js
@@ -1,12 +1,7 @@
 import { summary } from './summary.js'
 import { issues } from './issues.js'
 import { getDraftFiles, getPartialStatus } from '../../datalad/draft.js'
-import { getSnapshot, getSnapshots } from '../../datalad/snapshots.js'
-import { dataset } from './dataset.js'
 
-/**
- * Resolvers for state held by the datalad service
- */
 export const draft = obj => ({
   id: obj.revision,
   files: () => getDraftFiles(obj.id, obj.revision),
@@ -16,17 +11,9 @@ export const draft = obj => ({
   partial: () => partial(obj, { datasetId: obj.id }),
 })
 
-export const snapshots = obj => {
-  return getSnapshots(obj.id)
-}
-
-export const snapshot = (obj, { datasetId, tag }, context) => {
-  return getSnapshot(datasetId, tag).then(snapshot => ({
-    ...snapshot,
-    dataset: () => dataset(snapshot, { id: datasetId }, context),
-  }))
-}
-
+/**
+ * Check if a dataset draft is partially uploaded
+ */
 export const partial = (obj, { datasetId }) => {
   return getPartialStatus(datasetId)
 }

--- a/packages/openneuro-server/graphql/resolvers/index.js
+++ b/packages/openneuro-server/graphql/resolvers/index.js
@@ -15,8 +15,9 @@ import {
   analytics,
   trackAnalytics,
 } from './dataset.js'
+import { draft, partial } from './draft.js'
 import { updateSummary, updateValidation } from './validation.js'
-import { draft, snapshot, snapshots, partial } from './datalad.js'
+import { snapshot, snapshots } from './snapshots.js'
 import { whoami, user, users, removeUser, setAdmin } from './user.js'
 import {
   permissions,

--- a/packages/openneuro-server/graphql/resolvers/snapshots.js
+++ b/packages/openneuro-server/graphql/resolvers/snapshots.js
@@ -1,0 +1,13 @@
+import { getSnapshot, getSnapshots } from '../../datalad/snapshots.js'
+import { dataset } from './dataset.js'
+
+export const snapshots = obj => {
+  return getSnapshots(obj.id)
+}
+
+export const snapshot = (obj, { datasetId, tag }, context) => {
+  return getSnapshot(datasetId, tag).then(snapshot => ({
+    ...snapshot,
+    dataset: () => dataset(snapshot, { id: datasetId }, context),
+  }))
+}

--- a/packages/openneuro-server/graphql/schema.js
+++ b/packages/openneuro-server/graphql/schema.js
@@ -133,12 +133,19 @@ const typeDefs = `
 
   # Ephemeral draft or working tree for a dataset
   type Draft {
+    # The draft id is the git hexsha of the most recent committed draft
     id: ID
+    # Which dataset this draft is related to
     dataset: Dataset
+    # Last edit timestamp
     modified: DateTime
+    # Draft copy of authors list
     authors: [Author]
+    # Validator summary
     summary: Summary
+    # Validator issues
     issues: [ValidationIssue]
+    # Committed files in the working tree
     files: [DatasetFile]
     # Flag if a dataset operation is incomplete (and may be reverted or resumed)
     partial: Boolean
@@ -146,12 +153,17 @@ const typeDefs = `
 
   # Tagged snapshot of a draft
   type Snapshot {
+    # Snapshot ids are dataset:tag values
     id: ID!
+    # Git tag of this snapshot
     tag: String!
+    # The parent dataset for this snapshot
     dataset: Dataset!
     created: DateTime
     authors: [Author]
+    # bids-validator summary of this snapshot
     summary: Summary
+    # bids-validator issues for this snapshot
     issues: [ValidationIssue]
     files: [DatasetFile]
     analytics: Analytic


### PR DESCRIPTION
This allows clients to query for working tree files that have not yet been committed. Pre-requisite for upload resume support.