### PR TITLE
CLI resume upload support

### DIFF
--- a/packages/openneuro-cli/README.md
+++ b/packages/openneuro-cli/README.md
@@ -28,6 +28,6 @@ Your dataset must pass validation to upload but warnings can be skipped with `op
 
 To resume an interrupted upload or add files to an existing dataset:
 
-`openneuro upload --resume --dataset <accession number> <dataset directory>`
+`openneuro upload --dataset <accession number> <dataset directory>`
 
-This will add or replace any files in the dataset but does not delete any files that are only present in the server copy of the dataset. The `resume` flag will skip any files that exist remotely already.
+This will add or replace any files in the dataset but does not delete any files that are only present in the server copy of the dataset.

--- a/packages/openneuro-cli/README.md
+++ b/packages/openneuro-cli/README.md
@@ -26,8 +26,8 @@ To upload a new dataset:
 
 Your dataset must pass validation to upload but warnings can be skipped with `openneuro upload -i <dataset directory>`. A default label is set using the directory name.
 
-To add files to an existing dataset:
+To resume an interrupted upload or add files to an existing dataset:
 
-`openneuro upload --dataset <accession number> <dataset directory>` 
+`openneuro upload --resume --dataset <accession number> <dataset directory>`
 
-This will add or replace any files in the dataset but does not delete any files that are only present in the server copy of the dataset.
+This will add or replace any files in the dataset but does not delete any files that are only present in the server copy of the dataset. The `resume` flag will skip any files that exist remotely already.

--- a/packages/openneuro-cli/src/actions.js
+++ b/packages/openneuro-cli/src/actions.js
@@ -58,6 +58,15 @@ const uploadDataset = (dir, datasetId, validatorOptions) => {
           datasetId,
           remoteFiles,
           remove: false,
+        }).then(() => {
+          // create a snapshot of the freshly uploaded dataset
+          client.mutate({
+            mutation: snapshots.createSnapshot,
+            variables: {
+              datasetId,
+              tag: '1.0.0',
+            },
+          })
         }),
       )
   } else {

--- a/packages/openneuro-cli/src/actions.js
+++ b/packages/openneuro-cli/src/actions.js
@@ -43,32 +43,23 @@ export const login = () => {
  */
 export const loginAnswers = answers => answers
 
-const uploadDataset = (dir, datasetId, validatorOptions, uploadOptions) => {
+const uploadDataset = (dir, datasetId, validatorOptions) => {
   const url = getUrl()
   const client = createClient(`${url}crn/graphql`, getToken)
   if (datasetId) {
     // Check for dataset -> validation -> upload
-    if (uploadOptions.resume) {
-      // Get remote files and filter successful files out
-      return getDatasetFiles(client, datasetId)
-        .then(({ data }) =>
-          validation(dir, validatorOptions).then(
-            () => data.dataset.draft.files,
-          ),
-        )
-        .then(remoteFiles =>
-          uploadDirectory(client, dir, {
-            datasetId,
-            remoteFiles,
-            remove: false,
-          }),
-        )
-    } else {
-      // Upload all files regardless of remote state
-      return getDataset(client, dir, datasetId)
-        .then(() => validation(dir, validatorOptions))
-        .then(() => uploadDirectory(client, dir, { datasetId }))
-    }
+    // Get remote files and filter successful files out
+    return getDatasetFiles(client, datasetId)
+      .then(({ data }) =>
+        validation(dir, validatorOptions).then(() => data.dataset.draft.files),
+      )
+      .then(remoteFiles =>
+        uploadDirectory(client, dir, {
+          datasetId,
+          remoteFiles,
+          remove: false,
+        }),
+      )
   } else {
     // Validation -> create dataset -> upload
     return validation(dir, validatorOptions)
@@ -107,7 +98,7 @@ export const upload = (dir, cmd) => {
     if (cmd.dataset) {
       // eslint-disable-next-line no-console
       console.log(`Adding files to "${cmd.dataset}"`)
-      uploadDataset(dir, cmd.dataset, validatorOptions, { resume: cmd.resume })
+      uploadDataset(dir, cmd.dataset, validatorOptions)
     } else {
       inquirer
         .prompt({

--- a/packages/openneuro-cli/src/actions.js
+++ b/packages/openneuro-cli/src/actions.js
@@ -3,7 +3,7 @@ import inquirer from 'inquirer'
 import createClient, { snapshots } from 'openneuro-client'
 import { saveConfig, getToken, getUrl } from './config'
 import { validation, uploadDirectory } from './upload'
-import { getDataset, getDatasetFiles, createDataset } from './datasets'
+import { getDatasetFiles, createDataset } from './datasets'
 
 /**
  * Login action to save an auth key locally

--- a/packages/openneuro-cli/src/actions.js
+++ b/packages/openneuro-cli/src/actions.js
@@ -50,14 +50,18 @@ const uploadDataset = (dir, datasetId, validatorOptions, uploadOptions) => {
     // Check for dataset -> validation -> upload
     if (uploadOptions.resume) {
       // Get remote files and filter successful files out
-      return getDatasetFiles(client, dir, datasetId)
-        .then(queryData =>
+      return getDatasetFiles(client, datasetId)
+        .then(({ data }) =>
           validation(dir, validatorOptions).then(
-            () => queryData.dataset.draft.files,
+            () => data.dataset.draft.files,
           ),
         )
-        .then(files =>
-          uploadDirectory(client, dir, { datasetId, files, remove: false }),
+        .then(remoteFiles =>
+          uploadDirectory(client, dir, {
+            datasetId,
+            remoteFiles,
+            remove: false,
+          }),
         )
     } else {
       // Upload all files regardless of remote state

--- a/packages/openneuro-cli/src/cli.js
+++ b/packages/openneuro-cli/src/cli.js
@@ -16,12 +16,11 @@ commander
   .command('upload <dir>')
   .alias('u')
   .description('Upload or sync a dataset (if a accession number is provided)')
-  .option('-d, --dataset [dsId]', 'Specify the dataset to update')
-  .option('-i, --ignoreWarnings', 'Ignore validation warnings when uploading')
   .option(
-    '-r, --resume',
-    'Sync local content with remote, requires --dataset, does NOT remove remote files',
+    '-d, --dataset [dsId]',
+    'Specify the dataset to update, use this to resume uploads or add new files',
   )
+  .option('-i, --ignoreWarnings', 'Ignore validation warnings when uploading')
   .option(
     '-n, --ignoreNiftiHeaders',
     'Disregard NIfTI header content during validation',

--- a/packages/openneuro-cli/src/cli.js
+++ b/packages/openneuro-cli/src/cli.js
@@ -15,10 +15,13 @@ commander
 commander
   .command('upload <dir>')
   .alias('u')
-  .alias('sync')
   .description('Upload or sync a dataset (if a accession number is provided)')
   .option('-d, --dataset [dsId]', 'Specify the dataset to update')
   .option('-i, --ignoreWarnings', 'Ignore validation warnings when uploading')
+  .option(
+    '-r, --resume',
+    'Sync local content with remote, requires --dataset, does NOT remove remote files',
+  )
   .option(
     '-n, --ignoreNiftiHeaders',
     'Disregard NIfTI header content during validation',

--- a/packages/openneuro-cli/src/datasets.js
+++ b/packages/openneuro-cli/src/datasets.js
@@ -23,7 +23,7 @@ export const getDataset = (client, dir, datasetId) => {
  */
 export const getDatasetFiles = (client, datasetId) => {
   return client.query({
-    query: datasets.getDatasetFiles,
+    query: datasets.getUntrackedFiles,
     variables: { id: datasetId },
   })
 }

--- a/packages/openneuro-cli/src/datasets.js
+++ b/packages/openneuro-cli/src/datasets.js
@@ -17,6 +17,18 @@ export const getDataset = (client, dir, datasetId) => {
 }
 
 /**
+ * Get an existing dataset's files
+ * @param {object} client GraphQL client
+ * @param {*} datasetId
+ */
+export const getDatasetFiles = (client, datasetId) => {
+  return client.query({
+    query: datasets.getDatasetFiles,
+    variables: { id: datasetId },
+  })
+}
+
+/**
  * Create a dataset and return the new accession number
  * @param {object} client
  * @param {string} dir

--- a/packages/openneuro-cli/src/files.js
+++ b/packages/openneuro-cli/src/files.js
@@ -55,6 +55,7 @@ export const getFileTree = (
                 // File is the same size
                 if (remoteFile.size === stat.size) {
                   if (logging) {
+                    // eslint-disable-next-line no-console
                     console.log(`Skipping existing file - "${filePath}"`)
                   }
                   // Skip existing files

--- a/packages/openneuro-cli/src/upload.js
+++ b/packages/openneuro-cli/src/upload.js
@@ -69,8 +69,8 @@ export const uploadTree = (client, datasetId) => tree => {
  *
  * @param {Object} client - Initialized Apollo client to upload with
  * @param {string} dir - Directory to upload
- * @param {string} datasetId - Optionally update an existing dataset
+ * @param {Object} options - {datasetId: 'ds000001', delete: false, files: [paths, to, exclude]}
  */
-export const uploadDirectory = (client, dir, datasetId) => {
-  return getFileTree(dir, dir).then(uploadTree(client, datasetId))
+export const uploadDirectory = (client, dir, { datasetId, files }) => {
+  return getFileTree(dir, dir, { files }).then(uploadTree(client, datasetId))
 }

--- a/packages/openneuro-cli/src/upload.js
+++ b/packages/openneuro-cli/src/upload.js
@@ -71,6 +71,8 @@ export const uploadTree = (client, datasetId) => tree => {
  * @param {string} dir - Directory to upload
  * @param {Object} options - {datasetId: 'ds000001', delete: false, files: [paths, to, exclude]}
  */
-export const uploadDirectory = (client, dir, { datasetId, files }) => {
-  return getFileTree(dir, dir, { files }).then(uploadTree(client, datasetId))
+export const uploadDirectory = (client, dir, { datasetId, remoteFiles }) => {
+  return getFileTree(dir, dir, { remoteFiles }).then(
+    uploadTree(client, datasetId),
+  )
 }

--- a/packages/openneuro-client/src/datasets.js
+++ b/packages/openneuro-client/src/datasets.js
@@ -59,6 +59,23 @@ export const getDataset = gql`
   }
 `
 
+export const getDatasetFiles = gql`
+  query dataset($id: ID!) {
+    dataset(id: $id) {
+      id
+      draft {
+        id
+        files {
+          id
+          filename
+          size
+          objectpath
+        }
+      }
+    }
+  }
+`
+
 export const getDatasets = gql`
   query {
     datasets {

--- a/packages/openneuro-client/src/datasets.js
+++ b/packages/openneuro-client/src/datasets.js
@@ -59,17 +59,16 @@ export const getDataset = gql`
   }
 `
 
-export const getDatasetFiles = gql`
+// Get only working tree files
+export const getUntrackedFiles = gql`
   query dataset($id: ID!) {
     dataset(id: $id) {
       id
       draft {
         id
-        files {
-          id
+        files(untracked: true) {
           filename
           size
-          objectpath
         }
       }
     }

--- a/packages/openneuro-server/datalad/draft.js
+++ b/packages/openneuro-server/datalad/draft.js
@@ -19,7 +19,8 @@ const draftFilesKey = (datasetId, revision) => {
  * @param {string} revision Git hexsha to get files, does not apply to untracked
  * @param {object} options { untracked: true } - ignores the git index
  */
-export const getDraftFiles = async (datasetId, revision, { untracked }) => {
+export const getDraftFiles = async (datasetId, revision, options) => {
+  const untracked = options ? options.untracked : false
   const filesUrl = `${uri}/datasets/${datasetId}/files`
   const key = draftFilesKey(datasetId, revision)
   return redis.get(key).then(data => {

--- a/packages/openneuro-server/datalad/draft.js
+++ b/packages/openneuro-server/datalad/draft.js
@@ -27,11 +27,11 @@ export const getDraftFiles = async (datasetId, revision, { untracked }) => {
     else
       return request
         .get(filesUrl)
-        .query(untracked ? 'untracked' : null)
+        .query({ untracked })
         .set('Accept', 'application/json')
         .then(({ body: { files } }) => {
           const filesWithUrls = files.map(addFileUrl(datasetId))
-          if (untracked) {
+          if (!untracked) {
             redis.set(key, JSON.stringify(filesWithUrls))
           }
           return filesWithUrls

--- a/packages/openneuro-server/graphql/resolvers/draft.js
+++ b/packages/openneuro-server/graphql/resolvers/draft.js
@@ -3,8 +3,9 @@ import { issues } from './issues.js'
 import { getDraftFiles, getPartialStatus } from '../../datalad/draft.js'
 
 // A draft must have a dataset parent
-const draftFiles = dataset => (_, { untracked }) =>
-  getDraftFiles(dataset.id, dataset.revision, { untracked })
+const draftFiles = dataset => ({ untracked }) => {
+  return getDraftFiles(dataset.id, dataset.revision, { untracked })
+}
 
 export const draft = obj => ({
   id: obj.revision,

--- a/packages/openneuro-server/graphql/resolvers/draft.js
+++ b/packages/openneuro-server/graphql/resolvers/draft.js
@@ -3,8 +3,8 @@ import { issues } from './issues.js'
 import { getDraftFiles, getPartialStatus } from '../../datalad/draft.js'
 
 // A draft must have a dataset parent
-const draftFiles = dataset => ({ untracked }) => {
-  return getDraftFiles(dataset.id, dataset.revision, { untracked })
+const draftFiles = dataset => args => {
+  return getDraftFiles(dataset.id, dataset.revision, args)
 }
 
 export const draft = obj => ({

--- a/packages/openneuro-server/graphql/schema.js
+++ b/packages/openneuro-server/graphql/schema.js
@@ -146,7 +146,7 @@ const typeDefs = `
     # Validator issues
     issues: [ValidationIssue]
     # Committed files in the working tree
-    files: [DatasetFile]
+    files(untracked: Boolean): [DatasetFile]
     # Flag if a dataset operation is incomplete (and may be reverted or resumed)
     partial: Boolean
   }


### PR DESCRIPTION
Fixes the CLI half of #663

Updated documentation will be published with the npm package for the 2.1.0 release.

I removed the 'sync' alias because this seemed a bit confusing. Uploads now always try to resume without reuploading files if you've specified an accession number.