### PR TITLE
811 missing summary

### DIFF
--- a/packages/openneuro-app/src/scripts/utils/bids.js
+++ b/packages/openneuro-app/src/scripts/utils/bids.js
@@ -46,6 +46,7 @@ export default {
     const followers = (await crn.getSubscriptions()).body
     let resultDict = {}
     for (let project of projects) {
+      project.summary = project.draft ? project.draft.summary : null
       let dataset = this.formatDataset(project, null, users, stars, followers)
       let datasetId = dataset.hasOwnProperty('original')
         ? dataset.original
@@ -158,7 +159,13 @@ export default {
             project.snapshot_version = snapshot ? snapshot.tag : null
             project.analytics = snapshot
               ? snapshot.analytics
-              : project.analytics
+              : project.analyticsa
+
+            // get draft or snapshot summary
+            let draftSummary = draft ? draft.summary : null
+            let snapshotSummary = snapshot ? snapshot.summary : null
+            project.summary = snapshot ? snapshotSummary : draftSummary
+
             this.getMetadata(
               project,
               metadata => {
@@ -430,10 +437,7 @@ export default {
       description: this.formatDescription(project.metadata, description),
       userCreated: this.userCreated(project),
       access: this.userAccess(project),
-      summary:
-        project.metadata && project.metadata.summary
-          ? project.metadata.summary
-          : null,
+      summary: project.summary,
     }
     dataset.status = this.formatStatus(project, dataset.access)
     dataset.authors = dataset.description.Authors

--- a/packages/openneuro-app/src/scripts/utils/bids.js
+++ b/packages/openneuro-app/src/scripts/utils/bids.js
@@ -159,7 +159,7 @@ export default {
             project.snapshot_version = snapshot ? snapshot.tag : null
             project.analytics = snapshot
               ? snapshot.analytics
-              : project.analyticsa
+              : project.analytics
 
             // get draft or snapshot summary
             let draftSummary = draft ? draft.summary : null

--- a/packages/openneuro-client/src/datasets.js
+++ b/packages/openneuro-client/src/datasets.js
@@ -85,6 +85,14 @@ export const getDatasets = gql`
       draft {
         id
         partial
+        summary {
+          modalities
+          sessions
+          subjects
+          tasks
+          size
+          totalFiles
+        }
       }
       analytics {
         views


### PR DESCRIPTION
fixes #811 

* adds summary field to the openneuro-client getDatasets query
* updates the bids.js formatDataset constructor to use the validation summary provided by the new dataset backend