### PR TITLE
Handle JWT UTF-8 payloads

### DIFF
--- a/packages/openneuro-app/package.json
+++ b/packages/openneuro-app/package.json
@@ -30,6 +30,7 @@
     "es6-shim": "^0.35.3",
     "favico.js": "git://github.com/ejci/favico.js#0.3.10",
     "jszip": "^3.1.5",
+    "jwt-decode": "^2.2.0",
     "load-google-api": "^0.1.3",
     "loadable-components": "^2.2.2",
     "lodash.clonedeep": "^4.5.0",
@@ -103,14 +104,11 @@
     "webpack-visualizer-plugin": "^0.1.11"
   },
   "jest": {
-    "setupFiles": [
-      "./jestsetup.js"
-    ],
-    "snapshotSerializers": [
-      "enzyme-to-json/serializer"
-    ],
+    "setupFiles": ["./jestsetup.js"],
+    "snapshotSerializers": ["enzyme-to-json/serializer"],
     "moduleNameMapper": {
-      "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/__mocks__/fileMock.js",
+      "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$":
+        "<rootDir>/__mocks__/fileMock.js",
       "\\.(css|less)$": "<rootDir>/__mocks__/styleMock.js",
       "openneuro-content": "<rootDir>/__mocks__/contentMock.js"
     },

--- a/packages/openneuro-app/src/scripts/authentication/__tests__/profile.spec.js
+++ b/packages/openneuro-app/src/scripts/authentication/__tests__/profile.spec.js
@@ -1,0 +1,23 @@
+import { parseJwt } from '../profile.js'
+
+const asciiToken =
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c'
+const utf8Token =
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6Iuelnue1jOenkeWtpuiAhSIsImlhdCI6MTUxNjIzOTAyMn0.pUw2ARoXv4LkJXB1ZR3Th6xG83URT6mn1TftC7ac_O8'
+
+describe('authentication/profile', () => {
+  it('decodes a JWT to Javascript object', () => {
+    expect(parseJwt(asciiToken)).toEqual({
+      sub: '1234567890',
+      name: 'John Doe',
+      iat: 1516239022,
+    })
+  })
+  it('decodes a JWT with Unicode strings', () => {
+    expect(parseJwt(utf8Token)).toEqual({
+      sub: '1234567890',
+      name: '神経科学者',
+      iat: 1516239022,
+    })
+  })
+})

--- a/packages/openneuro-app/src/scripts/authentication/profile.js
+++ b/packages/openneuro-app/src/scripts/authentication/profile.js
@@ -1,14 +1,11 @@
 import Cookies from 'universal-cookie'
+import jwtDecode from 'jwt-decode'
 
 /**
  * Read JSON object from JWT string
  * @param {string} token
  */
-export const parseJwt = token => {
-  const base64Url = token.split('.')[1]
-  const base64 = base64Url.replace('-', '+').replace('_', '/')
-  return JSON.parse(global.atob(base64))
-}
+export const parseJwt = jwtDecode
 
 /**
  * Retrieve the user profile from JWT cookie

--- a/yarn.lock
+++ b/yarn.lock
@@ -6105,6 +6105,10 @@ jws@^3.1.5:
     jwa "^1.1.5"
     safe-buffer "^5.0.1"
 
+jwt-decode@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/jwt-decode/-/jwt-decode-2.2.0.tgz#7d86bd56679f58ce6a84704a657dd392bba81a79"
+
 kareem@2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/kareem/-/kareem-2.2.1.tgz#9950809415aa3cde62ab43b4f7b919d99816e015"


### PR DESCRIPTION
Replaces the short but ASCII only parseJwt implementation with the jwt-decode library. Fixes #833 