### PR TITLE
Fix files resolver returning untracked files by default

### DIFF
--- a/packages/openneuro-server/datalad/draft.js
+++ b/packages/openneuro-server/datalad/draft.js
@@ -19,8 +19,9 @@ const draftFilesKey = (datasetId, revision) => {
  * @param {string} revision Git hexsha to get files, does not apply to untracked
  * @param {object} options { untracked: true } - ignores the git index
  */
-export const getDraftFiles = async (datasetId, revision, options) => {
-  const untracked = options ? options.untracked : false
+export const getDraftFiles = async (datasetId, revision, options = {}) => {
+  // If untracked is set and true
+  const untracked = 'untracked' in options && options.untracked
   const filesUrl = `${uri}/datasets/${datasetId}/files`
   const key = draftFilesKey(datasetId, revision)
   return redis.get(key).then(data => {


### PR DESCRIPTION
A query with `draft { files {} }` would pass in an empty object instead of undefined or null.

This means you would get untracked files with no id if the argument was unspecified.

Fixes #840 