### PR TITLE
Don't create snapshots after uploading to an existing dataset via CLI

### DIFF
--- a/packages/openneuro-cli/src/actions.js
+++ b/packages/openneuro-cli/src/actions.js
@@ -58,15 +58,6 @@ const uploadDataset = (dir, datasetId, validatorOptions) => {
           datasetId,
           remoteFiles,
           remove: false,
-        }).then(() => {
-          // create a snapshot of the freshly uploaded dataset
-          client.mutate({
-            mutation: snapshots.createSnapshot,
-            variables: {
-              datasetId,
-              tag: '1.0.0',
-            },
-          })
         }),
       )
   } else {


### PR DESCRIPTION
See #863 - this has the consequence of never creating the first snapshot for a resumed upload but that's better than creating bogus snapshots on every CLI update.