### PR TITLE
Faster snapshot creation

### DIFF
--- a/packages/openneuro-server/datalad/draft.js
+++ b/packages/openneuro-server/datalad/draft.js
@@ -6,12 +6,9 @@ import mongo from '../libs/mongo.js'
 import { redis } from '../libs/redis.js'
 import config from '../config.js'
 import { addFileUrl } from './utils.js'
+import { commitFilesKey } from './files.js'
 
 const uri = config.datalad.uri
-
-const draftFilesKey = (datasetId, revision) => {
-  return `openneuro:draftFiles:${datasetId}:${revision}`
-}
 
 /**
  * Retrieve draft files from cache or the datalad-service backend
@@ -24,7 +21,7 @@ export const getDraftFiles = async (datasetId, revision, options = {}) => {
   const untracked = 'untracked' in options && options.untracked
   const query = untracked ? { untracked: true } : {}
   const filesUrl = `${uri}/datasets/${datasetId}/files`
-  const key = draftFilesKey(datasetId, revision)
+  const key = commitFilesKey(datasetId, revision)
   return redis.get(key).then(data => {
     if (!untracked && data) return JSON.parse(data)
     else

--- a/packages/openneuro-server/datalad/files.js
+++ b/packages/openneuro-server/datalad/files.js
@@ -1,0 +1,6 @@
+/**
+ * Hexsha files cache
+ */
+export const commitFilesKey = (datasetId, revision) => {
+  return `openneuro:commitFiles:${datasetId}:${revision}`
+}

--- a/packages/openneuro-server/datalad/files.js
+++ b/packages/openneuro-server/datalad/files.js
@@ -2,5 +2,5 @@
  * Hexsha files cache
  */
 export const commitFilesKey = (datasetId, revision) => {
-  return `openneuro:commitFiles:${datasetId}:${revision}`
+  return `openneuro:draftFiles:${datasetId}:${revision}`
 }


### PR DESCRIPTION
This reuses the files cache from the commit when a tag is created, avoiding an extra walk of the full git-annex tree during snapshot creation.

A fallback is included in cases where the cache is not available. Those cases don't benefit at all here, but they are rare.

Depends on https://github.com/OpenNeuroOrg/datalad-service/pull/58