### PR TITLE
cannot read property 'snapshot_version' of null

### DIFF
--- a/packages/openneuro-app/src/scripts/dataset/dataset.left-sidebar.jsx
+++ b/packages/openneuro-app/src/scripts/dataset/dataset.left-sidebar.jsx
@@ -68,6 +68,7 @@ export class LeftSidebar extends Reflux.Component {
           <Link
             to={snapshotUrl}
             className={
+              this.state.datasets.dataset &&
               this.state.datasets.dataset.snapshot_version == snapshot.tag
                 ? 'active'
                 : null


### PR DESCRIPTION
fix for bad behavior in #848. when the dataset does not exists (is null) we don't try to access the snapshot_version field.