### PR TITLE
Fix snapshot files cache miss

### DIFF
--- a/packages/openneuro-server/datalad/snapshots.js
+++ b/packages/openneuro-server/datalad/snapshots.js
@@ -80,7 +80,7 @@ export const createSnapshot = async (datasetId, tag, user) => {
         const fKey = commitFilesKey(datasetId, body.hexsha)
         const filesFromCache = await redis.get(fKey)
         if (filesFromCache) body.files = filesFromCache
-        else body.files = getDraftFiles(datasetId, body.hexsha)
+        else body.files = await getDraftFiles(datasetId, body.hexsha)
 
         // Eager caching for snapshots
         // Set the key and after resolve to body

--- a/packages/openneuro-server/datalad/snapshots.js
+++ b/packages/openneuro-server/datalad/snapshots.js
@@ -9,6 +9,7 @@ import pubsub from '../graphql/pubsub.js'
 import { commitFilesKey } from './files.js'
 import { addFileUrl } from './utils.js'
 import { generateDataladCookie } from '../libs/authentication/jwt'
+import { getDraftFiles } from './draft'
 
 const c = mongo.collections
 const uri = config.datalad.uri
@@ -79,10 +80,7 @@ export const createSnapshot = async (datasetId, tag, user) => {
         const fKey = commitFilesKey(datasetId, body.hexsha)
         const filesFromCache = await redis.get(fKey)
         if (filesFromCache) body.files = filesFromCache
-        else
-          body.files = (await request
-            .get(url)
-            .set('Accept', 'application/json')).files
+        else body.files = getDraftFiles(datasetId, body.hexsha)
 
         // Eager caching for snapshots
         // Set the key and after resolve to body

--- a/yarn.lock
+++ b/yarn.lock
@@ -6144,7 +6144,6 @@ interpret@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.1.0.tgz#7ed1b1410c6a0e0f78cf95d3b8440c63f78b8614"
 
-
 into-stream@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/into-stream/-/into-stream-3.1.0.tgz#96fb0a936c12babd6ff1752a17d05616abd094c6"
@@ -10721,7 +10720,7 @@ resolve@1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
 
-resolve@^1.4.0, resolve@^1.5.0, resolve@^1.6.0:
+resolve@^1.1.6, resolve@^1.4.0, resolve@^1.5.0, resolve@^1.6.0:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.8.1.tgz#82f1ec19a423ac1fbd080b0bab06ba36e84a7a26"
   dependencies:


### PR DESCRIPTION
Fixes a regression where there's a cache miss when the draft is accessed during initial snapshot publish to a remote.