### PR TITLE
getSnapshot error handling and serialization fix

### DIFF
--- a/packages/openneuro-app/src/scripts/utils/datalad.js
+++ b/packages/openneuro-app/src/scripts/utils/datalad.js
@@ -56,7 +56,7 @@ export default {
   async getSnapshot(datasetId, options) {
     return new Promise((resolve, reject) => {
       this.querySnapshot(datasetId, options.tag, (err, data) => {
-        if (err) reject(err)
+        if (err) return reject(err)
         data = clone(data)
         data.data.snapshot._id = options.datasetId
         resolve(data)

--- a/packages/openneuro-server/datalad/snapshots.js
+++ b/packages/openneuro-server/datalad/snapshots.js
@@ -79,7 +79,7 @@ export const createSnapshot = async (datasetId, tag, user) => {
         // We should almost always get the fast path here
         const fKey = commitFilesKey(datasetId, body.hexsha)
         const filesFromCache = await redis.get(fKey)
-        if (filesFromCache) body.files = filesFromCache
+        if (filesFromCache) body.files = JSON.parse(filesFromCache)
         else body.files = await getDraftFiles(datasetId, body.hexsha)
 
         // Eager caching for snapshots


### PR DESCRIPTION
This fixes #883 - fixing the missing files for public snapshots and rejecting the promise correctly if there is a query error in querySnapshot.