### PR TITLE
Clear incomplete cache when update/add files errors

### DIFF
--- a/packages/openneuro-server/datalad/dataset.js
+++ b/packages/openneuro-server/datalad/dataset.js
@@ -206,8 +206,8 @@ export const addFile = (datasetId, path, file) => {
           throw err
         }
       }),
-  ).then(data => {
-    return redis.del(draftPartialKey(datasetId)).then(() => data)
+  ).finally(() => {
+    return redis.del(draftPartialKey(datasetId))
   })
 }
 
@@ -230,8 +230,8 @@ export const updateFile = (datasetId, path, file) => {
         ),
       )
       .on('error', err => reject(err))
-  }).then(data => {
-    return redis.del(draftPartialKey(datasetId)).then(() => data)
+  }).finally(() => {
+    return redis.del(draftPartialKey(datasetId))
   })
 }
 


### PR DESCRIPTION
This forces a recheck of the incomplete status after errors in file writes.