### PR TITLE
Clear snapshot index only after snapshot is created

### DIFF
--- a/packages/openneuro-server/datalad/snapshots.js
+++ b/packages/openneuro-server/datalad/snapshots.js
@@ -67,41 +67,36 @@ export const createSnapshot = async (datasetId, tag, user) => {
   const url = `${uri}/datasets/${datasetId}/snapshots/${tag}`
   const indexKey = snapshotIndexKey(datasetId)
   const sKey = snapshotKey(datasetId, tag)
-  // Only create after the key is deleted to prevent race condition
-  return redis.del(indexKey).then(() =>
-    request
-      .post(url)
-      .set('Accept', 'application/json')
-      .set('Cookie', generateDataladCookie(config)(user))
-      .then(async ({ body }) => {
-        body.created = new Date()
+  return request
+    .post(url)
+    .set('Accept', 'application/json')
+    .set('Cookie', generateDataladCookie(config)(user))
+    .then(async ({ body }) => {
+      body.created = new Date()
 
-        // We should almost always get the fast path here
-        const fKey = commitFilesKey(datasetId, body.hexsha)
-        const filesFromCache = await redis.get(fKey)
-        if (filesFromCache) body.files = JSON.parse(filesFromCache)
-        else body.files = await getDraftFiles(datasetId, body.hexsha)
+      // We should almost always get the fast path here
+      const fKey = commitFilesKey(datasetId, body.hexsha)
+      const filesFromCache = await redis.get(fKey)
+      if (filesFromCache) body.files = JSON.parse(filesFromCache)
+      else body.files = await getDraftFiles(datasetId, body.hexsha)
 
-        // Eager caching for snapshots
-        // Set the key and after resolve to body
-        return (
-          redis
-            .set(sKey, JSON.stringify(body))
-            // Metadata for snapshots
-            .then(() =>
-              createSnapshotMetadata(
-                datasetId,
-                tag,
-                body.hexsha,
-                body.created,
-              ).then(() => {
+      // Eager caching for snapshots
+      // Set the key and after resolve to body
+      return (
+        redis
+          .set(sKey, JSON.stringify(body))
+          // Metadata for snapshots
+          .then(() =>
+            createSnapshotMetadata(datasetId, tag, body.hexsha, body.created)
+              // Clear the index now that the new snapshot is ready
+              .then(() => redis.del(indexKey))
+              .then(() => {
                 pubsub.publish('snapshotAdded', { id: datasetId })
                 return body
               }),
-            )
-        )
-      }),
-  )
+          )
+      )
+    })
 }
 
 // TODO - deleteSnapshot


### PR DESCRIPTION
This moved the snapshot index delete call to the end of snapshot creation, once metadata is available. This prevents a stale cache from being created while the snapshot request has been made but the snapshot is not yet complete.

Fixes #888 - particularly with DOI snapshots which were almost always causing this order of operations.