### PR TITLE
ORCID error messages

### DIFF
--- a/packages/openneuro-app/src/scripts/errors/errorRoute.jsx
+++ b/packages/openneuro-app/src/scripts/errors/errorRoute.jsx
@@ -2,7 +2,7 @@
  * Route for nice display of backend errors
  */
 import React from 'react'
-import { Route, Switch } from 'react-router-dom'
+import { Route } from 'react-router-dom'
 import OrcidGeneral from './orcid/general.jsx'
 import OrcidEmail from './orcid/email.jsx'
 import OrcidGiven from './orcid/given.jsx'

--- a/packages/openneuro-app/src/scripts/errors/errorRoute.jsx
+++ b/packages/openneuro-app/src/scripts/errors/errorRoute.jsx
@@ -1,0 +1,45 @@
+/**
+ * Route for nice display of backend errors
+ */
+import React from 'react'
+import { Route, Switch } from 'react-router-dom'
+import OrcidGeneral from './orcid/general.jsx'
+import OrcidEmail from './orcid/email.jsx'
+import OrcidGiven from './orcid/given.jsx'
+import OrcidFamily from './orcid/family.jsx'
+
+class ErrorRoute extends React.Component {
+  render() {
+    return (
+      <div className="container errors">
+        <div className="panel">
+          <Route
+            name="orcidError"
+            path="/error/orcid"
+            component={OrcidGeneral}
+          />
+          <Route
+            name="email"
+            exact
+            path="/error/orcid/email"
+            component={OrcidEmail}
+          />
+          <Route
+            name="given"
+            exact
+            path="/error/orcid/given"
+            component={OrcidGiven}
+          />
+          <Route
+            name="family"
+            exact
+            path="/error/orcid/family"
+            component={OrcidFamily}
+          />
+        </div>
+      </div>
+    )
+  }
+}
+
+export default ErrorRoute

--- a/packages/openneuro-app/src/scripts/errors/orcid/email.jsx
+++ b/packages/openneuro-app/src/scripts/errors/orcid/email.jsx
@@ -1,0 +1,11 @@
+import React from 'react'
+
+const EmailError = () => (
+  <div className="panel-body">
+    Your ORCID account does not have an e-mail, or your e-mail is not public.
+    Visit your <a href="https://orcid.org/my-orcid">ORCID profile</a> and verify
+    your primary email privacy is set to public and try again.
+  </div>
+)
+
+export default EmailError

--- a/packages/openneuro-app/src/scripts/errors/orcid/family.jsx
+++ b/packages/openneuro-app/src/scripts/errors/orcid/family.jsx
@@ -1,0 +1,12 @@
+import React from 'react'
+
+const FamilyError = () => (
+  <div className="panel-body">
+    Your ORCID account does not have a credit name or family name, or your name
+    is not public. Visit your{' '}
+    <a href="https://orcid.org/my-orcid">ORCID profile</a> and verify verify you
+    have a publicly available name set.
+  </div>
+)
+
+export default FamilyError

--- a/packages/openneuro-app/src/scripts/errors/orcid/general.jsx
+++ b/packages/openneuro-app/src/scripts/errors/orcid/general.jsx
@@ -1,0 +1,7 @@
+import React from 'react'
+
+export default () => (
+  <div className="panel-heading">
+    <h2>There was an issue logging into your ORCID account</h2>
+  </div>
+)

--- a/packages/openneuro-app/src/scripts/errors/orcid/general.jsx
+++ b/packages/openneuro-app/src/scripts/errors/orcid/general.jsx
@@ -2,6 +2,6 @@ import React from 'react'
 
 export default () => (
   <div className="panel-heading">
-    <h2>There was an issue logging into your ORCID account</h2>
+    <h2>There was an issue authenticating with your ORCID account</h2>
   </div>
 )

--- a/packages/openneuro-app/src/scripts/errors/orcid/general.jsx
+++ b/packages/openneuro-app/src/scripts/errors/orcid/general.jsx
@@ -1,7 +1,9 @@
 import React from 'react'
 
-export default () => (
+const OrcidError = () => (
   <div className="panel-heading">
     <h2>There was an issue authenticating with your ORCID account</h2>
   </div>
 )
+
+export default OrcidError

--- a/packages/openneuro-app/src/scripts/errors/orcid/given.jsx
+++ b/packages/openneuro-app/src/scripts/errors/orcid/given.jsx
@@ -1,0 +1,12 @@
+import React from 'react'
+
+const GivenError = () => (
+  <div className="panel-body">
+    Your ORCID account does not have a credit name or given name, or your name
+    is not public. Visit your{' '}
+    <a href="https://orcid.org/my-orcid">ORCID profile</a> and verify you have a
+    publicly available name set.
+  </div>
+)
+
+export default GivenError

--- a/packages/openneuro-app/src/scripts/routes.jsx
+++ b/packages/openneuro-app/src/scripts/routes.jsx
@@ -25,6 +25,9 @@ const SearchResults = loadable(() =>
 const APIKey = loadable(() =>
   import(/* webpackChunkName: 'APIKey' */ './user/api.jsx'),
 )
+const ErrorRoute = loadable(() =>
+  import(/* webpackChunkName: 'Errors' */ './errors/errorRoute.jsx'),
+)
 
 // routes ----------------------------------------------------------------
 
@@ -40,6 +43,7 @@ const appRoutes = () => (
     <Route name="dataset" path="/datasets" component={Dataset} />
     <Route name="search" path="/search/:query?" component={SearchResults} />
     <Route name="admin" path="/admin" component={Admin} />
+    <Route name="error" path="/error" component={ErrorRoute} />
   </Switch>
 )
 

--- a/packages/openneuro-server/app.js
+++ b/packages/openneuro-server/app.js
@@ -49,26 +49,6 @@ export default test => {
   // Raven reporting passes to the next step
   test || app.use(Raven.errorHandler())
 
-  app.use(function(err, req, res, next) {
-    res.header('Content-Type', 'application/json')
-    var send = { error: '' }
-    var http_code = typeof err.http_code === 'undefined' ? 500 : err.http_code
-    if (typeof err.message !== 'undefined' && err.message !== '') {
-      send.error = err.message
-    } else {
-      if (err.http_code == 400) {
-        send.error = 'there was something wrong with that request'
-      } else if (err.http_code == 401) {
-        send.error = 'you are not authorized to do that'
-      } else if (err.http_code == 404) {
-        send.error = 'that resource was not found'
-      } else {
-        send.error = 'there was a problem'
-      }
-    }
-    res.status(http_code).send(send)
-  })
-
   // Apollo engine setup
   const engineConfig = {
     privateVariables: ['files'],

--- a/packages/openneuro-server/libs/authentication/orcid.js
+++ b/packages/openneuro-server/libs/authentication/orcid.js
@@ -4,7 +4,20 @@ export const requestAuth = passport.authenticate('orcid', {
   session: false,
 })
 
-export const authCallback = passport.authenticate('orcid', {
-  failureRedirect: '/',
-  session: false,
-})
+export const authCallback = (req, res, next) =>
+  passport.authenticate('orcid', (err, user) => {
+    if (err) {
+      if (err.type) {
+        res.redirect(`/error/orcid/${err.type}`)
+      } else {
+        res.redirect('/error/orcid/unknown')
+      }
+    }
+    if (!user) {
+      res.redirect('/')
+    }
+    req.logIn(user, err => {
+      if (err) return next(err)
+      return res.redirect('/')
+    })
+  })(req, res, next)

--- a/packages/openneuro-server/libs/authentication/orcid.js
+++ b/packages/openneuro-server/libs/authentication/orcid.js
@@ -8,16 +8,15 @@ export const authCallback = (req, res, next) =>
   passport.authenticate('orcid', (err, user) => {
     if (err) {
       if (err.type) {
-        res.redirect(`/error/orcid/${err.type}`)
+        return res.redirect(`/error/orcid/${err.type}`)
       } else {
-        res.redirect('/error/orcid/unknown')
+        return res.redirect('/error/orcid/unknown')
       }
     }
     if (!user) {
-      res.redirect('/')
+      return res.redirect('/')
     }
     req.logIn(user, { session: false }, err => {
-      if (err) return next(err)
-      return res.redirect('/')
+      return next(err)
     })
   })(req, res, next)

--- a/packages/openneuro-server/libs/authentication/orcid.js
+++ b/packages/openneuro-server/libs/authentication/orcid.js
@@ -16,7 +16,7 @@ export const authCallback = (req, res, next) =>
     if (!user) {
       res.redirect('/')
     }
-    req.logIn(user, err => {
+    req.logIn(user, { session: false }, err => {
       if (err) return next(err)
       return res.redirect('/')
     })

--- a/packages/openneuro-server/libs/orcid.js
+++ b/packages/openneuro-server/libs/orcid.js
@@ -43,7 +43,7 @@ export default {
           if (!name) {
             if (!firstname) {
               reject({
-                url: 'given',
+                type: 'given',
                 message:
                   'Your ORCID account does not have a given name, or it is not public. Please fix your account before continuing.',
               })

--- a/packages/openneuro-server/libs/orcid.js
+++ b/packages/openneuro-server/libs/orcid.js
@@ -21,9 +21,10 @@ export default {
         (err, res) => {
           if (err) {
             Raven.captureMessage('Unexpected ORCID failure', { err })
-            reject(
-              'An unexpected ORCID login failure occurred, please try again later.',
-            )
+            reject({
+              message:
+                'An unexpected ORCID login failure occurred, please try again later.',
+            })
           }
           const doc = new xmldoc.XmlDocument(res.body)
           let name = doc.valueWithPath(
@@ -41,22 +42,28 @@ export default {
 
           if (!name) {
             if (!firstname) {
-              reject(
-                'Your ORCID account does not have a given name, or it is not public. Please fix your account before continuing.',
-              )
+              reject({
+                url: 'given',
+                message:
+                  'Your ORCID account does not have a given name, or it is not public. Please fix your account before continuing.',
+              })
             } else if (!lastname) {
-              reject(
-                'Your ORCID account does not have a family name, or it is not public. Please fix your account before continuing.',
-              )
+              reject({
+                type: 'family',
+                message:
+                  'Your ORCID account does not have a family name, or it is not public. Please fix your account before continuing.',
+              })
             } else {
               name = `${firstname} ${lastname}`
             }
           }
 
           if (!email) {
-            reject(
-              'Your ORCID account does not have an e-mail, or your e-mail is not public. Please fix your account before continuing.',
-            )
+            reject({
+              type: 'email',
+              message:
+                'Your ORCID account does not have an e-mail, or your e-mail is not public. Please fix your account before continuing.',
+            })
           }
 
           resolve({


### PR DESCRIPTION
This gives useful error pages during failed ORCID authentication. This is the top error in Sentry right now.

![screenshot from 2018-09-10 16-30-59](https://user-images.githubusercontent.com/11369795/45329918-a9a77780-b517-11e8-9d63-7f0e6c118d34.png)

You can either set a "credit name" or both a given name and family name, so the errors messages ask you to just make sure you have a public name of some kind. Hopefully that's enough guidance for users.

Fixes #770