### PR TITLE
Avoid holding onto invalid docker-compose dns in nginx

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,6 +1,5 @@
-upstream nodejs {
-    server server:8111 fail_timeout=10s max_fails=0;
-}
+# Override docker-compose 600s TTL
+resolver 127.0.0.11 valid=10s;
 
 server {
     listen 80;
@@ -33,6 +32,10 @@ server {
     ssl_certificate /etc/nginx/ssl/live/openneuro.org/fullchain.pem;
     ssl_certificate_key /etc/nginx/ssl/live/openneuro.org/privkey.pem;
 
+    # Use a variable to allow for IP changes when a new container starts
+    # https://www.nginx.com/blog/dns-service-discovery-nginx-plus/#domain-name-proxy_pass
+    set $openneuro_server server;
+
     add_header Strict-Transport-Security "max-age=31536000" always;
 
     gzip on;
@@ -50,11 +53,11 @@ server {
         proxy_set_header Connection "";
         proxy_http_version 1.1;
         proxy_request_buffering off;
-        proxy_pass http://nodejs;
+        proxy_pass http://$openneuro_server:8111;
     }
 
     location /graphql-subscriptions {
-        proxy_pass http://nodejs/graphql-subscriptions;
+        proxy_pass http://$openneuro_server:8111/graphql-subscriptions;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";

--- a/nginx/nginx.dev.conf
+++ b/nginx/nginx.dev.conf
@@ -1,6 +1,5 @@
-upstream nodejs {
-    server server:8111 fail_timeout=10s max_fails=0;
-}
+# Override docker-compose 600s TTL
+resolver 127.0.0.11 valid=10s;
 
 server {
     listen 80;
@@ -8,6 +7,10 @@ server {
     gzip on;
     gzip_proxied any;
     gzip_types text/html application/json text/css;
+
+    # Use a variable to allow for IP changes when a new container starts
+    # https://www.nginx.com/blog/dns-service-discovery-nginx-plus/#domain-name-proxy_pass
+    set $openneuro_server server;
 
     # crn-server proxy
     location /crn {
@@ -17,11 +20,11 @@ server {
         proxy_set_header Connection "";
         proxy_http_version 1.1;
         proxy_request_buffering off;
-        proxy_pass http://nodejs;
+        proxy_pass http://$openneuro_server:8111;
     }
 
     location /graphql-subscriptions {
-        proxy_pass http://nodejs/graphql-subscriptions;
+        proxy_pass http://$openneuro_server:8111/graphql-subscriptions;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";


### PR DESCRIPTION
Fixes #809 

The original fix here did work for the reproduction case tested but there's a secondary issue which looks almost same but only happens when the container exits unexpectedly (not just when the backend connection drops). The reproduction scenario is:

1. All containers start normally. Nginx resolves the DNS value when it sets up the upstream directive.
1. Server container exits and nginx marks the upstream down.
1. Server container is restarted by docker-compose. This gives it a new virtual network device - sometimes changing the IP address and DNS is updated.
1. If the IP changes, nginx never notices the backend is at the new address because the DNS resolved and this is cached internally by nginx as an already resolved server address (it helpfully round robins our one dead IP address).

The resolver cache can be forced to update at the TTL interval by [specifying the server name in a variable](https://www.nginx.com/blog/dns-service-discovery-nginx-plus/#domain-name-proxy_pass) which forces it to be rechecked in case the variable has been altered by another rule in the request. The docker-compose TTL is 600 seconds but nginx allows this to be overridden so I've lowered it to ten seconds which gives some pretty reliable recovery after a container IP change.