### PR TITLE
getDraftFiles - If no revision is specified, return untracked files.

### DIFF
--- a/packages/openneuro-server/datalad/draft.js
+++ b/packages/openneuro-server/datalad/draft.js
@@ -18,7 +18,7 @@ const uri = config.datalad.uri
  */
 export const getDraftFiles = async (datasetId, revision, options = {}) => {
   // If untracked is set and true
-  const untracked = 'untracked' in options && options.untracked
+  const untracked = ('untracked' in options && options.untracked) || !revision
   const query = untracked ? { untracked: true } : {}
   const filesUrl = `${uri}/datasets/${datasetId}/files`
   const key = commitFilesKey(datasetId, revision)


### PR DESCRIPTION
No revision means there's been no commits made yet, such as during initial upload. This avoids writing the incomplete files to cache and includes untracked files (since the draft only consists of untracked files in this case).

Fixes #926 