### PR TITLE
Clear snapshot caches on any failure during snapshot creation

### DIFF
--- a/packages/openneuro-server/datalad/__tests__/snapshots.spec.js
+++ b/packages/openneuro-server/datalad/__tests__/snapshots.spec.js
@@ -7,6 +7,8 @@ import config from '../../config.js'
 // Mock requests to Datalad service
 jest.mock('superagent')
 jest.mock('../../libs/redis.js')
+// Mock draft files calls
+jest.mock('../draft.js')
 
 beforeAll(async () => {
   await mongo.connect()
@@ -31,6 +33,20 @@ describe('snapshot model operations', () => {
         ),
       )
       done()
+    })
+    it('throws an exception if backend errors', async done => {
+      const tag = 'snapshot'
+      const dsId = await createDataset('a label 2')
+      // Reset call count for request.post
+      request.post.mockClear()
+      request.__setMockError({ error: 'something went wrong' })
+      try {
+        await createSnapshot(dsId, tag, false)
+        done.fail(new Error('Failed request did not throw exception'))
+      } catch (e) {
+        expect(request.post).toHaveBeenCalledTimes(1)
+        done()
+      }
     })
   })
 })

--- a/packages/openneuro-server/datalad/dataset.js
+++ b/packages/openneuro-server/datalad/dataset.js
@@ -43,7 +43,6 @@ export const createDataset = (label, uploader, userInfo) => {
         .subscribe(datasetId, uploader)
         .then(() => resolve({ id: datasetId, label }))
         .catch(err => reject(err))
-      // resolve({ id: datasetId, label })
     } else {
       reject(Error(`Failed to create ${datasetId} - "${label}"`))
     }

--- a/packages/openneuro-server/datalad/snapshots.js
+++ b/packages/openneuro-server/datalad/snapshots.js
@@ -96,6 +96,14 @@ export const createSnapshot = async (datasetId, tag, user) => {
           })
       )
     })
+    .catch(err => {
+      // Also delete the keys if any step fails to trigger a recheck
+      // this avoids inconsistent cache state after failures
+      redis.del(sKey)
+      redis.del(indexKey)
+      // Pass the actual error back to caller
+      throw err
+    })
 }
 
 // TODO - deleteSnapshot


### PR DESCRIPTION
If the createSnapshot request fails, it's possible the snapshot is created but there was an issue such as a timeout updating the cache. This leads to inconsistent cached data, where the index might be out of date but wasn't cleared or the files are missing for the snapshot but the backend did finish the request following a timeout.

Clearing these keys on any failure avoids those cases.

Adds a test to make sure createSnapshot passes the failure back up the chain.