### PR TITLE
Use no-cache for index.html over max-age=0

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -61,7 +61,7 @@ server {
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
-	    proxy_set_header Host $host;
+        proxy_set_header Host $host;
     }
 
     location = /content/openneuro-content.js {

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -76,7 +76,7 @@ server {
     # crn-web app
     root /srv/app/dist;
     location /index.html {
-        add_header Cache-Control 'max-age=0; public';
+        add_header Cache-Control 'no-cache; public';
     }
 
     location / {


### PR DESCRIPTION
This should prevent some reverse proxies from serving a stale index.html to clients. [no-cache MUST revlidate and max-age expiration SHOULD revalidate](https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9.1).

Fixes #939 