### PR TITLE
Add tests for resolver dataset permission helpers

### DIFF
--- a/packages/openneuro-server/graphql/__tests__/__snapshots__/permissions.spec.js.snap
+++ b/packages/openneuro-server/graphql/__tests__/__snapshots__/permissions.spec.js.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`resolver permissions helpers checkDatasetWrite resolves to false for anonymous users 1`] = `"You do not have access to modify this dataset."`;
+exports[`resolver permissions helpers checkDatasetWrite() resolves to false for anonymous users 1`] = `"You do not have access to modify this dataset."`;

--- a/packages/openneuro-server/graphql/__tests__/__snapshots__/permissions.spec.js.snap
+++ b/packages/openneuro-server/graphql/__tests__/__snapshots__/permissions.spec.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`resolver permissions helpers checkDatasetWrite resolves to false for anonymous users 1`] = `"You do not have access to modify this dataset."`;

--- a/packages/openneuro-server/graphql/__tests__/permissions.spec.js
+++ b/packages/openneuro-server/graphql/__tests__/permissions.spec.js
@@ -1,0 +1,50 @@
+import {
+  datasetReadQuery,
+  checkReadPermissionLevel,
+  checkDatasetWrite,
+} from '../permissions.js'
+
+describe('resolver permissions helpers', () => {
+  describe('datasetReadQuery', () => {
+    it('returns public for anonymous users', () => {
+      expect(datasetReadQuery('ds000001', null, null)).toHaveProperty(
+        'public',
+        true,
+      )
+    })
+    it('returns non-public for admins', () => {
+      expect(
+        datasetReadQuery('ds000001', '1234', { admin: true }),
+      ).not.toHaveProperty('public', true)
+    })
+    it('returns public for logged in users', () => {
+      expect(
+        datasetReadQuery('ds000001', '1234', { admin: false }),
+      ).toHaveProperty('public', true)
+    })
+  })
+  describe('checkReadPermissionLevel', () => {
+    it('returns false if no permission passed in', () => {
+      expect(checkReadPermissionLevel(null)).toBe(false)
+    })
+    it('returns true for valid read access level', () => {
+      expect(checkReadPermissionLevel({ level: 'admin' })).toBe(true)
+      expect(checkReadPermissionLevel({ level: 'ro' })).toBe(true)
+    })
+    it('returns false if an unexpected level is present', () => {
+      expect(checkReadPermissionLevel({ level: 'not-real' })).toBe(false)
+    })
+  })
+  describe('checkDatasetWrite', () => {
+    it('resolves to false for anonymous users', () => {
+      return expect(
+        checkDatasetWrite('ds000001', null, null),
+      ).rejects.toThrowErrorMatchingSnapshot()
+    })
+    it('resolves to true for admins', () => {
+      return expect(
+        checkDatasetWrite('ds000001', '1234', { admin: true }),
+      ).resolves.toBe(true)
+    })
+  })
+})

--- a/packages/openneuro-server/graphql/__tests__/permissions.spec.js
+++ b/packages/openneuro-server/graphql/__tests__/permissions.spec.js
@@ -1,11 +1,12 @@
 import {
   datasetReadQuery,
   checkReadPermissionLevel,
+  checkWritePermissionLevel,
   checkDatasetWrite,
 } from '../permissions.js'
 
 describe('resolver permissions helpers', () => {
-  describe('datasetReadQuery', () => {
+  describe('datasetReadQuery()', () => {
     it('returns public for anonymous users', () => {
       expect(datasetReadQuery('ds000001', null, null)).toHaveProperty(
         'public',
@@ -23,7 +24,7 @@ describe('resolver permissions helpers', () => {
       ).toHaveProperty('public', true)
     })
   })
-  describe('checkReadPermissionLevel', () => {
+  describe('checkReadPermissionLevel()', () => {
     it('returns false if no permission passed in', () => {
       expect(checkReadPermissionLevel(null)).toBe(false)
     })
@@ -35,7 +36,21 @@ describe('resolver permissions helpers', () => {
       expect(checkReadPermissionLevel({ level: 'not-real' })).toBe(false)
     })
   })
-  describe('checkDatasetWrite', () => {
+  describe('checkWritePermissionLevel()', () => {
+    it('returns false if no permission passed in', () => {
+      expect(checkWritePermissionLevel(null)).toBe(false)
+    })
+    it('returns true for admin', () => {
+      expect(checkWritePermissionLevel({ level: 'admin' })).toBe(true)
+    })
+    it('returns false for read only access', () => {
+      expect(checkWritePermissionLevel({ level: 'ro' })).toBe(false)
+    })
+    it('returns false if an unexpected level is present', () => {
+      expect(checkWritePermissionLevel({ level: 'not-real' })).toBe(false)
+    })
+  })
+  describe('checkDatasetWrite()', () => {
     it('resolves to false for anonymous users', () => {
       return expect(
         checkDatasetWrite('ds000001', null, null),

--- a/packages/openneuro-server/graphql/permissions.js
+++ b/packages/openneuro-server/graphql/permissions.js
@@ -54,6 +54,19 @@ export const checkDatasetRead = (datasetId, userId, userInfo) => {
 
 const writeErrorMessage = 'You do not have access to modify this dataset.'
 
+/**
+ * Return true on matching permission level
+ * @param {object} permission
+ * @returns {boolean} read access
+ */
+export const checkWritePermissionLevel = permission => {
+  if (permission && ['admin', 'rw'].includes(permission.level)) {
+    return true
+  } else {
+    return false
+  }
+}
+
 export const checkDatasetWrite = (datasetId, userId, userInfo) => {
   if (!userId) {
     // Quick path for anonymous writes
@@ -64,10 +77,7 @@ export const checkDatasetWrite = (datasetId, userId, userInfo) => {
     return Promise.resolve(true)
   }
   return Permission.findOne({ datasetId, userId }).then(permission => {
-    if (
-      permission &&
-      (permission.level === 'admin' || permission.level === 'rw')
-    ) {
+    if (checkWritePermissionLevel(permission)) {
       return true
     } else {
       throw new Error(writeErrorMessage)

--- a/packages/openneuro-server/graphql/permissions.js
+++ b/packages/openneuro-server/graphql/permissions.js
@@ -3,29 +3,53 @@ import mongo from '../libs/mongo.js'
 
 const c = mongo.collections
 
-export const checkDatasetRead = (datasetId, userId, userInfo) => {
-  const query = { id: datasetId }
+/**
+ * Query to check if datasets exist and are accessible due to public flag
+ * @param {string} datasetId
+ * @param {string} userId
+ * @param {object} userInfo
+ * @returns {object} MongoDB query object
+ */
+export const datasetReadQuery = (datasetId, userId, userInfo) => {
   if (!userId || (userInfo && !userInfo.admin)) {
-    query.public = true
+    return { id: datasetId, public: true }
+  } else {
+    return { id: datasetId }
   }
-  return c.crn.datasets.findOne(query).then(datasetFound => {
-    if (datasetFound) {
-      return true
-    } else {
-      return Permission.findOne({ datasetId, userId }).then(permission => {
-        if (
-          permission &&
-          (permission.level === 'admin' ||
-            permission.level === 'rw' ||
-            permission.level === 'ro')
-        ) {
-          return true
-        } else {
-          throw new Error('You do not have access to read this dataset.')
-        }
-      })
-    }
-  })
+}
+
+/**
+ * Return true on matching permission level
+ * @param {object} permission
+ * @returns {boolean} read access
+ */
+export const checkReadPermissionLevel = permission => {
+  if (permission && ['admin', 'rw', 'ro'].includes(permission.level)) {
+    return true
+  } else {
+    return false
+  }
+}
+
+export const checkDatasetRead = (datasetId, userId, userInfo) => {
+  // Look for any matching datasets
+  return c.crn.datasets
+    .findOne(datasetReadQuery(datasetId, userId, userInfo))
+    .then(datasetFound => {
+      // Found a dataset and don't need to match further (public or admin user)
+      if (datasetFound) {
+        return true
+      } else {
+        // Did not find a dataset, check permissions for additional read access
+        return Permission.findOne({ datasetId, userId }).then(permission => {
+          if (checkReadPermissionLevel(permission)) {
+            return true
+          } else {
+            throw new Error('You do not have access to read this dataset.')
+          }
+        })
+      }
+    })
 }
 
 const writeErrorMessage = 'You do not have access to modify this dataset.'
@@ -33,7 +57,7 @@ const writeErrorMessage = 'You do not have access to modify this dataset.'
 export const checkDatasetWrite = (datasetId, userId, userInfo) => {
   if (!userId) {
     // Quick path for anonymous writes
-    return Promise.reject(writeErrorMessage)
+    return Promise.reject(new Error(writeErrorMessage))
   }
   if (userId && userInfo.admin) {
     // Always allow admins


### PR DESCRIPTION
Breaks out checkDatasetRead into several functions and adds test coverage and better comments since this function is fairly unintuitive.