### PR TITLE
Fix anonymous snapshot redirect trailing slash issue

### DIFF
--- a/packages/openneuro-app/src/scripts/dataset/dataset.dataset-loader.jsx
+++ b/packages/openneuro-app/src/scripts/dataset/dataset.dataset-loader.jsx
@@ -136,7 +136,8 @@ class DatasetLoader extends Reflux.Component {
         return new Date(b.created) - new Date(a.created)
       })
       const newestSnapshot = snapshots[0].tag
-      const currentPath = this.props.location.pathname
+      // Trim trailing slash if needed
+      const currentPath = this.props.location.pathname.replace(/\/$/, '')
       const newestSnapshotUrl = `${currentPath}/versions/${newestSnapshot}`
       return (
         <LoggedOut>


### PR DESCRIPTION
I noticed this bug while debugging Google indexing. Snapshot redirects which can lead you to a blank page if you started from a URL with a trailing slash.