### PR TITLE
Remove conflicting `cache-control: public` from index.html

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -79,7 +79,7 @@ server {
     # crn-web app
     root /srv/app/dist;
     location /index.html {
-        add_header Cache-Control 'no-cache; public';
+        add_header Cache-Control 'no-cache';
     }
 
     location / {


### PR DESCRIPTION
This should weed out caches that are just looking for `public` to decide if they can cache index.html longer than expected.