### PR TITLE
Add download modal with instructions for alternate download methods

### DIFF
--- a/packages/openneuro-app/package.json
+++ b/packages/openneuro-app/package.json
@@ -66,6 +66,7 @@
     "serviceworker-webpack-plugin": "^1.0.1",
     "spark-md5": "^3.0.0",
     "stream-browserify": "^2.0.1",
+    "styled-components": "^4.0.0",
     "subscriptions-transport-ws": "^0.9.9",
     "superagent": "^3.6.0",
     "url-search-params-polyfill": "^2.0.1",

--- a/packages/openneuro-app/src/scripts/datalad/download/__tests__/__snapshots__/download-command-line.spec.jsx.snap
+++ b/packages/openneuro-app/src/scripts/datalad/download/__tests__/__snapshots__/download-command-line.spec.jsx.snap
@@ -2,11 +2,12 @@
 
 exports[`dataset/download DownloadSampleCommand component renders successfully 1`] = `
 <styled.pre>
-  # openneuro download 
+  openneuro download 
   ds000001
    
-  ds000001
-  -download/ 
   --draft
+   
+  ds000001
+  -download/
 </styled.pre>
 `;

--- a/packages/openneuro-app/src/scripts/datalad/download/__tests__/__snapshots__/download-command-line.spec.jsx.snap
+++ b/packages/openneuro-app/src/scripts/datalad/download/__tests__/__snapshots__/download-command-line.spec.jsx.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`dataset/download DownloadSampleCommand component renders successfully 1`] = `
+<styled.pre>
+  # openneuro download 
+  ds000001
+   
+  ds000001
+  -download/ 
+  --draft
+</styled.pre>
+`;

--- a/packages/openneuro-app/src/scripts/datalad/download/__tests__/__snapshots__/download-command-line.spec.jsx.snap
+++ b/packages/openneuro-app/src/scripts/datalad/download/__tests__/__snapshots__/download-command-line.spec.jsx.snap
@@ -3,9 +3,9 @@
 exports[`dataset/download DownloadSampleCommand component renders successfully 1`] = `
 <styled.pre>
   openneuro download 
-  ds000001
-   
   --draft
+   
+  ds000001
    
   ds000001
   -download/

--- a/packages/openneuro-app/src/scripts/datalad/download/__tests__/__snapshots__/download-dataset.spec.jsx.snap
+++ b/packages/openneuro-app/src/scripts/datalad/download/__tests__/__snapshots__/download-dataset.spec.jsx.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`dataset/download/DownloadDataset renders successfully 1`] = `
+<Route>
+  <Component />
+</Route>
+`;

--- a/packages/openneuro-app/src/scripts/datalad/download/__tests__/__snapshots__/download-link.spec.jsx.snap
+++ b/packages/openneuro-app/src/scripts/datalad/download/__tests__/__snapshots__/download-link.spec.jsx.snap
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`dataset/download/DownloadLink checkBrowserEnvironment should throw an error for no ReadableStream 1`] = `"Web streams are required to download. Try a recent version of Chrome or see the FAQ for how to enable these features on Firefox."`;
+
+exports[`dataset/download/DownloadLink checkBrowserEnvironment should throw an error for no service worker 1`] = `"Your browser must support service workers to download. See the FAQ for supported browsers."`;
+
+exports[`dataset/download/DownloadLink renders successfully 1`] = `
+<div>
+  <h4>
+    Download in your browser
+  </h4>
+  <p>
+    This method is convenient and best for smaller datasets and with a good internet connection.
+  </p>
+  <button
+    className="btn-warn-component warning"
+    onClick={[Function]}
+  >
+    <i
+      className="fa fa-download"
+    />
+     Click to Download
+  </button>
+</div>
+`;

--- a/packages/openneuro-app/src/scripts/datalad/download/__tests__/__snapshots__/download-link.spec.jsx.snap
+++ b/packages/openneuro-app/src/scripts/datalad/download/__tests__/__snapshots__/download-link.spec.jsx.snap
@@ -7,19 +7,19 @@ exports[`dataset/download/DownloadLink checkBrowserEnvironment should throw an e
 exports[`dataset/download/DownloadLink renders successfully 1`] = `
 <div>
   <h4>
-    Download in your browser
+    Download with your browser
   </h4>
   <p>
     This method is convenient and best for smaller datasets and with a good internet connection.
   </p>
   <button
-    className="btn-warn-component warning"
+    className="btn-blue"
     onClick={[Function]}
   >
     <i
       className="fa fa-download"
     />
-     Click to Download
+     Download
   </button>
 </div>
 `;

--- a/packages/openneuro-app/src/scripts/datalad/download/__tests__/__snapshots__/download-tool.spec.jsx.snap
+++ b/packages/openneuro-app/src/scripts/datalad/download/__tests__/__snapshots__/download-tool.spec.jsx.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`dataset/download/DownloadTool renders successfully 1`] = `
+<Route>
+  <Component />
+</Route>
+`;

--- a/packages/openneuro-app/src/scripts/datalad/download/__tests__/__snapshots__/shell-example.spec.jsx.snap
+++ b/packages/openneuro-app/src/scripts/datalad/download/__tests__/__snapshots__/shell-example.spec.jsx.snap
@@ -1,0 +1,29 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`dataset/download/ShellExample renders successfully 1`] = `
+<StyledComponent
+  forwardedClass={
+    Object {
+      "$$typeof": Symbol(react.forward_ref),
+      "attrs": undefined,
+      "componentStyle": ComponentStyle {
+        "componentId": "sc-bdVaJa",
+        "isStatic": true,
+        "rules": Array [
+          "
+  max-width: 80em;
+  white-space: pre-wrap;
+",
+        ],
+      },
+      "displayName": "styled.pre",
+      "render": [Function],
+      "styledComponentId": "sc-bdVaJa",
+      "target": "pre",
+      "warnTooManyClasses": [Function],
+      "withComponent": [Function],
+    }
+  }
+  forwardedRef={null}
+/>
+`;

--- a/packages/openneuro-app/src/scripts/datalad/download/__tests__/__snapshots__/shell-example.spec.jsx.snap
+++ b/packages/openneuro-app/src/scripts/datalad/download/__tests__/__snapshots__/shell-example.spec.jsx.snap
@@ -13,6 +13,7 @@ exports[`dataset/download/ShellExample renders successfully 1`] = `
           "
   max-width: 80em;
   white-space: pre-wrap;
+  word-break: keep-all;
 ",
         ],
       },

--- a/packages/openneuro-app/src/scripts/datalad/download/__tests__/download-command-line.spec.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/download/__tests__/download-command-line.spec.jsx
@@ -1,0 +1,26 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import { DownloadSampleCommand } from '../download-command-line.jsx'
+
+const defProps = { datasetId: 'ds000001' }
+
+describe('dataset/download', () => {
+  describe('DownloadSampleCommand component', () => {
+    it('renders successfully', () => {
+      const wrapper = shallow(<DownloadSampleCommand {...defProps} />)
+      expect(wrapper).toMatchSnapshot()
+    })
+    it('drafts show draft flag', () => {
+      const wrapper = shallow(<DownloadSampleCommand {...defProps} />)
+      expect(wrapper.text()).toEqual(expect.stringContaining('--draft'))
+      expect(wrapper.text()).toEqual(expect.not.stringContaining('--snapshot'))
+    })
+    it('snapshots show snapshot flag', () => {
+      const wrapper = shallow(
+        <DownloadSampleCommand {...defProps} snapshotTag="1.0.0" />,
+      )
+      expect(wrapper.text()).toEqual(expect.stringContaining('--snapshot'))
+      expect(wrapper.text()).toEqual(expect.not.stringContaining('--draft'))
+    })
+  })
+})

--- a/packages/openneuro-app/src/scripts/datalad/download/__tests__/download-dataset.spec.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/download/__tests__/download-dataset.spec.jsx
@@ -1,0 +1,19 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import DownloadDataset from '../download-dataset.jsx'
+
+const defProps = {
+  match: {
+    params: {
+      datasetId: 'ds000224',
+      snapshotId: '1.0.0',
+    },
+  },
+}
+
+describe('dataset/download/DownloadDataset', () => {
+  it('renders successfully', () => {
+    const wrapper = shallow(<DownloadDataset {...defProps} />)
+    expect(wrapper).toMatchSnapshot()
+  })
+})

--- a/packages/openneuro-app/src/scripts/datalad/download/__tests__/download-link.spec.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/download/__tests__/download-link.spec.jsx
@@ -1,0 +1,94 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import DownloadLink, {
+  downloadUri,
+  checkBrowserEnvironment,
+  awaitRegistration,
+} from '../download-link.jsx'
+
+const defProps = {
+  datasetId: 'ds000001',
+  snapshotTag: '1.0.0',
+}
+
+describe('dataset/download/DownloadLink', () => {
+  it('renders successfully', () => {
+    const wrapper = shallow(<DownloadLink {...defProps} />)
+    expect(wrapper).toMatchSnapshot()
+  })
+  describe('downloadUri', () => {
+    it('returns a draft path if snapshotTag is not defined', () => {
+      expect(downloadUri(defProps.datasetId)).toBe(
+        'localhost:9876/crn/datasets/ds000001/download',
+      )
+    })
+    it('returns a snapshot path if snapshotTag is defined', () => {
+      expect(downloadUri(defProps.datasetId, defProps.snapshotTag)).toBe(
+        'localhost:9876/crn/datasets/ds000001/snapshots/1.0.0/download',
+      )
+    })
+  })
+  describe('checkBrowserEnvironment', () => {
+    it('should throw an error for no service worker', () => {
+      const mockWindow = {
+        navigator: {},
+      }
+      expect(() =>
+        checkBrowserEnvironment(mockWindow),
+      ).toThrowErrorMatchingSnapshot()
+    })
+    it('should throw an error for no ReadableStream', () => {
+      const mockWindow = {
+        navigator: { serviceWorker: {} },
+      }
+      expect(() =>
+        checkBrowserEnvironment(mockWindow),
+      ).toThrowErrorMatchingSnapshot()
+    })
+    it('throws no errors if service worker and readable stream are available', () => {
+      const mockWindow = {
+        navigator: { serviceWorker: () => {} },
+        ReadableStream: () => {},
+      }
+      expect(() => checkBrowserEnvironment(mockWindow)).not.toThrowError()
+    })
+  })
+  describe('awaitRegistration', () => {
+    it('calls next if registration is active', async done => {
+      const mockRegistration = { active: true }
+      return expect(() =>
+        awaitRegistration(done, {})(mockRegistration),
+      ).not.toThrowError()
+    })
+    it('waits for worker if installing', async done => {
+      const mockWindow = {
+        navigator: {
+          serviceWorker: {
+            // Transition to active state immediately
+            addEventListener: jest.fn((state, callback) =>
+              callback({ target: { state: 'active' } }),
+            ),
+            removeEventListener: jest.fn(),
+          },
+        },
+      }
+      const mockRegistration = {
+        active: false,
+        installing: true,
+        waiting: false,
+      }
+
+      // Passes in done as next()
+      return expect(() => {
+        awaitRegistration(done, mockWindow)(mockRegistration)
+        // Check that listeners were actually used
+        expect(
+          mockWindow.navigator.serviceWorker.addEventListener,
+        ).toHaveBeenCalledTimes(1)
+        expect(
+          mockWindow.navigator.serviceWorker.removeEventListener,
+        ).toHaveBeenCalledTimes(1)
+      }).not.toThrowError()
+    })
+  })
+})

--- a/packages/openneuro-app/src/scripts/datalad/download/__tests__/download-tool.spec.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/download/__tests__/download-tool.spec.jsx
@@ -1,0 +1,19 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import DownloadTool from '../download-tool.jsx'
+
+const defProps = {
+  match: {
+    params: {
+      datasetId: 'ds000224',
+      snapshotId: '1.0.0',
+    },
+  },
+}
+
+describe('dataset/download/DownloadTool', () => {
+  it('renders successfully', () => {
+    const wrapper = shallow(<DownloadTool {...defProps} />)
+    expect(wrapper).toMatchSnapshot()
+  })
+})

--- a/packages/openneuro-app/src/scripts/datalad/download/__tests__/shell-example.spec.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/download/__tests__/shell-example.spec.jsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import ShellExample from '../shell-example.jsx'
+
+describe('dataset/download/ShellExample', () => {
+  it('renders successfully', () => {
+    const wrapper = shallow(<ShellExample />)
+    expect(wrapper).toMatchSnapshot()
+  })
+})

--- a/packages/openneuro-app/src/scripts/datalad/download/download-command-line.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/download/download-command-line.jsx
@@ -1,0 +1,42 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import ShellExample from './shell-example.jsx'
+
+export const DownloadSampleCommand = ({ datasetId, snapshotTag }) => (
+  <ShellExample>
+    # openneuro download {datasetId} {datasetId}
+    -download/ {snapshotTag ? `--snapshot ${snapshotTag}` : '--draft'}
+  </ShellExample>
+)
+
+DownloadSampleCommand.propTypes = {
+  datasetId: PropTypes.string,
+  snapshotTag: PropTypes.string,
+}
+
+const DownloadCommandLine = ({ datasetId, snapshotTag }) => (
+  <div>
+    <h4>Download with Node.js</h4>
+    <p>
+      Using{' '}
+      <a href="https://www.npmjs.com/package/openneuro-cli">openneuro-cli</a>{' '}
+      you can download this dataset from the command line using{' '}
+      <a href="https://nodejs.org/en/download/">Node.js</a>. This method is good
+      for larger datasets or unstable connections, but has known issues on
+      Windows.
+    </p>
+    <DownloadSampleCommand datasetId={datasetId} snapshotTag={snapshotTag} />
+    <p>
+      This will download to {datasetId}
+      -download/ in the current directory. If your download is interrupted and
+      you need to retry, rerun the command to resume the download.
+    </p>
+  </div>
+)
+
+DownloadCommandLine.propTypes = {
+  datasetId: PropTypes.string,
+  snapshotTag: PropTypes.string,
+}
+
+export default DownloadCommandLine

--- a/packages/openneuro-app/src/scripts/datalad/download/download-command-line.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/download/download-command-line.jsx
@@ -4,8 +4,8 @@ import ShellExample from './shell-example.jsx'
 
 export const DownloadSampleCommand = ({ datasetId, snapshotTag }) => (
   <ShellExample>
-    openneuro download {datasetId}{' '}
-    {snapshotTag ? `--snapshot ${snapshotTag}` : '--draft'} {datasetId}
+    openneuro download {snapshotTag ? `--snapshot ${snapshotTag}` : '--draft'}{' '}
+    {datasetId} {datasetId}
     -download/
   </ShellExample>
 )

--- a/packages/openneuro-app/src/scripts/datalad/download/download-command-line.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/download/download-command-line.jsx
@@ -4,8 +4,9 @@ import ShellExample from './shell-example.jsx'
 
 export const DownloadSampleCommand = ({ datasetId, snapshotTag }) => (
   <ShellExample>
-    # openneuro download {datasetId} {datasetId}
-    -download/ {snapshotTag ? `--snapshot ${snapshotTag}` : '--draft'}
+    openneuro download {datasetId}{' '}
+    {snapshotTag ? `--snapshot ${snapshotTag}` : '--draft'} {datasetId}
+    -download/
   </ShellExample>
 )
 

--- a/packages/openneuro-app/src/scripts/datalad/download/download-datalad.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/download/download-datalad.jsx
@@ -1,0 +1,51 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { getConfig } from '../../config.js'
+import ShellExample from './shell-example.jsx'
+
+const DownloadDataladExample = ({ datasetId, githubOrganization }) => (
+  <ShellExample>
+    # datalad install https://github.com/
+    {githubOrganization}/{datasetId}
+    .git
+  </ShellExample>
+)
+
+DownloadDataladExample.propTypes = {
+  datasetId: PropTypes.string,
+  githubOrganization: PropTypes.string,
+}
+
+const DownloadDataladInstructions = ({ datasetId, githubOrganization }) => (
+  <div>
+    <h4>Download with DataLad</h4>
+    <p>
+      Public datasets can be downloaded with{' '}
+      <a href="https://www.datalad.org">DataLad</a> or{' '}
+      <a href="https://git-annex.branchable.com/">Git Annex</a> from{' '}
+      <a href={`https://github.com/${githubOrganization}/${datasetId}`}>
+        GitHub.
+      </a>
+    </p>
+    <DownloadDataladExample
+      datasetId={datasetId}
+      githubOrganization={githubOrganization}
+    />
+  </div>
+)
+
+DownloadDataladInstructions.propTypes = {
+  datasetId: PropTypes.string,
+  githubOrganization: PropTypes.string,
+}
+
+const DownloadDatalad = props =>
+  // TODO - don't depend on async config
+  getConfig().hasOwnProperty('github') ? (
+    <DownloadDataladInstructions
+      {...props}
+      githubOrganization={getConfig().github}
+    />
+  ) : null
+
+export default DownloadDatalad

--- a/packages/openneuro-app/src/scripts/datalad/download/download-datalad.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/download/download-datalad.jsx
@@ -5,7 +5,7 @@ import ShellExample from './shell-example.jsx'
 
 const DownloadDataladExample = ({ datasetId, githubOrganization }) => (
   <ShellExample>
-    # datalad install https://github.com/
+    datalad install https://github.com/
     {githubOrganization}/{datasetId}
     .git
   </ShellExample>

--- a/packages/openneuro-app/src/scripts/datalad/download/download-datalad.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/download/download-datalad.jsx
@@ -31,6 +31,13 @@ const DownloadDataladInstructions = ({ datasetId, githubOrganization }) => (
       datasetId={datasetId}
       githubOrganization={githubOrganization}
     />
+    <p>
+      Check out{' '}
+      <a href="http://docs.datalad.org/en/latest/gettingstarted.html">
+        getting started with DataLad
+      </a>{' '}
+      for more on how to use this download method.
+    </p>
   </div>
 )
 

--- a/packages/openneuro-app/src/scripts/datalad/download/download-dataset.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/download/download-dataset.jsx
@@ -36,10 +36,6 @@ const DownloadDataset = ({
       </PaddedDiv>
     </div>
     <ExtraPaddedDiv className="col-xs-12">
-      <p>
-        If neither of the above methods meet your needs, try an advanced method
-        below.
-      </p>
       <Panel header="Advanced Methods" collapsible>
         <PaddedDiv className="col-xs-6">
           <DownloadCommandLine

--- a/packages/openneuro-app/src/scripts/datalad/download/download-dataset.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/download/download-dataset.jsx
@@ -1,0 +1,45 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { withRouter } from 'react-router-dom'
+import { Panel } from 'react-bootstrap'
+import DownloadLink from './download-link.jsx'
+import DownloadS3 from './download-s3.jsx'
+import DownloadCommandLine from './download-command-line.jsx'
+import DownloadDatalad from './download-datalad.jsx'
+
+const DownloadDataset = ({
+  match: {
+    // snapshotId is widely used but snapshotTag is more accurate
+    params: { datasetId, snapshotId: snapshotTag },
+  },
+}) => (
+  <div className="dataset-form">
+    <div className="col-xs-12 dataset-form-header">
+      <div className="form-group">
+        <label>How to Download</label>
+      </div>
+      <hr className="modal-inner" />
+    </div>
+    <div className="dataset-form-body col-xs-12">
+      <div className="dataset-form-content col-xs-12">
+        <DownloadLink datasetId={datasetId} snapshotTag={snapshotTag} />
+        <hr className="modal-inner" />
+        <DownloadS3 datasetId={datasetId} />
+        <hr className="modal-inner" />
+        <Panel header="Advanced Methods" collapsible>
+          <DownloadCommandLine
+            datasetId={datasetId}
+            snapshotTag={snapshotTag}
+          />
+          <DownloadDatalad datasetId={datasetId} />
+        </Panel>
+      </div>
+    </div>
+  </div>
+)
+
+DownloadDataset.propTypes = {
+  match: PropTypes.object,
+}
+
+export default withRouter(DownloadDataset)

--- a/packages/openneuro-app/src/scripts/datalad/download/download-dataset.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/download/download-dataset.jsx
@@ -2,10 +2,19 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { withRouter } from 'react-router-dom'
 import { Panel } from 'react-bootstrap'
+import styled from 'styled-components'
 import DownloadLink from './download-link.jsx'
 import DownloadS3 from './download-s3.jsx'
 import DownloadCommandLine from './download-command-line.jsx'
 import DownloadDatalad from './download-datalad.jsx'
+
+const PaddedDiv = styled.div`
+  padding: 1em;
+`
+
+const ExtraPaddedDiv = styled.div`
+  padding: 3em;
+`
 
 const DownloadDataset = ({
   match: {
@@ -13,28 +22,36 @@ const DownloadDataset = ({
     params: { datasetId, snapshotId: snapshotTag },
   },
 }) => (
-  <div className="dataset-form">
-    <div className="col-xs-12 dataset-form-header">
-      <div className="form-group">
-        <label>How to Download</label>
-      </div>
+  <div>
+    <div className="col-xs-12">
+      <h3>How to Download</h3>
       <hr className="modal-inner" />
     </div>
-    <div className="dataset-form-body col-xs-12">
-      <div className="dataset-form-content col-xs-12">
+    <div className="col-xs-12">
+      <PaddedDiv className="col-xs-6">
         <DownloadLink datasetId={datasetId} snapshotTag={snapshotTag} />
-        <hr className="modal-inner" />
+      </PaddedDiv>
+      <PaddedDiv className="col-xs-6">
         <DownloadS3 datasetId={datasetId} />
-        <hr className="modal-inner" />
-        <Panel header="Advanced Methods" collapsible>
+      </PaddedDiv>
+    </div>
+    <ExtraPaddedDiv className="col-xs-12">
+      <p>
+        If neither of the above methods meet your needs, try an advanced method
+        below.
+      </p>
+      <Panel header="Advanced Methods" collapsible>
+        <PaddedDiv className="col-xs-6">
           <DownloadCommandLine
             datasetId={datasetId}
             snapshotTag={snapshotTag}
           />
+        </PaddedDiv>
+        <PaddedDiv className="col-xs-6">
           <DownloadDatalad datasetId={datasetId} />
-        </Panel>
-      </div>
-    </div>
+        </PaddedDiv>
+      </Panel>
+    </ExtraPaddedDiv>
   </div>
 )
 

--- a/packages/openneuro-app/src/scripts/datalad/download/download-link.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/download/download-link.jsx
@@ -1,13 +1,14 @@
 /* eslint-disable no-console */
+import Raven from 'raven-js'
 import React from 'react'
 import PropTypes from 'prop-types'
-import WarnButton from '../../common/forms/warn-button.jsx'
 import config from '../../../../config.js'
 import datalad from '../../utils/datalad'
 
 const startDownload = uri => {
   global.location.assign(uri)
 }
+
 const trackDownload = (datasetId, snapshotTag) => {
   datalad.trackAnalytics(datasetId, {
     snapshot: true,
@@ -16,77 +17,106 @@ const trackDownload = (datasetId, snapshotTag) => {
   })
 }
 
+export const downloadUri = (datasetId, snapshotTag) =>
+  // This can't be a GraphQL query since it is intercepted
+  // by the service worker
+  snapshotTag
+    ? `${config.crn.url}datasets/${datasetId}/snapshots/${snapshotTag}/download`
+    : `${config.crn.url}datasets/${datasetId}/download`
+
+// Verify environment dependencies for downloads
+export const checkBrowserEnvironment = environment => {
+  if (!('serviceWorker' in environment.navigator)) {
+    throw new Error(
+      'Your browser must support service workers to download. See the FAQ for supported browsers.',
+    )
+  } else if (typeof environment.ReadableStream === 'undefined') {
+    throw new Error(
+      'Web streams are required to download. Try a recent version of Chrome or see the FAQ for how to enable these features on Firefox.',
+    )
+  }
+}
+
+// Wait for the service worker to be ready and call next()
+export const awaitRegistration = (next, environment) => registration =>
+  new Promise((resolve, reject) => {
+    if (registration.active) {
+      // Service worker is already running as expected
+      next()
+    } else {
+      // Waiting on the service worker
+      if (registration.installing || registration.waiting) {
+        environment.navigator.serviceWorker.addEventListener(
+          'statechange',
+          event => {
+            if (event.target.state === 'active') {
+              // Worker ready, start downloading
+              environment.navigator.serviceWorker.removeEventListener(
+                'statechange',
+                this,
+                true,
+              )
+              next()
+            }
+          },
+        )
+      } else {
+        reject(
+          new Error(
+            'Download failed, please refresh and try again in a few moments.',
+          ),
+        )
+      }
+    }
+  })
+
 /**
  * Event handler for initiating dataset or snapshot downloads
  * @param {string} datasetId Accession number string for a dataset
  */
 const downloadClick = (datasetId, snapshotTag) => callback => {
-  // This can't be a GraphQL query since it is intercepted
-  // by the service worker
-  const uri = snapshotTag
-    ? `${config.crn.url}datasets/${datasetId}/snapshots/${snapshotTag}/download`
-    : `${config.crn.url}datasets/${datasetId}/download`
   // Check that a service worker is registered
-  if (!('serviceWorker' in global.navigator)) {
-    global.alert(
-      'Your browser must support service workers to download. See the FAQ for supported browsers.',
-    )
-    callback()
-  } else if (typeof global.ReadableStream === 'undefined') {
-    // This is likely Firefox with flags disabled
-    global.alert(
-      'Web streams are required to download. Try a recent version of Chrome or see the FAQ for how to enable these features on Firefox.',
-    )
-    callback()
-  } else {
-    // Check for a running service worker
-    global.navigator.serviceWorker.getRegistration().then(registration => {
-      if (registration.active) {
-        // Service worker is already running as expected
-        startDownload(uri)
-        trackDownload(datasetId, snapshotTag)
-        callback()
-      } else {
-        // Waiting on the service worker
-        if (registration.installing || registration.waiting) {
-          global.navigator.serviceWorker.addEventListener(
-            'statechange',
-            function(e) {
-              if (e.target.state === 'active') {
-                // Worker ready, start downloading
-                global.navigator.serviceWorker.removeEventListener(
-                  'statechange',
-                  this,
-                  true,
-                )
-                startDownload(uri)
-                trackDownload(datasetId, snapshotTag)
-                callback()
-              }
-            },
-          )
-        } else {
-          global.alert(
-            'Download failed, please refresh and try again in a few moments.',
-          )
-          callback()
-        }
-      }
-    })
+  try {
+    checkBrowserEnvironment(global)
+  } catch (e) {
+    global.alert(e.message)
+    return callback()
   }
+  // Create a closure for download path, datasetId, and optional tag
+  const next = () => {
+    startDownload(downloadUri(datasetId, snapshotTag))
+    trackDownload(datasetId, snapshotTag)
+    callback()
+  }
+  // Check for a running service worker
+  global.navigator.serviceWorker
+    .getRegistration()
+    .then(awaitRegistration(next, global))
+    .then(() => {
+      // Download is going as expected
+      callback()
+    })
+    .catch(err => {
+      Raven.captureException(err)
+      callback()
+    })
 }
 
 /**
  * Generate a magic bundle link for this dataset
  */
 const DownloadLink = ({ datasetId, snapshotTag }) => (
-  <div role="presentation" className="tool">
-    <WarnButton
-      tooltip="Download"
-      icon="fa-download"
-      warn={false}
-      action={downloadClick(datasetId, snapshotTag)}
-    />
+  <div>
+    <h4>Download in your browser</h4>
+    <p>
+      This method is convenient and best for smaller datasets and with a good
+      internet connection.
+    </p>
+    <button
+      className="btn-warn-component warning"
+      onClick={downloadClick(datasetId, snapshotTag)}>
+      <i className={'fa fa-download'} /> Click to Download
+    </button>
   </div>
 )
 

--- a/packages/openneuro-app/src/scripts/datalad/download/download-link.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/download/download-link.jsx
@@ -107,15 +107,15 @@ const downloadClick = (datasetId, snapshotTag) => callback => {
  */
 const DownloadLink = ({ datasetId, snapshotTag }) => (
   <div>
-    <h4>Download in your browser</h4>
+    <h4>Download with your browser</h4>
     <p>
       This method is convenient and best for smaller datasets and with a good
       internet connection.
     </p>
     <button
-      className="btn-warn-component warning"
+      className="btn-blue"
       onClick={downloadClick(datasetId, snapshotTag)}>
-      <i className={'fa fa-download'} /> Click to Download
+      <i className={'fa fa-download'} /> Download
     </button>
   </div>
 )

--- a/packages/openneuro-app/src/scripts/datalad/download/download-s3.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/download/download-s3.jsx
@@ -20,12 +20,15 @@ const DownloadS3Instructions = ({ datasetId, s3Bucket }) => (
   <div>
     <h4>Download from S3</h4>
     <p>
-      Public snapshots are stored on AWS S3 and the most recent snapshot is
-      downloadable with standard S3 tools. This method is best for larger
-      datasets or unstable connections. This example uses{' '}
-      <a href="https://aws.amazon.com/cli/">AWS CLI.</a>
+      The most recently published snapshot can be downloaded from S3. This
+      method is best for larger datasets or unstable connections. This example
+      uses <a href="https://aws.amazon.com/cli/">AWS CLI.</a>
     </p>
     <DownloadSampleS3 datasetId={datasetId} s3Bucket={s3Bucket} />
+    <p>
+      To download unpublished datasets or older snapshots, see advanced methods
+      below.
+    </p>
   </div>
 )
 

--- a/packages/openneuro-app/src/scripts/datalad/download/download-s3.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/download/download-s3.jsx
@@ -5,7 +5,7 @@ import { getConfig } from '../../config.js'
 
 export const DownloadSampleS3 = ({ datasetId, s3Bucket }) => (
   <ShellExample>
-    # aws s3 sync --no-sign-request s3://
+    aws s3 sync --no-sign-request s3://
     {s3Bucket}/{datasetId} {datasetId}
     -download/
   </ShellExample>
@@ -20,7 +20,7 @@ const DownloadS3Instructions = ({ datasetId, s3Bucket }) => (
   <div>
     <h4>Download from S3</h4>
     <p>
-      Public snapshots are stored on S3 and the most recent snapshot is
+      Public snapshots are stored on AWS S3 and the most recent snapshot is
       downloadable with standard S3 tools. This method is best for larger
       datasets or unstable connections. This example uses{' '}
       <a href="https://aws.amazon.com/cli/">AWS CLI.</a>

--- a/packages/openneuro-app/src/scripts/datalad/download/download-s3.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/download/download-s3.jsx
@@ -1,0 +1,43 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import ShellExample from './shell-example.jsx'
+import { getConfig } from '../../config.js'
+
+export const DownloadSampleS3 = ({ datasetId, s3Bucket }) => (
+  <ShellExample>
+    # aws s3 sync --no-sign-request s3://
+    {s3Bucket}/{datasetId} {datasetId}
+    -download/
+  </ShellExample>
+)
+
+DownloadSampleS3.propTypes = {
+  datasetId: PropTypes.string,
+  s3Bucket: PropTypes.string,
+}
+
+const DownloadS3Instructions = ({ datasetId, s3Bucket }) => (
+  <div>
+    <h4>Download from S3</h4>
+    <p>
+      Public snapshots are stored on S3 and the most recent snapshot is
+      downloadable with standard S3 tools. This method is best for larger
+      datasets or unstable connections. This example uses{' '}
+      <a href="https://aws.amazon.com/cli/">AWS CLI.</a>
+    </p>
+    <DownloadSampleS3 datasetId={datasetId} s3Bucket={s3Bucket} />
+  </div>
+)
+
+DownloadS3Instructions.propTypes = {
+  datasetId: PropTypes.string,
+  s3Bucket: PropTypes.string,
+}
+
+const DownloadS3 = props =>
+  // TODO - don't depend on async config
+  getConfig().hasOwnProperty('publicBucket') ? (
+    <DownloadS3Instructions {...props} s3Bucket={getConfig().publicBucket} />
+  ) : null
+
+export default DownloadS3

--- a/packages/openneuro-app/src/scripts/datalad/download/download-tool.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/download/download-tool.jsx
@@ -1,0 +1,41 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { withRouter } from 'react-router-dom'
+import WarnButton from '../../common/forms/warn-button.jsx'
+
+/**
+ * Produce redirect function for this router, dataset, and snapshot
+ * @param {object} history React router history object
+ * @param {string} datasetId Accession number string
+ * @param {string} snapshotTag Optional snapshot tag to redirect to
+ * @returns {function}
+ */
+const downloadRedirect = (history, datasetId, snapshotTag) => callback => {
+  snapshotTag
+    ? history.push(`/datasets/${datasetId}/versions/${snapshotTag}/download`)
+    : history.push(`/datasets/${datasetId}/download`)
+
+  callback()
+}
+
+/**
+ * Toolbar component to redirect to download modal page
+ */
+const DownloadTool = ({ datasetId, snapshotTag, history }) => (
+  <div role="presentation" className="tool">
+    <WarnButton
+      tooltip="Download"
+      icon="fa-download"
+      warn={false}
+      action={downloadRedirect(history, datasetId, snapshotTag)}
+    />
+  </div>
+)
+
+DownloadTool.propTypes = {
+  history: PropTypes.object,
+  datasetId: PropTypes.string,
+  snapshotTag: PropTypes.string,
+}
+
+export default withRouter(DownloadTool)

--- a/packages/openneuro-app/src/scripts/datalad/download/shell-example.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/download/shell-example.jsx
@@ -3,6 +3,7 @@ import styled from 'styled-components'
 const ShellExample = styled.pre`
   max-width: 80em;
   white-space: pre-wrap;
+  word-break: keep-all;
 `
 
 export default ShellExample

--- a/packages/openneuro-app/src/scripts/datalad/download/shell-example.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/download/shell-example.jsx
@@ -1,0 +1,8 @@
+import styled from 'styled-components'
+
+const ShellExample = styled.pre`
+  max-width: 80em;
+  white-space: pre-wrap;
+`
+
+export default ShellExample

--- a/packages/openneuro-app/src/scripts/dataset/dataset.routes.jsx
+++ b/packages/openneuro-app/src/scripts/dataset/dataset.routes.jsx
@@ -14,6 +14,7 @@ import DatasetLoader from './dataset.dataset-loader.jsx'
 import SnapshotLoader from './dataset.snapshot-loader.jsx'
 import ResultsDisplay from './tools/jobs/results-display.jsx'
 import LogsDisplay from './tools/jobs/logs-display.jsx'
+import DownloadDataset from '../datalad/download/download-dataset.jsx'
 
 /**
  * This redirects old URLs ending in /versions to the first snapshot
@@ -52,6 +53,12 @@ export default class DatasetRoutes extends React.Component {
             exact
             path="/datasets/:datasetId"
             component={DatasetContent}
+          />
+          <Route
+            name="download"
+            exact
+            path="/datasets/:datasetId/download"
+            component={DownloadDataset}
           />
           <Route
             name="snapshot-create"
@@ -107,6 +114,12 @@ export default class DatasetRoutes extends React.Component {
             exact
             path="/datasets/:datasetId/versions"
             component={SnapshotDefaultRedirect}
+          />
+          <Route
+            name="download"
+            exact
+            path="/datasets/:datasetId/versions/:snapshotId/download"
+            component={DownloadDataset}
           />
           <Route
             name="snapshot"

--- a/packages/openneuro-app/src/scripts/dataset/tools/index.js
+++ b/packages/openneuro-app/src/scripts/dataset/tools/index.js
@@ -5,7 +5,7 @@ import Reflux from 'reflux'
 import PropTypes from 'prop-types'
 import { withRouter } from 'react-router-dom'
 import moment from 'moment'
-import DownloadLink from '../../datalad/download/download-link.jsx'
+import DownloadTool from '../../datalad/download/download-tool.jsx'
 import WarnButton from '../../common/forms/warn-button.jsx'
 import actions from '../dataset.actions.js'
 import datasetStore from '../dataset.store.js'
@@ -272,12 +272,12 @@ class Tools extends Reflux.Component {
           <div className="tools clearfix">
             {this._snapshotLabel(dataset)}
             {isSnapshot ? (
-              <DownloadLink
+              <DownloadTool
                 datasetId={dataset.linkID}
                 snapshotTag={dataset.snapshot_version}
               />
             ) : (
-              <DownloadLink datasetId={dataset.linkID} />
+              <DownloadTool datasetId={dataset.linkID} />
             )}
             {this._tools(tools)}
           </div>

--- a/packages/openneuro-app/src/scripts/sw.js
+++ b/packages/openneuro-app/src/scripts/sw.js
@@ -26,7 +26,7 @@ self.addEventListener('fetch', event => {
   // for non-GET requests.
   if (event.request.method === 'GET') {
     const url = new URL(event.request.url)
-    if (url.pathname.endsWith('download')) {
+    if (url.pathname.startsWith('/crn') && url.pathname.endsWith('download')) {
       // Catch any aggregate download requests
       return event.respondWith(bundleResponse(url))
     } else {

--- a/packages/openneuro-server/handlers/config.js
+++ b/packages/openneuro-server/handlers/config.js
@@ -74,6 +74,10 @@ const config = {
     enabled: process.env.ANALYSIS_ENABLED,
   },
 
+  github: process.env.DATALAD_GITHUB_ORG,
+
+  publicBucket: process.env.AWS_S3_PUBLIC_BUCKET,
+
   theme: {},
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -820,6 +820,18 @@
     lodash "^4.17.10"
     to-fast-properties "^2.0.0"
 
+"@emotion/is-prop-valid@^0.6.8":
+  version "0.6.8"
+  resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-0.6.8.tgz#68ad02831da41213a2089d2cab4e8ac8b30cbd85"
+  integrity sha512-IMSL7ekYhmFlILXcouA6ket3vV7u9BqStlXzbKOF9HBtpUPMMlHU+bBxrLOa2NvleVwNIxeq/zL8LafLbeUXcA==
+  dependencies:
+    "@emotion/memoize" "^0.6.6"
+
+"@emotion/memoize@^0.6.6":
+  version "0.6.6"
+  resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.6.6.tgz#004b98298d04c7ca3b4f50ca2035d4f60d2eed1b"
+  integrity sha512-h4t4jFjtm1YV7UirAFuSuFGyLa+NNxjdkq6DpFLANNQY5rHueFZHVY+8Cu1HYVP6DrheB0kv4m5xPjo7eKT7yQ==
+
 "@heroku-cli/color@^1.1.3":
   version "1.1.10"
   resolved "https://registry.yarnpkg.com/@heroku-cli/color/-/color-1.1.10.tgz#a9326b25da187fa64f28404f32c0708a37d7fbab"
@@ -2936,6 +2948,14 @@ babel-plugin-jest-hoist@^23.2.0:
   resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-23.2.0.tgz#e61fae05a1ca8801aadee57a6d66b8cefaf44167"
   integrity sha1-5h+uBaHKiAGq3uV6bWa4zvr0QWc=
 
+"babel-plugin-styled-components@>= 1":
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-styled-components/-/babel-plugin-styled-components-1.8.0.tgz#9dd054c8e86825203449a852a5746f29f2dab857"
+  integrity sha512-PcrdbXFO/9Plo9JURIj8G0Dsz+Ct8r+NvjoLh6qPt8Y/3EIAj1gHGW1ocPY1IkQbXZLBEZZSRBAxJem1KFdBXg==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.0.0"
+    lodash "^4.17.10"
+
 babel-plugin-syntax-dynamic-import@^6.18.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz#8d6a26229c83745a9982a441051572caa179b1da"
@@ -4762,6 +4782,11 @@ crypto-browserify@^3.11.0:
     randombytes "^2.0.0"
     randomfill "^1.0.3"
 
+css-color-keywords@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/css-color-keywords/-/css-color-keywords-1.0.0.tgz#fea2616dc676b2962686b3af8dbdbe180b244e05"
+  integrity sha1-/qJhbcZ2spYmhrOvjb2+GAskTgU=
+
 css-loader@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/css-loader/-/css-loader-1.0.0.tgz#9f46aaa5ca41dbe31860e3b62b8e23c42916bf56"
@@ -4798,6 +4823,15 @@ css-selector-tokenizer@^0.7.0:
     cssesc "^0.1.0"
     fastparse "^1.1.1"
     regexpu-core "^1.0.0"
+
+css-to-react-native@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/css-to-react-native/-/css-to-react-native-2.2.2.tgz#c077d0f7bf3e6c915a539e7325821c9dd01f9965"
+  integrity sha512-w99Fzop1FO8XKm0VpbQp3y5mnTnaS+rtCvS+ylSEOK76YXO5zoHQx/QMB1N54Cp+Ya9jB9922EHrh14ld4xmmw==
+  dependencies:
+    css-color-keywords "^1.0.0"
+    fbjs "^0.8.5"
+    postcss-value-parser "^3.3.0"
 
 css-what@2.1:
   version "2.1.0"
@@ -6458,7 +6492,7 @@ fbjs@^0.6.1:
     ua-parser-js "^0.7.9"
     whatwg-fetch "^0.9.0"
 
-fbjs@^0.8.15:
+fbjs@^0.8.15, fbjs@^0.8.5:
   version "0.8.17"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.17.tgz#c4d598ead6949112653d6588b01a5cdcd9f90fdd"
   integrity sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=
@@ -10078,6 +10112,11 @@ mem@^4.0.0:
     mimic-fn "^1.0.0"
     p-is-promise "^1.1.0"
 
+memoize-one@^4.0.0:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-4.0.2.tgz#3fb8db695aa14ab9c0f1644e1585a8806adc1aee"
+  integrity sha512-ucx2DmXTeZTsS4GPPUZCbULAN7kdPT1G+H49Y34JjbQ5ESc6OGhVxKvb1iKhr9v19ZB9OtnHwNnhUnNR/7Wteg==
+
 memoizee@~0.3.8:
   version "0.3.10"
   resolved "https://registry.yarnpkg.com/memoizee/-/memoizee-0.3.10.tgz#4eca0d8aed39ec9d017f4c5c2f2f6432f42e5c8f"
@@ -12404,7 +12443,7 @@ react-input-autosize@^2.1.2:
   dependencies:
     prop-types "^15.5.8"
 
-react-is@^16.3.2, react-is@^16.5.2:
+react-is@^16.3.1, react-is@^16.3.2, react-is@^16.5.2:
   version "16.5.2"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.5.2.tgz#e2a7b7c3f5d48062eb769fcb123505eb928722e3"
   integrity sha512-hSl7E6l25GTjNEZATqZIuWOgSnpXb3kD0DVCujmg46K5zLxsbiKaaT6VO9slkSBDPZfYs30lwfJwbOFOnoEnKQ==
@@ -14194,6 +14233,30 @@ style-loader@^0.23.1:
   dependencies:
     loader-utils "^1.1.0"
     schema-utils "^1.0.0"
+
+styled-components@^4.0.0:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-4.0.2.tgz#7d4409ada019cdd34c25ba68c4577ea95dbcf0c5"
+  integrity sha512-VTNCmBLNx0OS2GRaYk0yRAnQVDBCGnnxGkR6+BCmkKVv9VgICO7bEn3UDjlnwCw8hgIyecMzVLOPl+p1zqUxog==
+  dependencies:
+    "@emotion/is-prop-valid" "^0.6.8"
+    babel-plugin-styled-components ">= 1"
+    css-to-react-native "^2.2.2"
+    memoize-one "^4.0.0"
+    prop-types "^15.5.4"
+    react-is "^16.3.1"
+    stylis "^3.5.0"
+    stylis-rule-sheet "^0.0.10"
+
+stylis-rule-sheet@^0.0.10:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/stylis-rule-sheet/-/stylis-rule-sheet-0.0.10.tgz#44e64a2b076643f4b52e5ff71efc04d8c3c4a430"
+  integrity sha512-nTbZoaqoBnmK+ptANthb10ZRZOGC+EmTLLUxeYIuHNkEKcmKgXX1XWKkUBT2Ac4es3NybooPe0SmvKdhKJZAuw==
+
+stylis@^3.5.0:
+  version "3.5.3"
+  resolved "https://registry.yarnpkg.com/stylis/-/stylis-3.5.3.tgz#99fdc46afba6af4deff570825994181a5e6ce546"
+  integrity sha512-TxU0aAscJghF9I3V9q601xcK3Uw1JbXvpsBGj/HULqexKOKlOEzzlIpLFRbKkCK990ccuxfXUqmPbIIo7Fq/cQ==
 
 subscriptions-transport-ws@^0.9.11, subscriptions-transport-ws@^0.9.14, subscriptions-transport-ws@^0.9.9:
   version "0.9.15"


### PR DESCRIPTION
Fixes #908 

This is not integrated into the Reflux-less dataset page here since that's in another branch but this enables it for the current structure.