### PR TITLE
Fix the timestamp format for sitemap

### DIFF
--- a/packages/openneuro-server/handlers/sitemap.js
+++ b/packages/openneuro-server/handlers/sitemap.js
@@ -33,7 +33,9 @@ export const sitemapDynamicUrls = () =>
           url: {
             $concat: ['/datasets/', '$id', '/versions/', '$snapshots.tag'],
           },
-          lastmodISO: '$snapshots.created',
+          lastmodISO: {
+            $dateToString: { date: '$snapshots.created' },
+          },
           priority: 0.8,
           changefreq: 'daily', // To make sure new comments are indexed
         },


### PR DESCRIPTION
Sitemap expects an ISO8601 W3C profile date string and MongoDB returns a seconds since epoch value without conversion.

Fixes #970 