### PR TITLE
Remove extraneous callback from download button refactor

### DIFF
--- a/packages/openneuro-app/src/scripts/datalad/download/download-link.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/download/download-link.jsx
@@ -74,31 +74,24 @@ export const awaitRegistration = (next, environment) => registration =>
  * Event handler for initiating dataset or snapshot downloads
  * @param {string} datasetId Accession number string for a dataset
  */
-const downloadClick = (datasetId, snapshotTag) => callback => {
+const downloadClick = (datasetId, snapshotTag) => () => {
   // Check that a service worker is registered
   try {
     checkBrowserEnvironment(global)
   } catch (e) {
     global.alert(e.message)
-    return callback()
   }
   // Create a closure for download path, datasetId, and optional tag
   const next = () => {
     startDownload(downloadUri(datasetId, snapshotTag))
     trackDownload(datasetId, snapshotTag)
-    callback()
   }
   // Check for a running service worker
   global.navigator.serviceWorker
     .getRegistration()
     .then(awaitRegistration(next, global))
-    .then(() => {
-      // Download is going as expected
-      callback()
-    })
     .catch(err => {
       Raven.captureException(err)
-      callback()
     })
 }
 


### PR DESCRIPTION
This callback was left over from when this was part of the download toolbar. The current usage expects the inner function to accept zero arguments.

Fixes #972 