### PR TITLE
Resume upload in upload error toast

### DIFF
--- a/packages/openneuro-app/src/sass/crn_app/_elements-wrappers.scss
+++ b/packages/openneuro-app/src/sass/crn_app/_elements-wrappers.scss
@@ -647,6 +647,26 @@ h6 {
     }
 }
 
+// Toasts
+
+.Toastify__toast {
+    text-align: center;
+    background: $white;
+    color: $black;
+    padding: 1em;
+    .Toastify__close-button--error {
+        color: $black;
+    }
+}
+
+.Toastify__toast--warning {
+    border-top: 4px solid $warning;
+}
+
+.Toastify__toast--error {
+    border-top: 4px solid $danger;
+}
+
 //form ========================
 
 %form-field {

--- a/packages/openneuro-app/src/scripts/uploader/uploader.jsx
+++ b/packages/openneuro-app/src/scripts/uploader/uploader.jsx
@@ -293,9 +293,9 @@ export class UploadClient extends React.Component {
             <h3>Dataset upload failed</h3>
             <h4>Please check your connection</h4>
             <FileSelect
-              onChange={() => {
+              onChange={event => {
                 toast.dismiss(toastId)
-                this.resumeDataset(this.state.datasetId)()
+                this.resumeDataset(this.state.datasetId)(event)
               }}
               resume
             />

--- a/packages/openneuro-app/src/scripts/uploader/uploader.jsx
+++ b/packages/openneuro-app/src/scripts/uploader/uploader.jsx
@@ -4,6 +4,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { ApolloConsumer } from 'react-apollo'
 import UploaderContext from './uploader-context.js'
+import FileSelect from '../common/forms/file-select.jsx'
 import notifications from '../notification/notification.actions'
 import { locationFactory } from './uploader-location.js'
 import * as mutation from './upload-mutation.js'
@@ -187,7 +188,7 @@ export class UploadClient extends React.Component {
           toast.error(
             <span>
               <h3>Dataset creation failed</h3>
-              <p>Please check your connection</p>
+              <h4>Please check your connection</h4>
             </span>,
             { autoClose: false },
           )
@@ -287,10 +288,17 @@ export class UploadClient extends React.Component {
       })
       .catch(error => {
         Raven.captureException(error)
-        toast.error(
+        const toastId = toast.error(
           <span>
             <h3>Dataset upload failed</h3>
-            <p>Please check your connection</p>
+            <h4>Please check your connection</h4>
+            <FileSelect
+              onChange={() => {
+                toast.dismiss(toastId)
+                this.resumeDataset(this.state.datasetId)
+              }}
+              resume
+            />
           </span>,
           { autoClose: false },
         )

--- a/packages/openneuro-app/src/scripts/uploader/uploader.jsx
+++ b/packages/openneuro-app/src/scripts/uploader/uploader.jsx
@@ -295,7 +295,7 @@ export class UploadClient extends React.Component {
             <FileSelect
               onChange={() => {
                 toast.dismiss(toastId)
-                this.resumeDataset(this.state.datasetId)
+                this.resumeDataset(this.state.datasetId)()
               }}
               resume
             />


### PR DESCRIPTION
This adds a resume upload button to the interrupted upload error. This takes you back into the upload workflow for the dataset upload which triggered the error. Toasts are now styled to match site styles better as well.

![image](https://user-images.githubusercontent.com/11369795/47452092-35026280-d77e-11e8-9618-2f1c4e6fe5f4.png)
