### PR TITLE
Add maintenance page example to nginx.conf

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -42,6 +42,11 @@ server {
     gzip_proxied any;
     gzip_types text/html application/json text/css;
 
+    # Uncomment to enable the maintenance page for all requests
+    #location ~ ^/ {
+    #    try_files /maintenance.html =404;
+    #}
+
     # Return a well formed robots.txt
     location /robots.txt {return 200 "User-agent: *\nAllow: /\n";}
 


### PR DESCRIPTION
This rule will block any requests to backend services while it is enabled.