### PR TITLE
RF: Remove "Advanced Methods" decoration around cmdline and datalad download types

### DIFF
--- a/packages/openneuro-app/src/scripts/datalad/download/download-dataset.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/download/download-dataset.jsx
@@ -35,19 +35,17 @@ const DownloadDataset = ({
         <DownloadS3 datasetId={datasetId} />
       </PaddedDiv>
     </div>
-    <ExtraPaddedDiv className="col-xs-12">
-      <Panel header="Advanced Methods" collapsible>
-        <PaddedDiv className="col-xs-6">
-          <DownloadCommandLine
-            datasetId={datasetId}
-            snapshotTag={snapshotTag}
-          />
-        </PaddedDiv>
-        <PaddedDiv className="col-xs-6">
-          <DownloadDatalad datasetId={datasetId} />
-        </PaddedDiv>
-      </Panel>
-    </ExtraPaddedDiv>
+    <Panel header="Advanced Methods" collapsible>
+      <PaddedDiv className="col-xs-7">
+        <DownloadCommandLine
+          datasetId={datasetId}
+          snapshotTag={snapshotTag}
+        />
+      </PaddedDiv>
+      <PaddedDiv className="col-xs-7">
+        <DownloadDatalad datasetId={datasetId} />
+      </PaddedDiv>
+    </Panel>
   </div>
 )
 


### PR DESCRIPTION
- Generally that section is collapsed and makes those methods not visible
  to a regular user, so unlikely they would be interested to go "advanced route"
  and thus would not please greedy me to try to DataLad

- "Your advanced is my basic" or "Your basic is my crippled"
  aws cmdline is more advanced to me than DataLad invocation.
  All options besides "Download" button could be considered "Advanced",
  and "Download" button could be considered a "Crippled" way

So why discriminate? ;-)