### PR TITLE
Log download button click to Google analytics

### DIFF
--- a/packages/openneuro-app/src/scripts/datalad/download/download-link.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/download/download-link.jsx
@@ -7,15 +7,15 @@ import config from '../../../../config.js'
 import datalad from '../../utils/datalad'
 
 const startDownload = uri => {
-  ReactGA.event({
-    category: 'Download',
-    action: 'Started web download',
-    label: `${uri}`,
-  })
   global.location.assign(uri)
 }
 
 const trackDownload = (datasetId, snapshotTag) => {
+  ReactGA.event({
+    category: 'Download',
+    action: 'Started web download',
+    label: snapshotTag ? `${datasetId}:${snapshotTag}` : datasetId,
+  })
   datalad.trackAnalytics(datasetId, {
     snapshot: true,
     tag: snapshotTag,

--- a/packages/openneuro-app/src/scripts/datalad/download/download-link.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/download/download-link.jsx
@@ -2,10 +2,16 @@
 import Raven from 'raven-js'
 import React from 'react'
 import PropTypes from 'prop-types'
+import ReactGA from 'react-ga'
 import config from '../../../../config.js'
 import datalad from '../../utils/datalad'
 
 const startDownload = uri => {
+  ReactGA.event({
+    category: 'Download',
+    action: 'Started web download',
+    label: `${uri}`,
+  })
   global.location.assign(uri)
 }
 


### PR DESCRIPTION
Label is set to the URI for the draft or snapshot. This should already be tracked by the page tracking but just to make sure it's logged with the download event as well.

Tested this with Google analytics blocked/unblocked to make sure it doesn't interrupt downloads for anyone who blocks requests to GA.