### PR TITLE
Reduce subscription spam

### DIFF
--- a/packages/openneuro-app/src/scripts/dashboard/dashboard.datasets.jsx
+++ b/packages/openneuro-app/src/scripts/dashboard/dashboard.datasets.jsx
@@ -48,7 +48,7 @@ class Datasets extends Reflux.Component {
     Actions.update({ isPublic, isAdmin })
     Actions.getDatasets(isPublic, isAdmin)
     this._subscribeToNewDatasets(isPublic, isAdmin)
-    this._subscribeToDeletedDatasets(isPublic, isAdmin)
+    this._subscribeToDeletedDatasets()
   }
 
   componentWillReceiveProps() {
@@ -75,7 +75,7 @@ class Datasets extends Reflux.Component {
     })
   }
 
-  _subscribeToDeletedDatasets(isPublic, isAdmin) {
+  _subscribeToDeletedDatasets() {
     this.props.datasetsQuery.subscribeToMore({
       document: gql`
         subscription onDatasetDeleted {

--- a/packages/openneuro-app/src/scripts/dataset/dataset.dataset-loader.jsx
+++ b/packages/openneuro-app/src/scripts/dataset/dataset.dataset-loader.jsx
@@ -31,10 +31,15 @@ class DatasetLoader extends Reflux.Component {
   _subscribeToFileUpdates(props) {
     props.getDataset.subscribeToMore({
       document: gql`
-        subscription {
-          draftFilesUpdated
+        subscription onDraftFilesUpdated($datasetId: ID!) {
+          draftFilesUpdated(datasetId: $datasetId) {
+            id
+          }
         }
       `,
+      variables: {
+        datasetId: props.match.params.datasetId,
+      },
       updateQuery: () => {
         props.getDataset.refetch().then(() => {
           this._loadData(props, true)
@@ -46,10 +51,15 @@ class DatasetLoader extends Reflux.Component {
   _subscribeToPermissionsUpdates(props) {
     props.getDataset.subscribeToMore({
       document: gql`
-        subscription {
-          permissionsUpdated
+        subscription onPermissionsUpdated($datasetId: ID!) {
+          permissionsUpdated(datasetId: $datasetId) {
+            datasetId
+          }
         }
       `,
+      variables: {
+        datasetId: props.match.params.datasetId,
+      },
       updateQuery: () => {
         props.getDataset.refetch().then(() => {
           this._loadData(props, true)
@@ -61,10 +71,15 @@ class DatasetLoader extends Reflux.Component {
   _subscribeToSnapshotCreation(props) {
     props.getDataset.subscribeToMore({
       document: gql`
-        subscription {
-          snapshotAdded
+        subscription onSnapshotAdded($datasetId: ID!) {
+          snapshotAdded(datasetId: $datasetId) {
+            id
+          }
         }
       `,
+      variables: {
+        datasetId: props.match.params.datasetId,
+      },
       updateQuery: () => {
         props.getDataset.refetch().then(() => {
           this._loadData(props, true)
@@ -76,10 +91,13 @@ class DatasetLoader extends Reflux.Component {
   _subscribeToSnapshotDeletion(props) {
     props.getDataset.subscribeToMore({
       document: gql`
-        subscription {
-          snapshotDeleted
+        subscription onSnapshotDeleted($datasetId: ID!) {
+          snapshotDeleted(datasetId: $datasetId)
         }
       `,
+      variables: {
+        datasetId: props.match.params.datasetId,
+      },
       updateQuery: () => {
         props.getDataset.refetch().then(() => {
           props.history.push(

--- a/packages/openneuro-server/datalad/snapshots.js
+++ b/packages/openneuro-server/datalad/snapshots.js
@@ -95,7 +95,7 @@ export const createSnapshot = async (datasetId, tag, user) => {
             if (body.files) {
               notifications.snapshotCreated(datasetId, body, user) // send snapshot notification to subscribers
             }
-            pubsub.publish('snapshotAdded', { id: datasetId })
+            pubsub.publish('snapshotAdded', { datasetId })
             return body
           })
       )
@@ -122,7 +122,7 @@ export const deleteSnapshot = (datasetId, tag) => {
       .del(indexKey)
       .then(() => redis.del(sKey))
       .then(() => {
-        pubsub.publish('snapshotDeleted', { id: datasetId })
+        pubsub.publish('snapshotDeleted', { datasetId })
         return body
       }),
   )

--- a/packages/openneuro-server/graphql/resolvers/dataset.js
+++ b/packages/openneuro-server/graphql/resolvers/dataset.js
@@ -58,7 +58,7 @@ export const updateFiles = (
       .then(() =>
         datalad
           .commitFiles(datasetId, userInfo)
-          .then(() => pubsub.publish('draftFilesUpdated', { id: datasetId })),
+          .then(() => pubsub.publish('draftFilesUpdated', { datasetId })),
       )
       .then(() => ({
         id: new Date(),
@@ -98,7 +98,7 @@ export const deleteFiles = (
       .then(() =>
         datalad
           .commitFiles(datasetId, userInfo)
-          .then(() => pubsub.publish('draftFilesUpdated', { id: datasetId })),
+          .then(() => pubsub.publish('draftFilesUpdated', { datasetId })),
       )
       .then(() => ({
         id: new Date(),

--- a/packages/openneuro-server/graphql/resolvers/permissions.js
+++ b/packages/openneuro-server/graphql/resolvers/permissions.js
@@ -34,7 +34,7 @@ export const updatePermissions = async (obj, args) => {
     })
   })
   return Promise.all(userPromises).then(() => {
-    return pubsub.publish('permissionsUpdated')
+    return pubsub.publish('permissionsUpdated', { datasetId: args.datasetId })
   })
 }
 
@@ -48,6 +48,6 @@ export const removePermissions = (obj, args) => {
       userId: args.userId,
     })
     .then(() => {
-      return pubsub.publish('permissionsUpdated')
+      return pubsub.publish('permissionsUpdated', { datasetId: args.datasetId })
     })
 }

--- a/packages/openneuro-server/graphql/resolvers/subscriptions.js
+++ b/packages/openneuro-server/graphql/resolvers/subscriptions.js
@@ -1,4 +1,14 @@
 import pubsub from '../pubsub.js'
+import { withFilter } from 'graphql-subscriptions'
+
+/**
+ * Filter subscription to a specific dataset
+ * @param {object} payload
+ * @param {object} variables
+ * @returns {boolean}
+ */
+const filterDatasetId = (payload, variables) =>
+  payload.datasetId === variables.datasetId
 
 export const datasetCreated = {
   subscribe: () => pubsub.asyncIterator('datasetCreated'),
@@ -9,23 +19,38 @@ export const datasetDeleted = {
 }
 
 export const snapshotAdded = {
-  subscribe: () => pubsub.asyncIterator('snapshotAdded'),
+  subscribe: withFilter(
+    () => pubsub.asyncIterator('snapshotAdded'),
+    filterDatasetId,
+  ),
 }
 
 export const snapshotDeleted = {
-  subscribe: () => pubsub.asyncIterator('snapshotDeleted'),
+  subscribe: withFilter(
+    () => pubsub.asyncIterator('snapshotDeleted'),
+    filterDatasetId,
+  ),
 }
 
 export const datasetValidationUpdated = {
-  subscribe: () => pubsub.asyncIterator('datasetValidationUpdated'),
+  subscribe: withFilter(
+    () => pubsub.asyncIterator('datasetValidationUpdated'),
+    filterDatasetId,
+  ),
 }
 
 export const draftFilesUpdated = {
-  subscribe: () => pubsub.asyncIterator('draftFilesUpdated'),
+  subscribe: withFilter(
+    () => pubsub.asyncIterator('draftFilesUpdated'),
+    filterDatasetId,
+  ),
 }
 
 export const permissionsUpdated = {
-  subscribe: () => pubsub.asyncIterator('permissionsUpdated'),
+  subscribe: withFilter(
+    () => pubsub.asyncIterator('permissionsUpdated'),
+    filterDatasetId,
+  ),
 }
 
 const Subscription = {

--- a/packages/openneuro-server/graphql/resolvers/subscriptions.js
+++ b/packages/openneuro-server/graphql/resolvers/subscriptions.js
@@ -1,5 +1,9 @@
 import pubsub from '../pubsub.js'
 
+export const datasetCreated = {
+  subscribe: () => pubsub.asyncIterator('datasetCreated'),
+}
+
 export const datasetDeleted = {
   subscribe: () => pubsub.asyncIterator('datasetDeleted'),
 }
@@ -25,6 +29,7 @@ export const permissionsUpdated = {
 }
 
 const Subscription = {
+  datasetCreated,
   datasetDeleted,
   datasetValidationUpdated,
   draftFilesUpdated,

--- a/packages/openneuro-server/graphql/resolvers/validation.js
+++ b/packages/openneuro-server/graphql/resolvers/validation.js
@@ -17,7 +17,10 @@ export const updateValidation = (obj, args) => {
       },
     )
     .then(() => {
-      pubsub.publish('datasetValidationUpdated', {})
+      pubsub.publish('datasetValidationUpdated', {
+        id: args.validation.id,
+        datasetId: args.validation.datasetId,
+      })
       return true
     })
 }

--- a/packages/openneuro-server/graphql/schema.js
+++ b/packages/openneuro-server/graphql/schema.js
@@ -57,13 +57,13 @@ const typeDefs = `
   }
 
   type Subscription {
-    # Publishes when the set of datasets changes
+    datasetCreated: Dataset
     datasetDeleted: ID
-    snapshotAdded: ID
-    snapshotDeleted: ID
-    datasetValidationUpdated: ID
-    draftFilesUpdated: ID
-    permissionsUpdated: ID
+    snapshotAdded(datasetId: ID!): Snapshot
+    snapshotDeleted(datasetId: ID!): ID
+    datasetValidationUpdated(datasetId: ID!, hash: String!): [ValidationIssue]
+    draftFilesUpdated(datasetId: ID!): [DatasetFile]
+    permissionsUpdated(datasetId: ID!): [Permission]
   }
 
   input SummaryInput {


### PR DESCRIPTION
This narrows subscriptions to datasets users have actively open, removes one extra subscription to any dataset changes, and avoids an update query entirely for dataset deletion (though this does not update in the Reflux side of things).

There's a lot more fixes here but they depend on #905 - it's not possible to do optimistic updates without first removing the Reflux stores, so this is about all we can do to reduce the load generated until that's complete.

Fixes #919 and depends on changes in #1000 - so that will need to be merged first.