### PR TITLE
Add analytics events for upload states

### DIFF
--- a/packages/openneuro-app/src/scripts/uploader/uploader-setup-routes.jsx
+++ b/packages/openneuro-app/src/scripts/uploader/uploader-setup-routes.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { Route, Switch } from 'react-router-dom'
+import analyticsWrapper from '../utils/analytics.js'
 import UploaderModal from './uploader-modal.jsx'
 import UploadStep from './upload-step.jsx'
 import UploadSelect from './upload-select.jsx'
@@ -18,25 +19,25 @@ const UploaderSetupRoutes = props => (
             name="upload-select"
             path="/upload"
             exact
-            component={UploadSelect}
+            component={analyticsWrapper(UploadSelect)}
           />
           <Route
             name="upload-rename"
             path="/upload/rename"
             exact
-            component={UploadRename}
+            component={analyticsWrapper(UploadRename)}
           />
           <Route
             name="upload-issues"
             path="/upload/issues"
             exact
-            component={UploadIssues}
+            component={analyticsWrapper(UploadIssues)}
           />
           <Route
             name="upload-disclaimer"
             path="/upload/disclaimer"
             exact
-            component={UploadDisclaimer}
+            component={analyticsWrapper(UploadDisclaimer)}
           />
         </Switch>
       </div>

--- a/packages/openneuro-app/src/scripts/uploader/uploader-status-routes.jsx
+++ b/packages/openneuro-app/src/scripts/uploader/uploader-status-routes.jsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import analyticsWrapper from '../utils/analytics.js'
 import { Route, Switch } from 'react-router-dom'
 import UploaderModal from './uploader-modal.jsx'
 import UploadStatus from './upload-status.jsx'
@@ -13,7 +14,7 @@ const UploaderStatusRoutes = props => (
             name="upload-status"
             path="/upload"
             exact
-            component={UploadStatus}
+            component={analyticsWrapper(UploadStatus)}
           />
         </Switch>
       </div>

--- a/packages/openneuro-app/src/scripts/uploader/uploader.jsx
+++ b/packages/openneuro-app/src/scripts/uploader/uploader.jsx
@@ -3,6 +3,7 @@ import { toast } from 'react-toastify'
 import React from 'react'
 import PropTypes from 'prop-types'
 import { ApolloConsumer } from 'react-apollo'
+import ReactGA from 'react-ga'
 import UploaderContext from './uploader-context.js'
 import FileSelect from '../common/forms/file-select.jsx'
 import notifications from '../notification/notification.actions'
@@ -168,6 +169,12 @@ export class UploadClient extends React.Component {
   }
 
   upload() {
+    // Track the start of uploads
+    ReactGA.event({
+      category: 'Upload',
+      action: 'Started web upload',
+      label: this.state.datasetId,
+    })
     this.setState({
       uploading: true,
       location: locationFactory('/hidden'),
@@ -318,6 +325,12 @@ export class UploadClient extends React.Component {
   }
 
   uploadCompleteAction() {
+    // Record upload finished successfully with Google Analytics
+    ReactGA.event({
+      category: 'Upload',
+      action: 'Finished web upload',
+      label: this.state.datasetId,
+    })
     const datasetURL = `/datasets/${this.state.datasetId}`
     if (this.state.location.pathname !== locationFactory('/hidden').pathname) {
       this.props.history.push(datasetURL)


### PR DESCRIPTION
This adds Google Analytics to the uploader routes and tracks two events, "Started web upload" and "Finished web upload" in the "Upload" category.

Fixes #999 