### PR TITLE
Avoid an extra rerender for Uploader due to analytics change

### DIFF
--- a/packages/openneuro-app/src/scripts/uploader/__tests__/uploader.spec.js
+++ b/packages/openneuro-app/src/scripts/uploader/__tests__/uploader.spec.js
@@ -2,6 +2,8 @@ import React from 'react'
 import { shallow } from 'enzyme'
 import { UploadClient } from '../uploader.jsx'
 
+jest.mock('react-ga')
+
 // Stub constructor for File-like objects with webkitRelativePath
 const TestFile = (body, name, webkitRelativePath) => {
   const file = new Blob(body)

--- a/packages/openneuro-app/src/scripts/uploader/uploader-setup-routes.jsx
+++ b/packages/openneuro-app/src/scripts/uploader/uploader-setup-routes.jsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { Route, Switch } from 'react-router-dom'
-import analyticsWrapper from '../utils/analytics.js'
 import UploaderModal from './uploader-modal.jsx'
 import UploadStep from './upload-step.jsx'
 import UploadSelect from './upload-select.jsx'
@@ -19,25 +18,25 @@ const UploaderSetupRoutes = props => (
             name="upload-select"
             path="/upload"
             exact
-            component={analyticsWrapper(UploadSelect)}
+            component={UploadSelect}
           />
           <Route
             name="upload-rename"
             path="/upload/rename"
             exact
-            component={analyticsWrapper(UploadRename)}
+            component={UploadRename}
           />
           <Route
             name="upload-issues"
             path="/upload/issues"
             exact
-            component={analyticsWrapper(UploadIssues)}
+            component={UploadIssues}
           />
           <Route
             name="upload-disclaimer"
             path="/upload/disclaimer"
             exact
-            component={analyticsWrapper(UploadDisclaimer)}
+            component={UploadDisclaimer}
           />
         </Switch>
       </div>

--- a/packages/openneuro-app/src/scripts/uploader/uploader-status-routes.jsx
+++ b/packages/openneuro-app/src/scripts/uploader/uploader-status-routes.jsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import analyticsWrapper from '../utils/analytics.js'
 import { Route, Switch } from 'react-router-dom'
 import UploaderModal from './uploader-modal.jsx'
 import UploadStatus from './upload-status.jsx'
@@ -14,7 +13,7 @@ const UploaderStatusRoutes = props => (
             name="upload-status"
             path="/upload"
             exact
-            component={analyticsWrapper(UploadStatus)}
+            component={UploadStatus}
           />
         </Switch>
       </div>

--- a/packages/openneuro-app/src/scripts/uploader/uploader.jsx
+++ b/packages/openneuro-app/src/scripts/uploader/uploader.jsx
@@ -75,6 +75,7 @@ export class UploadClient extends React.Component {
    * @param {string} path Virtual router path for upload modal
    */
   setLocation(path) {
+    ReactGA.pageview(path)
     this.setState({ location: locationFactory(path) })
   }
 
@@ -120,8 +121,8 @@ export class UploadClient extends React.Component {
             resume: true,
             files: filesToUpload,
             selectedFiles: files,
-            location: locationFactory('/upload/issues'),
           })
+          this.setLocation('/upload/issues')
         })
     }
   }
@@ -159,9 +160,9 @@ export class UploadClient extends React.Component {
         this.setState({
           files,
           selectedFiles: files,
-          location: locationFactory('/upload/rename'),
           name,
         })
+        this.setLocation('/upload/rename')
       } else {
         throw new Error('No files selected')
       }
@@ -177,8 +178,8 @@ export class UploadClient extends React.Component {
     })
     this.setState({
       uploading: true,
-      location: locationFactory('/hidden'),
     })
+    this.setLocation('/hidden')
     if (this.state.resume && this.state.datasetId) {
       // Just add files since this is an existing dataset
       this._addFiles()
@@ -202,8 +203,8 @@ export class UploadClient extends React.Component {
           this.setState({
             error,
             uploading: false,
-            location: locationFactory('/hidden'),
           })
+          this.setLocation('/hidden')
         })
     }
   }
@@ -312,8 +313,8 @@ export class UploadClient extends React.Component {
         this.setState({
           error,
           uploading: false,
-          location: locationFactory('/hidden'),
         })
+        this.setLocation('/hidden')
         if (this.state.xhr) {
           try {
             this.state.xhr.abort()


### PR DESCRIPTION
Replaces the analytics HOC with a setLocation method that avoids extra re-rendering of input components.

Fixes #1004 