### PR TITLE
Remove unused ports from docker dev configuration

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -82,5 +82,3 @@ services:
       - ./nginx/nginx.dev.conf:/etc/nginx/conf.d/default.conf:ro
     ports:
       - "9876:80"
-      - "8110:8110"
-      - "8443:443"


### PR DESCRIPTION
Saves binding some ports only used by the old backend.