### PR TITLE
Add Sentry release metadata on every release build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,6 +107,22 @@ jobs:
               docker push "openneuro/server:${CIRCLE_TAG}"
             fi
 
+  sentry-release:
+    working_directory: ~/OpenNeuroOrg/openneuro
+    docker:
+      - image: circleci/node:8.11-jessie-browsers
+    steps:
+      - checkout
+      - run:
+          name: Install sentry-cli
+          command: yarn add -D sentry-cli
+      - run:
+          name: Create sentry release
+          command: yarn sentry-cli releases new -p openneuro $(jq -r .version lerna.json)
+      - run:
+          name: Associate releases with commits
+          command: yarn sentry-cli releases set-commits --auto $(jq -r .version lerna.json)
+
 workflows:
   version: 2
   build-and-deploy:
@@ -133,3 +149,12 @@ workflows:
           filters:
             tags:
               only: /^v.*/
+      - sentry-release:
+          requires:
+            - server-build
+            - app-build
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/

--- a/packages/openneuro-app/src/scripts/common/partials/__tests__/__snapshots__/footer.spec.jsx.snap
+++ b/packages/openneuro-app/src/scripts/common/partials/__tests__/__snapshots__/footer.spec.jsx.snap
@@ -31,7 +31,7 @@ exports[`common/partials/footer renders successfully 1`] = `
       >
         <span>
           © 
-          2018
+          2019
            
           squirrels
         </span>


### PR DESCRIPTION
This will make it easier to track issues associated with commits.