### PR TITLE
Fix race when loading additional dashboard pages

### DIFF
--- a/packages/openneuro-app/src/scripts/datalad/dashboard/datasets/dataset-query.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/dashboard/datasets/dataset-query.jsx
@@ -98,14 +98,13 @@ export const updateQuery = (previousResult, { fetchMoreResult }) => {
  * @param {string} data Next data cursor
  * @param {function} fetchMore Apollo fetchMore function from the original query
  */
-const loadMoreRows = (data, fetchMore) => () => {
+const loadMoreRows = (data, fetchMore) => () =>
   fetchMore({
     variables: {
       cursor: data.datasets.pageInfo.endCursor,
     },
     updateQuery,
   })
-}
 
 const datasetQueryDisplay = isPublic => ({
   loading,


### PR DESCRIPTION
Fixes #1027 by avoiding overlapping ranges getting loaded when more than one additional page is loading.