### PR TITLE
Ensure only unique results are merged in fast scrolling dashboard loads

### DIFF
--- a/packages/openneuro-app/src/scripts/datalad/dashboard/datasets/__tests__/dataset-query.spec.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/dashboard/datasets/__tests__/dataset-query.spec.jsx
@@ -6,18 +6,47 @@ describe('dashboard/datasets/DatasetQuery', () => {
       // This led to an error on the id property but __typename just needs to be included
       expect(
         updateQuery(
-          { datasets: { __typename: 'testType', edges: [1, 2] } },
-          { fetchMoreResult: { datasets: { edges: [3, 4], pageInfo: {} } } },
+          {
+            datasets: {
+              __typename: 'testType',
+              edges: [{ node: { id: 1 } }, { node: { id: 2 } }],
+            },
+          },
+          {
+            fetchMoreResult: {
+              datasets: {
+                edges: [{ node: { id: 3 } }, { node: { id: 4 } }],
+                pageInfo: {},
+              },
+            },
+          },
         ),
       ).toHaveProperty('datasets.__typename')
     })
     it('merges datasets from previousResult with fetchMoreResult', () => {
       expect(
         updateQuery(
-          { datasets: { __typename: 'testType', edges: [1, 2] } },
-          { fetchMoreResult: { datasets: { edges: [3, 4], pageInfo: {} } } },
+          {
+            datasets: {
+              __typename: 'testType',
+              edges: [{ node: { id: 1 } }, { node: { id: 2 } }],
+            },
+          },
+          {
+            fetchMoreResult: {
+              datasets: {
+                edges: [{ node: { id: 3 } }, { node: { id: 4 } }],
+                pageInfo: {},
+              },
+            },
+          },
         ).datasets.edges,
-      ).toEqual([1, 2, 3, 4])
+      ).toEqual([
+        { node: { id: 1 } },
+        { node: { id: 2 } },
+        { node: { id: 3 } },
+        { node: { id: 4 } },
+      ])
     })
   })
 })

--- a/packages/openneuro-app/src/scripts/datalad/dashboard/datasets/__tests__/dataset-query.spec.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/dashboard/datasets/__tests__/dataset-query.spec.jsx
@@ -48,5 +48,25 @@ describe('dashboard/datasets/DatasetQuery', () => {
         { node: { id: 4 } },
       ])
     })
+    it('does not produce duplicate ids after merge', () => {
+      expect(
+        updateQuery(
+          {
+            datasets: {
+              __typename: 'testType',
+              edges: [{ node: { id: 1 } }, { node: { id: 3 } }],
+            },
+          },
+          {
+            fetchMoreResult: {
+              datasets: {
+                edges: [{ node: { id: 3 } }, { node: { id: 4 } }],
+                pageInfo: {},
+              },
+            },
+          },
+        ).datasets.edges,
+      ).toEqual([{ node: { id: 1 } }, { node: { id: 3 } }, { node: { id: 4 } }])
+    })
   })
 })

--- a/packages/openneuro-app/src/scripts/datalad/dashboard/datasets/dataset-query.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/dashboard/datasets/dataset-query.jsx
@@ -87,7 +87,13 @@ export const updateQuery = (previousResult, { fetchMoreResult }) => {
   return {
     datasets: {
       __typename: previousResult.datasets.__typename,
-      edges: [...previousResult.datasets.edges, ...newEdges],
+      edges: [
+        ...previousResult.datasets.edges,
+        ...newEdges.filter(
+          n =>
+            !previousResult.datasets.edges.some(e => e.node.id === n.node.id),
+        ),
+      ],
       pageInfo,
     },
   }

--- a/packages/openneuro-app/src/scripts/dataset/dataset.content.jsx
+++ b/packages/openneuro-app/src/scripts/dataset/dataset.content.jsx
@@ -2,9 +2,8 @@
 
 import React from 'react'
 import PropTypes from 'prop-types'
-import { Link } from 'react-router-dom'
 import Reflux from 'reflux'
-import { Redirect, withRouter } from 'react-router-dom'
+import { Link, Redirect, withRouter } from 'react-router-dom'
 import { ProgressBar } from 'react-bootstrap'
 import Spinner from '../common/partials/spinner.jsx'
 import Timeout from '../common/partials/timeout.jsx'


### PR DESCRIPTION
This is needed to prevent multiple scroll events from loading duplicate rows if they request overlapping ranges. Fixes #1027 