### PR TITLE
Link to snapshots directly from public dashboard

### DIFF
--- a/packages/openneuro-app/src/scripts/datalad/dashboard/datasets/__tests__/__snapshots__/dataset-row.spec.jsx.snap
+++ b/packages/openneuro-app/src/scripts/datalad/dashboard/datasets/__tests__/__snapshots__/dataset-row.spec.jsx.snap
@@ -33,6 +33,7 @@ exports[`dashboard/datasets/DatasetRow renders successfully 1`] = `
                 },
               },
               "id": "ds000001",
+              "snapshots": Array [],
             }
           }
           fromDashboard={true}
@@ -50,6 +51,7 @@ exports[`dashboard/datasets/DatasetRow renders successfully 1`] = `
                 },
               },
               "id": "ds000001",
+              "snapshots": Array [],
             }
           }
           minimal={true}

--- a/packages/openneuro-app/src/scripts/datalad/dashboard/datasets/__tests__/dataset-row.spec.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/dashboard/datasets/__tests__/dataset-row.spec.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { shallow } from 'enzyme'
-import DatasetRow from '../dataset-row.jsx'
+import DatasetRow, { genLinkTarget } from '../dataset-row.jsx'
 
 const dataset = {
   id: 'ds000001',
@@ -9,10 +9,45 @@ const dataset = {
       Name: 'test dataset',
     },
   },
+  snapshots: [],
 }
 
 describe('dashboard/datasets/DatasetRow', () => {
   it('renders successfully', () => {
     expect(shallow(<DatasetRow dataset={dataset} />)).toMatchSnapshot()
+  })
+  describe('getLinkTarget', () => {
+    it('creates a draft link for datasets with no snapshots', () => {
+      const mockDataset = {
+        id: 'ds000001',
+        snapshots: [],
+      }
+      expect(genLinkTarget(mockDataset, true)).toBe('/datasets/ds000001')
+    })
+    it('creates a snapshot link for datasets with snapshots', () => {
+      const mockDataset = {
+        id: 'ds000001',
+        snapshots: [
+          {
+            id: 'ds000001:1.0.0',
+            created: new Date('2019-01-16T02:50:02.086Z'),
+            tag: '1.0.0',
+          },
+          {
+            id: 'ds000001:2.0.0',
+            created: new Date('2019-01-16T02:51:09.420Z'),
+            tag: '2.0.0',
+          },
+          {
+            id: 'ds000001:1.0.1',
+            created: new Date('2019-01-16T02:50:05.086Z'),
+            tag: '1.0.1',
+          },
+        ],
+      }
+      expect(genLinkTarget(mockDataset, true)).toBe(
+        '/datasets/ds000001/versions/2.0.0',
+      )
+    })
   })
 })

--- a/packages/openneuro-app/src/scripts/datalad/dashboard/datasets/dataset-query.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/dashboard/datasets/dataset-query.jsx
@@ -68,6 +68,11 @@ const getDatasets = gql`
             userId
             datasetId
           }
+          snapshots {
+            id
+            created
+            tag
+          }
         }
       }
       pageInfo {

--- a/packages/openneuro-app/src/scripts/datalad/dashboard/datasets/dataset-row.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/dashboard/datasets/dataset-row.jsx
@@ -7,6 +7,19 @@ import Summary from '../../fragments/dataset-summary.jsx'
 import { Link } from 'react-router-dom'
 import RowHeight from './row-height.jsx'
 
+export const genLinkTarget = (dataset, publicDashboard) => {
+  let linkTarget = '/datasets/' + dataset.id
+  if (dataset.snapshots.length > 0 && publicDashboard) {
+    const sortedSnapshots = [...dataset.snapshots].sort((a, b) => {
+      return new Date(b.created) - new Date(a.created)
+    })
+    const newestSnapshot = sortedSnapshots[0]
+    return `${linkTarget}/versions/${newestSnapshot.tag}`
+  } else {
+    return linkTarget
+  }
+}
+
 class DatasetRow extends React.Component {
   shouldComponentUpdate(nextProps) {
     return this.props.dataset.id !== nextProps.dataset.id
@@ -17,7 +30,7 @@ class DatasetRow extends React.Component {
       <div className="panel panel-default">
         <RowHeight className="panel-heading">
           <div className="header clearfix">
-            <Link to={'/datasets/' + dataset.id}>
+            <Link to={genLinkTarget(dataset, this.props.publicDashboard)}>
               <h4 className="dataset-name">{dataset.draft.description.Name}</h4>
               <Uploaded uploader={dataset.uploader} created={dataset.created} />
             </Link>
@@ -37,6 +50,7 @@ class DatasetRow extends React.Component {
 
 DatasetRow.propTypes = {
   dataset: PropTypes.object,
+  publicDashboard: PropTypes.bool,
 }
 
 export default DatasetRow

--- a/packages/openneuro-app/src/scripts/datalad/dashboard/datasets/dataset-tab.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/dashboard/datasets/dataset-tab.jsx
@@ -17,7 +17,7 @@ const FullHeightFlexDiv = styled.div`
 
 const title = isPublic => (isPublic ? 'Public Datasets' : 'My Datasets')
 
-const DatasetTabLoaded = ({ data, loadMoreRows }) => {
+const DatasetTabLoaded = ({ data, loadMoreRows, publicDashboard }) => {
   if (
     data &&
     data.datasets &&
@@ -29,6 +29,7 @@ const DatasetTabLoaded = ({ data, loadMoreRows }) => {
         datasets={data.datasets.edges}
         pageInfo={data.datasets.pageInfo}
         loadMoreRows={loadMoreRows}
+        publicDashboard={publicDashboard}
       />
     )
   } else {
@@ -82,7 +83,11 @@ const DatasetTab = ({
     {loading ? (
       <Spinner text="Loading Datasets" active />
     ) : (
-      <DatasetTabLoaded data={data} loadMoreRows={loadMoreRows} />
+      <DatasetTabLoaded
+        data={data}
+        loadMoreRows={loadMoreRows}
+        publicDashboard={publicDashboard}
+      />
     )}
   </FullHeightFlexDiv>
 )

--- a/packages/openneuro-app/src/scripts/datalad/dashboard/datasets/dataset-virtual-scroller.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/dashboard/datasets/dataset-virtual-scroller.jsx
@@ -31,7 +31,10 @@ class DatasetVirtualScroller extends React.Component {
     if (this._isRowLoaded({ index })) {
       return (
         <div key={key} style={style}>
-          <DatasetRow dataset={this.props.datasets[index].node} />
+          <DatasetRow
+            dataset={this.props.datasets[index].node}
+            publicDashboard={this.props.publicDashboard}
+          />
         </div>
       )
     } else {
@@ -110,6 +113,7 @@ DatasetVirtualScroller.propTypes = {
   datasets: PropTypes.array,
   pageInfo: PropTypes.object,
   loadMoreRows: PropTypes.func,
+  publicDashboard: PropTypes.bool,
 }
 
 export default DatasetVirtualScroller


### PR DESCRIPTION
This changes the dashboard links to point directly at the most recent snapshot for a given dataset as long as one is available. This will avoid an extra redirect, fixing one of the causes of #1034, and provides real URLs to crawlers for the public dashboard.

I'm not sure if we should redirect to the snapshot or draft from "my dashboard" though. I've kept the current behavior of "My Dashboard" linking to the drafts but it would be more consistent for it to also link to the newest snapshot. @chrisfilo Thoughts?