### PR TITLE
Replace Raven with Sentry-SDK

### DIFF
--- a/config.env.example
+++ b/config.env.example
@@ -44,8 +44,7 @@ DOI_PASSWORD=
 DOI_PREFIX=
 DOI_URL=
 
-# Enable sentry debugging and choose a unique environment key
-SENTRY_DSN=
+# Choose a unique environment key - used to group error reports in Sentry
 ENVIRONMENT=
 
 # Enable fresh desk support

--- a/packages/openneuro-app/package.json
+++ b/packages/openneuro-app/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@emotion/core": "^10.0.4",
     "@emotion/styled": "^10.0.4",
+    "@sentry/browser": "^4.5.3",
     "@types/jasmine": "^2.8.9",
     "apollo-client": "^2.4.7",
     "apollo-link-ws": "^1.0.9",
@@ -49,7 +50,6 @@
     "prettier": "^1.14.3",
     "prismjs": "^1.10.0",
     "prop-types": "^15.6.0",
-    "raven-js": "^3.20.1",
     "react": "16",
     "react-apollo": "^2.3.2",
     "react-bootstrap": "0.31.3",

--- a/packages/openneuro-app/src/scripts/client.jsx
+++ b/packages/openneuro-app/src/scripts/client.jsx
@@ -1,7 +1,7 @@
 // dependencies ---------------------------------------------------------
 import 'url-search-params-polyfill'
 import 'es6-shim'
-import Raven from 'raven-js'
+import Sentry from '@sentry/browser'
 import React from 'react'
 import ReactDOM from 'react-dom'
 import App from './app.jsx'
@@ -15,26 +15,18 @@ if (module.hot) module.hot.accept()
 loadConfig().then(config => {
   GoogleAnalytics.initialize(config.analytics.trackingId)
 
-  const ravenConfig = {
+  Sentry.config({
+    dsn: 'https://ba0c58863b3e40a2a412132bfd2711ea@sentry.io/251076',
     release: packageJson.version,
     environment: config.sentry.environment,
-    autoBreadcrumbs: {
-      console: false,
-    },
-  }
+  })
 
   // Setup the service worker
   if ('serviceWorker' in navigator) {
     runtime.register()
   } else {
-    Raven.captureMessage('Service worker registration failed.')
+    Sentry.captureMessage('Service worker registration failed.')
   }
-
-  // Uses the public DSN here - private should not be used in the client app
-  Raven.config(
-    'https://ba0c58863b3e40a2a412132bfd2711ea@sentry.io/251076',
-    ravenConfig,
-  ).install()
 
   ReactDOM.render(<App config={config} />, document.getElementById('main'))
 })

--- a/packages/openneuro-app/src/scripts/client.jsx
+++ b/packages/openneuro-app/src/scripts/client.jsx
@@ -1,7 +1,7 @@
 // dependencies ---------------------------------------------------------
 import 'url-search-params-polyfill'
 import 'es6-shim'
-import Sentry from '@sentry/browser'
+import * as Sentry from '@sentry/browser'
 import React from 'react'
 import ReactDOM from 'react-dom'
 import App from './app.jsx'
@@ -15,7 +15,7 @@ if (module.hot) module.hot.accept()
 loadConfig().then(config => {
   GoogleAnalytics.initialize(config.analytics.trackingId)
 
-  Sentry.config({
+  Sentry.init({
     dsn: 'https://ba0c58863b3e40a2a412132bfd2711ea@sentry.io/251076',
     release: packageJson.version,
     environment: config.sentry.environment,

--- a/packages/openneuro-app/src/scripts/datalad/download/download-link.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/download/download-link.jsx
@@ -1,5 +1,5 @@
 /* eslint-disable no-console */
-import Raven from 'raven-js'
+import Sentry from '@sentry/browser'
 import React from 'react'
 import PropTypes from 'prop-types'
 import ReactGA from 'react-ga'
@@ -97,7 +97,7 @@ const downloadClick = (datasetId, snapshotTag) => () => {
     .getRegistration()
     .then(awaitRegistration(next, global))
     .catch(err => {
-      Raven.captureException(err)
+      Sentry.captureException(err)
     })
 }
 

--- a/packages/openneuro-app/src/scripts/datalad/download/download-link.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/download/download-link.jsx
@@ -1,5 +1,5 @@
 /* eslint-disable no-console */
-import Sentry from '@sentry/browser'
+import * as Sentry from '@sentry/browser'
 import React from 'react'
 import PropTypes from 'prop-types'
 import ReactGA from 'react-ga'

--- a/packages/openneuro-app/src/scripts/errors/errorBoundary.jsx
+++ b/packages/openneuro-app/src/scripts/errors/errorBoundary.jsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import Sentry from '@sentry/browser'
+import * as Sentry from '@sentry/browser'
 
 class ErrorBoundary extends Component {
   constructor(props) {

--- a/packages/openneuro-app/src/scripts/errors/errorBoundary.jsx
+++ b/packages/openneuro-app/src/scripts/errors/errorBoundary.jsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import Raven from 'raven-js'
+import Sentry from '@sentry/browser'
 
 class ErrorBoundary extends Component {
   constructor(props) {
@@ -10,7 +10,7 @@ class ErrorBoundary extends Component {
 
   componentDidCatch(error, errorInfo) {
     this.setState({ hasError: true, errorInfo: errorInfo, error: error })
-    Raven.captureException(error, { extra: errorInfo })
+    Sentry.captureException(error, { extra: errorInfo })
   }
 
   render() {

--- a/packages/openneuro-app/src/scripts/uploader/uploader.jsx
+++ b/packages/openneuro-app/src/scripts/uploader/uploader.jsx
@@ -1,4 +1,4 @@
-import Raven from 'raven-js'
+import Sentry from '@sentry/browser'
 import { toast } from 'react-toastify'
 import ToastContent from '../common/partials/toast-content.jsx'
 import React from 'react'
@@ -191,7 +191,7 @@ export class UploadClient extends React.Component {
           this.setState({ datasetId }, this._addFiles)
         })
         .catch(error => {
-          Raven.captureException(error)
+          Sentry.captureException(error)
           toast.error(
             <ToastContent
               title="Dataset creation failed"
@@ -294,7 +294,7 @@ export class UploadClient extends React.Component {
           })
       })
       .catch(error => {
-        Raven.captureException(error)
+        Sentry.captureException(error)
         const toastId = toast.error(
           <ToastContent
             title="Dataset upload failed"
@@ -318,7 +318,7 @@ export class UploadClient extends React.Component {
           try {
             this.state.xhr.abort()
           } catch (e) {
-            Raven.captureException(e)
+            Sentry.captureException(e)
           }
         }
       })

--- a/packages/openneuro-app/src/scripts/uploader/uploader.jsx
+++ b/packages/openneuro-app/src/scripts/uploader/uploader.jsx
@@ -1,4 +1,4 @@
-import Sentry from '@sentry/browser'
+import * as Sentry from '@sentry/browser'
 import { toast } from 'react-toastify'
 import ToastContent from '../common/partials/toast-content.jsx'
 import React from 'react'

--- a/packages/openneuro-server/app.js
+++ b/packages/openneuro-server/app.js
@@ -5,7 +5,7 @@
  * Express app setup
  */
 import express from 'express'
-import Sentry from '@sentry/node'
+import * as Sentry from '@sentry/node'
 import passport from 'passport'
 import config from './config'
 import routes from './routes'

--- a/packages/openneuro-server/app.js
+++ b/packages/openneuro-server/app.js
@@ -5,7 +5,7 @@
  * Express app setup
  */
 import express from 'express'
-import Raven from 'raven'
+import Sentry from '@sentry/node'
 import passport from 'passport'
 import config from './config'
 import routes from './routes'
@@ -20,14 +20,14 @@ import { setupPassportAuth } from './libs/authentication/passport.js'
 // import events lib to instantiate CRN Emitter
 import events from './libs/events'
 
-// test flag disables Raven for tests
+// test flag disables Sentry for tests
 export default test => {
   const app = express()
 
   setupPassportAuth()
 
-  // Raven must be first to work
-  test || app.use(Raven.requestHandler())
+  // Sentry must be first to work
+  test || app.use(Sentry.Handlers.requestHandler())
 
   app.use(passport.initialize())
 
@@ -46,8 +46,8 @@ export default test => {
   app.use(config.apiPrefix, routes)
 
   // error handling --------------------------------------------------\
-  // Raven reporting passes to the next step
-  test || app.use(Raven.errorHandler())
+  // Sentry reporting passes to the next step
+  test || app.use(Sentry.Handlers.errorHandler())
 
   // Apollo engine setup
   const engineConfig = {

--- a/packages/openneuro-server/libs/orcid.js
+++ b/packages/openneuro-server/libs/orcid.js
@@ -1,6 +1,6 @@
 import request from 'request'
 import xmldoc from 'xmldoc'
-import Raven from 'raven'
+import Sentry from '@sentry/node'
 import config from '../config'
 
 export default {
@@ -20,7 +20,7 @@ export default {
         },
         (err, res) => {
           if (err) {
-            Raven.captureMessage('Unexpected ORCID failure', { err })
+            Sentry.captureException(err)
             reject({
               message:
                 'An unexpected ORCID login failure occurred, please try again later.',

--- a/packages/openneuro-server/libs/orcid.js
+++ b/packages/openneuro-server/libs/orcid.js
@@ -1,6 +1,6 @@
 import request from 'request'
 import xmldoc from 'xmldoc'
-import Sentry from '@sentry/node'
+import * as Sentry from '@sentry/node'
 import config from '../config'
 
 export default {

--- a/packages/openneuro-server/package.json
+++ b/packages/openneuro-server/package.json
@@ -15,6 +15,7 @@
   },
   "author": "Squishymedia",
   "dependencies": {
+    "@sentry/node": "^4.5.3",
     "ajv": "4.9.0",
     "apollo-client-preset": "^1.0.8",
     "apollo-server-express": "2.3.1",

--- a/packages/openneuro-server/package.json
+++ b/packages/openneuro-server/package.json
@@ -56,7 +56,6 @@
     "passport-google-oauth": "^1.0.0",
     "passport-jwt": "^4.0.0",
     "passport-orcid": "^0.0.3",
-    "raven": "^2.2.1",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
     "redis": "^2.8.0",

--- a/packages/openneuro-server/server.js
+++ b/packages/openneuro-server/server.js
@@ -1,4 +1,4 @@
-import Raven from 'raven'
+import Sentry from '@sentry/node'
 import { createServer } from 'http'
 import mongoose from 'mongoose'
 import subscriptionServerFactory from './libs/subscription-server.js'
@@ -30,12 +30,11 @@ const redisConnect = async () => {
   }
 }
 
-const ravenConfig = {
+Sentry.init({
+  dsn: config.sentry.DSN,
   release: packageJson.version,
   environment: config.sentry.ENVIRONMENT,
-  autoBreadcrumbs: true,
-}
-Raven.config(config.sentry.DSN, ravenConfig).install()
+})
 
 const app = createApp(false)
 

--- a/packages/openneuro-server/server.js
+++ b/packages/openneuro-server/server.js
@@ -31,7 +31,7 @@ const redisConnect = async () => {
 }
 
 Sentry.init({
-  dsn: config.sentry.DSN,
+  dsn: 'https://ba0c58863b3e40a2a412132bfd2711ea@sentry.io/251076',
   release: packageJson.version,
   environment: config.sentry.ENVIRONMENT,
 })

--- a/packages/openneuro-server/server.js
+++ b/packages/openneuro-server/server.js
@@ -1,4 +1,4 @@
-import Sentry from '@sentry/node'
+import * as Sentry from '@sentry/node'
 import { createServer } from 'http'
 import mongoose from 'mongoose'
 import subscriptionServerFactory from './libs/subscription-server.js'

--- a/yarn.lock
+++ b/yarn.lock
@@ -1680,6 +1680,65 @@
     progress "2.0.0"
     proxy-from-env "^1.0.0"
 
+"@sentry/core@4.5.3":
+  version "4.5.3"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-4.5.3.tgz#e55a42c694deec903aec2479e4a282d5a7a43878"
+  integrity sha512-off7XkyyiPXJTQ1XYPzxsY3zLHztMdK1kuIeHzyoIzu4kvs8H75eqou+fADo04JmfaMNy+OZSoW+5Aq2SZR2Ng==
+  dependencies:
+    "@sentry/hub" "4.5.3"
+    "@sentry/minimal" "4.5.3"
+    "@sentry/types" "4.5.3"
+    "@sentry/utils" "4.5.3"
+    tslib "^1.9.3"
+
+"@sentry/hub@4.5.3":
+  version "4.5.3"
+  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-4.5.3.tgz#54ce5988ac6dedbe9bba99e2c00f8f26eb677dfe"
+  integrity sha512-4b8oPVAGw/hf11CQN9J7hAk2wzD2HIZsQBl/PcB/p5r1UyHw8cibpVobJulkHJMBJMiZ/twIBGZ1G1qK3LJdhw==
+  dependencies:
+    "@sentry/types" "4.5.3"
+    "@sentry/utils" "4.5.3"
+    tslib "^1.9.3"
+
+"@sentry/minimal@4.5.3":
+  version "4.5.3"
+  resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-4.5.3.tgz#7b69481df2d61e4b935d067be62a52824190f616"
+  integrity sha512-W9+eEZosoDKTAJkab/bxsSRim7I4lqeWHLhmCchDimKcdmpBzC+gOCT0PywwOWRLW08LhTHfmnNSAJv6PaZiCA==
+  dependencies:
+    "@sentry/hub" "4.5.3"
+    "@sentry/types" "4.5.3"
+    tslib "^1.9.3"
+
+"@sentry/node@^4.5.3":
+  version "4.5.3"
+  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-4.5.3.tgz#f6b57747991c300d4f5f70add673ea3d1e78c873"
+  integrity sha512-glBIGsoYDcUEjZWDjbkDWt87cmuO/lcxpfz4zfTq9JfIfzI3WunJqABhFDc8tQSqUdHOlWb2QKvoNPvz+0EDfg==
+  dependencies:
+    "@sentry/core" "4.5.3"
+    "@sentry/hub" "4.5.3"
+    "@sentry/types" "4.5.3"
+    "@sentry/utils" "4.5.3"
+    "@types/stack-trace" "0.0.29"
+    cookie "0.3.1"
+    https-proxy-agent "2.2.1"
+    lru_map "0.3.3"
+    lsmod "1.0.0"
+    stack-trace "0.0.10"
+    tslib "^1.9.3"
+
+"@sentry/types@4.5.3":
+  version "4.5.3"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-4.5.3.tgz#3350dce2b7f9b936a8c327891c12e3aef7bd8852"
+  integrity sha512-7ll1PAFNjrBNX9rzy3P2qAQrpQwHaDO3uKj735qsnGw34OtAS8Xr8WYrjI14f9fMPa/XIeWvMPb4GMic28V/ag==
+
+"@sentry/utils@4.5.3":
+  version "4.5.3"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-4.5.3.tgz#6893fca9fde230b230360779362752e9b5570852"
+  integrity sha512-yIYqnuq9cd9nAUJ2MPmq++Mgy81qB2fglsDB8TiBfk2eaba79qFcKp8xg3w3EMDHZMlfmlx4fkTmZJ/+V02oWQ==
+  dependencies:
+    "@sentry/types" "4.5.3"
+    tslib "^1.9.3"
+
 "@sindresorhus/is@^0.7.0":
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.7.0.tgz#9a06f4f137ee84d7df0460c1fdb1135ffa6c50fd"
@@ -1835,6 +1894,11 @@
   dependencies:
     "@types/express-serve-static-core" "*"
     "@types/mime" "*"
+
+"@types/stack-trace@0.0.29":
+  version "0.0.29"
+  resolved "https://registry.yarnpkg.com/@types/stack-trace/-/stack-trace-0.0.29.tgz#eb7a7c60098edb35630ed900742a5ecb20cfcb4d"
+  integrity sha512-TgfOX+mGY/NyNxJLIbDWrO9DjGoVSW9+aB8H2yy1fy32jsvxijhmyJI9fDFgvz3YP4lvJaq9DzdR/M1bOgVc9g==
 
 "@types/ws@^6.0.0":
   version "6.0.1"
@@ -8115,7 +8179,7 @@ https-browserify@^1.0.0:
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
   integrity sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=
 
-https-proxy-agent@^2.2.1:
+https-proxy-agent@2.2.1, https-proxy-agent@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz#51552970fa04d723e04c56d04178c3f92592bbc0"
   integrity sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==
@@ -10370,6 +10434,16 @@ lru-queue@0.1:
   integrity sha1-Jzi9nw089PhEkMVzbEhpmsYyzaM=
   dependencies:
     es5-ext "~0.10.2"
+
+lru_map@0.3.3:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/lru_map/-/lru_map-0.3.3.tgz#b5c8351b9464cbd750335a79650a0ec0e56118dd"
+  integrity sha1-tcg1G5Rky9dQM1p5ZQoOwOVhGN0=
+
+lsmod@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/lsmod/-/lsmod-1.0.0.tgz#9a00f76dca36eb23fa05350afe1b585d4299e64b"
+  integrity sha1-mgD3bco26yP6BTUK/htYXUKZ5ks=
 
 mailcomposer@4.0.1:
   version "4.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1668,6 +1668,16 @@
   dependencies:
     any-observable "^0.3.0"
 
+"@sentry/browser@^4.5.3":
+  version "4.5.3"
+  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-4.5.3.tgz#69744d13b01c490f366cbf2676790624b9f7c0a0"
+  integrity sha512-ePbsyXtZS9jWM0lD8rxA46omJjJcQPaRZak08TyxFBGm1YOUFvvNAA6rNjUtK4fFEznLhPA5YcllcOCBE2bPPg==
+  dependencies:
+    "@sentry/core" "4.5.3"
+    "@sentry/types" "4.5.3"
+    "@sentry/utils" "4.5.3"
+    tslib "^1.9.3"
+
 "@sentry/cli@^1.37.2":
   version "1.37.2"
   resolved "https://registry.yarnpkg.com/@sentry/cli/-/cli-1.37.2.tgz#6c2abad08c6a85adaa3bd7221ef054036c9347ac"
@@ -4076,11 +4086,6 @@ chardet@^0.7.0:
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
   integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
 
-charenc@~0.0.1:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/charenc/-/charenc-0.0.2.tgz#c0a1d2f3a7092e03774bfa83f14c0fc5790a8667"
-  integrity sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc=
-
 cheerio@0.20.0:
   version "0.20.0"
   resolved "https://registry.yarnpkg.com/cheerio/-/cheerio-0.20.0.tgz#5c710f2bab95653272842ba01c6ea61b3545ec35"
@@ -5085,11 +5090,6 @@ cross-spawn@^6.0.0, cross-spawn@^6.0.5:
     semver "^5.5.0"
     shebang-command "^1.2.0"
     which "^1.2.9"
-
-crypt@~0.0.1:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/crypt/-/crypt-0.0.2.tgz#88d7ff7ec0dfb86f713dc87bbb42d044d3e6c41b"
-  integrity sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs=
 
 cryptiles@2.x.x:
   version "2.0.5"
@@ -8607,7 +8607,7 @@ is-boolean-object@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-boolean-object/-/is-boolean-object-1.0.0.tgz#98f8b28030684219a95f375cfbd88ce3405dff93"
   integrity sha1-mPiygDBoQhmpXzdc+9iM40Bd/5M=
 
-is-buffer@^1.1.4, is-buffer@^1.1.5, is-buffer@~1.1.1:
+is-buffer@^1.1.4, is-buffer@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
   integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
@@ -10531,15 +10531,6 @@ md5.js@^1.3.4:
     hash-base "^3.0.0"
     inherits "^2.0.1"
     safe-buffer "^5.1.2"
-
-md5@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/md5/-/md5-2.2.1.tgz#53ab38d5fe3c8891ba465329ea23fac0540126f9"
-  integrity sha1-U6s41f48iJG6RlMp6iP6wFQBJvk=
-  dependencies:
-    charenc "~0.0.1"
-    crypt "~0.0.1"
-    is-buffer "~1.1.1"
 
 mdast-add-list-metadata@1.0.1:
   version "1.0.1"
@@ -12789,22 +12780,6 @@ range-parser@^1.0.3, range-parser@~1.2.0:
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.0.tgz#f49be6b487894ddc40dcc94a322f611092e00d5e"
   integrity sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4=
 
-raven-js@^3.20.1:
-  version "3.27.0"
-  resolved "https://registry.yarnpkg.com/raven-js/-/raven-js-3.27.0.tgz#9f47c03e17933ce756e189f3669d49c441c1ba6e"
-  integrity sha512-vChdOL+yzecfnGA+B5EhEZkJ3kY3KlMzxEhShKh6Vdtooyl0yZfYNFQfYzgMf2v4pyQa+OTZ5esTxxgOOZDHqw==
-
-raven@^2.2.1:
-  version "2.6.4"
-  resolved "https://registry.yarnpkg.com/raven/-/raven-2.6.4.tgz#458d4a380c8fbb59e0150c655625aaf60c167ea3"
-  integrity sha512-6PQdfC4+DQSFncowthLf+B6Hr0JpPsFBgTVYTAOq7tCmx/kR4SXbeawtPch20+3QfUcQDoJBLjWW1ybvZ4kXTw==
-  dependencies:
-    cookie "0.3.1"
-    md5 "^2.2.1"
-    stack-trace "0.0.10"
-    timed-out "4.0.1"
-    uuid "3.3.2"
-
 raw-body@2.3.3:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-2.3.3.tgz#1b324ece6b5706e153855bc1148c65bb7f6ea0c3"
@@ -15010,7 +14985,7 @@ thunky@^1.0.2:
   resolved "https://registry.yarnpkg.com/thunky/-/thunky-1.0.3.tgz#f5df732453407b09191dae73e2a8cc73f381a826"
   integrity sha512-YwT8pjmNcAXBZqrubu22P4FYsh2D4dxRmnWBOL8Jk8bUcRUtc5326kx32tuTmFDAZtLOGEVNl8POAR8j896Iow==
 
-timed-out@4.0.1, timed-out@^4.0.0, timed-out@^4.0.1:
+timed-out@^4.0.0, timed-out@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/timed-out/-/timed-out-4.0.1.tgz#f32eacac5a175bea25d7fab565ab3ed8741ef56f"
   integrity sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=
@@ -15627,15 +15602,15 @@ uuid@3.1.0:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.1.0.tgz#3dd3d3e790abc24d7b0d3a034ffababe28ebbc04"
   integrity sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==
 
-uuid@3.3.2, uuid@^3.0.1, uuid@^3.1.0, uuid@^3.3.2:
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
-  integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
-
 uuid@^2.0.1:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-2.0.3.tgz#67e2e863797215530dff318e5bf9dcebfd47b21a"
   integrity sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho=
+
+uuid@^3.0.1, uuid@^3.1.0, uuid@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
+  integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
 
 v8-compile-cache@^2.0.2:
   version "2.0.2"


### PR DESCRIPTION
Sentry is moving away from the Raven library we are using and while it says it's maintained, not every feature is working anymore. This ports all Sentry usage to the new SDK.