### PR TITLE
openneuro-cli: Lazy open for uploaded files

### DIFF
--- a/packages/openneuro-cli/src/__tests__/lazyReadStream.spec.js
+++ b/packages/openneuro-cli/src/__tests__/lazyReadStream.spec.js
@@ -1,0 +1,20 @@
+import fs from 'fs'
+import { createLazyReadStream } from '../lazyReadStream.js'
+
+describe('lazyReadStream', () => {
+  it('returns a fs.ReadStream proxy', () => {
+    const readStream = createLazyReadStream('package.json')
+    expect(readStream instanceof fs.ReadStream).toBe(true)
+  })
+  it('does not call createReadStream before read', () => {
+    const readStream = createLazyReadStream('package.json')
+    expect(readStream.fd).toBe(-128)
+  })
+  it('calls createReadStream after read', async done => {
+    const readStream = createLazyReadStream('package.json')
+    expect(readStream.fd).toBe(-128)
+    await readStream.read(10)
+    expect(readStream.fd).not.toBe(-128)
+    done()
+  })
+})

--- a/packages/openneuro-cli/src/files.js
+++ b/packages/openneuro-cli/src/files.js
@@ -1,4 +1,5 @@
 import fs from 'fs'
+import { createLazyReadStream } from './lazyReadStream.js'
 import path from 'path'
 import moment from 'moment'
 import stream from 'stream'
@@ -74,7 +75,7 @@ export const getFileTree = (
           }
         })
         .map(({ stat, filePath, relativePath }) => {
-          const stream = fs.createReadStream(filePath)
+          const stream = createLazyReadStream(filePath)
           stream.pause()
           if (logging) {
             stream.on(

--- a/packages/openneuro-cli/src/lazyReadStream.js
+++ b/packages/openneuro-cli/src/lazyReadStream.js
@@ -1,0 +1,38 @@
+import fs from 'fs'
+
+/**
+ * Creates an fs.ReadStream and extends it with lazy file opening
+ * @param {string|Buffer|URL} path
+ * @param {string|Object} options
+ */
+export function LazyReadStream(path, options) {
+  // Set an invalid fd to skip the open call and signal to _read
+  const readStream = fs.createReadStream(path, { ...options, fd: -128 })
+  const realRead = readStream._read
+  readStream._read = function(size) {
+    if (this.fd === -128) {
+      // Open sync here
+      try {
+        this.fd = fs.openSync(this.path, this.flags, this.mode)
+        this.emit('open', this.fd)
+        this.emit('ready')
+      } catch (er) {
+        // Handle the regular error behavior if anything goes wrong
+        if (this.autoClose) {
+          this.destroy()
+        }
+        this.emit('error', er)
+      }
+    }
+    realRead.call(this, size)
+  }
+  return readStream
+}
+
+/**
+ * Equivalent to fs.createReadStream but opens on first read
+ * @param {string|Buffer|URL} path
+ * @param {string|Object} options
+ */
+export const createLazyReadStream = (path, options) =>
+  new LazyReadStream(path, options)


### PR DESCRIPTION
This limits how many file handles get used to one file at a time, fixing #1045 