### PR TITLE
Trace node warnings when site is running in developer mode

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -32,7 +32,7 @@ services:
   server:
     build:
       context: ./packages/openneuro-server
-    command: sh -c "apk add make gcc g++ python && yarn install && node /srv/index.js"
+    command: sh -c "apk add make gcc g++ python && yarn install && node --trace-warnings /srv/index.js"
     volumes:
       - ./packages/openneuro-server:/srv
       - yarn_cache:/root/.cache


### PR DESCRIPTION
This shows more complete tracebacks when an error is encountered in local developer mode.