### PR TITLE
Raise graphq-upload field limit size to infinite

### DIFF
--- a/packages/openneuro-server/app.js
+++ b/packages/openneuro-server/app.js
@@ -80,6 +80,8 @@ export default test => {
     // Enable cache options
     tracing: true,
     cacheControl: true,
+    // Don't limit the max size for dataset uploads
+    uploads: { maxFieldSize: Infinity },
   })
 
   // Setup pre-GraphQL middleware


### PR DESCRIPTION
This fixes the limit which results in the BadRequestError in #1049 

Without this change, maxFieldSize defaults to 1MB which is not always enough to encode the file tree for a dataset. Any dataset where the JSON encoding of the file tree exceeds this will throw this error. Raising it to infinite should always prevent this case and doesn't really open up abuse more than allowing infinitely large datasets to be uploaded anyways.