### PR TITLE
Highlight recently published / high traffic datasets on the front page

### DIFF
--- a/packages/openneuro-app/src/sass/crn_app/_frontPage.scss
+++ b/packages/openneuro-app/src/sass/crn_app/_frontPage.scss
@@ -367,7 +367,7 @@
         max-width: 1500px;
 
         .mate-slide{
-            height: 360px;
+            min-height: 360px;
             padding: 40px 50px 50px;
 
             h4{

--- a/packages/openneuro-app/src/scripts/front-page/__tests__/__snapshots__/front-page-top-datasets.spec.jsx.snap
+++ b/packages/openneuro-app/src/scripts/front-page/__tests__/__snapshots__/front-page-top-datasets.spec.jsx.snap
@@ -295,7 +295,7 @@ exports[`FrontPageTopDatasets renders container correctly 1`] = `
                                       },
                                       "value": Object {
                                         "kind": "EnumValue",
-                                        "value": "ascending",
+                                        "value": "descending",
                                       },
                                     },
                                   ],
@@ -377,7 +377,7 @@ exports[`FrontPageTopDatasets renders container correctly 1`] = `
                                               "kind": "Field",
                                               "name": Object {
                                                 "kind": "Name",
-                                                "value": "datePublished",
+                                                "value": "publishDate",
                                               },
                                               "selectionSet": undefined,
                                             },
@@ -449,7 +449,7 @@ exports[`FrontPageTopDatasets renders container correctly 1`] = `
                   ],
                   "kind": "Document",
                   "loc": Object {
-                    "end": 359,
+                    "end": 358,
                     "start": 0,
                   },
                 }

--- a/packages/openneuro-app/src/scripts/front-page/__tests__/__snapshots__/front-page-top-datasets.spec.jsx.snap
+++ b/packages/openneuro-app/src/scripts/front-page/__tests__/__snapshots__/front-page-top-datasets.spec.jsx.snap
@@ -1,0 +1,464 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`FrontPageTopDatasets renders container correctly 1`] = `
+<Fragment>
+  <div
+    className="browse-pipelines"
+  >
+    <h3
+      className="browse-pipeline-header"
+    >
+      Recent Activity
+    </h3>
+    <div
+      className="container"
+    >
+      <div
+        className="row"
+      >
+        <Styled(div)>
+          <div
+            className="col-sm-6 mate-slide fade-in"
+          >
+            <h4>
+              Most Active
+            </h4>
+            <FrontPageTopQuery
+              query={
+                Object {
+                  "definitions": Array [
+                    Object {
+                      "directives": Array [],
+                      "kind": "OperationDefinition",
+                      "name": Object {
+                        "kind": "Name",
+                        "value": "top_viewed_datasets",
+                      },
+                      "operation": "query",
+                      "selectionSet": Object {
+                        "kind": "SelectionSet",
+                        "selections": Array [
+                          Object {
+                            "alias": undefined,
+                            "arguments": Array [
+                              Object {
+                                "kind": "Argument",
+                                "name": Object {
+                                  "kind": "Name",
+                                  "value": "first",
+                                },
+                                "value": Object {
+                                  "kind": "IntValue",
+                                  "value": "5",
+                                },
+                              },
+                              Object {
+                                "kind": "Argument",
+                                "name": Object {
+                                  "kind": "Name",
+                                  "value": "orderBy",
+                                },
+                                "value": Object {
+                                  "fields": Array [
+                                    Object {
+                                      "kind": "ObjectField",
+                                      "name": Object {
+                                        "kind": "Name",
+                                        "value": "views",
+                                      },
+                                      "value": Object {
+                                        "kind": "EnumValue",
+                                        "value": "descending",
+                                      },
+                                    },
+                                  ],
+                                  "kind": "ObjectValue",
+                                },
+                              },
+                              Object {
+                                "kind": "Argument",
+                                "name": Object {
+                                  "kind": "Name",
+                                  "value": "filterBy",
+                                },
+                                "value": Object {
+                                  "fields": Array [
+                                    Object {
+                                      "kind": "ObjectField",
+                                      "name": Object {
+                                        "kind": "Name",
+                                        "value": "public",
+                                      },
+                                      "value": Object {
+                                        "kind": "BooleanValue",
+                                        "value": true,
+                                      },
+                                    },
+                                  ],
+                                  "kind": "ObjectValue",
+                                },
+                              },
+                            ],
+                            "directives": Array [],
+                            "kind": "Field",
+                            "name": Object {
+                              "kind": "Name",
+                              "value": "datasets",
+                            },
+                            "selectionSet": Object {
+                              "kind": "SelectionSet",
+                              "selections": Array [
+                                Object {
+                                  "alias": undefined,
+                                  "arguments": Array [],
+                                  "directives": Array [],
+                                  "kind": "Field",
+                                  "name": Object {
+                                    "kind": "Name",
+                                    "value": "edges",
+                                  },
+                                  "selectionSet": Object {
+                                    "kind": "SelectionSet",
+                                    "selections": Array [
+                                      Object {
+                                        "alias": undefined,
+                                        "arguments": Array [],
+                                        "directives": Array [],
+                                        "kind": "Field",
+                                        "name": Object {
+                                          "kind": "Name",
+                                          "value": "node",
+                                        },
+                                        "selectionSet": Object {
+                                          "kind": "SelectionSet",
+                                          "selections": Array [
+                                            Object {
+                                              "alias": undefined,
+                                              "arguments": Array [],
+                                              "directives": Array [],
+                                              "kind": "Field",
+                                              "name": Object {
+                                                "kind": "Name",
+                                                "value": "id",
+                                              },
+                                              "selectionSet": undefined,
+                                            },
+                                            Object {
+                                              "alias": undefined,
+                                              "arguments": Array [],
+                                              "directives": Array [],
+                                              "kind": "Field",
+                                              "name": Object {
+                                                "kind": "Name",
+                                                "value": "analytics",
+                                              },
+                                              "selectionSet": Object {
+                                                "kind": "SelectionSet",
+                                                "selections": Array [
+                                                  Object {
+                                                    "alias": undefined,
+                                                    "arguments": Array [],
+                                                    "directives": Array [],
+                                                    "kind": "Field",
+                                                    "name": Object {
+                                                      "kind": "Name",
+                                                      "value": "views",
+                                                    },
+                                                    "selectionSet": undefined,
+                                                  },
+                                                ],
+                                              },
+                                            },
+                                            Object {
+                                              "alias": undefined,
+                                              "arguments": Array [],
+                                              "directives": Array [],
+                                              "kind": "Field",
+                                              "name": Object {
+                                                "kind": "Name",
+                                                "value": "latestSnapshot",
+                                              },
+                                              "selectionSet": Object {
+                                                "kind": "SelectionSet",
+                                                "selections": Array [
+                                                  Object {
+                                                    "alias": undefined,
+                                                    "arguments": Array [],
+                                                    "directives": Array [],
+                                                    "kind": "Field",
+                                                    "name": Object {
+                                                      "kind": "Name",
+                                                      "value": "tag",
+                                                    },
+                                                    "selectionSet": undefined,
+                                                  },
+                                                  Object {
+                                                    "alias": undefined,
+                                                    "arguments": Array [],
+                                                    "directives": Array [],
+                                                    "kind": "Field",
+                                                    "name": Object {
+                                                      "kind": "Name",
+                                                      "value": "description",
+                                                    },
+                                                    "selectionSet": Object {
+                                                      "kind": "SelectionSet",
+                                                      "selections": Array [
+                                                        Object {
+                                                          "alias": undefined,
+                                                          "arguments": Array [],
+                                                          "directives": Array [],
+                                                          "kind": "Field",
+                                                          "name": Object {
+                                                            "kind": "Name",
+                                                            "value": "Name",
+                                                          },
+                                                          "selectionSet": undefined,
+                                                        },
+                                                      ],
+                                                    },
+                                                  },
+                                                ],
+                                              },
+                                            },
+                                          ],
+                                        },
+                                      },
+                                    ],
+                                  },
+                                },
+                              ],
+                            },
+                          },
+                        ],
+                      },
+                      "variableDefinitions": Array [],
+                    },
+                  ],
+                  "kind": "Document",
+                  "loc": Object {
+                    "end": 374,
+                    "start": 0,
+                  },
+                }
+              }
+            />
+          </div>
+          <div
+            className="col-sm-6 mate-slide fade-in browse"
+          >
+            <h4>
+              Recently Published
+            </h4>
+            <FrontPageTopQuery
+              query={
+                Object {
+                  "definitions": Array [
+                    Object {
+                      "directives": Array [],
+                      "kind": "OperationDefinition",
+                      "name": Object {
+                        "kind": "Name",
+                        "value": "recently_published_datasets",
+                      },
+                      "operation": "query",
+                      "selectionSet": Object {
+                        "kind": "SelectionSet",
+                        "selections": Array [
+                          Object {
+                            "alias": undefined,
+                            "arguments": Array [
+                              Object {
+                                "kind": "Argument",
+                                "name": Object {
+                                  "kind": "Name",
+                                  "value": "first",
+                                },
+                                "value": Object {
+                                  "kind": "IntValue",
+                                  "value": "5",
+                                },
+                              },
+                              Object {
+                                "kind": "Argument",
+                                "name": Object {
+                                  "kind": "Name",
+                                  "value": "orderBy",
+                                },
+                                "value": Object {
+                                  "fields": Array [
+                                    Object {
+                                      "kind": "ObjectField",
+                                      "name": Object {
+                                        "kind": "Name",
+                                        "value": "publishDate",
+                                      },
+                                      "value": Object {
+                                        "kind": "EnumValue",
+                                        "value": "ascending",
+                                      },
+                                    },
+                                  ],
+                                  "kind": "ObjectValue",
+                                },
+                              },
+                              Object {
+                                "kind": "Argument",
+                                "name": Object {
+                                  "kind": "Name",
+                                  "value": "filterBy",
+                                },
+                                "value": Object {
+                                  "fields": Array [
+                                    Object {
+                                      "kind": "ObjectField",
+                                      "name": Object {
+                                        "kind": "Name",
+                                        "value": "public",
+                                      },
+                                      "value": Object {
+                                        "kind": "BooleanValue",
+                                        "value": true,
+                                      },
+                                    },
+                                  ],
+                                  "kind": "ObjectValue",
+                                },
+                              },
+                            ],
+                            "directives": Array [],
+                            "kind": "Field",
+                            "name": Object {
+                              "kind": "Name",
+                              "value": "datasets",
+                            },
+                            "selectionSet": Object {
+                              "kind": "SelectionSet",
+                              "selections": Array [
+                                Object {
+                                  "alias": undefined,
+                                  "arguments": Array [],
+                                  "directives": Array [],
+                                  "kind": "Field",
+                                  "name": Object {
+                                    "kind": "Name",
+                                    "value": "edges",
+                                  },
+                                  "selectionSet": Object {
+                                    "kind": "SelectionSet",
+                                    "selections": Array [
+                                      Object {
+                                        "alias": undefined,
+                                        "arguments": Array [],
+                                        "directives": Array [],
+                                        "kind": "Field",
+                                        "name": Object {
+                                          "kind": "Name",
+                                          "value": "node",
+                                        },
+                                        "selectionSet": Object {
+                                          "kind": "SelectionSet",
+                                          "selections": Array [
+                                            Object {
+                                              "alias": undefined,
+                                              "arguments": Array [],
+                                              "directives": Array [],
+                                              "kind": "Field",
+                                              "name": Object {
+                                                "kind": "Name",
+                                                "value": "id",
+                                              },
+                                              "selectionSet": undefined,
+                                            },
+                                            Object {
+                                              "alias": undefined,
+                                              "arguments": Array [],
+                                              "directives": Array [],
+                                              "kind": "Field",
+                                              "name": Object {
+                                                "kind": "Name",
+                                                "value": "datePublished",
+                                              },
+                                              "selectionSet": undefined,
+                                            },
+                                            Object {
+                                              "alias": undefined,
+                                              "arguments": Array [],
+                                              "directives": Array [],
+                                              "kind": "Field",
+                                              "name": Object {
+                                                "kind": "Name",
+                                                "value": "latestSnapshot",
+                                              },
+                                              "selectionSet": Object {
+                                                "kind": "SelectionSet",
+                                                "selections": Array [
+                                                  Object {
+                                                    "alias": undefined,
+                                                    "arguments": Array [],
+                                                    "directives": Array [],
+                                                    "kind": "Field",
+                                                    "name": Object {
+                                                      "kind": "Name",
+                                                      "value": "tag",
+                                                    },
+                                                    "selectionSet": undefined,
+                                                  },
+                                                  Object {
+                                                    "alias": undefined,
+                                                    "arguments": Array [],
+                                                    "directives": Array [],
+                                                    "kind": "Field",
+                                                    "name": Object {
+                                                      "kind": "Name",
+                                                      "value": "description",
+                                                    },
+                                                    "selectionSet": Object {
+                                                      "kind": "SelectionSet",
+                                                      "selections": Array [
+                                                        Object {
+                                                          "alias": undefined,
+                                                          "arguments": Array [],
+                                                          "directives": Array [],
+                                                          "kind": "Field",
+                                                          "name": Object {
+                                                            "kind": "Name",
+                                                            "value": "Name",
+                                                          },
+                                                          "selectionSet": undefined,
+                                                        },
+                                                      ],
+                                                    },
+                                                  },
+                                                ],
+                                              },
+                                            },
+                                          ],
+                                        },
+                                      },
+                                    ],
+                                  },
+                                },
+                              ],
+                            },
+                          },
+                        ],
+                      },
+                      "variableDefinitions": Array [],
+                    },
+                  ],
+                  "kind": "Document",
+                  "loc": Object {
+                    "end": 359,
+                    "start": 0,
+                  },
+                }
+              }
+            />
+          </div>
+        </Styled(div)>
+      </div>
+    </div>
+  </div>
+</Fragment>
+`;

--- a/packages/openneuro-app/src/scripts/front-page/__tests__/front-page-top-datasets.spec.jsx
+++ b/packages/openneuro-app/src/scripts/front-page/__tests__/front-page-top-datasets.spec.jsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import FrontPageTopDatasets from '../front-page-top-datasets.jsx'
+
+describe('FrontPageTopDatasets', () => {
+  it('renders container correctly', () => {
+    const wrapper = shallow(<FrontPageTopDatasets />)
+    expect(wrapper).toMatchSnapshot()
+  })
+})

--- a/packages/openneuro-app/src/scripts/front-page/front-page-top-datasets.jsx
+++ b/packages/openneuro-app/src/scripts/front-page/front-page-top-datasets.jsx
@@ -1,0 +1,184 @@
+import * as Sentry from '@sentry/browser'
+import React from 'react'
+import PropTypes from 'prop-types'
+import gql from 'graphql-tag'
+import Spinner from '../common/partials/spinner.jsx'
+import { Query } from 'react-apollo'
+import { Link } from 'react-router-dom'
+import distanceInWordsToNow from 'date-fns/distance_in_words_to_now'
+import styled from '@emotion/styled'
+import Uppercase from '../styles/uppercase.jsx'
+
+const FontWeight600 = styled.span`
+  font-weight: 600;
+`
+
+const WhiteText = styled.div`
+  color: #fff;
+  font-size: 20px;
+  a {
+    color: #fff;
+    bottom-border: 1px dashed var(--tertiary);
+  }
+  a:hover {
+    color: #eee;
+  }
+`
+
+const PaddedRow = styled.div`
+  padding-bottom: 1em;
+`
+
+const TOP_VIEWED = gql`
+  query top_viewed_datasets {
+    datasets(
+      first: 5
+      orderBy: { views: descending }
+      filterBy: { public: true }
+    ) {
+      edges {
+        node {
+          id
+          analytics {
+            views
+          }
+          latestSnapshot {
+            tag
+            description {
+              Name
+            }
+          }
+        }
+      }
+    }
+  }
+`
+
+const RECENTLY_PUBLISHED = gql`
+  query recently_published_datasets {
+    datasets(
+      first: 5
+      orderBy: { publishDate: ascending }
+      filterBy: { public: true }
+    ) {
+      edges {
+        node {
+          id
+          datePublished
+          latestSnapshot {
+            tag
+            description {
+              Name
+            }
+          }
+        }
+      }
+    }
+  }
+`
+
+const DatasetLink = ({ node }) => {
+  return (
+    <Link to={`/datasets/${node.id}/versions/${node.latestSnapshot.tag}`}>
+      {node.latestSnapshot.description.Name}
+    </Link>
+  )
+}
+
+DatasetLink.propTypes = {
+  node: PropTypes.object,
+}
+
+const FrontPageTopActive = ({ datasets }) => {
+  return (
+    <>
+      {datasets.map(({ node }, index) => (
+        <PaddedRow className="row" key={index}>
+          <div className="col-sm-2">
+            <FontWeight600>
+              <i className="fa fa-eye" />{' '}
+              {node.analytics.views.toLocaleString()}
+            </FontWeight600>
+          </div>
+          <div className="col-sm-10">
+            <DatasetLink node={node} />
+          </div>
+        </PaddedRow>
+      ))}
+      <PaddedRow className="row">
+        <div className="col-sm-2"> </div>
+        <div className="col-sm-10">
+          <Link to="/public/datasets">View More...</Link>
+        </div>
+      </PaddedRow>
+    </>
+  )
+}
+
+const FrontPageTopRecent = ({ datasets }) => {
+  return (
+    <>
+      {datasets.reverse().map(({ node }, index) => (
+        <PaddedRow className="row" key={index}>
+          <div className="col-sm-8">
+            <DatasetLink node={node} />
+          </div>
+          <div className="col-sm-4">
+            <FontWeight600>
+              <Uppercase>
+                {distanceInWordsToNow(node.datePublished)} ago
+              </Uppercase>
+            </FontWeight600>
+          </div>
+        </PaddedRow>
+      ))}
+    </>
+  )
+}
+
+const FrontPageTopResult = query => ({ loading, error, data }) => {
+  if (error) {
+    Sentry.captureException(error)
+    return <div>Failed to load top datasets, please try again later.</div>
+  } else if (loading) {
+    return <Spinner active />
+  } else {
+    if (query === TOP_VIEWED) {
+      return <FrontPageTopActive datasets={data.datasets.edges} />
+    } else if (query === RECENTLY_PUBLISHED) {
+      return <FrontPageTopRecent datasets={data.datasets.edges} />
+    }
+  }
+}
+
+const FrontPageTopQuery = ({ query }) => (
+  <Query query={query}>{FrontPageTopResult(query)}</Query>
+)
+
+FrontPageTopQuery.propTypes = {
+  query: PropTypes.object,
+}
+
+const FrontPageTopDatasets = () => (
+  <>
+    <div className="browse-pipelines">
+      <h3 className="browse-pipeline-header">Recent Activity</h3>
+      <div className="container">
+        <div className="row">
+          <WhiteText>
+            <div className="col-sm-6 mate-slide fade-in">
+              <h4>Most Active</h4>
+              <FrontPageTopQuery query={TOP_VIEWED} />
+            </div>
+            <div className="col-sm-6 mate-slide fade-in browse">
+              <h4>Recently Published</h4>
+              <FrontPageTopQuery query={RECENTLY_PUBLISHED} />
+            </div>
+          </WhiteText>
+        </div>
+      </div>
+    </div>
+  </>
+)
+
+export default FrontPageTopDatasets

--- a/packages/openneuro-app/src/scripts/front-page/front-page-top-datasets.jsx
+++ b/packages/openneuro-app/src/scripts/front-page/front-page-top-datasets.jsx
@@ -58,13 +58,13 @@ const RECENTLY_PUBLISHED = gql`
   query recently_published_datasets {
     datasets(
       first: 5
-      orderBy: { publishDate: ascending }
+      orderBy: { publishDate: descending }
       filterBy: { public: true }
     ) {
       edges {
         node {
           id
-          datePublished
+          publishDate
           latestSnapshot {
             tag
             description {
@@ -118,7 +118,7 @@ const FrontPageTopActive = ({ datasets }) => {
 const FrontPageTopRecent = ({ datasets }) => {
   return (
     <>
-      {datasets.reverse().map(({ node }, index) => (
+      {datasets.map(({ node }, index) => (
         <PaddedRow className="row" key={index}>
           <div className="col-sm-8">
             <DatasetLink node={node} />
@@ -126,7 +126,7 @@ const FrontPageTopRecent = ({ datasets }) => {
           <div className="col-sm-4">
             <FontWeight600>
               <Uppercase>
-                {distanceInWordsToNow(node.datePublished)} ago
+                {distanceInWordsToNow(node.publishDate)} ago
               </Uppercase>
             </FontWeight600>
           </div>

--- a/packages/openneuro-app/src/scripts/front-page/front-page.jsx
+++ b/packages/openneuro-app/src/scripts/front-page/front-page.jsx
@@ -7,6 +7,7 @@ import Footer from '../common/partials/footer.jsx'
 import AdditionalInfo from './front-page-additional-info.jsx'
 import LoggedOut from '../authentication/logged-out.jsx'
 import AuthenticationButtons from '../authentication/buttons.jsx'
+import FrontPageTopDatasets from './front-page-top-datasets.jsx'
 //configurables
 import { frontPage } from 'openneuro-content'
 
@@ -47,6 +48,7 @@ class FrontPage extends React.Component {
           </div>
         </div>
         {frontPage.frontPageExtras ? <FrontPageTabs /> : null}
+        <FrontPageTopDatasets />
         <AdditionalInfo />
         <Footer />
       </span>

--- a/packages/openneuro-app/src/scripts/styles/uppercase.jsx
+++ b/packages/openneuro-app/src/scripts/styles/uppercase.jsx
@@ -1,0 +1,6 @@
+import styled from '@emotion/styled'
+
+const Uppercase = styled.span`
+  text-transform: uppercase;
+`
+export default Uppercase

--- a/packages/openneuro-server/datalad/__tests__/pagination.spec.js
+++ b/packages/openneuro-server/datalad/__tests__/pagination.spec.js
@@ -116,7 +116,16 @@ describe('pagination model operations', () => {
       expect(agg[0]).toHaveProperty('$lookup')
       expect(agg[1]).not.toHaveProperty('$addFields')
       // Ends with count sort
-      expect(agg.slice(-1)).toEqual([{ $sort: { 'downloads': 1 } }])
+      expect(agg.slice(-1)).toEqual([{ $sort: { downloads: 1 } }])
+    })
+    it('returns a lookup and no count stage for views', () => {
+      const agg = pagination.sortAggregate({
+        orderBy: { views: 'ascending' },
+      })
+      expect(agg[0]).toHaveProperty('$lookup')
+      expect(agg[1]).not.toHaveProperty('$addFields')
+      // Ends with count sort
+      expect(agg.slice(-1)).toEqual([{ $sort: { views: 1 } }])
     })
     it('does not explode with all sorts', () => {
       const agg = pagination.sortAggregate({

--- a/packages/openneuro-server/datalad/dataset.js
+++ b/packages/openneuro-server/datalad/dataset.js
@@ -325,7 +325,7 @@ export const deleteFile = (datasetId, path, file) => {
 export const updatePublic = (datasetId, publicFlag) =>
   c.crn.datasets.updateOne(
     { id: datasetId },
-    { $set: { public: publicFlag } },
+    { $set: { public: publicFlag, publishDate: new Date() } },
     { upsert: true },
   )
 

--- a/packages/openneuro-server/graphql/resolvers/dataset.js
+++ b/packages/openneuro-server/graphql/resolvers/dataset.js
@@ -1,6 +1,6 @@
 import * as datalad from '../../datalad/dataset.js'
 import pubsub from '../pubsub.js'
-import { snapshots } from './snapshots.js'
+import { snapshots, latestSnapshot } from './snapshots.js'
 import { description } from './description.js'
 import { checkDatasetRead, checkDatasetWrite } from '../permissions.js'
 import { user } from './user.js'
@@ -258,6 +258,7 @@ const Dataset = {
   uploader: ds => user(ds, { id: ds.uploader }),
   draft,
   snapshots,
+  latestSnapshot,
   analytics: ds => analytics(ds),
   stars: ds => stars(ds),
   followers: ds => followers(ds),

--- a/packages/openneuro-server/graphql/resolvers/snapshots.js
+++ b/packages/openneuro-server/graphql/resolvers/snapshots.js
@@ -20,6 +20,19 @@ export const snapshot = (obj, { datasetId, tag }, context) => {
   }))
 }
 
+const sortSnapshots = (a, b) => new Date(b.created) - new Date(a.created)
+
+export const latestSnapshot = (obj, _, context) => {
+  return datalad.getSnapshots(obj.id).then(snapshots => {
+    const sortedSnapshots = Array.prototype.sort.call(snapshots, sortSnapshots)
+    return snapshot(
+      obj,
+      { datasetId: obj.id, tag: sortedSnapshots[0].tag },
+      context,
+    )
+  })
+}
+
 /**
  * Tag the working tree for a dataset
  */

--- a/packages/openneuro-server/graphql/schema.js
+++ b/packages/openneuro-server/graphql/schema.js
@@ -198,6 +198,8 @@ const typeDefs = `
     public: Boolean
     draft: Draft
     snapshots: [Snapshot]
+    # Newest snapshot
+    latestSnapshot: Snapshot
     permissions: [Permission]
     analytics: Analytic
     stars: [Star]
@@ -210,6 +212,8 @@ const typeDefs = `
     following: Boolean
     # Have I starred this dataset?
     starred: Boolean
+    # When was this dataset first made public?
+    datePublished: DateTime
   }
 
   enum SortOrdering {
@@ -229,8 +233,12 @@ const typeDefs = `
     stars: SortOrdering
     # Order by download count
     downloads: SortOrdering
+    # Order by dataset views
+    views: SortOrdering
     # Order by count of dataset followers
     subscriptions: SortOrdering
+    # Order by publish date
+    publishDate: SortOrdering
   }
 
   # Dataset query filter flags

--- a/packages/openneuro-server/graphql/schema.js
+++ b/packages/openneuro-server/graphql/schema.js
@@ -213,7 +213,7 @@ const typeDefs = `
     # Have I starred this dataset?
     starred: Boolean
     # When was this dataset first made public?
-    datePublished: DateTime
+    publishDate: DateTime
   }
 
   enum SortOrdering {

--- a/packages/openneuro-server/models/dataset.js
+++ b/packages/openneuro-server/models/dataset.js
@@ -6,6 +6,7 @@ const datasetSchema = new mongoose.Schema(
     created: { type: Date, default: Date.now },
     modified: { type: Date, default: Date.now },
     public: Boolean,
+    publishDate: { type: Date, default: null },
     uploader: String,
     revision: String,
     name: String,


### PR DESCRIPTION
This adds two highlighted dataset columns to the landing page. Datasets with high view counts on the left and datasets that were recently made public on the right.

![Screenshot from 2019-04-16 15-31-26](https://user-images.githubusercontent.com/11369795/56248397-b9aea900-605c-11e9-8696-47c92b569420.png)

Fixes #1065 