### PR TITLE
Don't throw exception when dataset is fully uploaded but has no authors

### DIFF
--- a/packages/openneuro-app/src/scripts/datalad/fragments/dataset-authors.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/fragments/dataset-authors.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
-const DatasetAuthors = ({ authors }) => (
+const DatasetAuthors = ({ authors = [] }) => (
   <h6>{`authored by ${authors.join(', ')}`}</h6>
 )
 


### PR DESCRIPTION
Fixes #1084 