### PR TITLE
Separate file requests for draft working tree and commits

### DIFF
--- a/packages/openneuro-server/datalad/__tests__/files.spec.js
+++ b/packages/openneuro-server/datalad/__tests__/files.spec.js
@@ -1,5 +1,5 @@
 import {
-  commitFilesKey,
+  filesKey,
   encodeFilePath,
   decodeFilePath,
   fileUrl,
@@ -11,12 +11,12 @@ jest.mock('../../config.js')
 const filename = 'sub-01/anat/sub-01_T1w.nii.gz'
 
 describe('datalad files', () => {
-  describe('commitFilesKey()', () => {
+  describe('filesKey()', () => {
     it('encodes a valid cache key', () => {
       expect(
-        commitFilesKey('ds000001', '13582a0b2dc82b3644431ba54fd38926a5d2238f'),
+        filesKey('ds000001', '13582a0b2dc82b3644431ba54fd38926a5d2238f'),
       ).toBe(
-        'openneuro:draftFiles:ds000001:13582a0b2dc82b3644431ba54fd38926a5d2238f',
+        'openneuro:files:ds000001:13582a0b2dc82b3644431ba54fd38926a5d2238f',
       )
     })
   })

--- a/packages/openneuro-server/datalad/description.js
+++ b/packages/openneuro-server/datalad/description.js
@@ -4,8 +4,7 @@
 import request from 'superagent'
 import { redis } from '../libs/redis.js'
 import { addFileString, commitFiles } from './dataset.js'
-import { objectUrl } from './files.js'
-import { getDraftFiles } from './draft.js'
+import { objectUrl, getFiles } from './files.js'
 import { getSnapshotHexsha } from './snapshots.js'
 
 export const defaultDescription = {
@@ -56,7 +55,7 @@ export const description = (obj, { datasetId, revision, tag }) => {
         const gitRef = revision
           ? revision
           : await getSnapshotHexsha(datasetId, tag)
-        return getDraftFiles(datasetId, gitRef)
+        return getFiles(datasetId, gitRef)
           .then(getDescriptionObject(datasetId))
           .then(uncachedDescription => {
             redis.set(redisKey, JSON.stringify(uncachedDescription))

--- a/packages/openneuro-server/datalad/draft.js
+++ b/packages/openneuro-server/datalad/draft.js
@@ -6,22 +6,24 @@ import mongo from '../libs/mongo.js'
 import { redis } from '../libs/redis.js'
 import config from '../config.js'
 import { addFileUrl } from './utils.js'
-import { commitFilesKey } from './files.js'
 
 const uri = config.datalad.uri
+
+const draftFilesKey = datasetId => {
+  return `openneuro:draftFiles:${datasetId}`
+}
 
 /**
  * Retrieve draft files from cache or the datalad-service backend
  * @param {string} datasetId Accession number string
- * @param {string} revision Git hexsha to get files, does not apply to untracked
  * @param {object} options { untracked: true } - ignores the git index
  */
-export const getDraftFiles = async (datasetId, revision, options = {}) => {
+export const getDraftFiles = async (datasetId, options = {}) => {
   // If untracked is set and true
-  const untracked = ('untracked' in options && options.untracked) || !revision
+  const untracked = 'untracked' in options && options.untracked
   const query = untracked ? { untracked: true } : {}
   const filesUrl = `${uri}/datasets/${datasetId}/files`
-  const key = commitFilesKey(datasetId, revision)
+  const key = draftFilesKey(datasetId)
   return redis.get(key).then(data => {
     if (!untracked && data) return JSON.parse(data)
     else

--- a/packages/openneuro-server/datalad/snapshots.js
+++ b/packages/openneuro-server/datalad/snapshots.js
@@ -7,10 +7,9 @@ import { redis } from '../libs/redis.js'
 import config from '../config.js'
 import pubsub from '../graphql/pubsub.js'
 import { updateDatasetName } from '../graphql/resolvers/dataset.js'
-import { commitFilesKey } from './files.js'
+import { filesKey, getFiles } from './files.js'
 import { addFileUrl } from './utils.js'
 import { generateDataladCookie } from '../libs/authentication/jwt'
-import { getDraftFiles } from './draft'
 import notifications from '../libs/notifications'
 import Snapshot from '../models/snapshot.js'
 import { trackAnalytics } from './analytics.js'
@@ -79,7 +78,7 @@ export const createSnapshot = async (datasetId, tag, user) => {
       body.created = new Date()
 
       // We should almost always get the fast path here
-      const fKey = commitFilesKey(datasetId, body.hexsha)
+      const fKey = filesKey(datasetId, body.hexsha)
       const filesFromCache = await redis.get(fKey)
       if (filesFromCache) {
         body.files = JSON.parse(filesFromCache)
@@ -87,7 +86,7 @@ export const createSnapshot = async (datasetId, tag, user) => {
         redis.set(sKey, JSON.stringify(body))
       } else {
         // Return the promise so queries won't block
-        body.files = getDraftFiles(datasetId, body.hexsha)
+        body.files = getFiles(datasetId, body.hexsha)
       }
 
       return (

--- a/packages/openneuro-server/graphql/resolvers/draft.js
+++ b/packages/openneuro-server/graphql/resolvers/draft.js
@@ -6,7 +6,7 @@ import { getDraftFiles, getPartialStatus } from '../../datalad/draft.js'
 
 // A draft must have a dataset parent
 const draftFiles = dataset => args => {
-  return getDraftFiles(dataset.id, dataset.revision, args)
+  return getDraftFiles(dataset.id, args)
 }
 
 export const draft = obj => ({

--- a/packages/openneuro-server/handlers/datalad.js
+++ b/packages/openneuro-server/handlers/datalad.js
@@ -1,9 +1,9 @@
 import config from '../config'
 import request from 'superagent'
 import mime from 'mime-types'
-import { getDraftFiles, getDatasetRevision } from '../datalad/draft'
+import { getDatasetRevision } from '../datalad/draft'
 import { getSnapshot } from '../datalad/snapshots'
-import { decodeFilePath } from '../datalad/files.js'
+import { decodeFilePath, getFiles } from '../datalad/files.js'
 
 /**
  * Handlers for datalad dataset manipulation
@@ -32,7 +32,7 @@ export const getFile = async (req, res) => {
   } else {
     let currentRevision = await getDatasetRevision(datasetId)
     if (currentRevision) {
-      fileList = await getDraftFiles(datasetId, currentRevision)
+      fileList = await getFiles(datasetId, currentRevision)
     }
   }
   const file = fileList.find(f => {


### PR DESCRIPTION
getDraftFiles was being used in both cases since it optimistically cached specific revisions. This leads to the incorrect behavior where the cache is populated with a mismatched file tree if the sequence of writes/reads isn't exactly right.

This PR splits these two uses into two functions, one which retrieves draft state and another which gets the file tree for specific revisions and can't become out of sync.

Fixes #1091 