### PR TITLE
Prevent crash when dataset authors is not the expected array value

### DIFF
--- a/packages/openneuro-app/src/scripts/datalad/fragments/__tests__/__snapshots__/dataset-authors.spec.jsx.snap
+++ b/packages/openneuro-app/src/scripts/datalad/fragments/__tests__/__snapshots__/dataset-authors.spec.jsx.snap
@@ -1,5 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`DatasetAuthors component renders when authors is null 1`] = `
+<h6>
+  authored by 
+</h6>
+`;
+
 exports[`DatasetAuthors component renders with common props 1`] = `
 <h6>
   authored by One, Two

--- a/packages/openneuro-app/src/scripts/datalad/fragments/__tests__/dataset-authors.spec.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/fragments/__tests__/dataset-authors.spec.jsx
@@ -7,4 +7,16 @@ describe('DatasetAuthors component', () => {
     const wrapper = shallow(<DatasetAuthors authors={['One', 'Two']} />)
     expect(wrapper).toMatchSnapshot()
   })
+  it('renders when authors is null', () => {
+    const wrapper = shallow(<DatasetAuthors />)
+    expect(wrapper).toMatchSnapshot()
+  })
+
+  it('renders null when authors is not an array', () => {
+    // Catch the expected PropTypes error
+    // eslint-disable-next-line no-console
+    console.error = jest.fn()
+    const wrapper = shallow(<DatasetAuthors authors={''} />)
+    expect(wrapper.getElement()).toBe(null)
+  })
 })

--- a/packages/openneuro-app/src/scripts/datalad/fragments/dataset-authors.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/fragments/dataset-authors.jsx
@@ -1,9 +1,13 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
-const DatasetAuthors = ({ authors = [] }) => (
-  <h6>{`authored by ${authors.join(', ')}`}</h6>
-)
+const DatasetAuthors = ({ authors = [] }) => {
+  if (Array.isArray(authors)) {
+    return <h6>{`authored by ${authors.join(', ')}`}</h6>
+  } else {
+    return null
+  }
+}
 
 DatasetAuthors.propTypes = {
   authors: PropTypes.array,


### PR DESCRIPTION
The default value fixed this is some cases but not every case for the existing datasets. This adds test coverage for the other failure case (Authors fails the PropType validation) and returns null instead of throwing an exception.

Fixes #1084 