### PR TITLE
Return null for dataset.draft.readme if the file does not exist

### DIFF
--- a/packages/openneuro-server/datalad/readme.js
+++ b/packages/openneuro-server/datalad/readme.js
@@ -15,7 +15,9 @@ export const readme = (obj, { datasetId, revision }) => {
    *
    * We may want to use less superagent anyways just to avoid library weight
    */
-  return fetch(readmeUrl(datasetId, revision)).then(res => res.text())
+  return fetch(readmeUrl(datasetId, revision)).then(
+    res => (res.status === 200 ? res.text() : null),
+  )
 }
 
 export const setReadme = (datasetId, readme, user) => {


### PR DESCRIPTION
fetch() does not reject for 404 errors from the backend which leads to passing through error text as the content. If status != 200, there is no accessible readme and the field should be null.