### PR TITLE
Add an error boundary for dashboard result rows

### DIFF
--- a/packages/openneuro-app/src/scripts/datalad/dashboard/datasets/dataset-query.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/dashboard/datasets/dataset-query.jsx
@@ -1,3 +1,4 @@
+/* eslint react/prop-types: 0, react/display-name: 0 */
 import React from 'react'
 import PropTypes from 'prop-types'
 import { Query } from 'react-apollo'
@@ -138,32 +139,28 @@ const loadMoreRows = (data, fetchMore) => {
 
 const datasetQueryDisplay = isPublic => ({
   loading,
-  error,
   data,
   fetchMore,
   refetch,
   variables,
 }) => {
-  if (error) {
-    throw error
-  } else {
-    return (
-      <DatasetTab
-        loading={loading}
-        data={data}
-        loadMoreRows={loading ? () => {} : loadMoreRows(data, fetchMore)}
-        refetch={refetch}
-        queryVariables={variables}
-        publicDashboard={isPublic}
-      />
-    )
-  }
+  return (
+    <DatasetTab
+      loading={loading}
+      data={data}
+      loadMoreRows={loading ? () => {} : loadMoreRows(data, fetchMore)}
+      refetch={refetch}
+      queryVariables={variables}
+      publicDashboard={isPublic}
+    />
+  )
 }
 
 const DatasetQuery = ({ public: isPublic }) => (
   <Query
     query={getDatasets}
-    variables={{ filterBy: { public: isPublic }, myDatasets: !isPublic }}>
+    variables={{ filterBy: { public: isPublic }, myDatasets: !isPublic }}
+    errorPolicy="all">
     {datasetQueryDisplay(isPublic)}
   </Query>
 )

--- a/packages/openneuro-app/src/scripts/datalad/dashboard/datasets/dataset-row-error-boundary.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/dashboard/datasets/dataset-row-error-boundary.jsx
@@ -1,0 +1,58 @@
+import * as Sentry from '@sentry/browser'
+import React from 'react'
+import PropTypes from 'prop-types'
+import RowHeight from './row-height.jsx'
+
+/**
+ * Don't prevent rendering all of the other results if one has failed to load
+ */
+class DatasetRowErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props)
+    this.state = { hasError: false, eventId: null }
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true }
+  }
+
+  componentDidCatch(error) {
+    Sentry.withScope(scope => {
+      scope.setTag('datasetId', this.props.datasetId)
+      this.setState({ eventId: Sentry.captureException(error) })
+    })
+  }
+
+  render() {
+    if (this.state.hasError) {
+      const eventString = this.state.eventId
+        ? ` with reference "${this.state.eventId}"`
+        : ''
+      return (
+        <div className="panel panel-default">
+          <RowHeight className="panel-heading">
+            <div className="header clearfix">
+              <h4 className="dataset-title">
+                An error occurred while displaying this result
+              </h4>
+            </div>
+            <div className="clearfix minimal-summary">
+              <div className="summary-data">
+                <strong>If this persists, contact support {eventString}</strong>
+              </div>
+            </div>
+          </RowHeight>
+        </div>
+      )
+    }
+
+    return this.props.children
+  }
+}
+
+DatasetRowErrorBoundary.propTypes = {
+  datasetId: PropTypes.string,
+  children: PropTypes.node,
+}
+
+export default DatasetRowErrorBoundary

--- a/packages/openneuro-app/src/scripts/datalad/dashboard/datasets/dataset-row.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/dashboard/datasets/dataset-row.jsx
@@ -24,6 +24,7 @@ class DatasetRow extends React.Component {
   shouldComponentUpdate(nextProps) {
     return this.props.dataset.id !== nextProps.dataset.id
   }
+
   render() {
     const dataset = this.props.dataset
     return (

--- a/packages/openneuro-app/src/scripts/datalad/dashboard/datasets/dataset-virtual-scroller.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/dashboard/datasets/dataset-virtual-scroller.jsx
@@ -8,6 +8,7 @@ import {
 } from 'react-virtualized'
 import DatasetRow from './dataset-row.jsx'
 import DatasetRowSkeleton from './dataset-row-skeleton.jsx'
+import DatasetRowErrorBoundary from './dataset-row-error-boundary.jsx'
 import styled from '@emotion/styled'
 
 const FlexParent = styled.div`
@@ -31,10 +32,13 @@ class DatasetVirtualScroller extends React.Component {
     if (this._isRowLoaded({ index })) {
       return (
         <div key={key} style={style}>
-          <DatasetRow
-            dataset={this.props.datasets[index].node}
-            publicDashboard={this.props.publicDashboard}
-          />
+          <DatasetRowErrorBoundary
+            datasetId={this.props.datasets[index].node.id}>
+            <DatasetRow
+              dataset={this.props.datasets[index].node}
+              publicDashboard={this.props.publicDashboard}
+            />
+          </DatasetRowErrorBoundary>
         </div>
       )
     } else {


### PR DESCRIPTION
This is related to #1101 and #1102 - this fixes #1102 by rendering a placeholder if the row cannot be rendered due to another bug or corrupt data. Without this, one bad dataset can result in a blank page or raw error message even if the other 24 on the page would have otherwise worked.

![Screenshot from 2019-04-26 15-55-17](https://user-images.githubusercontent.com/11369795/56840736-0b65e900-683e-11e9-8114-88a98bef86c3.png)

@franklin-feingold What do you think of the error text and message to contact support?