### PR TITLE
Save initial dataset revision on create dataset

### DIFF
--- a/packages/openneuro-app/src/scripts/datalad/routes/dataset-content.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/routes/dataset-content.jsx
@@ -63,7 +63,7 @@ const DatasetContent = ({ dataset }) => {
   const hasEdit =
     ((user && user.admin) ||
       hasEditPermissions(dataset.permissions, user && user.sub)) &&
-    dataset.draft.id
+    !dataset.draft.partial
   return (
     <>
       <LoggedIn>

--- a/packages/openneuro-app/src/scripts/datalad/routes/dataset-content.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/routes/dataset-content.jsx
@@ -102,9 +102,11 @@ const DatasetContent = ({ dataset }) => {
           />
         </div>
         <div className="col-xs-6">
-          {(dataset.draft.id && (
+          {dataset.draft.partial || dataset.draft.files.length === 0 ? (
+            <IncompleteDataset datasetId={dataset.id} />
+          ) : (
             <Validation datasetId={dataset.id} issues={dataset.draft.issues} />
-          )) || <IncompleteDataset datasetId={dataset.id} />}
+          )}
           <DatasetFiles
             datasetId={dataset.id}
             datasetName={dataset.draft.description.Name}

--- a/packages/openneuro-server/datalad/dataset.js
+++ b/packages/openneuro-server/datalad/dataset.js
@@ -40,10 +40,12 @@ export const createDataset = async (uploader, userInfo) => {
   const datasetId = await getAccessionNumber()
   try {
     const ds = new Dataset({ id: datasetId, uploader })
-    await request
+    const req = await request
       .post(`${uri}/datasets/${datasetId}`)
       .set('Accept', 'application/json')
       .set('Cookie', generateDataladCookie(config)(userInfo))
+    // Record and initial revision (usually empty but could be a DataLad upload)
+    ds.revision = req.body.hexsha
     // Write the new dataset to mongo after creation
     await ds.save()
     await giveUploaderPermission(datasetId, uploader)


### PR DESCRIPTION
This prevents initially interrupted uploads from producing a dataset without a git hash (Dataset.revision field). Better to have it point at an empty initial commit than be entirely missing.

To reproduce the issue:
* Begin an upload and interrupt prior to the create dataset request returning 200.
* Without this change a backend error is reported because of a request for /datasets/.../snapshots/**undefined** when it should instead point at the untagged commit. With this change a valid request for the empty revision succeeds.

Fixes #1101 for new datasets. A fix for existing affected datasets is still needed.