### PR TITLE
Fix missing download button on snapshots

### DIFF
--- a/packages/openneuro-app/src/scripts/datalad/routes/snapshot-content.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/routes/snapshot-content.jsx
@@ -12,6 +12,7 @@ import DatasetAnalytics from '../fragments/dataset-analytics.jsx'
 import DatasetFiles from '../fragments/dataset-files.jsx'
 import DatasetReadme from '../fragments/dataset-readme.jsx'
 import DatasetDescription from '../dataset/dataset-description.jsx'
+import DownloadButton from '../fragments/download-button.jsx'
 import Validation from '../validation/validation.jsx'
 import { SNAPSHOT_ISSUES } from '../dataset/dataset-query-fragments.js'
 
@@ -95,6 +96,7 @@ const SnapshotDetails = ({ dataset, snapshot }) => {
           views={snapshot.analytics.views}
           snapshot
         />
+        <DownloadButton dataset={dataset} />
         <DatasetSummary summary={snapshot.summary} />
         <h2>README</h2>
         <DatasetReadme content={snapshot.readme} />


### PR DESCRIPTION
I missed this while reviewing #1111 - the button should also be included in the snapshot version of the dataset page.