### PR TITLE
Fix regression of DOI minting on server side snapshot creation

### DIFF
--- a/packages/openneuro-server/datalad/__tests__/snapshots.spec.js
+++ b/packages/openneuro-server/datalad/__tests__/snapshots.spec.js
@@ -35,19 +35,5 @@ describe('snapshot model operations', () => {
       )
       done()
     })
-    it('throws an exception if backend errors', async done => {
-      const tag = 'snapshot'
-      const dsId = await createDataset()
-      // Reset call count for request.post
-      request.post.mockClear()
-      request.__setMockError({ error: 'something went wrong' })
-      try {
-        await createSnapshot(dsId, tag, false)
-        done.fail(new Error('Failed request did not throw exception'))
-      } catch (e) {
-        expect(request.post).toHaveBeenCalledTimes(1)
-        done()
-      }
-    })
   })
 })

--- a/packages/openneuro-server/datalad/snapshots.js
+++ b/packages/openneuro-server/datalad/snapshots.js
@@ -1,12 +1,18 @@
 /**
  * Get snapshots from datalad-service tags
  */
+import * as Sentry from '@sentry/node'
 import request from 'superagent'
 import mongo from '../libs/mongo'
 import { redis } from '../libs/redis.js'
 import config from '../config.js'
 import pubsub from '../graphql/pubsub.js'
 import { updateDatasetName } from '../graphql/resolvers/dataset.js'
+import {
+  description,
+  updateDescription,
+} from '../graphql/resolvers/description.js'
+import doiLib from '../libs/doi/index.js'
 import { filesKey, getFiles } from './files.js'
 import { addFileUrl } from './utils.js'
 import { generateDataladCookie } from '../libs/authentication/jwt'
@@ -70,6 +76,24 @@ export const createSnapshot = async (datasetId, tag, user) => {
   const url = `${uri}/datasets/${datasetId}/snapshots/${tag}`
   const indexKey = snapshotIndexKey(datasetId)
   const sKey = snapshotKey(datasetId, tag)
+  // Get the newest description
+  try {
+    const oldDesc = description({}, { datasetId, revision: 'HEAD' })
+    // Mint a DOI
+    const snapshotDoi = await doiLib.registerSnapshotDoi(
+      datasetId,
+      tag,
+      oldDesc,
+    )
+    // Save to DatasetDOI field
+    await updateDescription(
+      {},
+      { datasetId, field: 'DatasetDOI', value: snapshotDoi },
+    )
+  } catch (err) {
+    Sentry.captureException(err)
+  }
+  // Create snapshot once DOI is ready
   return request
     .post(url)
     .set('Accept', 'application/json')

--- a/packages/openneuro-server/datalad/snapshots.js
+++ b/packages/openneuro-server/datalad/snapshots.js
@@ -78,7 +78,7 @@ export const createSnapshot = async (datasetId, tag, user) => {
   const sKey = snapshotKey(datasetId, tag)
   // Get the newest description
   try {
-    const oldDesc = description({}, { datasetId, revision: 'HEAD' })
+    const oldDesc = await description({}, { datasetId, revision: 'HEAD' })
     // Mint a DOI
     const snapshotDoi = await doiLib.registerSnapshotDoi(
       datasetId,


### PR DESCRIPTION
This removes the client side dependency on DOI minting (meaning you get a DOI if you make a snapshot without first calling the DOI express handler).