### PR TITLE
Reserve snapshot tag before attempting to mint a DOI

### DIFF
--- a/packages/openneuro-server/datalad/snapshots.js
+++ b/packages/openneuro-server/datalad/snapshots.js
@@ -79,22 +79,24 @@ export const createSnapshot = async (datasetId, tag, user) => {
   // Reserve snapshot id to prevent a race condition on 1.0.0 snapshot
   await createSnapshotMetadata(datasetId, tag, null, null)
   // Get the newest description
-  try {
-    const oldDesc = await description({}, { datasetId, revision: 'HEAD' })
-    // Mint a DOI
-    const snapshotDoi = await doiLib.registerSnapshotDoi(
-      datasetId,
-      tag,
-      oldDesc,
-    )
-    // Save to DatasetDOI field
-    await updateDescription(
-      {},
-      { datasetId, field: 'DatasetDOI', value: snapshotDoi },
-      { userInfo: user, user: user.id },
-    )
-  } catch (err) {
-    Sentry.captureException(err)
+  if (config.doi.username && config.doi.password) {
+    try {
+      const oldDesc = await description({}, { datasetId, revision: 'HEAD' })
+      // Mint a DOI
+      const snapshotDoi = await doiLib.registerSnapshotDoi(
+        datasetId,
+        tag,
+        oldDesc,
+      )
+      // Save to DatasetDOI field
+      await updateDescription(
+        {},
+        { datasetId, field: 'DatasetDOI', value: snapshotDoi },
+        { userInfo: user, user: user.id },
+      )
+    } catch (err) {
+      Sentry.captureException(err)
+    }
   }
   // Create snapshot once DOI is ready
   return request

--- a/packages/openneuro-server/datalad/snapshots.js
+++ b/packages/openneuro-server/datalad/snapshots.js
@@ -76,6 +76,8 @@ export const createSnapshot = async (datasetId, tag, user) => {
   const url = `${uri}/datasets/${datasetId}/snapshots/${tag}`
   const indexKey = snapshotIndexKey(datasetId)
   const sKey = snapshotKey(datasetId, tag)
+  // Reserve snapshot id to prevent a race condition on 1.0.0 snapshot
+  await createSnapshotMetadata(datasetId, tag, null, null)
   // Get the newest description
   try {
     const oldDesc = await description({}, { datasetId, revision: 'HEAD' })


### PR DESCRIPTION
This prevents a race condition between the initial upload snapshot and the edit made by DOI minting.