### PR TITLE
1133 generic error boundary

### DIFF
--- a/bin/dev-restart
+++ b/bin/dev-restart
@@ -1,0 +1,4 @@
+#!/bin/bash
+# kill all docker containers and restart in background
+docker kill $(docker ps -a -q);
+./bin/dev-compose up -dls

--- a/packages/openneuro-app/src/sass/main.scss
+++ b/packages/openneuro-app/src/sass/main.scss
@@ -257,3 +257,9 @@ $bootstrap-sass-asset-helper: true;
  margin: 15px 0;
  z-index: 1000;
 }
+
+.generic-error-message {
+    padding: 1rem;
+    border: $coral;
+    color: red;
+}

--- a/packages/openneuro-app/src/scripts/datalad/dashboard/datasets/dataset-query.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/dashboard/datasets/dataset-query.jsx
@@ -143,11 +143,13 @@ const datasetQueryDisplay = isPublic => ({
   fetchMore,
   refetch,
   variables,
+  error,
 }) => {
   return (
     <DatasetTab
       loading={loading}
       data={data}
+      error={error}
       loadMoreRows={loading ? () => {} : loadMoreRows(data, fetchMore)}
       refetch={refetch}
       queryVariables={variables}

--- a/packages/openneuro-app/src/scripts/datalad/dashboard/datasets/dataset-tab.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/dashboard/datasets/dataset-tab.jsx
@@ -103,6 +103,7 @@ DatasetTab.propTypes = {
   queryVariables: PropTypes.object,
   loading: PropTypes.bool,
   publicDashboard: PropTypes.bool,
+  error: PropTypes.object,
 }
 
 export default DatasetTab

--- a/packages/openneuro-app/src/scripts/datalad/dashboard/datasets/dataset-tab.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/dashboard/datasets/dataset-tab.jsx
@@ -85,7 +85,7 @@ const DatasetTab = ({
     {loading ? (
       <Spinner text="Loading Datasets" active />
     ) : (
-      <ErrorBoundary error={error}>
+      <ErrorBoundary error={error} subject={'error in dashboard dataset tab'}>
         <DatasetTabLoaded
           data={data}
           loadMoreRows={loadMoreRows}

--- a/packages/openneuro-app/src/scripts/datalad/dashboard/datasets/dataset-tab.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/dashboard/datasets/dataset-tab.jsx
@@ -7,6 +7,7 @@ import Search from '../../../common/partials/search.jsx'
 import DatasetVirtualScroller from './dataset-virtual-scroller.jsx'
 import DatasetSorter from './dataset-sorter.jsx'
 import DatasetFilter from './dataset-filter.jsx'
+import ErrorBoundary from '../../../errors/errorBoundary.jsx'
 import styled from '@emotion/styled'
 
 const FullHeightFlexDiv = styled.div`
@@ -49,6 +50,7 @@ const DatasetTab = ({
   queryVariables,
   loading,
   publicDashboard,
+  error,
 }) => (
   <FullHeightFlexDiv className="dashboard-dataset-teasers datasets datasets-private">
     <Helmet>
@@ -83,11 +85,13 @@ const DatasetTab = ({
     {loading ? (
       <Spinner text="Loading Datasets" active />
     ) : (
-      <DatasetTabLoaded
-        data={data}
-        loadMoreRows={loadMoreRows}
-        publicDashboard={publicDashboard}
-      />
+      <ErrorBoundary error={error}>
+        <DatasetTabLoaded
+          data={data}
+          loadMoreRows={loadMoreRows}
+          publicDashboard={publicDashboard}
+        />
+      </ErrorBoundary>
     )}
   </FullHeightFlexDiv>
 )

--- a/packages/openneuro-app/src/scripts/datalad/dataset/__tests__/__snapshots__/comments.spec.jsx.snap
+++ b/packages/openneuro-app/src/scripts/datalad/dataset/__tests__/__snapshots__/comments.spec.jsx.snap
@@ -36,254 +36,638 @@ exports[`Comments component recursively renders a tree of comments 1`] = `
       <h2>
         Comments
       </h2>
-      <LoggedIn />
-      <LoggedOut>
-        <div>
-          Please sign in to contribute to the discussion.
-        </div>
-      </LoggedOut>
-      <CommentTree
-        comments={
-          Array [
-            Object {
-              "id": "xyz",
-              "replies": Array [
-                Object {
-                  "id": "xyz",
-                  "replies": Array [],
-                  "text": "{\\"blocks\\":[{\\"key\\":\\"3sm42\\",\\"text\\":\\"\\",\\"type\\":\\"unstyled\\",\\"depth\\":0,\\"inlineStyleRanges\\":[],\\"entityRanges\\":[],\\"data\\":{}}],\\"entityMap\\":{}}",
-                  "user": Object {
-                    "email": "example@example.com",
-                    "id": "1234",
-                  },
-                },
-              ],
-              "text": "{\\"blocks\\":[{\\"key\\":\\"3sm42\\",\\"text\\":\\"\\",\\"type\\":\\"unstyled\\",\\"depth\\":0,\\"inlineStyleRanges\\":[],\\"entityRanges\\":[],\\"data\\":{}}],\\"entityMap\\":{}}",
-              "user": Object {
-                "email": "example@example.com",
-                "id": "1234",
-              },
-            },
-          ]
-        }
-        datasetId="ds000001"
+      <ErrorBoundary
+        subject="error in dataset comments"
       >
-        <Comment
-          data={
-            Object {
-              "id": "xyz",
-              "replies": Array [
-                Object {
-                  "id": "xyz",
-                  "replies": Array [],
-                  "text": "{\\"blocks\\":[{\\"key\\":\\"3sm42\\",\\"text\\":\\"\\",\\"type\\":\\"unstyled\\",\\"depth\\":0,\\"inlineStyleRanges\\":[],\\"entityRanges\\":[],\\"data\\":{}}],\\"entityMap\\":{}}",
-                  "user": Object {
-                    "email": "example@example.com",
-                    "id": "1234",
+        <LoggedIn />
+        <LoggedOut>
+          <div>
+            Please sign in to contribute to the discussion.
+          </div>
+        </LoggedOut>
+        <CommentTree
+          comments={
+            Array [
+              Object {
+                "id": "xyz",
+                "replies": Array [
+                  Object {
+                    "id": "xyz",
+                    "replies": Array [],
+                    "text": "{\\"blocks\\":[{\\"key\\":\\"3sm42\\",\\"text\\":\\"\\",\\"type\\":\\"unstyled\\",\\"depth\\":0,\\"inlineStyleRanges\\":[],\\"entityRanges\\":[],\\"data\\":{}}],\\"entityMap\\":{}}",
+                    "user": Object {
+                      "email": "example@example.com",
+                      "id": "1234",
+                    },
                   },
+                ],
+                "text": "{\\"blocks\\":[{\\"key\\":\\"3sm42\\",\\"text\\":\\"\\",\\"type\\":\\"unstyled\\",\\"depth\\":0,\\"inlineStyleRanges\\":[],\\"entityRanges\\":[],\\"data\\":{}}],\\"entityMap\\":{}}",
+                "user": Object {
+                  "email": "example@example.com",
+                  "id": "1234",
                 },
-              ],
-              "text": "{\\"blocks\\":[{\\"key\\":\\"3sm42\\",\\"text\\":\\"\\",\\"type\\":\\"unstyled\\",\\"depth\\":0,\\"inlineStyleRanges\\":[],\\"entityRanges\\":[],\\"data\\":{}}],\\"entityMap\\":{}}",
-              "user": Object {
-                "email": "example@example.com",
-                "id": "1234",
               },
-            }
+            ]
           }
           datasetId="ds000001"
-          key="xyz"
         >
-          <div
-            className="comment"
+          <Comment
+            data={
+              Object {
+                "id": "xyz",
+                "replies": Array [
+                  Object {
+                    "id": "xyz",
+                    "replies": Array [],
+                    "text": "{\\"blocks\\":[{\\"key\\":\\"3sm42\\",\\"text\\":\\"\\",\\"type\\":\\"unstyled\\",\\"depth\\":0,\\"inlineStyleRanges\\":[],\\"entityRanges\\":[],\\"data\\":{}}],\\"entityMap\\":{}}",
+                    "user": Object {
+                      "email": "example@example.com",
+                      "id": "1234",
+                    },
+                  },
+                ],
+                "text": "{\\"blocks\\":[{\\"key\\":\\"3sm42\\",\\"text\\":\\"\\",\\"type\\":\\"unstyled\\",\\"depth\\":0,\\"inlineStyleRanges\\":[],\\"entityRanges\\":[],\\"data\\":{}}],\\"entityMap\\":{}}",
+                "user": Object {
+                  "email": "example@example.com",
+                  "id": "1234",
+                },
+              }
+            }
+            datasetId="ds000001"
+            key="xyz"
           >
             <div
-              className="row comment-header"
+              className="comment"
             >
-              By example@example.com - almost NaN years ago
-            </div>
-            <div
-              className="row comment-body"
-            >
-              <img
-                className="comment-avatar"
-                src="https://www.gravatar.com/avatar/23463b99b62a72f26ed677cc556c44e8?s=200&d=identicon"
-              />
-              <DraftEditor
-                blockRenderMap={
-                  Immutable.Map {
-                    "ordered-list-item": Object {
-                      "element": "li",
-                      "wrapper": <ol
-                        className="public-DraftStyleDefault-ol"
-                      />,
-                    },
-                    "header-six": Object {
-                      "element": "h6",
-                    },
-                    "header-four": Object {
-                      "element": "h4",
-                    },
-                    "header-one": Object {
-                      "element": "h1",
-                    },
-                    "unordered-list-item": Object {
-                      "element": "li",
-                      "wrapper": <ul
-                        className="public-DraftStyleDefault-ul"
-                      />,
-                    },
-                    "atomic": Object {
-                      "element": "figure",
-                    },
-                    "unstyled": Object {
-                      "aliasedElements": Array [
-                        "p",
-                      ],
-                      "element": "div",
-                    },
-                    "header-two": Object {
-                      "element": "h2",
-                    },
-                    "code-block": Object {
-                      "element": "pre",
-                      "wrapper": <pre
-                        className="public-DraftStyleDefault-pre"
-                      />,
-                    },
-                    "blockquote": Object {
-                      "element": "blockquote",
-                    },
-                    "header-five": Object {
-                      "element": "h5",
-                    },
-                    "header-three": Object {
-                      "element": "h3",
-                    },
-                  }
-                }
-                blockRendererFn={[Function]}
-                blockStyleFn={[Function]}
-                editorKey="xyz"
-                editorState={
-                  EditorState {
-                    "_immutable": Immutable.Record {
-                      "allowUndo": true,
-                      "currentContent": Immutable.Record {
-                        "entityMap": Object {},
-                        "blockMap": Immutable.OrderedMap {
-                          "3sm42": Immutable.Record {
-                            "key": "3sm42",
-                            "type": "unstyled",
-                            "text": "",
-                            "characterList": Immutable.List [],
-                            "depth": 0,
-                            "data": Immutable.Map {},
-                          },
-                        },
-                        "selectionBefore": Immutable.Record {
-                          "anchorKey": "3sm42",
-                          "anchorOffset": 0,
-                          "focusKey": "3sm42",
-                          "focusOffset": 0,
-                          "isBackward": false,
-                          "hasFocus": false,
-                        },
-                        "selectionAfter": Immutable.Record {
-                          "anchorKey": "3sm42",
-                          "anchorOffset": 0,
-                          "focusKey": "3sm42",
-                          "focusOffset": 0,
-                          "isBackward": false,
-                          "hasFocus": false,
-                        },
-                      },
-                      "decorator": null,
-                      "directionMap": Immutable.OrderedMap {
-                        "3sm42": "LTR",
-                      },
-                      "forceSelection": false,
-                      "inCompositionMode": false,
-                      "inlineStyleOverride": null,
-                      "lastChangeType": null,
-                      "nativelyRenderedContent": null,
-                      "redoStack": Immutable.Stack [],
-                      "selection": Immutable.Record {
-                        "anchorKey": "3sm42",
-                        "anchorOffset": 0,
-                        "focusKey": "3sm42",
-                        "focusOffset": 0,
-                        "isBackward": false,
-                        "hasFocus": false,
-                      },
-                      "treeMap": Immutable.OrderedMap {
-                        "3sm42": Immutable.List [
-                          Immutable.Record {
-                            "start": 0,
-                            "end": 0,
-                            "decoratorKey": null,
-                            "leaves": Immutable.List [
-                              Immutable.Record {
-                                "start": 0,
-                                "end": 0,
-                              },
-                            ],
-                          },
-                        ],
-                      },
-                      "undoStack": Immutable.Stack [],
-                    },
-                  }
-                }
-                keyBindingFn={[Function]}
-                readOnly={false}
-                spellCheck={false}
-                stripPastedStyles={false}
+              <div
+                className="row comment-header"
               >
-                <div
-                  className="DraftEditor-root"
+                By example@example.com - almost NaN years ago
+              </div>
+              <div
+                className="row comment-body"
+              >
+                <img
+                  className="comment-avatar"
+                  src="https://www.gravatar.com/avatar/23463b99b62a72f26ed677cc556c44e8?s=200&d=identicon"
+                />
+                <DraftEditor
+                  blockRenderMap={
+                    Immutable.Map {
+                      "ordered-list-item": Object {
+                        "element": "li",
+                        "wrapper": <ol
+                          className="public-DraftStyleDefault-ol"
+                        />,
+                      },
+                      "header-six": Object {
+                        "element": "h6",
+                      },
+                      "header-four": Object {
+                        "element": "h4",
+                      },
+                      "header-one": Object {
+                        "element": "h1",
+                      },
+                      "unordered-list-item": Object {
+                        "element": "li",
+                        "wrapper": <ul
+                          className="public-DraftStyleDefault-ul"
+                        />,
+                      },
+                      "atomic": Object {
+                        "element": "figure",
+                      },
+                      "unstyled": Object {
+                        "aliasedElements": Array [
+                          "p",
+                        ],
+                        "element": "div",
+                      },
+                      "header-two": Object {
+                        "element": "h2",
+                      },
+                      "code-block": Object {
+                        "element": "pre",
+                        "wrapper": <pre
+                          className="public-DraftStyleDefault-pre"
+                        />,
+                      },
+                      "blockquote": Object {
+                        "element": "blockquote",
+                      },
+                      "header-five": Object {
+                        "element": "h5",
+                      },
+                      "header-three": Object {
+                        "element": "h3",
+                      },
+                    }
+                  }
+                  blockRendererFn={[Function]}
+                  blockStyleFn={[Function]}
+                  editorKey="xyz"
+                  editorState={
+                    EditorState {
+                      "_immutable": Immutable.Record {
+                        "allowUndo": true,
+                        "currentContent": Immutable.Record {
+                          "entityMap": Object {},
+                          "blockMap": Immutable.OrderedMap {
+                            "3sm42": Immutable.Record {
+                              "key": "3sm42",
+                              "type": "unstyled",
+                              "text": "",
+                              "characterList": Immutable.List [],
+                              "depth": 0,
+                              "data": Immutable.Map {},
+                            },
+                          },
+                          "selectionBefore": Immutable.Record {
+                            "anchorKey": "3sm42",
+                            "anchorOffset": 0,
+                            "focusKey": "3sm42",
+                            "focusOffset": 0,
+                            "isBackward": false,
+                            "hasFocus": false,
+                          },
+                          "selectionAfter": Immutable.Record {
+                            "anchorKey": "3sm42",
+                            "anchorOffset": 0,
+                            "focusKey": "3sm42",
+                            "focusOffset": 0,
+                            "isBackward": false,
+                            "hasFocus": false,
+                          },
+                        },
+                        "decorator": null,
+                        "directionMap": Immutable.OrderedMap {
+                          "3sm42": "LTR",
+                        },
+                        "forceSelection": false,
+                        "inCompositionMode": false,
+                        "inlineStyleOverride": null,
+                        "lastChangeType": null,
+                        "nativelyRenderedContent": null,
+                        "redoStack": Immutable.Stack [],
+                        "selection": Immutable.Record {
+                          "anchorKey": "3sm42",
+                          "anchorOffset": 0,
+                          "focusKey": "3sm42",
+                          "focusOffset": 0,
+                          "isBackward": false,
+                          "hasFocus": false,
+                        },
+                        "treeMap": Immutable.OrderedMap {
+                          "3sm42": Immutable.List [
+                            Immutable.Record {
+                              "start": 0,
+                              "end": 0,
+                              "decoratorKey": null,
+                              "leaves": Immutable.List [
+                                Immutable.Record {
+                                  "start": 0,
+                                  "end": 0,
+                                },
+                              ],
+                            },
+                          ],
+                        },
+                        "undoStack": Immutable.Stack [],
+                      },
+                    }
+                  }
+                  keyBindingFn={[Function]}
+                  readOnly={false}
+                  spellCheck={false}
+                  stripPastedStyles={false}
                 >
                   <div
-                    className="DraftEditor-editorContainer"
+                    className="DraftEditor-root"
                   >
                     <div
-                      aria-describedby="placeholder-xyz"
-                      aria-expanded={null}
-                      className="notranslate public-DraftEditor-content"
-                      contentEditable={true}
-                      onBeforeInput={[Function]}
-                      onBlur={[Function]}
-                      onCompositionEnd={[Function]}
-                      onCompositionStart={[Function]}
-                      onCopy={[Function]}
-                      onCut={[Function]}
-                      onDragEnd={[Function]}
-                      onDragEnter={[Function]}
-                      onDragLeave={[Function]}
-                      onDragOver={[Function]}
-                      onDragStart={[Function]}
-                      onDrop={[Function]}
-                      onFocus={[Function]}
-                      onInput={[Function]}
-                      onKeyDown={[Function]}
-                      onKeyPress={[Function]}
-                      onKeyUp={[Function]}
-                      onMouseUp={[Function]}
-                      onPaste={[Function]}
-                      onSelect={[Function]}
-                      role="textbox"
-                      spellCheck={false}
-                      style={
-                        Object {
-                          "WebkitUserSelect": "text",
-                          "outline": "none",
-                          "userSelect": "text",
-                          "whiteSpace": "pre-wrap",
-                          "wordWrap": "break-word",
-                        }
-                      }
-                      suppressContentEditableWarning={true}
+                      className="DraftEditor-editorContainer"
                     >
-                      <DraftEditorContents
+                      <div
+                        aria-describedby="placeholder-xyz"
+                        aria-expanded={null}
+                        className="notranslate public-DraftEditor-content"
+                        contentEditable={true}
+                        onBeforeInput={[Function]}
+                        onBlur={[Function]}
+                        onCompositionEnd={[Function]}
+                        onCompositionStart={[Function]}
+                        onCopy={[Function]}
+                        onCut={[Function]}
+                        onDragEnd={[Function]}
+                        onDragEnter={[Function]}
+                        onDragLeave={[Function]}
+                        onDragOver={[Function]}
+                        onDragStart={[Function]}
+                        onDrop={[Function]}
+                        onFocus={[Function]}
+                        onInput={[Function]}
+                        onKeyDown={[Function]}
+                        onKeyPress={[Function]}
+                        onKeyUp={[Function]}
+                        onMouseUp={[Function]}
+                        onPaste={[Function]}
+                        onSelect={[Function]}
+                        role="textbox"
+                        spellCheck={false}
+                        style={
+                          Object {
+                            "WebkitUserSelect": "text",
+                            "outline": "none",
+                            "userSelect": "text",
+                            "whiteSpace": "pre-wrap",
+                            "wordWrap": "break-word",
+                          }
+                        }
+                        suppressContentEditableWarning={true}
+                      >
+                        <DraftEditorContents
+                          blockRenderMap={
+                            Immutable.Map {
+                              "ordered-list-item": Object {
+                                "element": "li",
+                                "wrapper": <ol
+                                  className="public-DraftStyleDefault-ol"
+                                />,
+                              },
+                              "header-six": Object {
+                                "element": "h6",
+                              },
+                              "header-four": Object {
+                                "element": "h4",
+                              },
+                              "header-one": Object {
+                                "element": "h1",
+                              },
+                              "unordered-list-item": Object {
+                                "element": "li",
+                                "wrapper": <ul
+                                  className="public-DraftStyleDefault-ul"
+                                />,
+                              },
+                              "atomic": Object {
+                                "element": "figure",
+                              },
+                              "unstyled": Object {
+                                "aliasedElements": Array [
+                                  "p",
+                                ],
+                                "element": "div",
+                              },
+                              "header-two": Object {
+                                "element": "h2",
+                              },
+                              "code-block": Object {
+                                "element": "pre",
+                                "wrapper": <pre
+                                  className="public-DraftStyleDefault-pre"
+                                />,
+                              },
+                              "blockquote": Object {
+                                "element": "blockquote",
+                              },
+                              "header-five": Object {
+                                "element": "h5",
+                              },
+                              "header-three": Object {
+                                "element": "h3",
+                              },
+                            }
+                          }
+                          blockRendererFn={[Function]}
+                          blockStyleFn={[Function]}
+                          customStyleMap={
+                            Object {
+                              "BOLD": Object {
+                                "fontWeight": "bold",
+                              },
+                              "CODE": Object {
+                                "fontFamily": "monospace",
+                                "wordWrap": "break-word",
+                              },
+                              "ITALIC": Object {
+                                "fontStyle": "italic",
+                              },
+                              "STRIKETHROUGH": Object {
+                                "textDecoration": "line-through",
+                              },
+                              "UNDERLINE": Object {
+                                "textDecoration": "underline",
+                              },
+                            }
+                          }
+                          editorKey="xyz"
+                          editorState={
+                            EditorState {
+                              "_immutable": Immutable.Record {
+                                "allowUndo": true,
+                                "currentContent": Immutable.Record {
+                                  "entityMap": Object {},
+                                  "blockMap": Immutable.OrderedMap {
+                                    "3sm42": Immutable.Record {
+                                      "key": "3sm42",
+                                      "type": "unstyled",
+                                      "text": "",
+                                      "characterList": Immutable.List [],
+                                      "depth": 0,
+                                      "data": Immutable.Map {},
+                                    },
+                                  },
+                                  "selectionBefore": Immutable.Record {
+                                    "anchorKey": "3sm42",
+                                    "anchorOffset": 0,
+                                    "focusKey": "3sm42",
+                                    "focusOffset": 0,
+                                    "isBackward": false,
+                                    "hasFocus": false,
+                                  },
+                                  "selectionAfter": Immutable.Record {
+                                    "anchorKey": "3sm42",
+                                    "anchorOffset": 0,
+                                    "focusKey": "3sm42",
+                                    "focusOffset": 0,
+                                    "isBackward": false,
+                                    "hasFocus": false,
+                                  },
+                                },
+                                "decorator": null,
+                                "directionMap": Immutable.OrderedMap {
+                                  "3sm42": "LTR",
+                                },
+                                "forceSelection": false,
+                                "inCompositionMode": false,
+                                "inlineStyleOverride": null,
+                                "lastChangeType": null,
+                                "nativelyRenderedContent": null,
+                                "redoStack": Immutable.Stack [],
+                                "selection": Immutable.Record {
+                                  "anchorKey": "3sm42",
+                                  "anchorOffset": 0,
+                                  "focusKey": "3sm42",
+                                  "focusOffset": 0,
+                                  "isBackward": false,
+                                  "hasFocus": false,
+                                },
+                                "treeMap": Immutable.OrderedMap {
+                                  "3sm42": Immutable.List [
+                                    Immutable.Record {
+                                      "start": 0,
+                                      "end": 0,
+                                      "decoratorKey": null,
+                                      "leaves": Immutable.List [
+                                        Immutable.Record {
+                                          "start": 0,
+                                          "end": 0,
+                                        },
+                                      ],
+                                    },
+                                  ],
+                                },
+                                "undoStack": Immutable.Stack [],
+                              },
+                            }
+                          }
+                          key="contents0"
+                        >
+                          <div
+                            data-contents="true"
+                          >
+                            <div
+                              className=""
+                              data-block={true}
+                              data-editor="xyz"
+                              data-offset-key="3sm42-0-0"
+                              key="3sm42"
+                            >
+                              <DraftEditorBlock
+                                block={
+                                  Immutable.Record {
+                                    "key": "3sm42",
+                                    "type": "unstyled",
+                                    "text": "",
+                                    "characterList": Immutable.List [],
+                                    "depth": 0,
+                                    "data": Immutable.Map {},
+                                  }
+                                }
+                                blockStyleFn={[Function]}
+                                contentState={
+                                  Immutable.Record {
+                                    "entityMap": Object {},
+                                    "blockMap": Immutable.OrderedMap {
+                                      "3sm42": Immutable.Record {
+                                        "key": "3sm42",
+                                        "type": "unstyled",
+                                        "text": "",
+                                        "characterList": Immutable.List [],
+                                        "depth": 0,
+                                        "data": Immutable.Map {},
+                                      },
+                                    },
+                                    "selectionBefore": Immutable.Record {
+                                      "anchorKey": "3sm42",
+                                      "anchorOffset": 0,
+                                      "focusKey": "3sm42",
+                                      "focusOffset": 0,
+                                      "isBackward": false,
+                                      "hasFocus": false,
+                                    },
+                                    "selectionAfter": Immutable.Record {
+                                      "anchorKey": "3sm42",
+                                      "anchorOffset": 0,
+                                      "focusKey": "3sm42",
+                                      "focusOffset": 0,
+                                      "isBackward": false,
+                                      "hasFocus": false,
+                                    },
+                                  }
+                                }
+                                customStyleMap={
+                                  Object {
+                                    "BOLD": Object {
+                                      "fontWeight": "bold",
+                                    },
+                                    "CODE": Object {
+                                      "fontFamily": "monospace",
+                                      "wordWrap": "break-word",
+                                    },
+                                    "ITALIC": Object {
+                                      "fontStyle": "italic",
+                                    },
+                                    "STRIKETHROUGH": Object {
+                                      "textDecoration": "line-through",
+                                    },
+                                    "UNDERLINE": Object {
+                                      "textDecoration": "underline",
+                                    },
+                                  }
+                                }
+                                decorator={null}
+                                direction="LTR"
+                                forceSelection={false}
+                                key="3sm42"
+                                offsetKey="3sm42-0-0"
+                                selection={
+                                  Immutable.Record {
+                                    "anchorKey": "3sm42",
+                                    "anchorOffset": 0,
+                                    "focusKey": "3sm42",
+                                    "focusOffset": 0,
+                                    "isBackward": false,
+                                    "hasFocus": false,
+                                  }
+                                }
+                                tree={
+                                  Immutable.List [
+                                    Immutable.Record {
+                                      "start": 0,
+                                      "end": 0,
+                                      "decoratorKey": null,
+                                      "leaves": Immutable.List [
+                                        Immutable.Record {
+                                          "start": 0,
+                                          "end": 0,
+                                        },
+                                      ],
+                                    },
+                                  ]
+                                }
+                              >
+                                <div
+                                  className="public-DraftStyleDefault-block public-DraftStyleDefault-ltr"
+                                  data-offset-key="3sm42-0-0"
+                                >
+                                  <DraftEditorLeaf
+                                    block={
+                                      Immutable.Record {
+                                        "key": "3sm42",
+                                        "type": "unstyled",
+                                        "text": "",
+                                        "characterList": Immutable.List [],
+                                        "depth": 0,
+                                        "data": Immutable.Map {},
+                                      }
+                                    }
+                                    customStyleMap={
+                                      Object {
+                                        "BOLD": Object {
+                                          "fontWeight": "bold",
+                                        },
+                                        "CODE": Object {
+                                          "fontFamily": "monospace",
+                                          "wordWrap": "break-word",
+                                        },
+                                        "ITALIC": Object {
+                                          "fontStyle": "italic",
+                                        },
+                                        "STRIKETHROUGH": Object {
+                                          "textDecoration": "line-through",
+                                        },
+                                        "UNDERLINE": Object {
+                                          "textDecoration": "underline",
+                                        },
+                                      }
+                                    }
+                                    forceSelection={false}
+                                    isLast={true}
+                                    key="3sm42-0-0"
+                                    offsetKey="3sm42-0-0"
+                                    selection={
+                                      Immutable.Record {
+                                        "anchorKey": "3sm42",
+                                        "anchorOffset": 0,
+                                        "focusKey": "3sm42",
+                                        "focusOffset": 0,
+                                        "isBackward": false,
+                                        "hasFocus": false,
+                                      }
+                                    }
+                                    start={0}
+                                    styleSet={Immutable.OrderedSet []}
+                                    text=""
+                                  >
+                                    <span
+                                      data-offset-key="3sm42-0-0"
+                                      style={Object {}}
+                                    >
+                                      <DraftEditorTextNode>
+                                        <br
+                                          data-text="true"
+                                          key="B"
+                                        />
+                                      </DraftEditorTextNode>
+                                    </span>
+                                  </DraftEditorLeaf>
+                                </div>
+                              </DraftEditorBlock>
+                            </div>
+                          </div>
+                        </DraftEditorContents>
+                      </div>
+                    </div>
+                  </div>
+                </DraftEditor>
+              </div>
+              <LoggedIn />
+            </div>
+            <div
+              className="row replies"
+            >
+              <div
+                className="comment-reply"
+              />
+              <CommentTree
+                comments={
+                  Array [
+                    Object {
+                      "id": "xyz",
+                      "replies": Array [],
+                      "text": "{\\"blocks\\":[{\\"key\\":\\"3sm42\\",\\"text\\":\\"\\",\\"type\\":\\"unstyled\\",\\"depth\\":0,\\"inlineStyleRanges\\":[],\\"entityRanges\\":[],\\"data\\":{}}],\\"entityMap\\":{}}",
+                      "user": Object {
+                        "email": "example@example.com",
+                        "id": "1234",
+                      },
+                    },
+                  ]
+                }
+                datasetId="ds000001"
+              >
+                <Comment
+                  data={
+                    Object {
+                      "id": "xyz",
+                      "replies": Array [],
+                      "text": "{\\"blocks\\":[{\\"key\\":\\"3sm42\\",\\"text\\":\\"\\",\\"type\\":\\"unstyled\\",\\"depth\\":0,\\"inlineStyleRanges\\":[],\\"entityRanges\\":[],\\"data\\":{}}],\\"entityMap\\":{}}",
+                      "user": Object {
+                        "email": "example@example.com",
+                        "id": "1234",
+                      },
+                    }
+                  }
+                  datasetId="ds000001"
+                  key="xyz"
+                >
+                  <div
+                    className="comment"
+                  >
+                    <div
+                      className="row comment-header"
+                    >
+                      By example@example.com - almost NaN years ago
+                    </div>
+                    <div
+                      className="row comment-body"
+                    >
+                      <img
+                        className="comment-avatar"
+                        src="https://www.gravatar.com/avatar/23463b99b62a72f26ed677cc556c44e8?s=200&d=identicon"
+                      />
+                      <DraftEditor
                         blockRenderMap={
                           Immutable.Map {
                             "ordered-list-item": Object {
@@ -338,26 +722,6 @@ exports[`Comments component recursively renders a tree of comments 1`] = `
                         }
                         blockRendererFn={[Function]}
                         blockStyleFn={[Function]}
-                        customStyleMap={
-                          Object {
-                            "BOLD": Object {
-                              "fontWeight": "bold",
-                            },
-                            "CODE": Object {
-                              "fontFamily": "monospace",
-                              "wordWrap": "break-word",
-                            },
-                            "ITALIC": Object {
-                              "fontStyle": "italic",
-                            },
-                            "STRIKETHROUGH": Object {
-                              "textDecoration": "line-through",
-                            },
-                            "UNDERLINE": Object {
-                              "textDecoration": "underline",
-                            },
-                          }
-                        }
                         editorKey="xyz"
                         editorState={
                           EditorState {
@@ -429,588 +793,136 @@ exports[`Comments component recursively renders a tree of comments 1`] = `
                             },
                           }
                         }
-                        key="contents0"
+                        keyBindingFn={[Function]}
+                        readOnly={false}
+                        spellCheck={false}
+                        stripPastedStyles={false}
                       >
                         <div
-                          data-contents="true"
+                          className="DraftEditor-root"
                         >
                           <div
-                            className=""
-                            data-block={true}
-                            data-editor="xyz"
-                            data-offset-key="3sm42-0-0"
-                            key="3sm42"
+                            className="DraftEditor-editorContainer"
                           >
-                            <DraftEditorBlock
-                              block={
-                                Immutable.Record {
-                                  "key": "3sm42",
-                                  "type": "unstyled",
-                                  "text": "",
-                                  "characterList": Immutable.List [],
-                                  "depth": 0,
-                                  "data": Immutable.Map {},
-                                }
-                              }
-                              blockStyleFn={[Function]}
-                              contentState={
-                                Immutable.Record {
-                                  "entityMap": Object {},
-                                  "blockMap": Immutable.OrderedMap {
-                                    "3sm42": Immutable.Record {
-                                      "key": "3sm42",
-                                      "type": "unstyled",
-                                      "text": "",
-                                      "characterList": Immutable.List [],
-                                      "depth": 0,
-                                      "data": Immutable.Map {},
-                                    },
-                                  },
-                                  "selectionBefore": Immutable.Record {
-                                    "anchorKey": "3sm42",
-                                    "anchorOffset": 0,
-                                    "focusKey": "3sm42",
-                                    "focusOffset": 0,
-                                    "isBackward": false,
-                                    "hasFocus": false,
-                                  },
-                                  "selectionAfter": Immutable.Record {
-                                    "anchorKey": "3sm42",
-                                    "anchorOffset": 0,
-                                    "focusKey": "3sm42",
-                                    "focusOffset": 0,
-                                    "isBackward": false,
-                                    "hasFocus": false,
-                                  },
-                                }
-                              }
-                              customStyleMap={
+                            <div
+                              aria-describedby="placeholder-xyz"
+                              aria-expanded={null}
+                              className="notranslate public-DraftEditor-content"
+                              contentEditable={true}
+                              onBeforeInput={[Function]}
+                              onBlur={[Function]}
+                              onCompositionEnd={[Function]}
+                              onCompositionStart={[Function]}
+                              onCopy={[Function]}
+                              onCut={[Function]}
+                              onDragEnd={[Function]}
+                              onDragEnter={[Function]}
+                              onDragLeave={[Function]}
+                              onDragOver={[Function]}
+                              onDragStart={[Function]}
+                              onDrop={[Function]}
+                              onFocus={[Function]}
+                              onInput={[Function]}
+                              onKeyDown={[Function]}
+                              onKeyPress={[Function]}
+                              onKeyUp={[Function]}
+                              onMouseUp={[Function]}
+                              onPaste={[Function]}
+                              onSelect={[Function]}
+                              role="textbox"
+                              spellCheck={false}
+                              style={
                                 Object {
-                                  "BOLD": Object {
-                                    "fontWeight": "bold",
-                                  },
-                                  "CODE": Object {
-                                    "fontFamily": "monospace",
-                                    "wordWrap": "break-word",
-                                  },
-                                  "ITALIC": Object {
-                                    "fontStyle": "italic",
-                                  },
-                                  "STRIKETHROUGH": Object {
-                                    "textDecoration": "line-through",
-                                  },
-                                  "UNDERLINE": Object {
-                                    "textDecoration": "underline",
-                                  },
+                                  "WebkitUserSelect": "text",
+                                  "outline": "none",
+                                  "userSelect": "text",
+                                  "whiteSpace": "pre-wrap",
+                                  "wordWrap": "break-word",
                                 }
                               }
-                              decorator={null}
-                              direction="LTR"
-                              forceSelection={false}
-                              key="3sm42"
-                              offsetKey="3sm42-0-0"
-                              selection={
-                                Immutable.Record {
-                                  "anchorKey": "3sm42",
-                                  "anchorOffset": 0,
-                                  "focusKey": "3sm42",
-                                  "focusOffset": 0,
-                                  "isBackward": false,
-                                  "hasFocus": false,
-                                }
-                              }
-                              tree={
-                                Immutable.List [
-                                  Immutable.Record {
-                                    "start": 0,
-                                    "end": 0,
-                                    "decoratorKey": null,
-                                    "leaves": Immutable.List [
-                                      Immutable.Record {
-                                        "start": 0,
-                                        "end": 0,
-                                      },
-                                    ],
-                                  },
-                                ]
-                              }
+                              suppressContentEditableWarning={true}
                             >
-                              <div
-                                className="public-DraftStyleDefault-block public-DraftStyleDefault-ltr"
-                                data-offset-key="3sm42-0-0"
-                              >
-                                <DraftEditorLeaf
-                                  block={
-                                    Immutable.Record {
-                                      "key": "3sm42",
-                                      "type": "unstyled",
-                                      "text": "",
-                                      "characterList": Immutable.List [],
-                                      "depth": 0,
-                                      "data": Immutable.Map {},
-                                    }
-                                  }
-                                  customStyleMap={
-                                    Object {
-                                      "BOLD": Object {
-                                        "fontWeight": "bold",
-                                      },
-                                      "CODE": Object {
-                                        "fontFamily": "monospace",
-                                        "wordWrap": "break-word",
-                                      },
-                                      "ITALIC": Object {
-                                        "fontStyle": "italic",
-                                      },
-                                      "STRIKETHROUGH": Object {
-                                        "textDecoration": "line-through",
-                                      },
-                                      "UNDERLINE": Object {
-                                        "textDecoration": "underline",
-                                      },
-                                    }
-                                  }
-                                  forceSelection={false}
-                                  isLast={true}
-                                  key="3sm42-0-0"
-                                  offsetKey="3sm42-0-0"
-                                  selection={
-                                    Immutable.Record {
-                                      "anchorKey": "3sm42",
-                                      "anchorOffset": 0,
-                                      "focusKey": "3sm42",
-                                      "focusOffset": 0,
-                                      "isBackward": false,
-                                      "hasFocus": false,
-                                    }
-                                  }
-                                  start={0}
-                                  styleSet={Immutable.OrderedSet []}
-                                  text=""
-                                >
-                                  <span
-                                    data-offset-key="3sm42-0-0"
-                                    style={Object {}}
-                                  >
-                                    <DraftEditorTextNode>
-                                      <br
-                                        data-text="true"
-                                        key="B"
-                                      />
-                                    </DraftEditorTextNode>
-                                  </span>
-                                </DraftEditorLeaf>
-                              </div>
-                            </DraftEditorBlock>
-                          </div>
-                        </div>
-                      </DraftEditorContents>
-                    </div>
-                  </div>
-                </div>
-              </DraftEditor>
-            </div>
-            <LoggedIn />
-          </div>
-          <div
-            className="row replies"
-          >
-            <div
-              className="comment-reply"
-            />
-            <CommentTree
-              comments={
-                Array [
-                  Object {
-                    "id": "xyz",
-                    "replies": Array [],
-                    "text": "{\\"blocks\\":[{\\"key\\":\\"3sm42\\",\\"text\\":\\"\\",\\"type\\":\\"unstyled\\",\\"depth\\":0,\\"inlineStyleRanges\\":[],\\"entityRanges\\":[],\\"data\\":{}}],\\"entityMap\\":{}}",
-                    "user": Object {
-                      "email": "example@example.com",
-                      "id": "1234",
-                    },
-                  },
-                ]
-              }
-              datasetId="ds000001"
-            >
-              <Comment
-                data={
-                  Object {
-                    "id": "xyz",
-                    "replies": Array [],
-                    "text": "{\\"blocks\\":[{\\"key\\":\\"3sm42\\",\\"text\\":\\"\\",\\"type\\":\\"unstyled\\",\\"depth\\":0,\\"inlineStyleRanges\\":[],\\"entityRanges\\":[],\\"data\\":{}}],\\"entityMap\\":{}}",
-                    "user": Object {
-                      "email": "example@example.com",
-                      "id": "1234",
-                    },
-                  }
-                }
-                datasetId="ds000001"
-                key="xyz"
-              >
-                <div
-                  className="comment"
-                >
-                  <div
-                    className="row comment-header"
-                  >
-                    By example@example.com - almost NaN years ago
-                  </div>
-                  <div
-                    className="row comment-body"
-                  >
-                    <img
-                      className="comment-avatar"
-                      src="https://www.gravatar.com/avatar/23463b99b62a72f26ed677cc556c44e8?s=200&d=identicon"
-                    />
-                    <DraftEditor
-                      blockRenderMap={
-                        Immutable.Map {
-                          "ordered-list-item": Object {
-                            "element": "li",
-                            "wrapper": <ol
-                              className="public-DraftStyleDefault-ol"
-                            />,
-                          },
-                          "header-six": Object {
-                            "element": "h6",
-                          },
-                          "header-four": Object {
-                            "element": "h4",
-                          },
-                          "header-one": Object {
-                            "element": "h1",
-                          },
-                          "unordered-list-item": Object {
-                            "element": "li",
-                            "wrapper": <ul
-                              className="public-DraftStyleDefault-ul"
-                            />,
-                          },
-                          "atomic": Object {
-                            "element": "figure",
-                          },
-                          "unstyled": Object {
-                            "aliasedElements": Array [
-                              "p",
-                            ],
-                            "element": "div",
-                          },
-                          "header-two": Object {
-                            "element": "h2",
-                          },
-                          "code-block": Object {
-                            "element": "pre",
-                            "wrapper": <pre
-                              className="public-DraftStyleDefault-pre"
-                            />,
-                          },
-                          "blockquote": Object {
-                            "element": "blockquote",
-                          },
-                          "header-five": Object {
-                            "element": "h5",
-                          },
-                          "header-three": Object {
-                            "element": "h3",
-                          },
-                        }
-                      }
-                      blockRendererFn={[Function]}
-                      blockStyleFn={[Function]}
-                      editorKey="xyz"
-                      editorState={
-                        EditorState {
-                          "_immutable": Immutable.Record {
-                            "allowUndo": true,
-                            "currentContent": Immutable.Record {
-                              "entityMap": Object {},
-                              "blockMap": Immutable.OrderedMap {
-                                "3sm42": Immutable.Record {
-                                  "key": "3sm42",
-                                  "type": "unstyled",
-                                  "text": "",
-                                  "characterList": Immutable.List [],
-                                  "depth": 0,
-                                  "data": Immutable.Map {},
-                                },
-                              },
-                              "selectionBefore": Immutable.Record {
-                                "anchorKey": "3sm42",
-                                "anchorOffset": 0,
-                                "focusKey": "3sm42",
-                                "focusOffset": 0,
-                                "isBackward": false,
-                                "hasFocus": false,
-                              },
-                              "selectionAfter": Immutable.Record {
-                                "anchorKey": "3sm42",
-                                "anchorOffset": 0,
-                                "focusKey": "3sm42",
-                                "focusOffset": 0,
-                                "isBackward": false,
-                                "hasFocus": false,
-                              },
-                            },
-                            "decorator": null,
-                            "directionMap": Immutable.OrderedMap {
-                              "3sm42": "LTR",
-                            },
-                            "forceSelection": false,
-                            "inCompositionMode": false,
-                            "inlineStyleOverride": null,
-                            "lastChangeType": null,
-                            "nativelyRenderedContent": null,
-                            "redoStack": Immutable.Stack [],
-                            "selection": Immutable.Record {
-                              "anchorKey": "3sm42",
-                              "anchorOffset": 0,
-                              "focusKey": "3sm42",
-                              "focusOffset": 0,
-                              "isBackward": false,
-                              "hasFocus": false,
-                            },
-                            "treeMap": Immutable.OrderedMap {
-                              "3sm42": Immutable.List [
-                                Immutable.Record {
-                                  "start": 0,
-                                  "end": 0,
-                                  "decoratorKey": null,
-                                  "leaves": Immutable.List [
-                                    Immutable.Record {
-                                      "start": 0,
-                                      "end": 0,
+                              <DraftEditorContents
+                                blockRenderMap={
+                                  Immutable.Map {
+                                    "ordered-list-item": Object {
+                                      "element": "li",
+                                      "wrapper": <ol
+                                        className="public-DraftStyleDefault-ol"
+                                      />,
                                     },
-                                  ],
-                                },
-                              ],
-                            },
-                            "undoStack": Immutable.Stack [],
-                          },
-                        }
-                      }
-                      keyBindingFn={[Function]}
-                      readOnly={false}
-                      spellCheck={false}
-                      stripPastedStyles={false}
-                    >
-                      <div
-                        className="DraftEditor-root"
-                      >
-                        <div
-                          className="DraftEditor-editorContainer"
-                        >
-                          <div
-                            aria-describedby="placeholder-xyz"
-                            aria-expanded={null}
-                            className="notranslate public-DraftEditor-content"
-                            contentEditable={true}
-                            onBeforeInput={[Function]}
-                            onBlur={[Function]}
-                            onCompositionEnd={[Function]}
-                            onCompositionStart={[Function]}
-                            onCopy={[Function]}
-                            onCut={[Function]}
-                            onDragEnd={[Function]}
-                            onDragEnter={[Function]}
-                            onDragLeave={[Function]}
-                            onDragOver={[Function]}
-                            onDragStart={[Function]}
-                            onDrop={[Function]}
-                            onFocus={[Function]}
-                            onInput={[Function]}
-                            onKeyDown={[Function]}
-                            onKeyPress={[Function]}
-                            onKeyUp={[Function]}
-                            onMouseUp={[Function]}
-                            onPaste={[Function]}
-                            onSelect={[Function]}
-                            role="textbox"
-                            spellCheck={false}
-                            style={
-                              Object {
-                                "WebkitUserSelect": "text",
-                                "outline": "none",
-                                "userSelect": "text",
-                                "whiteSpace": "pre-wrap",
-                                "wordWrap": "break-word",
-                              }
-                            }
-                            suppressContentEditableWarning={true}
-                          >
-                            <DraftEditorContents
-                              blockRenderMap={
-                                Immutable.Map {
-                                  "ordered-list-item": Object {
-                                    "element": "li",
-                                    "wrapper": <ol
-                                      className="public-DraftStyleDefault-ol"
-                                    />,
-                                  },
-                                  "header-six": Object {
-                                    "element": "h6",
-                                  },
-                                  "header-four": Object {
-                                    "element": "h4",
-                                  },
-                                  "header-one": Object {
-                                    "element": "h1",
-                                  },
-                                  "unordered-list-item": Object {
-                                    "element": "li",
-                                    "wrapper": <ul
-                                      className="public-DraftStyleDefault-ul"
-                                    />,
-                                  },
-                                  "atomic": Object {
-                                    "element": "figure",
-                                  },
-                                  "unstyled": Object {
-                                    "aliasedElements": Array [
-                                      "p",
-                                    ],
-                                    "element": "div",
-                                  },
-                                  "header-two": Object {
-                                    "element": "h2",
-                                  },
-                                  "code-block": Object {
-                                    "element": "pre",
-                                    "wrapper": <pre
-                                      className="public-DraftStyleDefault-pre"
-                                    />,
-                                  },
-                                  "blockquote": Object {
-                                    "element": "blockquote",
-                                  },
-                                  "header-five": Object {
-                                    "element": "h5",
-                                  },
-                                  "header-three": Object {
-                                    "element": "h3",
-                                  },
-                                }
-                              }
-                              blockRendererFn={[Function]}
-                              blockStyleFn={[Function]}
-                              customStyleMap={
-                                Object {
-                                  "BOLD": Object {
-                                    "fontWeight": "bold",
-                                  },
-                                  "CODE": Object {
-                                    "fontFamily": "monospace",
-                                    "wordWrap": "break-word",
-                                  },
-                                  "ITALIC": Object {
-                                    "fontStyle": "italic",
-                                  },
-                                  "STRIKETHROUGH": Object {
-                                    "textDecoration": "line-through",
-                                  },
-                                  "UNDERLINE": Object {
-                                    "textDecoration": "underline",
-                                  },
-                                }
-                              }
-                              editorKey="xyz"
-                              editorState={
-                                EditorState {
-                                  "_immutable": Immutable.Record {
-                                    "allowUndo": true,
-                                    "currentContent": Immutable.Record {
-                                      "entityMap": Object {},
-                                      "blockMap": Immutable.OrderedMap {
-                                        "3sm42": Immutable.Record {
-                                          "key": "3sm42",
-                                          "type": "unstyled",
-                                          "text": "",
-                                          "characterList": Immutable.List [],
-                                          "depth": 0,
-                                          "data": Immutable.Map {},
-                                        },
-                                      },
-                                      "selectionBefore": Immutable.Record {
-                                        "anchorKey": "3sm42",
-                                        "anchorOffset": 0,
-                                        "focusKey": "3sm42",
-                                        "focusOffset": 0,
-                                        "isBackward": false,
-                                        "hasFocus": false,
-                                      },
-                                      "selectionAfter": Immutable.Record {
-                                        "anchorKey": "3sm42",
-                                        "anchorOffset": 0,
-                                        "focusKey": "3sm42",
-                                        "focusOffset": 0,
-                                        "isBackward": false,
-                                        "hasFocus": false,
-                                      },
+                                    "header-six": Object {
+                                      "element": "h6",
                                     },
-                                    "decorator": null,
-                                    "directionMap": Immutable.OrderedMap {
-                                      "3sm42": "LTR",
+                                    "header-four": Object {
+                                      "element": "h4",
                                     },
-                                    "forceSelection": false,
-                                    "inCompositionMode": false,
-                                    "inlineStyleOverride": null,
-                                    "lastChangeType": null,
-                                    "nativelyRenderedContent": null,
-                                    "redoStack": Immutable.Stack [],
-                                    "selection": Immutable.Record {
-                                      "anchorKey": "3sm42",
-                                      "anchorOffset": 0,
-                                      "focusKey": "3sm42",
-                                      "focusOffset": 0,
-                                      "isBackward": false,
-                                      "hasFocus": false,
+                                    "header-one": Object {
+                                      "element": "h1",
                                     },
-                                    "treeMap": Immutable.OrderedMap {
-                                      "3sm42": Immutable.List [
-                                        Immutable.Record {
-                                          "start": 0,
-                                          "end": 0,
-                                          "decoratorKey": null,
-                                          "leaves": Immutable.List [
-                                            Immutable.Record {
-                                              "start": 0,
-                                              "end": 0,
-                                            },
-                                          ],
-                                        },
+                                    "unordered-list-item": Object {
+                                      "element": "li",
+                                      "wrapper": <ul
+                                        className="public-DraftStyleDefault-ul"
+                                      />,
+                                    },
+                                    "atomic": Object {
+                                      "element": "figure",
+                                    },
+                                    "unstyled": Object {
+                                      "aliasedElements": Array [
+                                        "p",
                                       ],
+                                      "element": "div",
                                     },
-                                    "undoStack": Immutable.Stack [],
-                                  },
+                                    "header-two": Object {
+                                      "element": "h2",
+                                    },
+                                    "code-block": Object {
+                                      "element": "pre",
+                                      "wrapper": <pre
+                                        className="public-DraftStyleDefault-pre"
+                                      />,
+                                    },
+                                    "blockquote": Object {
+                                      "element": "blockquote",
+                                    },
+                                    "header-five": Object {
+                                      "element": "h5",
+                                    },
+                                    "header-three": Object {
+                                      "element": "h3",
+                                    },
+                                  }
                                 }
-                              }
-                              key="contents0"
-                            >
-                              <div
-                                data-contents="true"
-                              >
-                                <div
-                                  className=""
-                                  data-block={true}
-                                  data-editor="xyz"
-                                  data-offset-key="3sm42-0-0"
-                                  key="3sm42"
-                                >
-                                  <DraftEditorBlock
-                                    block={
-                                      Immutable.Record {
-                                        "key": "3sm42",
-                                        "type": "unstyled",
-                                        "text": "",
-                                        "characterList": Immutable.List [],
-                                        "depth": 0,
-                                        "data": Immutable.Map {},
-                                      }
-                                    }
-                                    blockStyleFn={[Function]}
-                                    contentState={
-                                      Immutable.Record {
+                                blockRendererFn={[Function]}
+                                blockStyleFn={[Function]}
+                                customStyleMap={
+                                  Object {
+                                    "BOLD": Object {
+                                      "fontWeight": "bold",
+                                    },
+                                    "CODE": Object {
+                                      "fontFamily": "monospace",
+                                      "wordWrap": "break-word",
+                                    },
+                                    "ITALIC": Object {
+                                      "fontStyle": "italic",
+                                    },
+                                    "STRIKETHROUGH": Object {
+                                      "textDecoration": "line-through",
+                                    },
+                                    "UNDERLINE": Object {
+                                      "textDecoration": "underline",
+                                    },
+                                  }
+                                }
+                                editorKey="xyz"
+                                editorState={
+                                  EditorState {
+                                    "_immutable": Immutable.Record {
+                                      "allowUndo": true,
+                                      "currentContent": Immutable.Record {
                                         "entityMap": Object {},
                                         "blockMap": Immutable.OrderedMap {
                                           "3sm42": Immutable.Record {
@@ -1038,148 +950,240 @@ exports[`Comments component recursively renders a tree of comments 1`] = `
                                           "isBackward": false,
                                           "hasFocus": false,
                                         },
-                                      }
-                                    }
-                                    customStyleMap={
-                                      Object {
-                                        "BOLD": Object {
-                                          "fontWeight": "bold",
-                                        },
-                                        "CODE": Object {
-                                          "fontFamily": "monospace",
-                                          "wordWrap": "break-word",
-                                        },
-                                        "ITALIC": Object {
-                                          "fontStyle": "italic",
-                                        },
-                                        "STRIKETHROUGH": Object {
-                                          "textDecoration": "line-through",
-                                        },
-                                        "UNDERLINE": Object {
-                                          "textDecoration": "underline",
-                                        },
-                                      }
-                                    }
-                                    decorator={null}
-                                    direction="LTR"
-                                    forceSelection={false}
-                                    key="3sm42"
-                                    offsetKey="3sm42-0-0"
-                                    selection={
-                                      Immutable.Record {
+                                      },
+                                      "decorator": null,
+                                      "directionMap": Immutable.OrderedMap {
+                                        "3sm42": "LTR",
+                                      },
+                                      "forceSelection": false,
+                                      "inCompositionMode": false,
+                                      "inlineStyleOverride": null,
+                                      "lastChangeType": null,
+                                      "nativelyRenderedContent": null,
+                                      "redoStack": Immutable.Stack [],
+                                      "selection": Immutable.Record {
                                         "anchorKey": "3sm42",
                                         "anchorOffset": 0,
                                         "focusKey": "3sm42",
                                         "focusOffset": 0,
                                         "isBackward": false,
                                         "hasFocus": false,
-                                      }
-                                    }
-                                    tree={
-                                      Immutable.List [
-                                        Immutable.Record {
-                                          "start": 0,
-                                          "end": 0,
-                                          "decoratorKey": null,
-                                          "leaves": Immutable.List [
-                                            Immutable.Record {
-                                              "start": 0,
-                                              "end": 0,
-                                            },
-                                          ],
-                                        },
-                                      ]
-                                    }
+                                      },
+                                      "treeMap": Immutable.OrderedMap {
+                                        "3sm42": Immutable.List [
+                                          Immutable.Record {
+                                            "start": 0,
+                                            "end": 0,
+                                            "decoratorKey": null,
+                                            "leaves": Immutable.List [
+                                              Immutable.Record {
+                                                "start": 0,
+                                                "end": 0,
+                                              },
+                                            ],
+                                          },
+                                        ],
+                                      },
+                                      "undoStack": Immutable.Stack [],
+                                    },
+                                  }
+                                }
+                                key="contents0"
+                              >
+                                <div
+                                  data-contents="true"
+                                >
+                                  <div
+                                    className=""
+                                    data-block={true}
+                                    data-editor="xyz"
+                                    data-offset-key="3sm42-0-0"
+                                    key="3sm42"
                                   >
-                                    <div
-                                      className="public-DraftStyleDefault-block public-DraftStyleDefault-ltr"
-                                      data-offset-key="3sm42-0-0"
-                                    >
-                                      <DraftEditorLeaf
-                                        block={
-                                          Immutable.Record {
-                                            "key": "3sm42",
-                                            "type": "unstyled",
-                                            "text": "",
-                                            "characterList": Immutable.List [],
-                                            "depth": 0,
-                                            "data": Immutable.Map {},
-                                          }
+                                    <DraftEditorBlock
+                                      block={
+                                        Immutable.Record {
+                                          "key": "3sm42",
+                                          "type": "unstyled",
+                                          "text": "",
+                                          "characterList": Immutable.List [],
+                                          "depth": 0,
+                                          "data": Immutable.Map {},
                                         }
-                                        customStyleMap={
-                                          Object {
-                                            "BOLD": Object {
-                                              "fontWeight": "bold",
+                                      }
+                                      blockStyleFn={[Function]}
+                                      contentState={
+                                        Immutable.Record {
+                                          "entityMap": Object {},
+                                          "blockMap": Immutable.OrderedMap {
+                                            "3sm42": Immutable.Record {
+                                              "key": "3sm42",
+                                              "type": "unstyled",
+                                              "text": "",
+                                              "characterList": Immutable.List [],
+                                              "depth": 0,
+                                              "data": Immutable.Map {},
                                             },
-                                            "CODE": Object {
-                                              "fontFamily": "monospace",
-                                              "wordWrap": "break-word",
-                                            },
-                                            "ITALIC": Object {
-                                              "fontStyle": "italic",
-                                            },
-                                            "STRIKETHROUGH": Object {
-                                              "textDecoration": "line-through",
-                                            },
-                                            "UNDERLINE": Object {
-                                              "textDecoration": "underline",
-                                            },
-                                          }
-                                        }
-                                        forceSelection={false}
-                                        isLast={true}
-                                        key="3sm42-0-0"
-                                        offsetKey="3sm42-0-0"
-                                        selection={
-                                          Immutable.Record {
+                                          },
+                                          "selectionBefore": Immutable.Record {
                                             "anchorKey": "3sm42",
                                             "anchorOffset": 0,
                                             "focusKey": "3sm42",
                                             "focusOffset": 0,
                                             "isBackward": false,
                                             "hasFocus": false,
-                                          }
+                                          },
+                                          "selectionAfter": Immutable.Record {
+                                            "anchorKey": "3sm42",
+                                            "anchorOffset": 0,
+                                            "focusKey": "3sm42",
+                                            "focusOffset": 0,
+                                            "isBackward": false,
+                                            "hasFocus": false,
+                                          },
                                         }
-                                        start={0}
-                                        styleSet={Immutable.OrderedSet []}
-                                        text=""
+                                      }
+                                      customStyleMap={
+                                        Object {
+                                          "BOLD": Object {
+                                            "fontWeight": "bold",
+                                          },
+                                          "CODE": Object {
+                                            "fontFamily": "monospace",
+                                            "wordWrap": "break-word",
+                                          },
+                                          "ITALIC": Object {
+                                            "fontStyle": "italic",
+                                          },
+                                          "STRIKETHROUGH": Object {
+                                            "textDecoration": "line-through",
+                                          },
+                                          "UNDERLINE": Object {
+                                            "textDecoration": "underline",
+                                          },
+                                        }
+                                      }
+                                      decorator={null}
+                                      direction="LTR"
+                                      forceSelection={false}
+                                      key="3sm42"
+                                      offsetKey="3sm42-0-0"
+                                      selection={
+                                        Immutable.Record {
+                                          "anchorKey": "3sm42",
+                                          "anchorOffset": 0,
+                                          "focusKey": "3sm42",
+                                          "focusOffset": 0,
+                                          "isBackward": false,
+                                          "hasFocus": false,
+                                        }
+                                      }
+                                      tree={
+                                        Immutable.List [
+                                          Immutable.Record {
+                                            "start": 0,
+                                            "end": 0,
+                                            "decoratorKey": null,
+                                            "leaves": Immutable.List [
+                                              Immutable.Record {
+                                                "start": 0,
+                                                "end": 0,
+                                              },
+                                            ],
+                                          },
+                                        ]
+                                      }
+                                    >
+                                      <div
+                                        className="public-DraftStyleDefault-block public-DraftStyleDefault-ltr"
+                                        data-offset-key="3sm42-0-0"
                                       >
-                                        <span
-                                          data-offset-key="3sm42-0-0"
-                                          style={Object {}}
+                                        <DraftEditorLeaf
+                                          block={
+                                            Immutable.Record {
+                                              "key": "3sm42",
+                                              "type": "unstyled",
+                                              "text": "",
+                                              "characterList": Immutable.List [],
+                                              "depth": 0,
+                                              "data": Immutable.Map {},
+                                            }
+                                          }
+                                          customStyleMap={
+                                            Object {
+                                              "BOLD": Object {
+                                                "fontWeight": "bold",
+                                              },
+                                              "CODE": Object {
+                                                "fontFamily": "monospace",
+                                                "wordWrap": "break-word",
+                                              },
+                                              "ITALIC": Object {
+                                                "fontStyle": "italic",
+                                              },
+                                              "STRIKETHROUGH": Object {
+                                                "textDecoration": "line-through",
+                                              },
+                                              "UNDERLINE": Object {
+                                                "textDecoration": "underline",
+                                              },
+                                            }
+                                          }
+                                          forceSelection={false}
+                                          isLast={true}
+                                          key="3sm42-0-0"
+                                          offsetKey="3sm42-0-0"
+                                          selection={
+                                            Immutable.Record {
+                                              "anchorKey": "3sm42",
+                                              "anchorOffset": 0,
+                                              "focusKey": "3sm42",
+                                              "focusOffset": 0,
+                                              "isBackward": false,
+                                              "hasFocus": false,
+                                            }
+                                          }
+                                          start={0}
+                                          styleSet={Immutable.OrderedSet []}
+                                          text=""
                                         >
-                                          <DraftEditorTextNode>
-                                            <br
-                                              data-text="true"
-                                              key="B"
-                                            />
-                                          </DraftEditorTextNode>
-                                        </span>
-                                      </DraftEditorLeaf>
-                                    </div>
-                                  </DraftEditorBlock>
+                                          <span
+                                            data-offset-key="3sm42-0-0"
+                                            style={Object {}}
+                                          >
+                                            <DraftEditorTextNode>
+                                              <br
+                                                data-text="true"
+                                                key="B"
+                                              />
+                                            </DraftEditorTextNode>
+                                          </span>
+                                        </DraftEditorLeaf>
+                                      </div>
+                                    </DraftEditorBlock>
+                                  </div>
                                 </div>
-                              </div>
-                            </DraftEditorContents>
+                              </DraftEditorContents>
+                            </div>
                           </div>
                         </div>
-                      </div>
-                    </DraftEditor>
+                      </DraftEditor>
+                    </div>
+                    <LoggedIn />
                   </div>
-                  <LoggedIn />
-                </div>
-                <div
-                  className="row replies"
-                >
                   <div
-                    className="comment-reply"
-                  />
-                </div>
-              </Comment>
-            </CommentTree>
-          </div>
-        </Comment>
-      </CommentTree>
+                    className="row replies"
+                  >
+                    <div
+                      className="comment-reply"
+                    />
+                  </div>
+                </Comment>
+              </CommentTree>
+            </div>
+          </Comment>
+        </CommentTree>
+      </ErrorBoundary>
     </div>
   </div>
 </Comments>
@@ -1211,405 +1215,317 @@ exports[`Comments component renders one top level comment 1`] = `
       <h2>
         Comments
       </h2>
-      <LoggedIn />
-      <LoggedOut>
-        <div>
-          Please sign in to contribute to the discussion.
-        </div>
-      </LoggedOut>
-      <CommentTree
-        comments={
-          Array [
-            Object {
-              "id": "xyz",
-              "replies": Array [],
-              "text": "{\\"blocks\\":[{\\"key\\":\\"3sm42\\",\\"text\\":\\"\\",\\"type\\":\\"unstyled\\",\\"depth\\":0,\\"inlineStyleRanges\\":[],\\"entityRanges\\":[],\\"data\\":{}}],\\"entityMap\\":{}}",
-              "user": Object {
-                "email": "example@example.com",
-                "id": "1234",
-              },
-            },
-          ]
-        }
-        datasetId="ds000001"
+      <ErrorBoundary
+        subject="error in dataset comments"
       >
-        <Comment
-          data={
-            Object {
-              "id": "xyz",
-              "replies": Array [],
-              "text": "{\\"blocks\\":[{\\"key\\":\\"3sm42\\",\\"text\\":\\"\\",\\"type\\":\\"unstyled\\",\\"depth\\":0,\\"inlineStyleRanges\\":[],\\"entityRanges\\":[],\\"data\\":{}}],\\"entityMap\\":{}}",
-              "user": Object {
-                "email": "example@example.com",
-                "id": "1234",
+        <LoggedIn />
+        <LoggedOut>
+          <div>
+            Please sign in to contribute to the discussion.
+          </div>
+        </LoggedOut>
+        <CommentTree
+          comments={
+            Array [
+              Object {
+                "id": "xyz",
+                "replies": Array [],
+                "text": "{\\"blocks\\":[{\\"key\\":\\"3sm42\\",\\"text\\":\\"\\",\\"type\\":\\"unstyled\\",\\"depth\\":0,\\"inlineStyleRanges\\":[],\\"entityRanges\\":[],\\"data\\":{}}],\\"entityMap\\":{}}",
+                "user": Object {
+                  "email": "example@example.com",
+                  "id": "1234",
+                },
               },
-            }
+            ]
           }
           datasetId="ds000001"
-          key="xyz"
         >
-          <div
-            className="comment"
+          <Comment
+            data={
+              Object {
+                "id": "xyz",
+                "replies": Array [],
+                "text": "{\\"blocks\\":[{\\"key\\":\\"3sm42\\",\\"text\\":\\"\\",\\"type\\":\\"unstyled\\",\\"depth\\":0,\\"inlineStyleRanges\\":[],\\"entityRanges\\":[],\\"data\\":{}}],\\"entityMap\\":{}}",
+                "user": Object {
+                  "email": "example@example.com",
+                  "id": "1234",
+                },
+              }
+            }
+            datasetId="ds000001"
+            key="xyz"
           >
             <div
-              className="row comment-header"
+              className="comment"
             >
-              By example@example.com - almost NaN years ago
-            </div>
-            <div
-              className="row comment-body"
-            >
-              <img
-                className="comment-avatar"
-                src="https://www.gravatar.com/avatar/23463b99b62a72f26ed677cc556c44e8?s=200&d=identicon"
-              />
-              <DraftEditor
-                blockRenderMap={
-                  Immutable.Map {
-                    "ordered-list-item": Object {
-                      "element": "li",
-                      "wrapper": <ol
-                        className="public-DraftStyleDefault-ol"
-                      />,
-                    },
-                    "header-six": Object {
-                      "element": "h6",
-                    },
-                    "header-four": Object {
-                      "element": "h4",
-                    },
-                    "header-one": Object {
-                      "element": "h1",
-                    },
-                    "unordered-list-item": Object {
-                      "element": "li",
-                      "wrapper": <ul
-                        className="public-DraftStyleDefault-ul"
-                      />,
-                    },
-                    "atomic": Object {
-                      "element": "figure",
-                    },
-                    "unstyled": Object {
-                      "aliasedElements": Array [
-                        "p",
-                      ],
-                      "element": "div",
-                    },
-                    "header-two": Object {
-                      "element": "h2",
-                    },
-                    "code-block": Object {
-                      "element": "pre",
-                      "wrapper": <pre
-                        className="public-DraftStyleDefault-pre"
-                      />,
-                    },
-                    "blockquote": Object {
-                      "element": "blockquote",
-                    },
-                    "header-five": Object {
-                      "element": "h5",
-                    },
-                    "header-three": Object {
-                      "element": "h3",
-                    },
-                  }
-                }
-                blockRendererFn={[Function]}
-                blockStyleFn={[Function]}
-                editorKey="xyz"
-                editorState={
-                  EditorState {
-                    "_immutable": Immutable.Record {
-                      "allowUndo": true,
-                      "currentContent": Immutable.Record {
-                        "entityMap": Object {},
-                        "blockMap": Immutable.OrderedMap {
-                          "3sm42": Immutable.Record {
-                            "key": "3sm42",
-                            "type": "unstyled",
-                            "text": "",
-                            "characterList": Immutable.List [],
-                            "depth": 0,
-                            "data": Immutable.Map {},
-                          },
-                        },
-                        "selectionBefore": Immutable.Record {
-                          "anchorKey": "3sm42",
-                          "anchorOffset": 0,
-                          "focusKey": "3sm42",
-                          "focusOffset": 0,
-                          "isBackward": false,
-                          "hasFocus": false,
-                        },
-                        "selectionAfter": Immutable.Record {
-                          "anchorKey": "3sm42",
-                          "anchorOffset": 0,
-                          "focusKey": "3sm42",
-                          "focusOffset": 0,
-                          "isBackward": false,
-                          "hasFocus": false,
-                        },
-                      },
-                      "decorator": null,
-                      "directionMap": Immutable.OrderedMap {
-                        "3sm42": "LTR",
-                      },
-                      "forceSelection": false,
-                      "inCompositionMode": false,
-                      "inlineStyleOverride": null,
-                      "lastChangeType": null,
-                      "nativelyRenderedContent": null,
-                      "redoStack": Immutable.Stack [],
-                      "selection": Immutable.Record {
-                        "anchorKey": "3sm42",
-                        "anchorOffset": 0,
-                        "focusKey": "3sm42",
-                        "focusOffset": 0,
-                        "isBackward": false,
-                        "hasFocus": false,
-                      },
-                      "treeMap": Immutable.OrderedMap {
-                        "3sm42": Immutable.List [
-                          Immutable.Record {
-                            "start": 0,
-                            "end": 0,
-                            "decoratorKey": null,
-                            "leaves": Immutable.List [
-                              Immutable.Record {
-                                "start": 0,
-                                "end": 0,
-                              },
-                            ],
-                          },
-                        ],
-                      },
-                      "undoStack": Immutable.Stack [],
-                    },
-                  }
-                }
-                keyBindingFn={[Function]}
-                readOnly={false}
-                spellCheck={false}
-                stripPastedStyles={false}
+              <div
+                className="row comment-header"
               >
-                <div
-                  className="DraftEditor-root"
+                By example@example.com - almost NaN years ago
+              </div>
+              <div
+                className="row comment-body"
+              >
+                <img
+                  className="comment-avatar"
+                  src="https://www.gravatar.com/avatar/23463b99b62a72f26ed677cc556c44e8?s=200&d=identicon"
+                />
+                <DraftEditor
+                  blockRenderMap={
+                    Immutable.Map {
+                      "ordered-list-item": Object {
+                        "element": "li",
+                        "wrapper": <ol
+                          className="public-DraftStyleDefault-ol"
+                        />,
+                      },
+                      "header-six": Object {
+                        "element": "h6",
+                      },
+                      "header-four": Object {
+                        "element": "h4",
+                      },
+                      "header-one": Object {
+                        "element": "h1",
+                      },
+                      "unordered-list-item": Object {
+                        "element": "li",
+                        "wrapper": <ul
+                          className="public-DraftStyleDefault-ul"
+                        />,
+                      },
+                      "atomic": Object {
+                        "element": "figure",
+                      },
+                      "unstyled": Object {
+                        "aliasedElements": Array [
+                          "p",
+                        ],
+                        "element": "div",
+                      },
+                      "header-two": Object {
+                        "element": "h2",
+                      },
+                      "code-block": Object {
+                        "element": "pre",
+                        "wrapper": <pre
+                          className="public-DraftStyleDefault-pre"
+                        />,
+                      },
+                      "blockquote": Object {
+                        "element": "blockquote",
+                      },
+                      "header-five": Object {
+                        "element": "h5",
+                      },
+                      "header-three": Object {
+                        "element": "h3",
+                      },
+                    }
+                  }
+                  blockRendererFn={[Function]}
+                  blockStyleFn={[Function]}
+                  editorKey="xyz"
+                  editorState={
+                    EditorState {
+                      "_immutable": Immutable.Record {
+                        "allowUndo": true,
+                        "currentContent": Immutable.Record {
+                          "entityMap": Object {},
+                          "blockMap": Immutable.OrderedMap {
+                            "3sm42": Immutable.Record {
+                              "key": "3sm42",
+                              "type": "unstyled",
+                              "text": "",
+                              "characterList": Immutable.List [],
+                              "depth": 0,
+                              "data": Immutable.Map {},
+                            },
+                          },
+                          "selectionBefore": Immutable.Record {
+                            "anchorKey": "3sm42",
+                            "anchorOffset": 0,
+                            "focusKey": "3sm42",
+                            "focusOffset": 0,
+                            "isBackward": false,
+                            "hasFocus": false,
+                          },
+                          "selectionAfter": Immutable.Record {
+                            "anchorKey": "3sm42",
+                            "anchorOffset": 0,
+                            "focusKey": "3sm42",
+                            "focusOffset": 0,
+                            "isBackward": false,
+                            "hasFocus": false,
+                          },
+                        },
+                        "decorator": null,
+                        "directionMap": Immutable.OrderedMap {
+                          "3sm42": "LTR",
+                        },
+                        "forceSelection": false,
+                        "inCompositionMode": false,
+                        "inlineStyleOverride": null,
+                        "lastChangeType": null,
+                        "nativelyRenderedContent": null,
+                        "redoStack": Immutable.Stack [],
+                        "selection": Immutable.Record {
+                          "anchorKey": "3sm42",
+                          "anchorOffset": 0,
+                          "focusKey": "3sm42",
+                          "focusOffset": 0,
+                          "isBackward": false,
+                          "hasFocus": false,
+                        },
+                        "treeMap": Immutable.OrderedMap {
+                          "3sm42": Immutable.List [
+                            Immutable.Record {
+                              "start": 0,
+                              "end": 0,
+                              "decoratorKey": null,
+                              "leaves": Immutable.List [
+                                Immutable.Record {
+                                  "start": 0,
+                                  "end": 0,
+                                },
+                              ],
+                            },
+                          ],
+                        },
+                        "undoStack": Immutable.Stack [],
+                      },
+                    }
+                  }
+                  keyBindingFn={[Function]}
+                  readOnly={false}
+                  spellCheck={false}
+                  stripPastedStyles={false}
                 >
                   <div
-                    className="DraftEditor-editorContainer"
+                    className="DraftEditor-root"
                   >
                     <div
-                      aria-describedby="placeholder-xyz"
-                      aria-expanded={null}
-                      className="notranslate public-DraftEditor-content"
-                      contentEditable={true}
-                      onBeforeInput={[Function]}
-                      onBlur={[Function]}
-                      onCompositionEnd={[Function]}
-                      onCompositionStart={[Function]}
-                      onCopy={[Function]}
-                      onCut={[Function]}
-                      onDragEnd={[Function]}
-                      onDragEnter={[Function]}
-                      onDragLeave={[Function]}
-                      onDragOver={[Function]}
-                      onDragStart={[Function]}
-                      onDrop={[Function]}
-                      onFocus={[Function]}
-                      onInput={[Function]}
-                      onKeyDown={[Function]}
-                      onKeyPress={[Function]}
-                      onKeyUp={[Function]}
-                      onMouseUp={[Function]}
-                      onPaste={[Function]}
-                      onSelect={[Function]}
-                      role="textbox"
-                      spellCheck={false}
-                      style={
-                        Object {
-                          "WebkitUserSelect": "text",
-                          "outline": "none",
-                          "userSelect": "text",
-                          "whiteSpace": "pre-wrap",
-                          "wordWrap": "break-word",
-                        }
-                      }
-                      suppressContentEditableWarning={true}
+                      className="DraftEditor-editorContainer"
                     >
-                      <DraftEditorContents
-                        blockRenderMap={
-                          Immutable.Map {
-                            "ordered-list-item": Object {
-                              "element": "li",
-                              "wrapper": <ol
-                                className="public-DraftStyleDefault-ol"
-                              />,
-                            },
-                            "header-six": Object {
-                              "element": "h6",
-                            },
-                            "header-four": Object {
-                              "element": "h4",
-                            },
-                            "header-one": Object {
-                              "element": "h1",
-                            },
-                            "unordered-list-item": Object {
-                              "element": "li",
-                              "wrapper": <ul
-                                className="public-DraftStyleDefault-ul"
-                              />,
-                            },
-                            "atomic": Object {
-                              "element": "figure",
-                            },
-                            "unstyled": Object {
-                              "aliasedElements": Array [
-                                "p",
-                              ],
-                              "element": "div",
-                            },
-                            "header-two": Object {
-                              "element": "h2",
-                            },
-                            "code-block": Object {
-                              "element": "pre",
-                              "wrapper": <pre
-                                className="public-DraftStyleDefault-pre"
-                              />,
-                            },
-                            "blockquote": Object {
-                              "element": "blockquote",
-                            },
-                            "header-five": Object {
-                              "element": "h5",
-                            },
-                            "header-three": Object {
-                              "element": "h3",
-                            },
-                          }
-                        }
-                        blockRendererFn={[Function]}
-                        blockStyleFn={[Function]}
-                        customStyleMap={
+                      <div
+                        aria-describedby="placeholder-xyz"
+                        aria-expanded={null}
+                        className="notranslate public-DraftEditor-content"
+                        contentEditable={true}
+                        onBeforeInput={[Function]}
+                        onBlur={[Function]}
+                        onCompositionEnd={[Function]}
+                        onCompositionStart={[Function]}
+                        onCopy={[Function]}
+                        onCut={[Function]}
+                        onDragEnd={[Function]}
+                        onDragEnter={[Function]}
+                        onDragLeave={[Function]}
+                        onDragOver={[Function]}
+                        onDragStart={[Function]}
+                        onDrop={[Function]}
+                        onFocus={[Function]}
+                        onInput={[Function]}
+                        onKeyDown={[Function]}
+                        onKeyPress={[Function]}
+                        onKeyUp={[Function]}
+                        onMouseUp={[Function]}
+                        onPaste={[Function]}
+                        onSelect={[Function]}
+                        role="textbox"
+                        spellCheck={false}
+                        style={
                           Object {
-                            "BOLD": Object {
-                              "fontWeight": "bold",
-                            },
-                            "CODE": Object {
-                              "fontFamily": "monospace",
-                              "wordWrap": "break-word",
-                            },
-                            "ITALIC": Object {
-                              "fontStyle": "italic",
-                            },
-                            "STRIKETHROUGH": Object {
-                              "textDecoration": "line-through",
-                            },
-                            "UNDERLINE": Object {
-                              "textDecoration": "underline",
-                            },
+                            "WebkitUserSelect": "text",
+                            "outline": "none",
+                            "userSelect": "text",
+                            "whiteSpace": "pre-wrap",
+                            "wordWrap": "break-word",
                           }
                         }
-                        editorKey="xyz"
-                        editorState={
-                          EditorState {
-                            "_immutable": Immutable.Record {
-                              "allowUndo": true,
-                              "currentContent": Immutable.Record {
-                                "entityMap": Object {},
-                                "blockMap": Immutable.OrderedMap {
-                                  "3sm42": Immutable.Record {
-                                    "key": "3sm42",
-                                    "type": "unstyled",
-                                    "text": "",
-                                    "characterList": Immutable.List [],
-                                    "depth": 0,
-                                    "data": Immutable.Map {},
-                                  },
-                                },
-                                "selectionBefore": Immutable.Record {
-                                  "anchorKey": "3sm42",
-                                  "anchorOffset": 0,
-                                  "focusKey": "3sm42",
-                                  "focusOffset": 0,
-                                  "isBackward": false,
-                                  "hasFocus": false,
-                                },
-                                "selectionAfter": Immutable.Record {
-                                  "anchorKey": "3sm42",
-                                  "anchorOffset": 0,
-                                  "focusKey": "3sm42",
-                                  "focusOffset": 0,
-                                  "isBackward": false,
-                                  "hasFocus": false,
-                                },
-                              },
-                              "decorator": null,
-                              "directionMap": Immutable.OrderedMap {
-                                "3sm42": "LTR",
-                              },
-                              "forceSelection": false,
-                              "inCompositionMode": false,
-                              "inlineStyleOverride": null,
-                              "lastChangeType": null,
-                              "nativelyRenderedContent": null,
-                              "redoStack": Immutable.Stack [],
-                              "selection": Immutable.Record {
-                                "anchorKey": "3sm42",
-                                "anchorOffset": 0,
-                                "focusKey": "3sm42",
-                                "focusOffset": 0,
-                                "isBackward": false,
-                                "hasFocus": false,
-                              },
-                              "treeMap": Immutable.OrderedMap {
-                                "3sm42": Immutable.List [
-                                  Immutable.Record {
-                                    "start": 0,
-                                    "end": 0,
-                                    "decoratorKey": null,
-                                    "leaves": Immutable.List [
-                                      Immutable.Record {
-                                        "start": 0,
-                                        "end": 0,
-                                      },
-                                    ],
-                                  },
-                                ],
-                              },
-                              "undoStack": Immutable.Stack [],
-                            },
-                          }
-                        }
-                        key="contents0"
+                        suppressContentEditableWarning={true}
                       >
-                        <div
-                          data-contents="true"
-                        >
-                          <div
-                            className=""
-                            data-block={true}
-                            data-editor="xyz"
-                            data-offset-key="3sm42-0-0"
-                            key="3sm42"
-                          >
-                            <DraftEditorBlock
-                              block={
-                                Immutable.Record {
-                                  "key": "3sm42",
-                                  "type": "unstyled",
-                                  "text": "",
-                                  "characterList": Immutable.List [],
-                                  "depth": 0,
-                                  "data": Immutable.Map {},
-                                }
-                              }
-                              blockStyleFn={[Function]}
-                              contentState={
-                                Immutable.Record {
+                        <DraftEditorContents
+                          blockRenderMap={
+                            Immutable.Map {
+                              "ordered-list-item": Object {
+                                "element": "li",
+                                "wrapper": <ol
+                                  className="public-DraftStyleDefault-ol"
+                                />,
+                              },
+                              "header-six": Object {
+                                "element": "h6",
+                              },
+                              "header-four": Object {
+                                "element": "h4",
+                              },
+                              "header-one": Object {
+                                "element": "h1",
+                              },
+                              "unordered-list-item": Object {
+                                "element": "li",
+                                "wrapper": <ul
+                                  className="public-DraftStyleDefault-ul"
+                                />,
+                              },
+                              "atomic": Object {
+                                "element": "figure",
+                              },
+                              "unstyled": Object {
+                                "aliasedElements": Array [
+                                  "p",
+                                ],
+                                "element": "div",
+                              },
+                              "header-two": Object {
+                                "element": "h2",
+                              },
+                              "code-block": Object {
+                                "element": "pre",
+                                "wrapper": <pre
+                                  className="public-DraftStyleDefault-pre"
+                                />,
+                              },
+                              "blockquote": Object {
+                                "element": "blockquote",
+                              },
+                              "header-five": Object {
+                                "element": "h5",
+                              },
+                              "header-three": Object {
+                                "element": "h3",
+                              },
+                            }
+                          }
+                          blockRendererFn={[Function]}
+                          blockStyleFn={[Function]}
+                          customStyleMap={
+                            Object {
+                              "BOLD": Object {
+                                "fontWeight": "bold",
+                              },
+                              "CODE": Object {
+                                "fontFamily": "monospace",
+                                "wordWrap": "break-word",
+                              },
+                              "ITALIC": Object {
+                                "fontStyle": "italic",
+                              },
+                              "STRIKETHROUGH": Object {
+                                "textDecoration": "line-through",
+                              },
+                              "UNDERLINE": Object {
+                                "textDecoration": "underline",
+                              },
+                            }
+                          }
+                          editorKey="xyz"
+                          editorState={
+                            EditorState {
+                              "_immutable": Immutable.Record {
+                                "allowUndo": true,
+                                "currentContent": Immutable.Record {
                                   "entityMap": Object {},
                                   "blockMap": Immutable.OrderedMap {
                                     "3sm42": Immutable.Record {
@@ -1637,145 +1553,237 @@ exports[`Comments component renders one top level comment 1`] = `
                                     "isBackward": false,
                                     "hasFocus": false,
                                   },
-                                }
-                              }
-                              customStyleMap={
-                                Object {
-                                  "BOLD": Object {
-                                    "fontWeight": "bold",
-                                  },
-                                  "CODE": Object {
-                                    "fontFamily": "monospace",
-                                    "wordWrap": "break-word",
-                                  },
-                                  "ITALIC": Object {
-                                    "fontStyle": "italic",
-                                  },
-                                  "STRIKETHROUGH": Object {
-                                    "textDecoration": "line-through",
-                                  },
-                                  "UNDERLINE": Object {
-                                    "textDecoration": "underline",
-                                  },
-                                }
-                              }
-                              decorator={null}
-                              direction="LTR"
-                              forceSelection={false}
-                              key="3sm42"
-                              offsetKey="3sm42-0-0"
-                              selection={
-                                Immutable.Record {
+                                },
+                                "decorator": null,
+                                "directionMap": Immutable.OrderedMap {
+                                  "3sm42": "LTR",
+                                },
+                                "forceSelection": false,
+                                "inCompositionMode": false,
+                                "inlineStyleOverride": null,
+                                "lastChangeType": null,
+                                "nativelyRenderedContent": null,
+                                "redoStack": Immutable.Stack [],
+                                "selection": Immutable.Record {
                                   "anchorKey": "3sm42",
                                   "anchorOffset": 0,
                                   "focusKey": "3sm42",
                                   "focusOffset": 0,
                                   "isBackward": false,
                                   "hasFocus": false,
-                                }
-                              }
-                              tree={
-                                Immutable.List [
-                                  Immutable.Record {
-                                    "start": 0,
-                                    "end": 0,
-                                    "decoratorKey": null,
-                                    "leaves": Immutable.List [
-                                      Immutable.Record {
-                                        "start": 0,
-                                        "end": 0,
-                                      },
-                                    ],
-                                  },
-                                ]
-                              }
+                                },
+                                "treeMap": Immutable.OrderedMap {
+                                  "3sm42": Immutable.List [
+                                    Immutable.Record {
+                                      "start": 0,
+                                      "end": 0,
+                                      "decoratorKey": null,
+                                      "leaves": Immutable.List [
+                                        Immutable.Record {
+                                          "start": 0,
+                                          "end": 0,
+                                        },
+                                      ],
+                                    },
+                                  ],
+                                },
+                                "undoStack": Immutable.Stack [],
+                              },
+                            }
+                          }
+                          key="contents0"
+                        >
+                          <div
+                            data-contents="true"
+                          >
+                            <div
+                              className=""
+                              data-block={true}
+                              data-editor="xyz"
+                              data-offset-key="3sm42-0-0"
+                              key="3sm42"
                             >
-                              <div
-                                className="public-DraftStyleDefault-block public-DraftStyleDefault-ltr"
-                                data-offset-key="3sm42-0-0"
-                              >
-                                <DraftEditorLeaf
-                                  block={
-                                    Immutable.Record {
-                                      "key": "3sm42",
-                                      "type": "unstyled",
-                                      "text": "",
-                                      "characterList": Immutable.List [],
-                                      "depth": 0,
-                                      "data": Immutable.Map {},
-                                    }
+                              <DraftEditorBlock
+                                block={
+                                  Immutable.Record {
+                                    "key": "3sm42",
+                                    "type": "unstyled",
+                                    "text": "",
+                                    "characterList": Immutable.List [],
+                                    "depth": 0,
+                                    "data": Immutable.Map {},
                                   }
-                                  customStyleMap={
-                                    Object {
-                                      "BOLD": Object {
-                                        "fontWeight": "bold",
+                                }
+                                blockStyleFn={[Function]}
+                                contentState={
+                                  Immutable.Record {
+                                    "entityMap": Object {},
+                                    "blockMap": Immutable.OrderedMap {
+                                      "3sm42": Immutable.Record {
+                                        "key": "3sm42",
+                                        "type": "unstyled",
+                                        "text": "",
+                                        "characterList": Immutable.List [],
+                                        "depth": 0,
+                                        "data": Immutable.Map {},
                                       },
-                                      "CODE": Object {
-                                        "fontFamily": "monospace",
-                                        "wordWrap": "break-word",
-                                      },
-                                      "ITALIC": Object {
-                                        "fontStyle": "italic",
-                                      },
-                                      "STRIKETHROUGH": Object {
-                                        "textDecoration": "line-through",
-                                      },
-                                      "UNDERLINE": Object {
-                                        "textDecoration": "underline",
-                                      },
-                                    }
-                                  }
-                                  forceSelection={false}
-                                  isLast={true}
-                                  key="3sm42-0-0"
-                                  offsetKey="3sm42-0-0"
-                                  selection={
-                                    Immutable.Record {
+                                    },
+                                    "selectionBefore": Immutable.Record {
                                       "anchorKey": "3sm42",
                                       "anchorOffset": 0,
                                       "focusKey": "3sm42",
                                       "focusOffset": 0,
                                       "isBackward": false,
                                       "hasFocus": false,
-                                    }
+                                    },
+                                    "selectionAfter": Immutable.Record {
+                                      "anchorKey": "3sm42",
+                                      "anchorOffset": 0,
+                                      "focusKey": "3sm42",
+                                      "focusOffset": 0,
+                                      "isBackward": false,
+                                      "hasFocus": false,
+                                    },
                                   }
-                                  start={0}
-                                  styleSet={Immutable.OrderedSet []}
-                                  text=""
+                                }
+                                customStyleMap={
+                                  Object {
+                                    "BOLD": Object {
+                                      "fontWeight": "bold",
+                                    },
+                                    "CODE": Object {
+                                      "fontFamily": "monospace",
+                                      "wordWrap": "break-word",
+                                    },
+                                    "ITALIC": Object {
+                                      "fontStyle": "italic",
+                                    },
+                                    "STRIKETHROUGH": Object {
+                                      "textDecoration": "line-through",
+                                    },
+                                    "UNDERLINE": Object {
+                                      "textDecoration": "underline",
+                                    },
+                                  }
+                                }
+                                decorator={null}
+                                direction="LTR"
+                                forceSelection={false}
+                                key="3sm42"
+                                offsetKey="3sm42-0-0"
+                                selection={
+                                  Immutable.Record {
+                                    "anchorKey": "3sm42",
+                                    "anchorOffset": 0,
+                                    "focusKey": "3sm42",
+                                    "focusOffset": 0,
+                                    "isBackward": false,
+                                    "hasFocus": false,
+                                  }
+                                }
+                                tree={
+                                  Immutable.List [
+                                    Immutable.Record {
+                                      "start": 0,
+                                      "end": 0,
+                                      "decoratorKey": null,
+                                      "leaves": Immutable.List [
+                                        Immutable.Record {
+                                          "start": 0,
+                                          "end": 0,
+                                        },
+                                      ],
+                                    },
+                                  ]
+                                }
+                              >
+                                <div
+                                  className="public-DraftStyleDefault-block public-DraftStyleDefault-ltr"
+                                  data-offset-key="3sm42-0-0"
                                 >
-                                  <span
-                                    data-offset-key="3sm42-0-0"
-                                    style={Object {}}
+                                  <DraftEditorLeaf
+                                    block={
+                                      Immutable.Record {
+                                        "key": "3sm42",
+                                        "type": "unstyled",
+                                        "text": "",
+                                        "characterList": Immutable.List [],
+                                        "depth": 0,
+                                        "data": Immutable.Map {},
+                                      }
+                                    }
+                                    customStyleMap={
+                                      Object {
+                                        "BOLD": Object {
+                                          "fontWeight": "bold",
+                                        },
+                                        "CODE": Object {
+                                          "fontFamily": "monospace",
+                                          "wordWrap": "break-word",
+                                        },
+                                        "ITALIC": Object {
+                                          "fontStyle": "italic",
+                                        },
+                                        "STRIKETHROUGH": Object {
+                                          "textDecoration": "line-through",
+                                        },
+                                        "UNDERLINE": Object {
+                                          "textDecoration": "underline",
+                                        },
+                                      }
+                                    }
+                                    forceSelection={false}
+                                    isLast={true}
+                                    key="3sm42-0-0"
+                                    offsetKey="3sm42-0-0"
+                                    selection={
+                                      Immutable.Record {
+                                        "anchorKey": "3sm42",
+                                        "anchorOffset": 0,
+                                        "focusKey": "3sm42",
+                                        "focusOffset": 0,
+                                        "isBackward": false,
+                                        "hasFocus": false,
+                                      }
+                                    }
+                                    start={0}
+                                    styleSet={Immutable.OrderedSet []}
+                                    text=""
                                   >
-                                    <DraftEditorTextNode>
-                                      <br
-                                        data-text="true"
-                                        key="B"
-                                      />
-                                    </DraftEditorTextNode>
-                                  </span>
-                                </DraftEditorLeaf>
-                              </div>
-                            </DraftEditorBlock>
+                                    <span
+                                      data-offset-key="3sm42-0-0"
+                                      style={Object {}}
+                                    >
+                                      <DraftEditorTextNode>
+                                        <br
+                                          data-text="true"
+                                          key="B"
+                                        />
+                                      </DraftEditorTextNode>
+                                    </span>
+                                  </DraftEditorLeaf>
+                                </div>
+                              </DraftEditorBlock>
+                            </div>
                           </div>
-                        </div>
-                      </DraftEditorContents>
+                        </DraftEditorContents>
+                      </div>
                     </div>
                   </div>
-                </div>
-              </DraftEditor>
+                </DraftEditor>
+              </div>
+              <LoggedIn />
             </div>
-            <LoggedIn />
-          </div>
-          <div
-            className="row replies"
-          >
             <div
-              className="comment-reply"
-            />
-          </div>
-        </Comment>
-      </CommentTree>
+              className="row replies"
+            >
+              <div
+                className="comment-reply"
+              />
+            </div>
+          </Comment>
+        </CommentTree>
+      </ErrorBoundary>
     </div>
   </div>
 </Comments>

--- a/packages/openneuro-app/src/scripts/datalad/dataset/__tests__/__snapshots__/dataset-query.spec.jsx.snap
+++ b/packages/openneuro-app/src/scripts/datalad/dataset/__tests__/__snapshots__/dataset-query.spec.jsx.snap
@@ -1,1402 +1,1406 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`DatasetQuery component renders with common params 1`] = `
-<Query
-  query={
-    Object {
-      "definitions": Array [
-        Object {
-          "directives": Array [],
-          "kind": "OperationDefinition",
-          "name": Object {
-            "kind": "Name",
-            "value": "dataset",
-          },
-          "operation": "query",
-          "selectionSet": Object {
-            "kind": "SelectionSet",
-            "selections": Array [
-              Object {
-                "alias": undefined,
-                "arguments": Array [
-                  Object {
-                    "kind": "Argument",
-                    "name": Object {
-                      "kind": "Name",
-                      "value": "id",
-                    },
-                    "value": Object {
-                      "kind": "Variable",
-                      "name": Object {
-                        "kind": "Name",
-                        "value": "datasetId",
-                      },
-                    },
-                  },
-                ],
-                "directives": Array [],
-                "kind": "Field",
-                "name": Object {
-                  "kind": "Name",
-                  "value": "dataset",
-                },
-                "selectionSet": Object {
-                  "kind": "SelectionSet",
-                  "selections": Array [
+<ErrorBoundary
+  subject="error in dataset query"
+>
+  <Query
+    query={
+      Object {
+        "definitions": Array [
+          Object {
+            "directives": Array [],
+            "kind": "OperationDefinition",
+            "name": Object {
+              "kind": "Name",
+              "value": "dataset",
+            },
+            "operation": "query",
+            "selectionSet": Object {
+              "kind": "SelectionSet",
+              "selections": Array [
+                Object {
+                  "alias": undefined,
+                  "arguments": Array [
                     Object {
-                      "alias": undefined,
-                      "arguments": Array [],
-                      "directives": Array [],
-                      "kind": "Field",
+                      "kind": "Argument",
                       "name": Object {
                         "kind": "Name",
                         "value": "id",
                       },
-                      "selectionSet": undefined,
-                    },
-                    Object {
-                      "alias": undefined,
-                      "arguments": Array [],
-                      "directives": Array [],
-                      "kind": "Field",
-                      "name": Object {
-                        "kind": "Name",
-                        "value": "created",
+                      "value": Object {
+                        "kind": "Variable",
+                        "name": Object {
+                          "kind": "Name",
+                          "value": "datasetId",
+                        },
                       },
-                      "selectionSet": undefined,
-                    },
-                    Object {
-                      "alias": undefined,
-                      "arguments": Array [],
-                      "directives": Array [],
-                      "kind": "Field",
-                      "name": Object {
-                        "kind": "Name",
-                        "value": "public",
-                      },
-                      "selectionSet": undefined,
-                    },
-                    Object {
-                      "alias": undefined,
-                      "arguments": Array [],
-                      "directives": Array [],
-                      "kind": "Field",
-                      "name": Object {
-                        "kind": "Name",
-                        "value": "following",
-                      },
-                      "selectionSet": undefined,
-                    },
-                    Object {
-                      "alias": undefined,
-                      "arguments": Array [],
-                      "directives": Array [],
-                      "kind": "Field",
-                      "name": Object {
-                        "kind": "Name",
-                        "value": "starred",
-                      },
-                      "selectionSet": undefined,
-                    },
-                    Object {
-                      "directives": Array [],
-                      "kind": "FragmentSpread",
-                      "name": Object {
-                        "kind": "Name",
-                        "value": "DatasetDraft",
-                      },
-                    },
-                    Object {
-                      "directives": Array [],
-                      "kind": "FragmentSpread",
-                      "name": Object {
-                        "kind": "Name",
-                        "value": "DatasetPermissions",
-                      },
-                    },
-                    Object {
-                      "directives": Array [],
-                      "kind": "FragmentSpread",
-                      "name": Object {
-                        "kind": "Name",
-                        "value": "DatasetSnapshots",
-                      },
-                    },
-                    Object {
-                      "directives": Array [],
-                      "kind": "FragmentSpread",
-                      "name": Object {
-                        "kind": "Name",
-                        "value": "DatasetComments",
-                      },
-                    },
-                    Object {
-                      "directives": Array [],
-                      "kind": "FragmentSpread",
-                      "name": Object {
-                        "kind": "Name",
-                        "value": "DatasetIssues",
-                      },
-                    },
-                    Object {
-                      "alias": undefined,
-                      "arguments": Array [],
-                      "directives": Array [],
-                      "kind": "Field",
-                      "name": Object {
-                        "kind": "Name",
-                        "value": "uploader",
-                      },
-                      "selectionSet": Object {
-                        "kind": "SelectionSet",
-                        "selections": Array [
-                          Object {
-                            "alias": undefined,
-                            "arguments": Array [],
-                            "directives": Array [],
-                            "kind": "Field",
-                            "name": Object {
-                              "kind": "Name",
-                              "value": "id",
-                            },
-                            "selectionSet": undefined,
-                          },
-                          Object {
-                            "alias": undefined,
-                            "arguments": Array [],
-                            "directives": Array [],
-                            "kind": "Field",
-                            "name": Object {
-                              "kind": "Name",
-                              "value": "name",
-                            },
-                            "selectionSet": undefined,
-                          },
-                          Object {
-                            "alias": undefined,
-                            "arguments": Array [],
-                            "directives": Array [],
-                            "kind": "Field",
-                            "name": Object {
-                              "kind": "Name",
-                              "value": "email",
-                            },
-                            "selectionSet": undefined,
-                          },
-                        ],
-                      },
-                    },
-                    Object {
-                      "alias": undefined,
-                      "arguments": Array [],
-                      "directives": Array [],
-                      "kind": "Field",
-                      "name": Object {
-                        "kind": "Name",
-                        "value": "analytics",
-                      },
-                      "selectionSet": Object {
-                        "kind": "SelectionSet",
-                        "selections": Array [
-                          Object {
-                            "alias": undefined,
-                            "arguments": Array [],
-                            "directives": Array [],
-                            "kind": "Field",
-                            "name": Object {
-                              "kind": "Name",
-                              "value": "downloads",
-                            },
-                            "selectionSet": undefined,
-                          },
-                          Object {
-                            "alias": undefined,
-                            "arguments": Array [],
-                            "directives": Array [],
-                            "kind": "Field",
-                            "name": Object {
-                              "kind": "Name",
-                              "value": "views",
-                            },
-                            "selectionSet": undefined,
-                          },
-                        ],
-                      },
-                    },
-                    Object {
-                      "alias": undefined,
-                      "arguments": Array [],
-                      "directives": Array [],
-                      "kind": "Field",
-                      "name": Object {
-                        "kind": "Name",
-                        "value": "onBrainlife",
-                      },
-                      "selectionSet": undefined,
                     },
                   ],
-                },
-              },
-            ],
-          },
-          "variableDefinitions": Array [
-            Object {
-              "defaultValue": undefined,
-              "directives": Array [],
-              "kind": "VariableDefinition",
-              "type": Object {
-                "kind": "NonNullType",
-                "type": Object {
-                  "kind": "NamedType",
+                  "directives": Array [],
+                  "kind": "Field",
                   "name": Object {
                     "kind": "Name",
-                    "value": "ID",
+                    "value": "dataset",
+                  },
+                  "selectionSet": Object {
+                    "kind": "SelectionSet",
+                    "selections": Array [
+                      Object {
+                        "alias": undefined,
+                        "arguments": Array [],
+                        "directives": Array [],
+                        "kind": "Field",
+                        "name": Object {
+                          "kind": "Name",
+                          "value": "id",
+                        },
+                        "selectionSet": undefined,
+                      },
+                      Object {
+                        "alias": undefined,
+                        "arguments": Array [],
+                        "directives": Array [],
+                        "kind": "Field",
+                        "name": Object {
+                          "kind": "Name",
+                          "value": "created",
+                        },
+                        "selectionSet": undefined,
+                      },
+                      Object {
+                        "alias": undefined,
+                        "arguments": Array [],
+                        "directives": Array [],
+                        "kind": "Field",
+                        "name": Object {
+                          "kind": "Name",
+                          "value": "public",
+                        },
+                        "selectionSet": undefined,
+                      },
+                      Object {
+                        "alias": undefined,
+                        "arguments": Array [],
+                        "directives": Array [],
+                        "kind": "Field",
+                        "name": Object {
+                          "kind": "Name",
+                          "value": "following",
+                        },
+                        "selectionSet": undefined,
+                      },
+                      Object {
+                        "alias": undefined,
+                        "arguments": Array [],
+                        "directives": Array [],
+                        "kind": "Field",
+                        "name": Object {
+                          "kind": "Name",
+                          "value": "starred",
+                        },
+                        "selectionSet": undefined,
+                      },
+                      Object {
+                        "directives": Array [],
+                        "kind": "FragmentSpread",
+                        "name": Object {
+                          "kind": "Name",
+                          "value": "DatasetDraft",
+                        },
+                      },
+                      Object {
+                        "directives": Array [],
+                        "kind": "FragmentSpread",
+                        "name": Object {
+                          "kind": "Name",
+                          "value": "DatasetPermissions",
+                        },
+                      },
+                      Object {
+                        "directives": Array [],
+                        "kind": "FragmentSpread",
+                        "name": Object {
+                          "kind": "Name",
+                          "value": "DatasetSnapshots",
+                        },
+                      },
+                      Object {
+                        "directives": Array [],
+                        "kind": "FragmentSpread",
+                        "name": Object {
+                          "kind": "Name",
+                          "value": "DatasetComments",
+                        },
+                      },
+                      Object {
+                        "directives": Array [],
+                        "kind": "FragmentSpread",
+                        "name": Object {
+                          "kind": "Name",
+                          "value": "DatasetIssues",
+                        },
+                      },
+                      Object {
+                        "alias": undefined,
+                        "arguments": Array [],
+                        "directives": Array [],
+                        "kind": "Field",
+                        "name": Object {
+                          "kind": "Name",
+                          "value": "uploader",
+                        },
+                        "selectionSet": Object {
+                          "kind": "SelectionSet",
+                          "selections": Array [
+                            Object {
+                              "alias": undefined,
+                              "arguments": Array [],
+                              "directives": Array [],
+                              "kind": "Field",
+                              "name": Object {
+                                "kind": "Name",
+                                "value": "id",
+                              },
+                              "selectionSet": undefined,
+                            },
+                            Object {
+                              "alias": undefined,
+                              "arguments": Array [],
+                              "directives": Array [],
+                              "kind": "Field",
+                              "name": Object {
+                                "kind": "Name",
+                                "value": "name",
+                              },
+                              "selectionSet": undefined,
+                            },
+                            Object {
+                              "alias": undefined,
+                              "arguments": Array [],
+                              "directives": Array [],
+                              "kind": "Field",
+                              "name": Object {
+                                "kind": "Name",
+                                "value": "email",
+                              },
+                              "selectionSet": undefined,
+                            },
+                          ],
+                        },
+                      },
+                      Object {
+                        "alias": undefined,
+                        "arguments": Array [],
+                        "directives": Array [],
+                        "kind": "Field",
+                        "name": Object {
+                          "kind": "Name",
+                          "value": "analytics",
+                        },
+                        "selectionSet": Object {
+                          "kind": "SelectionSet",
+                          "selections": Array [
+                            Object {
+                              "alias": undefined,
+                              "arguments": Array [],
+                              "directives": Array [],
+                              "kind": "Field",
+                              "name": Object {
+                                "kind": "Name",
+                                "value": "downloads",
+                              },
+                              "selectionSet": undefined,
+                            },
+                            Object {
+                              "alias": undefined,
+                              "arguments": Array [],
+                              "directives": Array [],
+                              "kind": "Field",
+                              "name": Object {
+                                "kind": "Name",
+                                "value": "views",
+                              },
+                              "selectionSet": undefined,
+                            },
+                          ],
+                        },
+                      },
+                      Object {
+                        "alias": undefined,
+                        "arguments": Array [],
+                        "directives": Array [],
+                        "kind": "Field",
+                        "name": Object {
+                          "kind": "Name",
+                          "value": "onBrainlife",
+                        },
+                        "selectionSet": undefined,
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+            "variableDefinitions": Array [
+              Object {
+                "defaultValue": undefined,
+                "directives": Array [],
+                "kind": "VariableDefinition",
+                "type": Object {
+                  "kind": "NonNullType",
+                  "type": Object {
+                    "kind": "NamedType",
+                    "name": Object {
+                      "kind": "Name",
+                      "value": "ID",
+                    },
+                  },
+                },
+                "variable": Object {
+                  "kind": "Variable",
+                  "name": Object {
+                    "kind": "Name",
+                    "value": "datasetId",
                   },
                 },
               },
-              "variable": Object {
-                "kind": "Variable",
-                "name": Object {
-                  "kind": "Name",
-                  "value": "datasetId",
-                },
-              },
-            },
-          ],
-        },
-        Object {
-          "directives": Array [],
-          "kind": "FragmentDefinition",
-          "name": Object {
-            "kind": "Name",
-            "value": "DatasetDraft",
-          },
-          "selectionSet": Object {
-            "kind": "SelectionSet",
-            "selections": Array [
-              Object {
-                "alias": undefined,
-                "arguments": Array [],
-                "directives": Array [],
-                "kind": "Field",
-                "name": Object {
-                  "kind": "Name",
-                  "value": "id",
-                },
-                "selectionSet": undefined,
-              },
-              Object {
-                "alias": undefined,
-                "arguments": Array [],
-                "directives": Array [],
-                "kind": "Field",
-                "name": Object {
-                  "kind": "Name",
-                  "value": "draft",
-                },
-                "selectionSet": Object {
-                  "kind": "SelectionSet",
-                  "selections": Array [
-                    Object {
-                      "alias": undefined,
-                      "arguments": Array [],
-                      "directives": Array [],
-                      "kind": "Field",
-                      "name": Object {
-                        "kind": "Name",
-                        "value": "id",
-                      },
-                      "selectionSet": undefined,
-                    },
-                    Object {
-                      "alias": undefined,
-                      "arguments": Array [],
-                      "directives": Array [],
-                      "kind": "Field",
-                      "name": Object {
-                        "kind": "Name",
-                        "value": "modified",
-                      },
-                      "selectionSet": undefined,
-                    },
-                    Object {
-                      "alias": undefined,
-                      "arguments": Array [],
-                      "directives": Array [],
-                      "kind": "Field",
-                      "name": Object {
-                        "kind": "Name",
-                        "value": "readme",
-                      },
-                      "selectionSet": undefined,
-                    },
-                    Object {
-                      "alias": undefined,
-                      "arguments": Array [],
-                      "directives": Array [],
-                      "kind": "Field",
-                      "name": Object {
-                        "kind": "Name",
-                        "value": "partial",
-                      },
-                      "selectionSet": undefined,
-                    },
-                    Object {
-                      "alias": undefined,
-                      "arguments": Array [],
-                      "directives": Array [],
-                      "kind": "Field",
-                      "name": Object {
-                        "kind": "Name",
-                        "value": "description",
-                      },
-                      "selectionSet": Object {
-                        "kind": "SelectionSet",
-                        "selections": Array [
-                          Object {
-                            "alias": undefined,
-                            "arguments": Array [],
-                            "directives": Array [],
-                            "kind": "Field",
-                            "name": Object {
-                              "kind": "Name",
-                              "value": "Name",
-                            },
-                            "selectionSet": undefined,
-                          },
-                          Object {
-                            "alias": undefined,
-                            "arguments": Array [],
-                            "directives": Array [],
-                            "kind": "Field",
-                            "name": Object {
-                              "kind": "Name",
-                              "value": "Authors",
-                            },
-                            "selectionSet": undefined,
-                          },
-                          Object {
-                            "alias": undefined,
-                            "arguments": Array [],
-                            "directives": Array [],
-                            "kind": "Field",
-                            "name": Object {
-                              "kind": "Name",
-                              "value": "DatasetDOI",
-                            },
-                            "selectionSet": undefined,
-                          },
-                          Object {
-                            "alias": undefined,
-                            "arguments": Array [],
-                            "directives": Array [],
-                            "kind": "Field",
-                            "name": Object {
-                              "kind": "Name",
-                              "value": "License",
-                            },
-                            "selectionSet": undefined,
-                          },
-                          Object {
-                            "alias": undefined,
-                            "arguments": Array [],
-                            "directives": Array [],
-                            "kind": "Field",
-                            "name": Object {
-                              "kind": "Name",
-                              "value": "Acknowledgements",
-                            },
-                            "selectionSet": undefined,
-                          },
-                          Object {
-                            "alias": undefined,
-                            "arguments": Array [],
-                            "directives": Array [],
-                            "kind": "Field",
-                            "name": Object {
-                              "kind": "Name",
-                              "value": "HowToAcknowledge",
-                            },
-                            "selectionSet": undefined,
-                          },
-                          Object {
-                            "alias": undefined,
-                            "arguments": Array [],
-                            "directives": Array [],
-                            "kind": "Field",
-                            "name": Object {
-                              "kind": "Name",
-                              "value": "Funding",
-                            },
-                            "selectionSet": undefined,
-                          },
-                          Object {
-                            "alias": undefined,
-                            "arguments": Array [],
-                            "directives": Array [],
-                            "kind": "Field",
-                            "name": Object {
-                              "kind": "Name",
-                              "value": "ReferencesAndLinks",
-                            },
-                            "selectionSet": undefined,
-                          },
-                        ],
-                      },
-                    },
-                    Object {
-                      "alias": undefined,
-                      "arguments": Array [],
-                      "directives": Array [],
-                      "kind": "Field",
-                      "name": Object {
-                        "kind": "Name",
-                        "value": "files",
-                      },
-                      "selectionSet": Object {
-                        "kind": "SelectionSet",
-                        "selections": Array [
-                          Object {
-                            "alias": undefined,
-                            "arguments": Array [],
-                            "directives": Array [],
-                            "kind": "Field",
-                            "name": Object {
-                              "kind": "Name",
-                              "value": "id",
-                            },
-                            "selectionSet": undefined,
-                          },
-                          Object {
-                            "alias": undefined,
-                            "arguments": Array [],
-                            "directives": Array [],
-                            "kind": "Field",
-                            "name": Object {
-                              "kind": "Name",
-                              "value": "filename",
-                            },
-                            "selectionSet": undefined,
-                          },
-                          Object {
-                            "alias": undefined,
-                            "arguments": Array [],
-                            "directives": Array [],
-                            "kind": "Field",
-                            "name": Object {
-                              "kind": "Name",
-                              "value": "size",
-                            },
-                            "selectionSet": undefined,
-                          },
-                        ],
-                      },
-                    },
-                    Object {
-                      "alias": undefined,
-                      "arguments": Array [],
-                      "directives": Array [],
-                      "kind": "Field",
-                      "name": Object {
-                        "kind": "Name",
-                        "value": "summary",
-                      },
-                      "selectionSet": Object {
-                        "kind": "SelectionSet",
-                        "selections": Array [
-                          Object {
-                            "alias": undefined,
-                            "arguments": Array [],
-                            "directives": Array [],
-                            "kind": "Field",
-                            "name": Object {
-                              "kind": "Name",
-                              "value": "modalities",
-                            },
-                            "selectionSet": undefined,
-                          },
-                          Object {
-                            "alias": undefined,
-                            "arguments": Array [],
-                            "directives": Array [],
-                            "kind": "Field",
-                            "name": Object {
-                              "kind": "Name",
-                              "value": "sessions",
-                            },
-                            "selectionSet": undefined,
-                          },
-                          Object {
-                            "alias": undefined,
-                            "arguments": Array [],
-                            "directives": Array [],
-                            "kind": "Field",
-                            "name": Object {
-                              "kind": "Name",
-                              "value": "subjects",
-                            },
-                            "selectionSet": undefined,
-                          },
-                          Object {
-                            "alias": undefined,
-                            "arguments": Array [],
-                            "directives": Array [],
-                            "kind": "Field",
-                            "name": Object {
-                              "kind": "Name",
-                              "value": "tasks",
-                            },
-                            "selectionSet": undefined,
-                          },
-                          Object {
-                            "alias": undefined,
-                            "arguments": Array [],
-                            "directives": Array [],
-                            "kind": "Field",
-                            "name": Object {
-                              "kind": "Name",
-                              "value": "size",
-                            },
-                            "selectionSet": undefined,
-                          },
-                          Object {
-                            "alias": undefined,
-                            "arguments": Array [],
-                            "directives": Array [],
-                            "kind": "Field",
-                            "name": Object {
-                              "kind": "Name",
-                              "value": "totalFiles",
-                            },
-                            "selectionSet": undefined,
-                          },
-                        ],
-                      },
-                    },
-                  ],
-                },
-              },
             ],
           },
-          "typeCondition": Object {
-            "kind": "NamedType",
+          Object {
+            "directives": Array [],
+            "kind": "FragmentDefinition",
             "name": Object {
               "kind": "Name",
-              "value": "Dataset",
+              "value": "DatasetDraft",
+            },
+            "selectionSet": Object {
+              "kind": "SelectionSet",
+              "selections": Array [
+                Object {
+                  "alias": undefined,
+                  "arguments": Array [],
+                  "directives": Array [],
+                  "kind": "Field",
+                  "name": Object {
+                    "kind": "Name",
+                    "value": "id",
+                  },
+                  "selectionSet": undefined,
+                },
+                Object {
+                  "alias": undefined,
+                  "arguments": Array [],
+                  "directives": Array [],
+                  "kind": "Field",
+                  "name": Object {
+                    "kind": "Name",
+                    "value": "draft",
+                  },
+                  "selectionSet": Object {
+                    "kind": "SelectionSet",
+                    "selections": Array [
+                      Object {
+                        "alias": undefined,
+                        "arguments": Array [],
+                        "directives": Array [],
+                        "kind": "Field",
+                        "name": Object {
+                          "kind": "Name",
+                          "value": "id",
+                        },
+                        "selectionSet": undefined,
+                      },
+                      Object {
+                        "alias": undefined,
+                        "arguments": Array [],
+                        "directives": Array [],
+                        "kind": "Field",
+                        "name": Object {
+                          "kind": "Name",
+                          "value": "modified",
+                        },
+                        "selectionSet": undefined,
+                      },
+                      Object {
+                        "alias": undefined,
+                        "arguments": Array [],
+                        "directives": Array [],
+                        "kind": "Field",
+                        "name": Object {
+                          "kind": "Name",
+                          "value": "readme",
+                        },
+                        "selectionSet": undefined,
+                      },
+                      Object {
+                        "alias": undefined,
+                        "arguments": Array [],
+                        "directives": Array [],
+                        "kind": "Field",
+                        "name": Object {
+                          "kind": "Name",
+                          "value": "partial",
+                        },
+                        "selectionSet": undefined,
+                      },
+                      Object {
+                        "alias": undefined,
+                        "arguments": Array [],
+                        "directives": Array [],
+                        "kind": "Field",
+                        "name": Object {
+                          "kind": "Name",
+                          "value": "description",
+                        },
+                        "selectionSet": Object {
+                          "kind": "SelectionSet",
+                          "selections": Array [
+                            Object {
+                              "alias": undefined,
+                              "arguments": Array [],
+                              "directives": Array [],
+                              "kind": "Field",
+                              "name": Object {
+                                "kind": "Name",
+                                "value": "Name",
+                              },
+                              "selectionSet": undefined,
+                            },
+                            Object {
+                              "alias": undefined,
+                              "arguments": Array [],
+                              "directives": Array [],
+                              "kind": "Field",
+                              "name": Object {
+                                "kind": "Name",
+                                "value": "Authors",
+                              },
+                              "selectionSet": undefined,
+                            },
+                            Object {
+                              "alias": undefined,
+                              "arguments": Array [],
+                              "directives": Array [],
+                              "kind": "Field",
+                              "name": Object {
+                                "kind": "Name",
+                                "value": "DatasetDOI",
+                              },
+                              "selectionSet": undefined,
+                            },
+                            Object {
+                              "alias": undefined,
+                              "arguments": Array [],
+                              "directives": Array [],
+                              "kind": "Field",
+                              "name": Object {
+                                "kind": "Name",
+                                "value": "License",
+                              },
+                              "selectionSet": undefined,
+                            },
+                            Object {
+                              "alias": undefined,
+                              "arguments": Array [],
+                              "directives": Array [],
+                              "kind": "Field",
+                              "name": Object {
+                                "kind": "Name",
+                                "value": "Acknowledgements",
+                              },
+                              "selectionSet": undefined,
+                            },
+                            Object {
+                              "alias": undefined,
+                              "arguments": Array [],
+                              "directives": Array [],
+                              "kind": "Field",
+                              "name": Object {
+                                "kind": "Name",
+                                "value": "HowToAcknowledge",
+                              },
+                              "selectionSet": undefined,
+                            },
+                            Object {
+                              "alias": undefined,
+                              "arguments": Array [],
+                              "directives": Array [],
+                              "kind": "Field",
+                              "name": Object {
+                                "kind": "Name",
+                                "value": "Funding",
+                              },
+                              "selectionSet": undefined,
+                            },
+                            Object {
+                              "alias": undefined,
+                              "arguments": Array [],
+                              "directives": Array [],
+                              "kind": "Field",
+                              "name": Object {
+                                "kind": "Name",
+                                "value": "ReferencesAndLinks",
+                              },
+                              "selectionSet": undefined,
+                            },
+                          ],
+                        },
+                      },
+                      Object {
+                        "alias": undefined,
+                        "arguments": Array [],
+                        "directives": Array [],
+                        "kind": "Field",
+                        "name": Object {
+                          "kind": "Name",
+                          "value": "files",
+                        },
+                        "selectionSet": Object {
+                          "kind": "SelectionSet",
+                          "selections": Array [
+                            Object {
+                              "alias": undefined,
+                              "arguments": Array [],
+                              "directives": Array [],
+                              "kind": "Field",
+                              "name": Object {
+                                "kind": "Name",
+                                "value": "id",
+                              },
+                              "selectionSet": undefined,
+                            },
+                            Object {
+                              "alias": undefined,
+                              "arguments": Array [],
+                              "directives": Array [],
+                              "kind": "Field",
+                              "name": Object {
+                                "kind": "Name",
+                                "value": "filename",
+                              },
+                              "selectionSet": undefined,
+                            },
+                            Object {
+                              "alias": undefined,
+                              "arguments": Array [],
+                              "directives": Array [],
+                              "kind": "Field",
+                              "name": Object {
+                                "kind": "Name",
+                                "value": "size",
+                              },
+                              "selectionSet": undefined,
+                            },
+                          ],
+                        },
+                      },
+                      Object {
+                        "alias": undefined,
+                        "arguments": Array [],
+                        "directives": Array [],
+                        "kind": "Field",
+                        "name": Object {
+                          "kind": "Name",
+                          "value": "summary",
+                        },
+                        "selectionSet": Object {
+                          "kind": "SelectionSet",
+                          "selections": Array [
+                            Object {
+                              "alias": undefined,
+                              "arguments": Array [],
+                              "directives": Array [],
+                              "kind": "Field",
+                              "name": Object {
+                                "kind": "Name",
+                                "value": "modalities",
+                              },
+                              "selectionSet": undefined,
+                            },
+                            Object {
+                              "alias": undefined,
+                              "arguments": Array [],
+                              "directives": Array [],
+                              "kind": "Field",
+                              "name": Object {
+                                "kind": "Name",
+                                "value": "sessions",
+                              },
+                              "selectionSet": undefined,
+                            },
+                            Object {
+                              "alias": undefined,
+                              "arguments": Array [],
+                              "directives": Array [],
+                              "kind": "Field",
+                              "name": Object {
+                                "kind": "Name",
+                                "value": "subjects",
+                              },
+                              "selectionSet": undefined,
+                            },
+                            Object {
+                              "alias": undefined,
+                              "arguments": Array [],
+                              "directives": Array [],
+                              "kind": "Field",
+                              "name": Object {
+                                "kind": "Name",
+                                "value": "tasks",
+                              },
+                              "selectionSet": undefined,
+                            },
+                            Object {
+                              "alias": undefined,
+                              "arguments": Array [],
+                              "directives": Array [],
+                              "kind": "Field",
+                              "name": Object {
+                                "kind": "Name",
+                                "value": "size",
+                              },
+                              "selectionSet": undefined,
+                            },
+                            Object {
+                              "alias": undefined,
+                              "arguments": Array [],
+                              "directives": Array [],
+                              "kind": "Field",
+                              "name": Object {
+                                "kind": "Name",
+                                "value": "totalFiles",
+                              },
+                              "selectionSet": undefined,
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+            "typeCondition": Object {
+              "kind": "NamedType",
+              "name": Object {
+                "kind": "Name",
+                "value": "Dataset",
+              },
             },
           },
-        },
-        Object {
-          "directives": Array [],
-          "kind": "FragmentDefinition",
-          "name": Object {
-            "kind": "Name",
-            "value": "DatasetPermissions",
-          },
-          "selectionSet": Object {
-            "kind": "SelectionSet",
-            "selections": Array [
-              Object {
-                "alias": undefined,
-                "arguments": Array [],
-                "directives": Array [],
-                "kind": "Field",
-                "name": Object {
-                  "kind": "Name",
-                  "value": "id",
-                },
-                "selectionSet": undefined,
-              },
-              Object {
-                "alias": undefined,
-                "arguments": Array [],
-                "directives": Array [],
-                "kind": "Field",
-                "name": Object {
-                  "kind": "Name",
-                  "value": "permissions",
-                },
-                "selectionSet": Object {
-                  "kind": "SelectionSet",
-                  "selections": Array [
-                    Object {
-                      "alias": undefined,
-                      "arguments": Array [],
-                      "directives": Array [],
-                      "kind": "Field",
-                      "name": Object {
-                        "kind": "Name",
-                        "value": "user",
-                      },
-                      "selectionSet": Object {
-                        "kind": "SelectionSet",
-                        "selections": Array [
-                          Object {
-                            "alias": undefined,
-                            "arguments": Array [],
-                            "directives": Array [],
-                            "kind": "Field",
-                            "name": Object {
-                              "kind": "Name",
-                              "value": "id",
-                            },
-                            "selectionSet": undefined,
-                          },
-                          Object {
-                            "alias": undefined,
-                            "arguments": Array [],
-                            "directives": Array [],
-                            "kind": "Field",
-                            "name": Object {
-                              "kind": "Name",
-                              "value": "email",
-                            },
-                            "selectionSet": undefined,
-                          },
-                        ],
-                      },
-                    },
-                    Object {
-                      "alias": undefined,
-                      "arguments": Array [],
-                      "directives": Array [],
-                      "kind": "Field",
-                      "name": Object {
-                        "kind": "Name",
-                        "value": "level",
-                      },
-                      "selectionSet": undefined,
-                    },
-                  ],
-                },
-              },
-            ],
-          },
-          "typeCondition": Object {
-            "kind": "NamedType",
+          Object {
+            "directives": Array [],
+            "kind": "FragmentDefinition",
             "name": Object {
               "kind": "Name",
-              "value": "Dataset",
+              "value": "DatasetPermissions",
+            },
+            "selectionSet": Object {
+              "kind": "SelectionSet",
+              "selections": Array [
+                Object {
+                  "alias": undefined,
+                  "arguments": Array [],
+                  "directives": Array [],
+                  "kind": "Field",
+                  "name": Object {
+                    "kind": "Name",
+                    "value": "id",
+                  },
+                  "selectionSet": undefined,
+                },
+                Object {
+                  "alias": undefined,
+                  "arguments": Array [],
+                  "directives": Array [],
+                  "kind": "Field",
+                  "name": Object {
+                    "kind": "Name",
+                    "value": "permissions",
+                  },
+                  "selectionSet": Object {
+                    "kind": "SelectionSet",
+                    "selections": Array [
+                      Object {
+                        "alias": undefined,
+                        "arguments": Array [],
+                        "directives": Array [],
+                        "kind": "Field",
+                        "name": Object {
+                          "kind": "Name",
+                          "value": "user",
+                        },
+                        "selectionSet": Object {
+                          "kind": "SelectionSet",
+                          "selections": Array [
+                            Object {
+                              "alias": undefined,
+                              "arguments": Array [],
+                              "directives": Array [],
+                              "kind": "Field",
+                              "name": Object {
+                                "kind": "Name",
+                                "value": "id",
+                              },
+                              "selectionSet": undefined,
+                            },
+                            Object {
+                              "alias": undefined,
+                              "arguments": Array [],
+                              "directives": Array [],
+                              "kind": "Field",
+                              "name": Object {
+                                "kind": "Name",
+                                "value": "email",
+                              },
+                              "selectionSet": undefined,
+                            },
+                          ],
+                        },
+                      },
+                      Object {
+                        "alias": undefined,
+                        "arguments": Array [],
+                        "directives": Array [],
+                        "kind": "Field",
+                        "name": Object {
+                          "kind": "Name",
+                          "value": "level",
+                        },
+                        "selectionSet": undefined,
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+            "typeCondition": Object {
+              "kind": "NamedType",
+              "name": Object {
+                "kind": "Name",
+                "value": "Dataset",
+              },
             },
           },
-        },
-        Object {
-          "directives": Array [],
-          "kind": "FragmentDefinition",
-          "name": Object {
-            "kind": "Name",
-            "value": "DatasetSnapshots",
-          },
-          "selectionSet": Object {
-            "kind": "SelectionSet",
-            "selections": Array [
-              Object {
-                "alias": undefined,
-                "arguments": Array [],
-                "directives": Array [],
-                "kind": "Field",
-                "name": Object {
-                  "kind": "Name",
-                  "value": "id",
-                },
-                "selectionSet": undefined,
-              },
-              Object {
-                "alias": undefined,
-                "arguments": Array [],
-                "directives": Array [],
-                "kind": "Field",
-                "name": Object {
-                  "kind": "Name",
-                  "value": "snapshots",
-                },
-                "selectionSet": Object {
-                  "kind": "SelectionSet",
-                  "selections": Array [
-                    Object {
-                      "alias": undefined,
-                      "arguments": Array [],
-                      "directives": Array [],
-                      "kind": "Field",
-                      "name": Object {
-                        "kind": "Name",
-                        "value": "id",
-                      },
-                      "selectionSet": undefined,
-                    },
-                    Object {
-                      "alias": undefined,
-                      "arguments": Array [],
-                      "directives": Array [],
-                      "kind": "Field",
-                      "name": Object {
-                        "kind": "Name",
-                        "value": "tag",
-                      },
-                      "selectionSet": undefined,
-                    },
-                    Object {
-                      "alias": undefined,
-                      "arguments": Array [],
-                      "directives": Array [],
-                      "kind": "Field",
-                      "name": Object {
-                        "kind": "Name",
-                        "value": "created",
-                      },
-                      "selectionSet": undefined,
-                    },
-                  ],
-                },
-              },
-            ],
-          },
-          "typeCondition": Object {
-            "kind": "NamedType",
+          Object {
+            "directives": Array [],
+            "kind": "FragmentDefinition",
             "name": Object {
               "kind": "Name",
-              "value": "Dataset",
+              "value": "DatasetSnapshots",
+            },
+            "selectionSet": Object {
+              "kind": "SelectionSet",
+              "selections": Array [
+                Object {
+                  "alias": undefined,
+                  "arguments": Array [],
+                  "directives": Array [],
+                  "kind": "Field",
+                  "name": Object {
+                    "kind": "Name",
+                    "value": "id",
+                  },
+                  "selectionSet": undefined,
+                },
+                Object {
+                  "alias": undefined,
+                  "arguments": Array [],
+                  "directives": Array [],
+                  "kind": "Field",
+                  "name": Object {
+                    "kind": "Name",
+                    "value": "snapshots",
+                  },
+                  "selectionSet": Object {
+                    "kind": "SelectionSet",
+                    "selections": Array [
+                      Object {
+                        "alias": undefined,
+                        "arguments": Array [],
+                        "directives": Array [],
+                        "kind": "Field",
+                        "name": Object {
+                          "kind": "Name",
+                          "value": "id",
+                        },
+                        "selectionSet": undefined,
+                      },
+                      Object {
+                        "alias": undefined,
+                        "arguments": Array [],
+                        "directives": Array [],
+                        "kind": "Field",
+                        "name": Object {
+                          "kind": "Name",
+                          "value": "tag",
+                        },
+                        "selectionSet": undefined,
+                      },
+                      Object {
+                        "alias": undefined,
+                        "arguments": Array [],
+                        "directives": Array [],
+                        "kind": "Field",
+                        "name": Object {
+                          "kind": "Name",
+                          "value": "created",
+                        },
+                        "selectionSet": undefined,
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+            "typeCondition": Object {
+              "kind": "NamedType",
+              "name": Object {
+                "kind": "Name",
+                "value": "Dataset",
+              },
             },
           },
-        },
-        Object {
-          "directives": Array [],
-          "kind": "FragmentDefinition",
-          "name": Object {
-            "kind": "Name",
-            "value": "DatasetComments",
-          },
-          "selectionSet": Object {
-            "kind": "SelectionSet",
-            "selections": Array [
-              Object {
-                "alias": undefined,
-                "arguments": Array [],
-                "directives": Array [],
-                "kind": "Field",
-                "name": Object {
-                  "kind": "Name",
-                  "value": "id",
+          Object {
+            "directives": Array [],
+            "kind": "FragmentDefinition",
+            "name": Object {
+              "kind": "Name",
+              "value": "DatasetComments",
+            },
+            "selectionSet": Object {
+              "kind": "SelectionSet",
+              "selections": Array [
+                Object {
+                  "alias": undefined,
+                  "arguments": Array [],
+                  "directives": Array [],
+                  "kind": "Field",
+                  "name": Object {
+                    "kind": "Name",
+                    "value": "id",
+                  },
+                  "selectionSet": undefined,
                 },
-                "selectionSet": undefined,
-              },
-              Object {
-                "alias": undefined,
-                "arguments": Array [],
-                "directives": Array [],
-                "kind": "Field",
-                "name": Object {
-                  "kind": "Name",
-                  "value": "comments",
-                },
-                "selectionSet": Object {
-                  "kind": "SelectionSet",
-                  "selections": Array [
-                    Object {
-                      "alias": undefined,
-                      "arguments": Array [],
-                      "directives": Array [],
-                      "kind": "Field",
-                      "name": Object {
-                        "kind": "Name",
-                        "value": "id",
+                Object {
+                  "alias": undefined,
+                  "arguments": Array [],
+                  "directives": Array [],
+                  "kind": "Field",
+                  "name": Object {
+                    "kind": "Name",
+                    "value": "comments",
+                  },
+                  "selectionSet": Object {
+                    "kind": "SelectionSet",
+                    "selections": Array [
+                      Object {
+                        "alias": undefined,
+                        "arguments": Array [],
+                        "directives": Array [],
+                        "kind": "Field",
+                        "name": Object {
+                          "kind": "Name",
+                          "value": "id",
+                        },
+                        "selectionSet": undefined,
                       },
-                      "selectionSet": undefined,
-                    },
-                    Object {
-                      "alias": undefined,
-                      "arguments": Array [],
-                      "directives": Array [],
-                      "kind": "Field",
-                      "name": Object {
-                        "kind": "Name",
-                        "value": "text",
+                      Object {
+                        "alias": undefined,
+                        "arguments": Array [],
+                        "directives": Array [],
+                        "kind": "Field",
+                        "name": Object {
+                          "kind": "Name",
+                          "value": "text",
+                        },
+                        "selectionSet": undefined,
                       },
-                      "selectionSet": undefined,
-                    },
-                    Object {
-                      "alias": undefined,
-                      "arguments": Array [],
-                      "directives": Array [],
-                      "kind": "Field",
-                      "name": Object {
-                        "kind": "Name",
-                        "value": "createDate",
+                      Object {
+                        "alias": undefined,
+                        "arguments": Array [],
+                        "directives": Array [],
+                        "kind": "Field",
+                        "name": Object {
+                          "kind": "Name",
+                          "value": "createDate",
+                        },
+                        "selectionSet": undefined,
                       },
-                      "selectionSet": undefined,
-                    },
-                    Object {
-                      "alias": undefined,
-                      "arguments": Array [],
-                      "directives": Array [],
-                      "kind": "Field",
-                      "name": Object {
-                        "kind": "Name",
-                        "value": "user",
-                      },
-                      "selectionSet": Object {
-                        "kind": "SelectionSet",
-                        "selections": Array [
-                          Object {
-                            "alias": undefined,
-                            "arguments": Array [],
-                            "directives": Array [],
-                            "kind": "Field",
-                            "name": Object {
-                              "kind": "Name",
-                              "value": "email",
+                      Object {
+                        "alias": undefined,
+                        "arguments": Array [],
+                        "directives": Array [],
+                        "kind": "Field",
+                        "name": Object {
+                          "kind": "Name",
+                          "value": "user",
+                        },
+                        "selectionSet": Object {
+                          "kind": "SelectionSet",
+                          "selections": Array [
+                            Object {
+                              "alias": undefined,
+                              "arguments": Array [],
+                              "directives": Array [],
+                              "kind": "Field",
+                              "name": Object {
+                                "kind": "Name",
+                                "value": "email",
+                              },
+                              "selectionSet": undefined,
                             },
-                            "selectionSet": undefined,
-                          },
-                        ],
+                          ],
+                        },
                       },
-                    },
-                    Object {
-                      "alias": undefined,
-                      "arguments": Array [],
-                      "directives": Array [],
-                      "kind": "Field",
-                      "name": Object {
-                        "kind": "Name",
-                        "value": "replies",
-                      },
-                      "selectionSet": Object {
-                        "kind": "SelectionSet",
-                        "selections": Array [
-                          Object {
-                            "alias": undefined,
-                            "arguments": Array [],
-                            "directives": Array [],
-                            "kind": "Field",
-                            "name": Object {
-                              "kind": "Name",
-                              "value": "id",
+                      Object {
+                        "alias": undefined,
+                        "arguments": Array [],
+                        "directives": Array [],
+                        "kind": "Field",
+                        "name": Object {
+                          "kind": "Name",
+                          "value": "replies",
+                        },
+                        "selectionSet": Object {
+                          "kind": "SelectionSet",
+                          "selections": Array [
+                            Object {
+                              "alias": undefined,
+                              "arguments": Array [],
+                              "directives": Array [],
+                              "kind": "Field",
+                              "name": Object {
+                                "kind": "Name",
+                                "value": "id",
+                              },
+                              "selectionSet": undefined,
                             },
-                            "selectionSet": undefined,
-                          },
-                          Object {
-                            "alias": undefined,
-                            "arguments": Array [],
-                            "directives": Array [],
-                            "kind": "Field",
-                            "name": Object {
-                              "kind": "Name",
-                              "value": "text",
+                            Object {
+                              "alias": undefined,
+                              "arguments": Array [],
+                              "directives": Array [],
+                              "kind": "Field",
+                              "name": Object {
+                                "kind": "Name",
+                                "value": "text",
+                              },
+                              "selectionSet": undefined,
                             },
-                            "selectionSet": undefined,
-                          },
-                          Object {
-                            "alias": undefined,
-                            "arguments": Array [],
-                            "directives": Array [],
-                            "kind": "Field",
-                            "name": Object {
-                              "kind": "Name",
-                              "value": "createDate",
+                            Object {
+                              "alias": undefined,
+                              "arguments": Array [],
+                              "directives": Array [],
+                              "kind": "Field",
+                              "name": Object {
+                                "kind": "Name",
+                                "value": "createDate",
+                              },
+                              "selectionSet": undefined,
                             },
-                            "selectionSet": undefined,
-                          },
-                          Object {
-                            "alias": undefined,
-                            "arguments": Array [],
-                            "directives": Array [],
-                            "kind": "Field",
-                            "name": Object {
-                              "kind": "Name",
-                              "value": "user",
-                            },
-                            "selectionSet": Object {
-                              "kind": "SelectionSet",
-                              "selections": Array [
-                                Object {
-                                  "alias": undefined,
-                                  "arguments": Array [],
-                                  "directives": Array [],
-                                  "kind": "Field",
-                                  "name": Object {
-                                    "kind": "Name",
-                                    "value": "email",
+                            Object {
+                              "alias": undefined,
+                              "arguments": Array [],
+                              "directives": Array [],
+                              "kind": "Field",
+                              "name": Object {
+                                "kind": "Name",
+                                "value": "user",
+                              },
+                              "selectionSet": Object {
+                                "kind": "SelectionSet",
+                                "selections": Array [
+                                  Object {
+                                    "alias": undefined,
+                                    "arguments": Array [],
+                                    "directives": Array [],
+                                    "kind": "Field",
+                                    "name": Object {
+                                      "kind": "Name",
+                                      "value": "email",
+                                    },
+                                    "selectionSet": undefined,
                                   },
-                                  "selectionSet": undefined,
-                                },
-                              ],
+                                ],
+                              },
                             },
-                          },
-                          Object {
-                            "alias": undefined,
-                            "arguments": Array [],
-                            "directives": Array [],
-                            "kind": "Field",
-                            "name": Object {
-                              "kind": "Name",
-                              "value": "replies",
-                            },
-                            "selectionSet": Object {
-                              "kind": "SelectionSet",
-                              "selections": Array [
-                                Object {
-                                  "alias": undefined,
-                                  "arguments": Array [],
-                                  "directives": Array [],
-                                  "kind": "Field",
-                                  "name": Object {
-                                    "kind": "Name",
-                                    "value": "id",
+                            Object {
+                              "alias": undefined,
+                              "arguments": Array [],
+                              "directives": Array [],
+                              "kind": "Field",
+                              "name": Object {
+                                "kind": "Name",
+                                "value": "replies",
+                              },
+                              "selectionSet": Object {
+                                "kind": "SelectionSet",
+                                "selections": Array [
+                                  Object {
+                                    "alias": undefined,
+                                    "arguments": Array [],
+                                    "directives": Array [],
+                                    "kind": "Field",
+                                    "name": Object {
+                                      "kind": "Name",
+                                      "value": "id",
+                                    },
+                                    "selectionSet": undefined,
                                   },
-                                  "selectionSet": undefined,
-                                },
-                                Object {
-                                  "alias": undefined,
-                                  "arguments": Array [],
-                                  "directives": Array [],
-                                  "kind": "Field",
-                                  "name": Object {
-                                    "kind": "Name",
-                                    "value": "text",
+                                  Object {
+                                    "alias": undefined,
+                                    "arguments": Array [],
+                                    "directives": Array [],
+                                    "kind": "Field",
+                                    "name": Object {
+                                      "kind": "Name",
+                                      "value": "text",
+                                    },
+                                    "selectionSet": undefined,
                                   },
-                                  "selectionSet": undefined,
-                                },
-                                Object {
-                                  "alias": undefined,
-                                  "arguments": Array [],
-                                  "directives": Array [],
-                                  "kind": "Field",
-                                  "name": Object {
-                                    "kind": "Name",
-                                    "value": "createDate",
+                                  Object {
+                                    "alias": undefined,
+                                    "arguments": Array [],
+                                    "directives": Array [],
+                                    "kind": "Field",
+                                    "name": Object {
+                                      "kind": "Name",
+                                      "value": "createDate",
+                                    },
+                                    "selectionSet": undefined,
                                   },
-                                  "selectionSet": undefined,
-                                },
-                                Object {
-                                  "alias": undefined,
-                                  "arguments": Array [],
-                                  "directives": Array [],
-                                  "kind": "Field",
-                                  "name": Object {
-                                    "kind": "Name",
-                                    "value": "user",
-                                  },
-                                  "selectionSet": Object {
-                                    "kind": "SelectionSet",
-                                    "selections": Array [
-                                      Object {
-                                        "alias": undefined,
-                                        "arguments": Array [],
-                                        "directives": Array [],
-                                        "kind": "Field",
-                                        "name": Object {
-                                          "kind": "Name",
-                                          "value": "email",
+                                  Object {
+                                    "alias": undefined,
+                                    "arguments": Array [],
+                                    "directives": Array [],
+                                    "kind": "Field",
+                                    "name": Object {
+                                      "kind": "Name",
+                                      "value": "user",
+                                    },
+                                    "selectionSet": Object {
+                                      "kind": "SelectionSet",
+                                      "selections": Array [
+                                        Object {
+                                          "alias": undefined,
+                                          "arguments": Array [],
+                                          "directives": Array [],
+                                          "kind": "Field",
+                                          "name": Object {
+                                            "kind": "Name",
+                                            "value": "email",
+                                          },
+                                          "selectionSet": undefined,
                                         },
-                                        "selectionSet": undefined,
-                                      },
-                                    ],
+                                      ],
+                                    },
                                   },
-                                },
-                                Object {
-                                  "alias": undefined,
-                                  "arguments": Array [],
-                                  "directives": Array [],
-                                  "kind": "Field",
-                                  "name": Object {
-                                    "kind": "Name",
-                                    "value": "replies",
-                                  },
-                                  "selectionSet": Object {
-                                    "kind": "SelectionSet",
-                                    "selections": Array [
-                                      Object {
-                                        "alias": undefined,
-                                        "arguments": Array [],
-                                        "directives": Array [],
-                                        "kind": "Field",
-                                        "name": Object {
-                                          "kind": "Name",
-                                          "value": "id",
+                                  Object {
+                                    "alias": undefined,
+                                    "arguments": Array [],
+                                    "directives": Array [],
+                                    "kind": "Field",
+                                    "name": Object {
+                                      "kind": "Name",
+                                      "value": "replies",
+                                    },
+                                    "selectionSet": Object {
+                                      "kind": "SelectionSet",
+                                      "selections": Array [
+                                        Object {
+                                          "alias": undefined,
+                                          "arguments": Array [],
+                                          "directives": Array [],
+                                          "kind": "Field",
+                                          "name": Object {
+                                            "kind": "Name",
+                                            "value": "id",
+                                          },
+                                          "selectionSet": undefined,
                                         },
-                                        "selectionSet": undefined,
-                                      },
-                                      Object {
-                                        "alias": undefined,
-                                        "arguments": Array [],
-                                        "directives": Array [],
-                                        "kind": "Field",
-                                        "name": Object {
-                                          "kind": "Name",
-                                          "value": "text",
+                                        Object {
+                                          "alias": undefined,
+                                          "arguments": Array [],
+                                          "directives": Array [],
+                                          "kind": "Field",
+                                          "name": Object {
+                                            "kind": "Name",
+                                            "value": "text",
+                                          },
+                                          "selectionSet": undefined,
                                         },
-                                        "selectionSet": undefined,
-                                      },
-                                      Object {
-                                        "alias": undefined,
-                                        "arguments": Array [],
-                                        "directives": Array [],
-                                        "kind": "Field",
-                                        "name": Object {
-                                          "kind": "Name",
-                                          "value": "createDate",
+                                        Object {
+                                          "alias": undefined,
+                                          "arguments": Array [],
+                                          "directives": Array [],
+                                          "kind": "Field",
+                                          "name": Object {
+                                            "kind": "Name",
+                                            "value": "createDate",
+                                          },
+                                          "selectionSet": undefined,
                                         },
-                                        "selectionSet": undefined,
-                                      },
-                                      Object {
-                                        "alias": undefined,
-                                        "arguments": Array [],
-                                        "directives": Array [],
-                                        "kind": "Field",
-                                        "name": Object {
-                                          "kind": "Name",
-                                          "value": "user",
-                                        },
-                                        "selectionSet": Object {
-                                          "kind": "SelectionSet",
-                                          "selections": Array [
-                                            Object {
-                                              "alias": undefined,
-                                              "arguments": Array [],
-                                              "directives": Array [],
-                                              "kind": "Field",
-                                              "name": Object {
-                                                "kind": "Name",
-                                                "value": "email",
+                                        Object {
+                                          "alias": undefined,
+                                          "arguments": Array [],
+                                          "directives": Array [],
+                                          "kind": "Field",
+                                          "name": Object {
+                                            "kind": "Name",
+                                            "value": "user",
+                                          },
+                                          "selectionSet": Object {
+                                            "kind": "SelectionSet",
+                                            "selections": Array [
+                                              Object {
+                                                "alias": undefined,
+                                                "arguments": Array [],
+                                                "directives": Array [],
+                                                "kind": "Field",
+                                                "name": Object {
+                                                  "kind": "Name",
+                                                  "value": "email",
+                                                },
+                                                "selectionSet": undefined,
                                               },
-                                              "selectionSet": undefined,
-                                            },
-                                          ],
+                                            ],
+                                          },
                                         },
-                                      },
-                                      Object {
-                                        "alias": undefined,
-                                        "arguments": Array [],
-                                        "directives": Array [],
-                                        "kind": "Field",
-                                        "name": Object {
-                                          "kind": "Name",
-                                          "value": "replies",
-                                        },
-                                        "selectionSet": Object {
-                                          "kind": "SelectionSet",
-                                          "selections": Array [
-                                            Object {
-                                              "alias": undefined,
-                                              "arguments": Array [],
-                                              "directives": Array [],
-                                              "kind": "Field",
-                                              "name": Object {
-                                                "kind": "Name",
-                                                "value": "id",
+                                        Object {
+                                          "alias": undefined,
+                                          "arguments": Array [],
+                                          "directives": Array [],
+                                          "kind": "Field",
+                                          "name": Object {
+                                            "kind": "Name",
+                                            "value": "replies",
+                                          },
+                                          "selectionSet": Object {
+                                            "kind": "SelectionSet",
+                                            "selections": Array [
+                                              Object {
+                                                "alias": undefined,
+                                                "arguments": Array [],
+                                                "directives": Array [],
+                                                "kind": "Field",
+                                                "name": Object {
+                                                  "kind": "Name",
+                                                  "value": "id",
+                                                },
+                                                "selectionSet": undefined,
                                               },
-                                              "selectionSet": undefined,
-                                            },
-                                            Object {
-                                              "alias": undefined,
-                                              "arguments": Array [],
-                                              "directives": Array [],
-                                              "kind": "Field",
-                                              "name": Object {
-                                                "kind": "Name",
-                                                "value": "text",
+                                              Object {
+                                                "alias": undefined,
+                                                "arguments": Array [],
+                                                "directives": Array [],
+                                                "kind": "Field",
+                                                "name": Object {
+                                                  "kind": "Name",
+                                                  "value": "text",
+                                                },
+                                                "selectionSet": undefined,
                                               },
-                                              "selectionSet": undefined,
-                                            },
-                                            Object {
-                                              "alias": undefined,
-                                              "arguments": Array [],
-                                              "directives": Array [],
-                                              "kind": "Field",
-                                              "name": Object {
-                                                "kind": "Name",
-                                                "value": "createDate",
+                                              Object {
+                                                "alias": undefined,
+                                                "arguments": Array [],
+                                                "directives": Array [],
+                                                "kind": "Field",
+                                                "name": Object {
+                                                  "kind": "Name",
+                                                  "value": "createDate",
+                                                },
+                                                "selectionSet": undefined,
                                               },
-                                              "selectionSet": undefined,
-                                            },
-                                            Object {
-                                              "alias": undefined,
-                                              "arguments": Array [],
-                                              "directives": Array [],
-                                              "kind": "Field",
-                                              "name": Object {
-                                                "kind": "Name",
-                                                "value": "user",
-                                              },
-                                              "selectionSet": Object {
-                                                "kind": "SelectionSet",
-                                                "selections": Array [
-                                                  Object {
-                                                    "alias": undefined,
-                                                    "arguments": Array [],
-                                                    "directives": Array [],
-                                                    "kind": "Field",
-                                                    "name": Object {
-                                                      "kind": "Name",
-                                                      "value": "email",
+                                              Object {
+                                                "alias": undefined,
+                                                "arguments": Array [],
+                                                "directives": Array [],
+                                                "kind": "Field",
+                                                "name": Object {
+                                                  "kind": "Name",
+                                                  "value": "user",
+                                                },
+                                                "selectionSet": Object {
+                                                  "kind": "SelectionSet",
+                                                  "selections": Array [
+                                                    Object {
+                                                      "alias": undefined,
+                                                      "arguments": Array [],
+                                                      "directives": Array [],
+                                                      "kind": "Field",
+                                                      "name": Object {
+                                                        "kind": "Name",
+                                                        "value": "email",
+                                                      },
+                                                      "selectionSet": undefined,
                                                     },
-                                                    "selectionSet": undefined,
-                                                  },
-                                                ],
+                                                  ],
+                                                },
                                               },
-                                            },
-                                          ],
+                                            ],
+                                          },
                                         },
-                                      },
-                                    ],
+                                      ],
+                                    },
                                   },
-                                },
-                              ],
+                                ],
+                              },
                             },
-                          },
-                        ],
+                          ],
+                        },
                       },
-                    },
-                  ],
+                    ],
+                  },
                 },
+              ],
+            },
+            "typeCondition": Object {
+              "kind": "NamedType",
+              "name": Object {
+                "kind": "Name",
+                "value": "Dataset",
               },
-            ],
-          },
-          "typeCondition": Object {
-            "kind": "NamedType",
-            "name": Object {
-              "kind": "Name",
-              "value": "Dataset",
             },
           },
-        },
-        Object {
-          "directives": Array [],
-          "kind": "FragmentDefinition",
-          "name": Object {
-            "kind": "Name",
-            "value": "DatasetIssues",
-          },
-          "selectionSet": Object {
-            "kind": "SelectionSet",
-            "selections": Array [
-              Object {
-                "alias": undefined,
-                "arguments": Array [],
-                "directives": Array [],
-                "kind": "Field",
-                "name": Object {
-                  "kind": "Name",
-                  "value": "id",
-                },
-                "selectionSet": undefined,
-              },
-              Object {
-                "alias": undefined,
-                "arguments": Array [],
-                "directives": Array [],
-                "kind": "Field",
-                "name": Object {
-                  "kind": "Name",
-                  "value": "draft",
-                },
-                "selectionSet": Object {
-                  "kind": "SelectionSet",
-                  "selections": Array [
-                    Object {
-                      "alias": undefined,
-                      "arguments": Array [],
-                      "directives": Array [],
-                      "kind": "Field",
-                      "name": Object {
-                        "kind": "Name",
-                        "value": "id",
-                      },
-                      "selectionSet": undefined,
-                    },
-                    Object {
-                      "alias": undefined,
-                      "arguments": Array [],
-                      "directives": Array [],
-                      "kind": "Field",
-                      "name": Object {
-                        "kind": "Name",
-                        "value": "issues",
-                      },
-                      "selectionSet": Object {
-                        "kind": "SelectionSet",
-                        "selections": Array [
-                          Object {
-                            "alias": undefined,
-                            "arguments": Array [],
-                            "directives": Array [],
-                            "kind": "Field",
-                            "name": Object {
-                              "kind": "Name",
-                              "value": "severity",
-                            },
-                            "selectionSet": undefined,
-                          },
-                          Object {
-                            "alias": undefined,
-                            "arguments": Array [],
-                            "directives": Array [],
-                            "kind": "Field",
-                            "name": Object {
-                              "kind": "Name",
-                              "value": "code",
-                            },
-                            "selectionSet": undefined,
-                          },
-                          Object {
-                            "alias": undefined,
-                            "arguments": Array [],
-                            "directives": Array [],
-                            "kind": "Field",
-                            "name": Object {
-                              "kind": "Name",
-                              "value": "reason",
-                            },
-                            "selectionSet": undefined,
-                          },
-                          Object {
-                            "alias": undefined,
-                            "arguments": Array [],
-                            "directives": Array [],
-                            "kind": "Field",
-                            "name": Object {
-                              "kind": "Name",
-                              "value": "files",
-                            },
-                            "selectionSet": Object {
-                              "kind": "SelectionSet",
-                              "selections": Array [
-                                Object {
-                                  "alias": undefined,
-                                  "arguments": Array [],
-                                  "directives": Array [],
-                                  "kind": "Field",
-                                  "name": Object {
-                                    "kind": "Name",
-                                    "value": "evidence",
-                                  },
-                                  "selectionSet": undefined,
-                                },
-                                Object {
-                                  "alias": undefined,
-                                  "arguments": Array [],
-                                  "directives": Array [],
-                                  "kind": "Field",
-                                  "name": Object {
-                                    "kind": "Name",
-                                    "value": "line",
-                                  },
-                                  "selectionSet": undefined,
-                                },
-                                Object {
-                                  "alias": undefined,
-                                  "arguments": Array [],
-                                  "directives": Array [],
-                                  "kind": "Field",
-                                  "name": Object {
-                                    "kind": "Name",
-                                    "value": "character",
-                                  },
-                                  "selectionSet": undefined,
-                                },
-                                Object {
-                                  "alias": undefined,
-                                  "arguments": Array [],
-                                  "directives": Array [],
-                                  "kind": "Field",
-                                  "name": Object {
-                                    "kind": "Name",
-                                    "value": "reason",
-                                  },
-                                  "selectionSet": undefined,
-                                },
-                                Object {
-                                  "alias": undefined,
-                                  "arguments": Array [],
-                                  "directives": Array [],
-                                  "kind": "Field",
-                                  "name": Object {
-                                    "kind": "Name",
-                                    "value": "file",
-                                  },
-                                  "selectionSet": Object {
-                                    "kind": "SelectionSet",
-                                    "selections": Array [
-                                      Object {
-                                        "alias": undefined,
-                                        "arguments": Array [],
-                                        "directives": Array [],
-                                        "kind": "Field",
-                                        "name": Object {
-                                          "kind": "Name",
-                                          "value": "name",
-                                        },
-                                        "selectionSet": undefined,
-                                      },
-                                      Object {
-                                        "alias": undefined,
-                                        "arguments": Array [],
-                                        "directives": Array [],
-                                        "kind": "Field",
-                                        "name": Object {
-                                          "kind": "Name",
-                                          "value": "path",
-                                        },
-                                        "selectionSet": undefined,
-                                      },
-                                      Object {
-                                        "alias": undefined,
-                                        "arguments": Array [],
-                                        "directives": Array [],
-                                        "kind": "Field",
-                                        "name": Object {
-                                          "kind": "Name",
-                                          "value": "relativePath",
-                                        },
-                                        "selectionSet": undefined,
-                                      },
-                                    ],
-                                  },
-                                },
-                              ],
-                            },
-                          },
-                          Object {
-                            "alias": undefined,
-                            "arguments": Array [],
-                            "directives": Array [],
-                            "kind": "Field",
-                            "name": Object {
-                              "kind": "Name",
-                              "value": "additionalFileCount",
-                            },
-                            "selectionSet": undefined,
-                          },
-                        ],
-                      },
-                    },
-                  ],
-                },
-              },
-            ],
-          },
-          "typeCondition": Object {
-            "kind": "NamedType",
+          Object {
+            "directives": Array [],
+            "kind": "FragmentDefinition",
             "name": Object {
               "kind": "Name",
-              "value": "Dataset",
+              "value": "DatasetIssues",
+            },
+            "selectionSet": Object {
+              "kind": "SelectionSet",
+              "selections": Array [
+                Object {
+                  "alias": undefined,
+                  "arguments": Array [],
+                  "directives": Array [],
+                  "kind": "Field",
+                  "name": Object {
+                    "kind": "Name",
+                    "value": "id",
+                  },
+                  "selectionSet": undefined,
+                },
+                Object {
+                  "alias": undefined,
+                  "arguments": Array [],
+                  "directives": Array [],
+                  "kind": "Field",
+                  "name": Object {
+                    "kind": "Name",
+                    "value": "draft",
+                  },
+                  "selectionSet": Object {
+                    "kind": "SelectionSet",
+                    "selections": Array [
+                      Object {
+                        "alias": undefined,
+                        "arguments": Array [],
+                        "directives": Array [],
+                        "kind": "Field",
+                        "name": Object {
+                          "kind": "Name",
+                          "value": "id",
+                        },
+                        "selectionSet": undefined,
+                      },
+                      Object {
+                        "alias": undefined,
+                        "arguments": Array [],
+                        "directives": Array [],
+                        "kind": "Field",
+                        "name": Object {
+                          "kind": "Name",
+                          "value": "issues",
+                        },
+                        "selectionSet": Object {
+                          "kind": "SelectionSet",
+                          "selections": Array [
+                            Object {
+                              "alias": undefined,
+                              "arguments": Array [],
+                              "directives": Array [],
+                              "kind": "Field",
+                              "name": Object {
+                                "kind": "Name",
+                                "value": "severity",
+                              },
+                              "selectionSet": undefined,
+                            },
+                            Object {
+                              "alias": undefined,
+                              "arguments": Array [],
+                              "directives": Array [],
+                              "kind": "Field",
+                              "name": Object {
+                                "kind": "Name",
+                                "value": "code",
+                              },
+                              "selectionSet": undefined,
+                            },
+                            Object {
+                              "alias": undefined,
+                              "arguments": Array [],
+                              "directives": Array [],
+                              "kind": "Field",
+                              "name": Object {
+                                "kind": "Name",
+                                "value": "reason",
+                              },
+                              "selectionSet": undefined,
+                            },
+                            Object {
+                              "alias": undefined,
+                              "arguments": Array [],
+                              "directives": Array [],
+                              "kind": "Field",
+                              "name": Object {
+                                "kind": "Name",
+                                "value": "files",
+                              },
+                              "selectionSet": Object {
+                                "kind": "SelectionSet",
+                                "selections": Array [
+                                  Object {
+                                    "alias": undefined,
+                                    "arguments": Array [],
+                                    "directives": Array [],
+                                    "kind": "Field",
+                                    "name": Object {
+                                      "kind": "Name",
+                                      "value": "evidence",
+                                    },
+                                    "selectionSet": undefined,
+                                  },
+                                  Object {
+                                    "alias": undefined,
+                                    "arguments": Array [],
+                                    "directives": Array [],
+                                    "kind": "Field",
+                                    "name": Object {
+                                      "kind": "Name",
+                                      "value": "line",
+                                    },
+                                    "selectionSet": undefined,
+                                  },
+                                  Object {
+                                    "alias": undefined,
+                                    "arguments": Array [],
+                                    "directives": Array [],
+                                    "kind": "Field",
+                                    "name": Object {
+                                      "kind": "Name",
+                                      "value": "character",
+                                    },
+                                    "selectionSet": undefined,
+                                  },
+                                  Object {
+                                    "alias": undefined,
+                                    "arguments": Array [],
+                                    "directives": Array [],
+                                    "kind": "Field",
+                                    "name": Object {
+                                      "kind": "Name",
+                                      "value": "reason",
+                                    },
+                                    "selectionSet": undefined,
+                                  },
+                                  Object {
+                                    "alias": undefined,
+                                    "arguments": Array [],
+                                    "directives": Array [],
+                                    "kind": "Field",
+                                    "name": Object {
+                                      "kind": "Name",
+                                      "value": "file",
+                                    },
+                                    "selectionSet": Object {
+                                      "kind": "SelectionSet",
+                                      "selections": Array [
+                                        Object {
+                                          "alias": undefined,
+                                          "arguments": Array [],
+                                          "directives": Array [],
+                                          "kind": "Field",
+                                          "name": Object {
+                                            "kind": "Name",
+                                            "value": "name",
+                                          },
+                                          "selectionSet": undefined,
+                                        },
+                                        Object {
+                                          "alias": undefined,
+                                          "arguments": Array [],
+                                          "directives": Array [],
+                                          "kind": "Field",
+                                          "name": Object {
+                                            "kind": "Name",
+                                            "value": "path",
+                                          },
+                                          "selectionSet": undefined,
+                                        },
+                                        Object {
+                                          "alias": undefined,
+                                          "arguments": Array [],
+                                          "directives": Array [],
+                                          "kind": "Field",
+                                          "name": Object {
+                                            "kind": "Name",
+                                            "value": "relativePath",
+                                          },
+                                          "selectionSet": undefined,
+                                        },
+                                      ],
+                                    },
+                                  },
+                                ],
+                              },
+                            },
+                            Object {
+                              "alias": undefined,
+                              "arguments": Array [],
+                              "directives": Array [],
+                              "kind": "Field",
+                              "name": Object {
+                                "kind": "Name",
+                                "value": "additionalFileCount",
+                              },
+                              "selectionSet": undefined,
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+            "typeCondition": Object {
+              "kind": "NamedType",
+              "name": Object {
+                "kind": "Name",
+                "value": "Dataset",
+              },
             },
           },
+        ],
+        "kind": "Document",
+        "loc": Object {
+          "end": 2106,
+          "start": 0,
         },
-      ],
-      "kind": "Document",
-      "loc": Object {
-        "end": 2106,
-        "start": 0,
-      },
+      }
     }
-  }
-  variables={
-    Object {
-      "datasetId": "ds000001",
+    variables={
+      Object {
+        "datasetId": "ds000001",
+      }
     }
-  }
->
-  <Component />
-</Query>
+  >
+    <Component />
+  </Query>
+</ErrorBoundary>
 `;

--- a/packages/openneuro-app/src/scripts/datalad/dataset/comments.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/dataset/comments.jsx
@@ -4,6 +4,7 @@ import Comment from './comment.jsx'
 import CommentEditor from '../comments/comment-editor.jsx'
 import LoggedIn from '../../authentication/logged-in.jsx'
 import LoggedOut from '../../authentication/logged-out.jsx'
+import ErrorBoundary from '../../errors/errorBoundary.jsx'
 
 const CommentTree = ({ datasetId, uploader, comments }) => (
   <>
@@ -39,17 +40,19 @@ const Comments = ({ datasetId, uploader, comments }) => {
     <div className="col-xs-12">
       <div className="dataset-comments">
         <h2>Comments</h2>
-        <LoggedIn>
-          <CommentEditor datasetId={datasetId} />
-        </LoggedIn>
-        <LoggedOut>
-          <div>Please sign in to contribute to the discussion.</div>
-        </LoggedOut>
-        <CommentTree
-          datasetId={datasetId}
-          uploader={uploader}
-          comments={comments}
-        />
+        <ErrorBoundary>
+          <LoggedIn>
+            <CommentEditor datasetId={datasetId} />
+          </LoggedIn>
+          <LoggedOut>
+            <div>Please sign in to contribute to the discussion.</div>
+          </LoggedOut>
+          <CommentTree
+            datasetId={datasetId}
+            uploader={uploader}
+            comments={comments}
+          />
+        </ErrorBoundary>
       </div>
     </div>
   )

--- a/packages/openneuro-app/src/scripts/datalad/dataset/comments.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/dataset/comments.jsx
@@ -40,7 +40,7 @@ const Comments = ({ datasetId, uploader, comments }) => {
     <div className="col-xs-12">
       <div className="dataset-comments">
         <h2>Comments</h2>
-        <ErrorBoundary>
+        <ErrorBoundary subject="error in dataset comments">
           <LoggedIn>
             <CommentEditor datasetId={datasetId} />
           </LoggedIn>

--- a/packages/openneuro-app/src/scripts/datalad/dataset/dataset-page.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/dataset/dataset-page.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types'
 import LeftSidebar from './left-sidebar.jsx'
 import DatasetMain from './dataset-main.jsx'
 import DatasetTools from '../fragments/dataset-tools.jsx'
-import ErrorBoundary from '../../errors/errorBoundary.jsx'
 
 class DatasetPage extends React.Component {
   constructor(props) {
@@ -19,35 +18,33 @@ class DatasetPage extends React.Component {
   }
 
   render() {
-    const { dataset, error } = this.props
+    const { dataset } = this.props
     return (
       <div className="page dataset">
         <div
           className={
             this.state.sidebar ? 'open dataset-container' : 'dataset-container'
           }>
-          <ErrorBoundary error={error}>
-            <LeftSidebar
-              datasetId={dataset.id}
-              snapshots={dataset.snapshots}
-              draftModified={dataset.draft.modified}
-            />
-            <span className="show-nav-btn" onClick={this.toggleSidebar}>
-              {this.state.sidebar ? (
-                <i className="fa fa-angle-double-left" aria-hidden="true" />
-              ) : (
-                <i className="fa fa-angle-double-right" aria-hidden="true" />
-              )}
-            </span>
-            <DatasetTools dataset={dataset} />
-            <div className="fade-in inner-route dataset-route light">
-              <div className="clearfix dataset-wrap">
-                <div className="dataset-animation dataset-inner">
-                  <DatasetMain dataset={dataset} />
-                </div>
+          <LeftSidebar
+            datasetId={dataset.id}
+            snapshots={dataset.snapshots}
+            draftModified={dataset.draft.modified}
+          />
+          <span className="show-nav-btn" onClick={this.toggleSidebar}>
+            {this.state.sidebar ? (
+              <i className="fa fa-angle-double-left" aria-hidden="true" />
+            ) : (
+              <i className="fa fa-angle-double-right" aria-hidden="true" />
+            )}
+          </span>
+          <DatasetTools dataset={dataset} />
+          <div className="fade-in inner-route dataset-route light">
+            <div className="clearfix dataset-wrap">
+              <div className="dataset-animation dataset-inner">
+                <DatasetMain dataset={dataset} />
               </div>
             </div>
-          </ErrorBoundary>
+          </div>
         </div>
       </div>
     )

--- a/packages/openneuro-app/src/scripts/datalad/dataset/dataset-page.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/dataset/dataset-page.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import LeftSidebar from './left-sidebar.jsx'
 import DatasetMain from './dataset-main.jsx'
 import DatasetTools from '../fragments/dataset-tools.jsx'
+import ErrorBoundary from '../../errors/errorBoundary.jsx'
 
 class DatasetPage extends React.Component {
   constructor(props) {
@@ -18,33 +19,35 @@ class DatasetPage extends React.Component {
   }
 
   render() {
-    const { dataset } = this.props
+    const { dataset, error } = this.props
     return (
       <div className="page dataset">
         <div
           className={
             this.state.sidebar ? 'open dataset-container' : 'dataset-container'
           }>
-          <LeftSidebar
-            datasetId={dataset.id}
-            snapshots={dataset.snapshots}
-            draftModified={dataset.draft.modified}
-          />
-          <span className="show-nav-btn" onClick={this.toggleSidebar}>
-            {this.state.sidebar ? (
-              <i className="fa fa-angle-double-left" aria-hidden="true" />
-            ) : (
-              <i className="fa fa-angle-double-right" aria-hidden="true" />
-            )}
-          </span>
-          <DatasetTools dataset={dataset} />
-          <div className="fade-in inner-route dataset-route light">
-            <div className="clearfix dataset-wrap">
-              <div className="dataset-animation dataset-inner">
-                <DatasetMain dataset={dataset} />
+          <ErrorBoundary error={error}>
+            <LeftSidebar
+              datasetId={dataset.id}
+              snapshots={dataset.snapshots}
+              draftModified={dataset.draft.modified}
+            />
+            <span className="show-nav-btn" onClick={this.toggleSidebar}>
+              {this.state.sidebar ? (
+                <i className="fa fa-angle-double-left" aria-hidden="true" />
+              ) : (
+                <i className="fa fa-angle-double-right" aria-hidden="true" />
+              )}
+            </span>
+            <DatasetTools dataset={dataset} />
+            <div className="fade-in inner-route dataset-route light">
+              <div className="clearfix dataset-wrap">
+                <div className="dataset-animation dataset-inner">
+                  <DatasetMain dataset={dataset} />
+                </div>
               </div>
             </div>
-          </div>
+          </ErrorBoundary>
         </div>
       </div>
     )

--- a/packages/openneuro-app/src/scripts/datalad/dataset/dataset-query.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/dataset/dataset-query.jsx
@@ -45,7 +45,11 @@ export const DatasetQueryRender = ({ loading, error, data }) => {
     return <Spinner text="Loading Dataset" active />
   } else {
     if (error) Sentry.captureException(error)
-    return <DatasetPage dataset={data.dataset} error={error} />
+    return (
+      <ErrorBoundary error={error} subject={'error in dataset page'}>
+        <DatasetPage dataset={data.dataset} />
+      </ErrorBoundary>
+    )
   }
 }
 
@@ -56,7 +60,7 @@ DatasetQueryRender.propTypes = {
 }
 
 const DatasetQuery = ({ match }) => (
-  <ErrorBoundary>
+  <ErrorBoundary subject={'error in dataset query'}>
     <Query
       query={getDatasetPage}
       variables={{ datasetId: match.params.datasetId }}>

--- a/packages/openneuro-app/src/scripts/datalad/dataset/dataset-query.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/dataset/dataset-query.jsx
@@ -6,6 +6,7 @@ import gql from 'graphql-tag'
 import Spinner from '../../common/partials/spinner.jsx'
 import DatasetPage from './dataset-page.jsx'
 import * as DatasetQueryFragments from './dataset-query-fragments.js'
+import ErrorBoundary from '../../errors/errorBoundary.jsx'
 
 export const getDatasetPage = gql`
   query dataset($datasetId: ID!) {
@@ -42,11 +43,9 @@ export const getDatasetPage = gql`
 export const DatasetQueryRender = ({ loading, error, data }) => {
   if (loading) {
     return <Spinner text="Loading Dataset" active />
-  } else if (error) {
-    Sentry.captureException(error)
-    throw new Error(error)
   } else {
-    return <DatasetPage dataset={data.dataset} />
+    if (error) Sentry.captureException(error)
+    return <DatasetPage dataset={data.dataset} error={error} />
   }
 }
 
@@ -57,11 +56,13 @@ DatasetQueryRender.propTypes = {
 }
 
 const DatasetQuery = ({ match }) => (
-  <Query
-    query={getDatasetPage}
-    variables={{ datasetId: match.params.datasetId }}>
-    {DatasetQueryRender}
-  </Query>
+  <ErrorBoundary>
+    <Query
+      query={getDatasetPage}
+      variables={{ datasetId: match.params.datasetId }}>
+      {DatasetQueryRender}
+    </Query>
+  </ErrorBoundary>
 )
 
 DatasetQuery.propTypes = {

--- a/packages/openneuro-app/src/scripts/datalad/fragments/dataset-files.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/fragments/dataset-files.jsx
@@ -19,7 +19,7 @@ const DatasetFiles = ({
           </div>
           <div className="panel-collapse" aria-expanded="false">
             <div className="panel-body">
-              <ErrorBoundary>
+              <ErrorBoundary subject={'error in dataset filetree'}>
                 <Files
                   datasetId={datasetId}
                   snapshotTag={snapshotTag}

--- a/packages/openneuro-app/src/scripts/datalad/fragments/dataset-files.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/fragments/dataset-files.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import Files from '../../file-tree/files.jsx'
+import ErrorBoundary from '../../errors/errorBoundary.jsx'
 
 const DatasetFiles = ({
   datasetId,
@@ -18,13 +19,15 @@ const DatasetFiles = ({
           </div>
           <div className="panel-collapse" aria-expanded="false">
             <div className="panel-body">
-              <Files
-                datasetId={datasetId}
-                snapshotTag={snapshotTag}
-                datasetName={datasetName}
-                files={files}
-                editMode={editMode}
-              />
+              <ErrorBoundary>
+                <Files
+                  datasetId={datasetId}
+                  snapshotTag={snapshotTag}
+                  datasetName={datasetName}
+                  files={files}
+                  editMode={editMode}
+                />
+              </ErrorBoundary>
             </div>
           </div>
         </div>

--- a/packages/openneuro-app/src/scripts/datalad/fragments/freshdesk-widget.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/fragments/freshdesk-widget.jsx
@@ -4,7 +4,7 @@ import config from '../../../../config'
 
 const prepopulatedFieldsQuery = prepopulatedFields => {
   const fieldQueries = Object.entries(prepopulatedFields)
-    .filter(([_, value]) => value)
+    .filter(([, value]) => value)
     .map(([key, value]) => `helpdesk_ticket[${key}]=${value}`)
   return fieldQueries.length ? `&${fieldQueries.join(';')}` : ''
 }

--- a/packages/openneuro-app/src/scripts/datalad/fragments/freshdesk-widget.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/fragments/freshdesk-widget.jsx
@@ -1,16 +1,19 @@
 import React from 'react'
-import withProfile from '../../authentication/withProfile.js'
+import { getProfile } from '../../authentication/profile'
 import config from '../../../../config'
 
 const prepopulatedFieldsQuery = prepopulatedFields => {
   const fieldQueries = Object.entries(prepopulatedFields)
     .filter(([key, value]) => value)
     .map(([key, value]) => `helpdesk_ticket[${key}]=${value}`)
-  return `&${fieldQueries.join(';')}`
+  return fieldQueries.length ? `&${fieldQueries.join(';')}` : ''
 }
 
-function FreshdeskWidget({ profile, subject, description }) {
-  console.log(profile, subject, description)
+function FreshdeskWidget(props) {
+  const profile = getProfile()
+  const { subject, error } = props
+  let { description } = props
+  description = [description, error].filter(item => item).join('\n\n')
   return (
     <>
       <script
@@ -29,7 +32,7 @@ function FreshdeskWidget({ profile, subject, description }) {
         src={
           config.support.url +
           prepopulatedFieldsQuery({
-            requester: profile.email,
+            requester: profile && profile.email,
             subject,
             description,
           })
@@ -43,4 +46,4 @@ function FreshdeskWidget({ profile, subject, description }) {
   )
 }
 
-export default withProfile(FreshdeskWidget)
+export default FreshdeskWidget

--- a/packages/openneuro-app/src/scripts/datalad/fragments/freshdesk-widget.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/fragments/freshdesk-widget.jsx
@@ -4,7 +4,7 @@ import config from '../../../../config'
 
 const prepopulatedFieldsQuery = prepopulatedFields => {
   const fieldQueries = Object.entries(prepopulatedFields)
-    .filter(([key, value]) => value)
+    .filter(([_, value]) => value)
     .map(([key, value]) => `helpdesk_ticket[${key}]=${value}`)
   return fieldQueries.length ? `&${fieldQueries.join(';')}` : ''
 }

--- a/packages/openneuro-app/src/scripts/datalad/fragments/freshdesk-widget.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/fragments/freshdesk-widget.jsx
@@ -1,0 +1,46 @@
+import React from 'react'
+import withProfile from '../../authentication/withProfile.js'
+import config from '../../../../config'
+
+const prepopulatedFieldsQuery = prepopulatedFields => {
+  const fieldQueries = Object.entries(prepopulatedFields)
+    .filter(([key, value]) => value)
+    .map(([key, value]) => `helpdesk_ticket[${key}]=${value}`)
+  return `&${fieldQueries.join(';')}`
+}
+
+function FreshdeskWidget({ profile, subject, description }) {
+  console.log(profile, subject, description)
+  return (
+    <>
+      <script
+        type="text/javascript"
+        src="https://s3.amazonaws.com/assets.freshdesk.com/widget/freshwidget.js"
+      />
+      <style type="text/css" media="screen, projection">
+        {
+          '@import url(https://s3.amazonaws.com/assets.freshdesk.com/widget/freshwidget.css); '
+        }
+      </style>
+      <iframe
+        title="Feedback Form"
+        className="freshwidget-embedded-form"
+        id="freshwidget-embedded-form"
+        src={
+          config.support.url +
+          prepopulatedFieldsQuery({
+            requester: profile.email,
+            subject,
+            description,
+          })
+        }
+        scrolling="no"
+        height="500px"
+        width="100%"
+        frameBorder="0"
+      />
+    </>
+  )
+}
+
+export default withProfile(FreshdeskWidget)

--- a/packages/openneuro-app/src/scripts/datalad/routes/dataset-content.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/routes/dataset-content.jsx
@@ -19,6 +19,7 @@ import EditReadme from '../fragments/edit-readme.jsx'
 import IncompleteDataset from '../fragments/incomplete-dataset.jsx'
 import LoggedIn from '../../authentication/logged-in.jsx'
 import LoggedOut from '../../authentication/logged-out.jsx'
+import ErrorBoundary from '../../errors/errorBoundary.jsx'
 import { getProfile } from '../../authentication/profile.js'
 import DraftSubscription from '../subscriptions/draft-subscription.jsx'
 import styled from '@emotion/styled'
@@ -103,9 +104,11 @@ const DatasetContent = ({ dataset }) => {
           <DatasetProminentLinks dataset={dataset} />
           <DatasetSummary summary={dataset.draft.summary} />
           <h2>README</h2>
-          <EditReadme datasetId={dataset.id} content={dataset.draft.readme}>
-            <DatasetReadme content={dataset.draft.readme} />
-          </EditReadme>
+          <ErrorBoundary>
+            <EditReadme datasetId={dataset.id} content={dataset.draft.readme}>
+              <DatasetReadme content={dataset.draft.readme} />
+            </EditReadme>
+          </ErrorBoundary>
           <DatasetDescription
             datasetId={dataset.id}
             description={dataset.draft.description}

--- a/packages/openneuro-app/src/scripts/datalad/routes/dataset-content.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/routes/dataset-content.jsx
@@ -104,7 +104,7 @@ const DatasetContent = ({ dataset }) => {
           <DatasetProminentLinks dataset={dataset} />
           <DatasetSummary summary={dataset.draft.summary} />
           <h2>README</h2>
-          <ErrorBoundary>
+          <ErrorBoundary subject={'error in dataset readme component'}>
             <EditReadme datasetId={dataset.id} content={dataset.draft.readme}>
               <DatasetReadme content={dataset.draft.readme} />
             </EditReadme>

--- a/packages/openneuro-app/src/scripts/datalad/validation/validation.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/validation/validation.jsx
@@ -7,7 +7,7 @@ const Validation = ({ issues }) => {
   return (
     <div className="fade-in col-xs-12 validation">
       <h3 className="metaheader">BIDS Validation</h3>
-      <ErrorBoundary>
+      <ErrorBoundary error subject={'Error in dataset validation component'}>
         <ValidationStatus issues={issues} />
       </ErrorBoundary>
     </div>

--- a/packages/openneuro-app/src/scripts/datalad/validation/validation.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/validation/validation.jsx
@@ -7,7 +7,7 @@ const Validation = ({ issues }) => {
   return (
     <div className="fade-in col-xs-12 validation">
       <h3 className="metaheader">BIDS Validation</h3>
-      <ErrorBoundary error subject={'Error in dataset validation component'}>
+      <ErrorBoundary subject={'error in dataset validation component'}>
         <ValidationStatus issues={issues} />
       </ErrorBoundary>
     </div>

--- a/packages/openneuro-app/src/scripts/datalad/validation/validation.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/validation/validation.jsx
@@ -1,12 +1,15 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import ValidationStatus from './validation-status.jsx'
+import ErrorBoundary from '../../errors/errorBoundary.jsx'
 
-const Validation = ({ datasetId, issues }) => {
+const Validation = ({ issues }) => {
   return (
     <div className="fade-in col-xs-12 validation">
       <h3 className="metaheader">BIDS Validation</h3>
-      <ValidationStatus issues={issues} datasetId={datasetId} />
+      <ErrorBoundary>
+        <ValidationStatus issues={issues} />
+      </ErrorBoundary>
     </div>
   )
 }

--- a/packages/openneuro-app/src/scripts/errors/errorBoundary.jsx
+++ b/packages/openneuro-app/src/scripts/errors/errorBoundary.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { Modal } from '../utils/modal.jsx'
-import config from '../../../config'
+import FreshdeskWidget from '../datalad/fragments/freshdesk-widget.jsx'
 
 class ErrorBoundary extends React.Component {
   constructor(props) {
@@ -9,7 +9,7 @@ class ErrorBoundary extends React.Component {
     const errorAbove = Boolean(props.error)
     this.state = {
       hasError: errorAbove,
-      supportModal: errorAbove,
+      supportModal: false,
       error: props.error,
     }
   }
@@ -32,6 +32,7 @@ class ErrorBoundary extends React.Component {
   }
 
   render() {
+    const { subject, description } = this.props
     return this.state.hasError ? (
       <>
         <p className="generic-error-message">
@@ -49,32 +50,7 @@ class ErrorBoundary extends React.Component {
           </Modal.Header>
           <hr className="modal-inner" />
           <Modal.Body>
-            If you have a question about details of a particular dataset
-            (clarifying the design, asking for additional metadata etc.) please
-            post it as a comment underneath the dataset. If you would like to
-            suggest a new feature please post it at
-            <a href="https://openneuro.featureupvote.com/">
-              https://openneuro.featureupvote.com/
-            </a>
-            <script
-              type="text/javascript"
-              src="https://s3.amazonaws.com/assets.freshdesk.com/widget/freshwidget.js"
-            />
-            <style type="text/css" media="screen, projection">
-              {
-                '@import url(https://s3.amazonaws.com/assets.freshdesk.com/widget/freshwidget.css); '
-              }
-            </style>
-            <iframe
-              title="Feedback Form"
-              className="freshwidget-embedded-form"
-              id="freshwidget-embedded-form"
-              src={config.support.url}
-              scrolling="no"
-              height="500px"
-              width="100%"
-              frameBorder="0"
-            />
+            <FreshdeskWidget {...{ subject, description }} />
           </Modal.Body>
           <Modal.Footer>
             <a onClick={this.closeSupportModal}>Close</a>

--- a/packages/openneuro-app/src/scripts/errors/errorBoundary.jsx
+++ b/packages/openneuro-app/src/scripts/errors/errorBoundary.jsx
@@ -1,0 +1,112 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { Modal } from '../utils/modal.jsx'
+import config from '../../../config'
+
+class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props)
+    this.state = {
+      hasError: false,
+      supportModal: false,
+    }
+  }
+
+  static getDerivedStateFromError(error) {
+    console.log('in static', error)
+    return { hasError: true, supportModal: true }
+  }
+
+  componentDidCatch(error, info) {
+    console.log('in catch', { error, info })
+  }
+
+  componentDidMount() {
+    window.addEventListener('error', this.handleGlobalError)
+  }
+  componentWillUnmount() {
+    window.removeEventListener('error', this.handleGlobalError)
+  }
+
+  handleGlobalError = e => {
+    console.log('global error', e)
+  }
+
+  closeSupportModal = () =>
+    this.setState(prevState => ({
+      ...prevState,
+      supportModal: false,
+    }))
+  openSupportModalFromLink = e => {
+    e.preventDefault()
+    this.setState(prevState => ({
+      ...prevState,
+      supportModal: true,
+    }))
+  }
+
+  render() {
+    return this.state.hasError ? (
+      <>
+        <p className="generic-error-message">
+          {this.props.errorMessage || 'An error has occurred.'}
+          <br />
+          Please support us by documenting the issue with{' '}
+          <a onClick={this.openSupportModalFromLink}>
+            <u>FreshDesk</u>
+          </a>
+          .
+        </p>
+        <Modal show={this.state.supportModal} onHide={this.closeSupportModal}>
+          <Modal.Header closeButton>
+            <Modal.Title>Support</Modal.Title>
+          </Modal.Header>
+          <hr className="modal-inner" />
+          <Modal.Body>
+            If you have a question about details of a particular dataset
+            (clarifying the design, asking for additional metadata etc.) please
+            post it as a comment underneath the dataset. If you would like to
+            suggest a new feature please post it at
+            <a href="https://openneuro.featureupvote.com/">
+              https://openneuro.featureupvote.com/
+            </a>
+            <script
+              type="text/javascript"
+              src="https://s3.amazonaws.com/assets.freshdesk.com/widget/freshwidget.js"
+            />
+            <style type="text/css" media="screen, projection">
+              {
+                '@import url(https://s3.amazonaws.com/assets.freshdesk.com/widget/freshwidget.css); '
+              }
+            </style>
+            <iframe
+              title="Feedback Form"
+              className="freshwidget-embedded-form"
+              id="freshwidget-embedded-form"
+              src={config.support.url}
+              scrolling="no"
+              height="500px"
+              width="100%"
+              frameBorder="0"
+            />
+          </Modal.Body>
+          <Modal.Footer>
+            <a onClick={this.closeSupportModal}>Close</a>
+          </Modal.Footer>
+        </Modal>
+      </>
+    ) : (
+      this.props.children
+    )
+  }
+}
+
+ErrorBoundary.propTypes = {
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.node),
+    PropTypes.node,
+  ]),
+  errorMessage: PropTypes.string,
+}
+
+export default ErrorBoundary

--- a/packages/openneuro-app/src/scripts/errors/errorBoundary.jsx
+++ b/packages/openneuro-app/src/scripts/errors/errorBoundary.jsx
@@ -33,6 +33,7 @@ class ErrorBoundary extends React.Component {
 
   render() {
     const { subject, description } = this.props
+    const error = this.props.error || this.state.error
     return this.state.hasError ? (
       <>
         <p className="generic-error-message">
@@ -50,7 +51,7 @@ class ErrorBoundary extends React.Component {
           </Modal.Header>
           <hr className="modal-inner" />
           <Modal.Body>
-            <FreshdeskWidget {...{ subject, description }} />
+            <FreshdeskWidget {...{ subject, description, error }} />
           </Modal.Body>
           <Modal.Footer>
             <a onClick={this.closeSupportModal}>Close</a>

--- a/packages/openneuro-app/src/scripts/errors/errorBoundary.jsx
+++ b/packages/openneuro-app/src/scripts/errors/errorBoundary.jsx
@@ -6,30 +6,16 @@ import config from '../../../config'
 class ErrorBoundary extends React.Component {
   constructor(props) {
     super(props)
+    const errorAbove = Boolean(props.error)
     this.state = {
-      hasError: false,
-      supportModal: false,
+      hasError: errorAbove,
+      supportModal: errorAbove,
+      error: props.error,
     }
   }
 
   static getDerivedStateFromError(error) {
-    console.log('in static', error)
-    return { hasError: true, supportModal: true }
-  }
-
-  componentDidCatch(error, info) {
-    console.log('in catch', { error, info })
-  }
-
-  componentDidMount() {
-    window.addEventListener('error', this.handleGlobalError)
-  }
-  componentWillUnmount() {
-    window.removeEventListener('error', this.handleGlobalError)
-  }
-
-  handleGlobalError = e => {
-    console.log('global error', e)
+    return { hasError: true, supportModal: true, error: error }
   }
 
   closeSupportModal = () =>

--- a/packages/openneuro-app/src/scripts/nav/navbar.jsx
+++ b/packages/openneuro-app/src/scripts/nav/navbar.jsx
@@ -7,7 +7,7 @@ import NavMenu from './navbar.navmenu.jsx'
 import { Navbar } from 'react-bootstrap'
 import { Modal } from '../utils/modal.jsx'
 import LoginModal from '../common/partials/login.jsx'
-import config from '../../../config'
+import FreshdeskWidget from '../datalad/fragments/freshdesk-widget.jsx'
 import { frontPage } from 'openneuro-content'
 import styled from '@emotion/styled'
 
@@ -104,25 +104,7 @@ class BSNavbar extends React.Component {
           <a href="https://openneuro.featureupvote.com/">
             https://openneuro.featureupvote.com/
           </a>
-          <script
-            type="text/javascript"
-            src="https://s3.amazonaws.com/assets.freshdesk.com/widget/freshwidget.js"
-          />
-          <style type="text/css" media="screen, projection">
-            {
-              '@import url(https://s3.amazonaws.com/assets.freshdesk.com/widget/freshwidget.css); '
-            }
-          </style>
-          <iframe
-            title="Feedback Form"
-            className="freshwidget-embedded-form"
-            id="freshwidget-embedded-form"
-            src={config.support.url}
-            scrolling="no"
-            height="500px"
-            width="100%"
-            frameBorder="0"
-          />
+          <FreshdeskWidget />
         </Modal.Body>
         <Modal.Footer>
           <a onClick={() => this.setState({ supportModal: false })}>Close</a>


### PR DESCRIPTION
Added error boundaries above dashboard dataset tab, dataset page, comments, validator, and editable fields to catch errors and prompt user with prepopulated freshdesk widget in modal. Error message is also presented in place of component with error.