### PR TITLE
1147 redirect latest snapshot

### DIFF
--- a/packages/openneuro-app/src/scripts/authentication/profile.js
+++ b/packages/openneuro-app/src/scripts/authentication/profile.js
@@ -14,3 +14,16 @@ export const getProfile = () => {
   const accessToken = cookies.get('accessToken')
   return accessToken ? parseJwt(accessToken) : null
 }
+
+// Return true if the active user has write permission
+export const hasEditPermissions = (permissions, userId) => {
+  if (userId) {
+    const permission = permissions.find(perm => perm.user.id === userId)
+    return (
+      (permission &&
+        (permission.level === 'admin' || permission.level === 'rw')) ||
+      false
+    )
+  }
+  return false
+}

--- a/packages/openneuro-app/src/scripts/datalad/dataset/dataset-page.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/dataset/dataset-page.jsx
@@ -26,6 +26,7 @@ class DatasetPage extends React.Component {
             this.state.sidebar ? 'open dataset-container' : 'dataset-container'
           }>
           <LeftSidebar
+            dataset={dataset}
             datasetId={dataset.id}
             snapshots={dataset.snapshots}
             draftModified={dataset.draft.modified}

--- a/packages/openneuro-app/src/scripts/datalad/dataset/left-sidebar.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/dataset/left-sidebar.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import { Link, withRouter } from 'react-router-dom'
 import snapshotVersion from '../snapshotVersion.js'
 import format from 'date-fns/format'
-import LoggedIn from '../../authentication/logged-in.jsx'
+import { getProfile, hasEditPermissions } from '../../authentication/profile.js'
 
 export const SidebarRow = ({
   datasetId,
@@ -45,8 +45,19 @@ SidebarRow.propTypes = {
   modified: PropTypes.string,
 }
 
-const LeftSidebar = ({ datasetId, draftModified, snapshots, location }) => {
+const LeftSidebar = ({
+  dataset,
+  datasetId,
+  draftModified,
+  snapshots,
+  location,
+}) => {
   const active = snapshotVersion(location) || 'draft'
+  const user = getProfile()
+  const hasEdit =
+    ((user && user.admin) ||
+      hasEditPermissions(dataset.permissions, user && user.sub)) &&
+    !dataset.draft.partial
   return (
     <div className="left-sidebar">
       <span className="slide">
@@ -54,7 +65,7 @@ const LeftSidebar = ({ datasetId, draftModified, snapshots, location }) => {
           <span>
             <h3>Versions</h3>
             <ul>
-              <LoggedIn>
+              {hasEdit && (
                 <SidebarRow
                   key={'Draft'}
                   id={datasetId}
@@ -64,7 +75,7 @@ const LeftSidebar = ({ datasetId, draftModified, snapshots, location }) => {
                   draft
                   active={active}
                 />
-              </LoggedIn>
+              )}
               {snapshots.map(snapshot => (
                 <SidebarRow
                   key={snapshot.id}

--- a/packages/openneuro-app/src/scripts/datalad/dataset/left-sidebar.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/dataset/left-sidebar.jsx
@@ -96,6 +96,7 @@ const LeftSidebar = ({
 
 LeftSidebar.propTypes = {
   active: PropTypes.string,
+  dataset: PropTypes.object,
   datasetId: PropTypes.string,
   snapshots: PropTypes.array,
   location: PropTypes.object,

--- a/packages/openneuro-app/src/scripts/datalad/fragments/edit-readme.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/fragments/edit-readme.jsx
@@ -6,7 +6,7 @@ import CancelButton from './cancel-button.jsx'
 /**
  * This extends EditDescriptionField with Markdown display and a custom mutation
  */
-const EditReadme = ({ datasetId, content, children }) => {
+const EditReadme = ({ datasetId, content, children, hasEdit }) => {
   const [editing, setEditing] = useState(false)
   const [value, setValue] = useState(content || '')
 
@@ -30,7 +30,7 @@ const EditReadme = ({ datasetId, content, children }) => {
     return (
       <>
         {children}
-        <EditButton action={() => setEditing(true)} />
+        {hasEdit ? <EditButton action={() => setEditing(true)} /> : null}
       </>
     )
   }

--- a/packages/openneuro-app/src/scripts/datalad/routes/dataset-content.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/routes/dataset-content.jsx
@@ -18,9 +18,8 @@ import Validation from '../validation/validation.jsx'
 import EditReadme from '../fragments/edit-readme.jsx'
 import IncompleteDataset from '../fragments/incomplete-dataset.jsx'
 import LoggedIn from '../../authentication/logged-in.jsx'
-import LoggedOut from '../../authentication/logged-out.jsx'
 import ErrorBoundary from '../../errors/errorBoundary.jsx'
-import { getProfile } from '../../authentication/profile.js'
+import { getProfile, hasEditPermissions } from '../../authentication/profile.js'
 import DraftSubscription from '../subscriptions/draft-subscription.jsx'
 import styled from '@emotion/styled'
 
@@ -45,19 +44,6 @@ export const HasBeenPublished = ({ isPublic, datasetId }) =>
 HasBeenPublished.propTypes = {
   isPublic: PropTypes.bool,
   datasetId: PropTypes.string,
-}
-
-// Return true if the active user has write permission
-export const hasEditPermissions = (permissions, userId) => {
-  if (userId) {
-    const permission = permissions.find(perm => perm.user.id === userId)
-    return (
-      (permission &&
-        (permission.level === 'admin' || permission.level === 'rw')) ||
-      false
-    )
-  }
-  return false
 }
 
 /**

--- a/packages/openneuro-app/src/scripts/datalad/routes/dataset-content.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/routes/dataset-content.jsx
@@ -69,8 +69,6 @@ const DatasetContent = ({ dataset }) => {
     ((user && user.admin) ||
       hasEditPermissions(dataset.permissions, user && user.sub)) &&
     !dataset.draft.partial
-  console.log('snapshots: ', dataset.snapshots)
-  console.log('does not have edit: ', !hasEdit)
   return (
     <>
       <LoggedIn>

--- a/packages/openneuro-app/src/scripts/datalad/routes/dataset-content.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/routes/dataset-content.jsx
@@ -105,7 +105,10 @@ const DatasetContent = ({ dataset }) => {
           <DatasetSummary summary={dataset.draft.summary} />
           <h2>README</h2>
           <ErrorBoundary subject={'error in dataset readme component'}>
-            <EditReadme datasetId={dataset.id} content={dataset.draft.readme}>
+            <EditReadme
+              datasetId={dataset.id}
+              content={dataset.draft.readme}
+              hasEdit={hasEdit}>
               <DatasetReadme content={dataset.draft.readme} />
             </EditReadme>
           </ErrorBoundary>

--- a/packages/openneuro-app/src/scripts/datalad/routes/dataset-content.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/routes/dataset-content.jsx
@@ -69,6 +69,8 @@ const DatasetContent = ({ dataset }) => {
     ((user && user.admin) ||
       hasEditPermissions(dataset.permissions, user && user.sub)) &&
     !dataset.draft.partial
+  console.log('snapshots: ', dataset.snapshots)
+  console.log('does not have edit: ', !hasEdit)
   return (
     <>
       <LoggedIn>
@@ -133,14 +135,13 @@ const DatasetContent = ({ dataset }) => {
         </div>
         <DraftSubscription datasetId={dataset.id} />
       </LoggedIn>
-      <LoggedOut>
-        {dataset.snapshots && (
+      {dataset.snapshots &&
+        !hasEdit && (
           <Redirect
             to={`/datasets/${dataset.id}/versions/${dataset.snapshots.length &&
-              dataset.snapshots[0].tag}`}
+              dataset.snapshots[dataset.snapshots.length - 1].tag}`}
           />
         )}
-      </LoggedOut>
     </>
   )
 }


### PR DESCRIPTION
#1147
navigation to /datasets/dataset-id redirects to latest snapshot when user is not logged in or does not have edit privileges on dataset
only show readme edit button to users with edit privileges
fix regression: only show drafts to users with edit privileges