### PR TITLE
Add maintanence warning toast

### DIFF
--- a/packages/openneuro-app/src/sass/crn_app/_elements-wrappers.scss
+++ b/packages/openneuro-app/src/sass/crn_app/_elements-wrappers.scss
@@ -662,6 +662,9 @@ h6 {
     .Toastify__close-button--error {
         color: $black;
     }
+    .Toastify__progress-bar {
+        background: $eee;
+    }
 }
 
 .Toastify__toast--success {

--- a/packages/openneuro-app/src/scripts/app.jsx
+++ b/packages/openneuro-app/src/scripts/app.jsx
@@ -9,8 +9,13 @@ import analyticsWrapper from './utils/analytics.js'
 import getClient from 'openneuro-client'
 import { CookiesProvider } from 'react-cookie'
 import { ToastContainer } from 'react-toastify'
+import { expiringBanner } from './utils/userNotify.js'
 
 const App = ({ config }) => {
+  expiringBanner(
+    'OpenNeuro will be unavailable for approximately 1 hour for planned maintenance on Wednesday, July 17th at 19:00 UTC',
+    new Date(1563519600 * 1000), // Friday, July 19th
+  )
   return (
     <CookiesProvider>
       <ApolloProvider client={getClient(`${config.url}/crn/graphql`)}>

--- a/packages/openneuro-app/src/scripts/index.jsx
+++ b/packages/openneuro-app/src/scripts/index.jsx
@@ -5,13 +5,8 @@ import Navbar from './nav/navbar.jsx'
 import Happybrowser from './common/partials/happybrowser.jsx'
 import Routes from './routes.jsx'
 import Uploader from './uploader/uploader.jsx'
-import { expiringBanner } from './utils/userNotify.js'
 
 const Index = () => {
-  expiringBanner(
-    'OpenNeuro will be unavailable for approximately 1 hour for planned maintenance on Wednesday, July 17th at 19:00 UTC',
-    new Date(1563519600 * 1000), // Friday, July 19th
-  )
   return (
     <Uploader>
       <div className="page">

--- a/packages/openneuro-app/src/scripts/index.jsx
+++ b/packages/openneuro-app/src/scripts/index.jsx
@@ -5,17 +5,24 @@ import Navbar from './nav/navbar.jsx'
 import Happybrowser from './common/partials/happybrowser.jsx'
 import Routes from './routes.jsx'
 import Uploader from './uploader/uploader.jsx'
+import { expiringBanner } from './utils/userNotify.js'
 
-const Index = () => (
-  <Uploader>
-    <div className="page">
-      <Happybrowser />
-      <div className="main">
-        <Navbar />
-        <Routes />
+const Index = () => {
+  expiringBanner(
+    'OpenNeuro will be unavailable for approximately 1 hour for planned maintenance on Wednesday, July 17th at 19:00 UTC',
+    new Date(1563519600 * 1000), // Friday, July 19th
+  )
+  return (
+    <Uploader>
+      <div className="page">
+        <Happybrowser />
+        <div className="main">
+          <Navbar />
+          <Routes />
+        </div>
       </div>
-    </div>
-  </Uploader>
-)
+    </Uploader>
+  )
+}
 
 export default Index

--- a/packages/openneuro-app/src/scripts/utils/__tests__/userNotify.spec.js
+++ b/packages/openneuro-app/src/scripts/utils/__tests__/userNotify.spec.js
@@ -1,0 +1,29 @@
+import { expiringBanner } from '../userNotify.js'
+const { toast } = require.requireMock('react-toastify')
+
+jest.mock('react-toastify', () => ({
+  ...jest.requireActual('react-toastify'),
+  toast: { warn: jest.fn() },
+}))
+
+describe('userNotify.js', () => {
+  describe('expiringBanner', () => {
+    afterEach(() => {
+      jest.clearAllMocks()
+    })
+    it('is displayed before expiration time', () => {
+      const future = new Date()
+      // Engage the flux capacitor
+      future.setSeconds(future.getSeconds() + 30)
+      expiringBanner('message', future)
+      expect(toast.warn).toHaveBeenCalled()
+    })
+    it('is not displayed after expiration', () => {
+      const past = new Date()
+      // Rewind time 30 seconds
+      past.setSeconds(past.getSeconds() - 30)
+      expiringBanner('message', past)
+      expect(toast.warn).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/packages/openneuro-app/src/scripts/utils/userNotify.js
+++ b/packages/openneuro-app/src/scripts/utils/userNotify.js
@@ -1,0 +1,8 @@
+import { toast } from 'react-toastify'
+import isFuture from 'date-fns/is_future'
+
+export const expiringBanner = (message, expiration) => {
+  if (isFuture(expiration)) {
+    toast.warn(message, { autoClose: 15000 })
+  }
+}


### PR DESCRIPTION
This adds a banner that will be shown until Friday, July 19th warning users about a maintenance window on July 17th to migrate to the new hosting configuration.

![Screenshot from 2019-07-10 12-09-49](https://user-images.githubusercontent.com/11369795/60997502-cebd7000-a30b-11e9-8f56-934c2d502b85.png)
