### PR TITLE
add publish reminder message after cli upload

### DIFF
--- a/packages/openneuro-cli/src/actions.js
+++ b/packages/openneuro-cli/src/actions.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import fs from 'fs'
 import inquirer from 'inquirer'
 import createClient from 'openneuro-client'
@@ -72,6 +73,19 @@ const uploadDataset = (dir, datasetId, validatorOptions) => {
   }
 }
 
+const notifyUploadComplete = datasetId => {
+  console.log(
+    '=====================================================================',
+  )
+  console.log('Upload Complete')
+  console.log(
+    `To publish your dataset go to https://openneuro.org/datasets/${datasetId}`,
+  )
+  console.log(
+    '=====================================================================',
+  )
+}
+
 /**
  * Upload files to a dataset draft
  *
@@ -91,7 +105,9 @@ export const upload = (dir, cmd) => {
     if (cmd.dataset) {
       // eslint-disable-next-line no-console
       console.log(`Adding files to "${cmd.dataset}"`)
-      uploadDataset(dir, cmd.dataset, validatorOptions)
+      uploadDataset(dir, cmd.dataset, validatorOptions).then(
+        notifyUploadComplete,
+      )
     } else {
       inquirer
         .prompt({
@@ -102,7 +118,9 @@ export const upload = (dir, cmd) => {
         })
         .then(({ yes }) => {
           if (yes) {
-            uploadDataset(dir, cmd.dataset, validatorOptions)
+            uploadDataset(dir, cmd.dataset, validatorOptions).then(
+              notifyUploadComplete,
+            )
           }
         })
     }

--- a/packages/openneuro-cli/src/actions.js
+++ b/packages/openneuro-cli/src/actions.js
@@ -75,14 +75,14 @@ const uploadDataset = (dir, datasetId, validatorOptions) => {
 
 const notifyUploadComplete = datasetId => {
   console.log(
-    '=====================================================================',
+    '=======================================================================',
   )
   console.log('Upload Complete')
   console.log(
     `To publish your dataset go to https://openneuro.org/datasets/${datasetId}`,
   )
   console.log(
-    '=====================================================================',
+    '=======================================================================',
   )
 }
 

--- a/packages/openneuro-cli/src/actions.js
+++ b/packages/openneuro-cli/src/actions.js
@@ -78,9 +78,7 @@ const notifyUploadComplete = datasetId => {
     '=======================================================================',
   )
   console.log('Upload Complete')
-  console.log(
-    `To publish your dataset go to https://openneuro.org/datasets/${datasetId}`,
-  )
+  console.log(`To publish your dataset go to ${getUrl()}datasets/${datasetId}`)
   console.log(
     '=======================================================================',
   )

--- a/packages/openneuro-cli/src/upload.js
+++ b/packages/openneuro-cli/src/upload.js
@@ -72,9 +72,11 @@ export const uploadTree = (client, datasetId) => tree => {
  * @param {Object} options - {datasetId: 'ds000001', delete: false, files: [paths, to, exclude]}
  */
 export const uploadDirectory = (client, dir, { datasetId, remoteFiles }) => {
-  return getFileTree(dir, dir, { remoteFiles }).then(tree => {
-    tree = generateChanges(tree)
-    tree.files = files.sortFiles(tree.files)
-    return uploadTree(client, datasetId)(tree)
-  })
+  return getFileTree(dir, dir, { remoteFiles })
+    .then(tree => {
+      tree = generateChanges(tree)
+      tree.files = files.sortFiles(tree.files)
+      return uploadTree(client, datasetId)(tree)
+    })
+    .then(() => datasetId)
 }


### PR DESCRIPTION
adds feature mentioned in #1085 
closes #1186 
```
(base) MacBook-Pro-4:openneuro david$ /Users/david/projects/openNeuro/openneuro/openneuro/packages/openneuro-cli/src/index.js upload "/Users/david/Documents/bids datasets/32 Mb/ds001421-1.0.1" -i
? This will create a new dataset, continue? Yes
"ds002032" created with label "ds001421-1.0.1"
Transferring "dataset_description.json" - 100% complete 
Transferring ".bidsignore" - 100% complete 
Transferring "CHANGES" - 100% complete 
Transferring "README" - 100% complete 
Transferring "sub-01/ses-01/anat/sub-01_ses-01_T1w.json" - 100% complete 
Transferring "sub-01/ses-01/anat/sub-01_ses-01_T1w.nii" - 100% complete 
Transferring "sub-01/ses-01/pet/sub-01_ses-01_pet.json" - 100% complete 
Transferring "sub-01/ses-01/pet/sub-01_ses-01_pet.nii.gz" - 100% complete 
Transferring "sub-01/ses-02/anat/sub-01_ses-02_T1w.json" - 100% complete 
Transferring "sub-01/ses-02/anat/sub-01_ses-02_T1w.nii" - 100% complete 
Transferring "sub-01/ses-02/pet/sub-01_ses-02_pet.json" - 100% complete 
Transferring "sub-01/ses-02/pet/sub-01_ses-02_pet.nii.gz" - 100% complete 
=======================================================================
Upload Complete
To publish your dataset, go to https://openneuro.org/datasets/ds002032
=======================================================================
```