### PR TITLE
[WIP] 1180 freshdesk copy rewrite

### DIFF
--- a/packages/openneuro-app/src/scripts/datalad/fragments/freshdesk-widget.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/fragments/freshdesk-widget.jsx
@@ -2,11 +2,14 @@ import React from 'react'
 import { getProfile } from '../../authentication/profile'
 import config from '../../../../config'
 
-const prepopulatedFieldsQuery = prepopulatedFields => {
-  const fieldQueries = Object.entries(prepopulatedFields)
-    .filter(([, value]) => value)
-    .map(([key, value]) => `helpdesk_ticket[${key}]=${value}`)
-  return fieldQueries.length ? `&${fieldQueries.join(';')}` : ''
+const buildCustomQuery = (customText, prepopulatedFields) => {
+  const customizerQueries = [
+    ...Object.entries(customText).map(([key, value]) => `${key}=${value}`),
+    ...Object.entries(prepopulatedFields)
+      .filter(([, value]) => value)
+      .map(([key, value]) => `helpdesk_ticket[${key}]=${value}`),
+  ]
+  return customizerQueries.length ? `&${customizerQueries.join(';')}` : ''
 }
 
 function FreshdeskWidget(props) {
@@ -17,6 +20,21 @@ function FreshdeskWidget(props) {
   description = [sentry, description, error]
     .filter(item => item)
     .join(' \u2014 ')
+
+  const customText = {
+    widgetType: 'embedded',
+    formTitle: 'Report+an+Issue',
+    submitTitle: 'Request+Support',
+    submitThanks:
+      'Thank+you+for+taking+the+time+to+report+your+case.+A+support+representative+will+be+reviewing+your+request+and+will+send+you+a+personal+response+within+24+to+48+hours.',
+    screenshot: 'No',
+    captcha: 'yes',
+  }
+  const prepopulatedFields = {
+    requester: profile && profile.email,
+    subject,
+    description,
+  }
   return (
     <>
       <script
@@ -33,12 +51,7 @@ function FreshdeskWidget(props) {
         className="freshwidget-embedded-form"
         id="freshwidget-embedded-form"
         src={
-          config.support.url +
-          prepopulatedFieldsQuery({
-            requester: profile && profile.email,
-            subject,
-            description,
-          })
+          config.support.url + buildCustomQuery(customText, prepopulatedFields)
         }
         scrolling="no"
         height="500px"

--- a/packages/openneuro-app/src/scripts/datalad/fragments/freshdesk-widget.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/fragments/freshdesk-widget.jsx
@@ -11,9 +11,12 @@ const prepopulatedFieldsQuery = prepopulatedFields => {
 
 function FreshdeskWidget(props) {
   const profile = getProfile()
-  const { subject, error } = props
+  const { subject, error, sentryId } = props
   let { description } = props
-  description = [description, error].filter(item => item).join('\n\n')
+  const sentry = sentryId && `Sentry ID: ${sentryId}`
+  description = [sentry, description, error]
+    .filter(item => item)
+    .join(' \u2014 ')
   return (
     <>
       <script

--- a/packages/openneuro-app/src/scripts/errors/errorBoundary.jsx
+++ b/packages/openneuro-app/src/scripts/errors/errorBoundary.jsx
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/browser'
 import React from 'react'
 import PropTypes from 'prop-types'
 import { Modal } from '../utils/modal.jsx'
@@ -11,11 +12,19 @@ class ErrorBoundary extends React.Component {
       hasError: errorAbove,
       supportModal: false,
       error: props.error,
+      eventId: null,
     }
   }
 
   static getDerivedStateFromError(error) {
     return { hasError: true, supportModal: true, error: error }
+  }
+
+  componentDidCatch(error) {
+    Sentry.withScope(scope => {
+      scope.setTag('datasetId', this.props.datasetId)
+      this.setState({ eventId: Sentry.captureException(error) })
+    })
   }
 
   closeSupportModal = () =>
@@ -51,7 +60,9 @@ class ErrorBoundary extends React.Component {
           </Modal.Header>
           <hr className="modal-inner" />
           <Modal.Body>
-            <FreshdeskWidget {...{ subject, description, error }} />
+            <FreshdeskWidget
+              {...{ subject, description, error, sentryId: this.state.eventId }}
+            />
           </Modal.Body>
           <Modal.Footer>
             <a onClick={this.closeSupportModal}>Close</a>

--- a/packages/openneuro-app/src/scripts/errors/errorBoundary.jsx
+++ b/packages/openneuro-app/src/scripts/errors/errorBoundary.jsx
@@ -60,6 +60,9 @@ class ErrorBoundary extends React.Component {
           </Modal.Header>
           <hr className="modal-inner" />
           <Modal.Body>
+            To ensure that we can quickly help resolve this issue, please
+            provide as much detail as you can, including what you were trying to
+            accomplish when the error occurred.
             <FreshdeskWidget
               {...{ subject, description, error, sentryId: this.state.eventId }}
             />

--- a/packages/openneuro-app/src/scripts/nav/navbar.jsx
+++ b/packages/openneuro-app/src/scripts/nav/navbar.jsx
@@ -97,13 +97,6 @@ class BSNavbar extends React.Component {
         </Modal.Header>
         <hr className="modal-inner" />
         <Modal.Body>
-          If you have a question about details of a particular dataset
-          (clarifying the design, asking for additional metadata etc.) please
-          post it as a comment underneath the dataset. If you would like to
-          suggest a new feature please post it at
-          <a href="https://openneuro.featureupvote.com/">
-            https://openneuro.featureupvote.com/
-          </a>
           <FreshdeskWidget />
         </Modal.Body>
         <Modal.Footer>

--- a/packages/openneuro-app/src/scripts/nav/navbar.jsx
+++ b/packages/openneuro-app/src/scripts/nav/navbar.jsx
@@ -97,6 +97,20 @@ class BSNavbar extends React.Component {
         </Modal.Header>
         <hr className="modal-inner" />
         <Modal.Body>
+          <p>
+            If you would like to report an issue with openneuro.org, please
+            provide details in the text box below and an OpenNeuro
+            representative will be in touch with you by the next business day.
+          </p>
+          <p>
+            If you have concerns regarding a specific dataset (clarifying the
+            design, asking for additional metadata, etc.), please post them in
+            the comments beneath that dataset.
+          </p>
+          <p>
+            If you would like to suggest a new site feature, please post it at
+            https://openneuro.featureupvote.com/
+          </p>
           <FreshdeskWidget />
         </Modal.Body>
         <Modal.Footer>


### PR DESCRIPTION
Update modal language in support and on error and set custom widget text.
Support:
<img width="771" alt="Screen Shot 2019-07-18 at 09 43 47" src="https://user-images.githubusercontent.com/28666458/61476184-4c533280-a941-11e9-9043-4db5741941ef.png">
Error:
<img width="773" alt="Screen Shot 2019-07-18 at 09 48 03" src="https://user-images.githubusercontent.com/28666458/61476195-51b07d00-a941-11e9-9625-438166e7a84b.png">

TODO: fix: auto-populated description text not always passed to Freshdesk helpdesk