### PR TITLE
Return 200 on requests to openneuro-server root for health check

### DIFF
--- a/helm/openneuro/Chart.yaml
+++ b/helm/openneuro/Chart.yaml
@@ -5,7 +5,7 @@ description: OpenNeuro production deployment chart
 home: https://openneuro.org
 sources:
   - https://github.com/openNeuroOrg/openneuro
-appVersion: 3.1.5-17
+appVersion: 3.3.1
 dependencies:
   - name: redis
     version: 7.1.0

--- a/packages/openneuro-server/routes.js
+++ b/packages/openneuro-server/routes.js
@@ -17,6 +17,14 @@ import doi from './handlers/doi'
 import { sitemapHandler } from './handlers/sitemap.js'
 
 const routes = [
+  // Health check --------------------------------
+  {
+    method: 'get',
+    url: '/',
+    handler: (req, res) => {
+      res.sendStatus(200)
+    },
+  },
   // React config --------------------------------
   {
     method: 'get',


### PR DESCRIPTION
This returns 200 at the same path as the static Nginx service so API requests do not fail load balancer health checks after the first timeout interval.