### PR TITLE
Fix mismatched worker count in Helm configuration

### DIFF
--- a/helm/openneuro/templates/configmap.yaml
+++ b/helm/openneuro/templates/configmap.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ .Release.Name }}-configmap
 data:
   CRN_SERVER_URL: {{ .Values.url | quote }}
-  DATALAD_WORKERS: "16"
+  DATALAD_WORKERS: {{ .Values.dataladWorkers | quote }}
   FRESH_DESK_URL: {{ .Values.freshDeskUrl | quote }}
   ENVIRONMENT: {{ .Values.environment | quote }}
   GOOGLE_TRACKING_ID: {{ .Values.googleTrackingId | quote }}

--- a/helm/openneuro/templates/secret.yaml
+++ b/helm/openneuro/templates/secret.yaml
@@ -36,3 +36,4 @@ stringData:
   DOI_URL: {{ required "DOI_URL is required" .Values.secrets.doi.DOI_URL | quote }}
   FLOWER_BASIC_AUTH: {{ required "FLOWER_BASIC_AUTH must be set to avoid insecure default values" .Values.secrets.flower.FLOWER_BASIC_AUTH | quote }}
   MONGO_URL: {{ required "MONGO_URL with credentials is required" .Values.secrets.mongo.MONGO_URL | quote }}
+  ENGINE_API_KEY: {{ .Values.secrets.apollo.ENGINE_API_KEY | quote }}

--- a/helm/secrets.yaml.example
+++ b/helm/secrets.yaml.example
@@ -2,6 +2,10 @@ secrets:
   # A unique true random string used to secure JWT tokens
   JWT_SECRET:
 
+  # Apollo GraphQL configuration
+  apollo:
+    # ENGINE_API_KEY:
+
   # At least one auth method must be configured
   auth:
     # Google oauth2 configuration - configure to enable Google auth


### PR DESCRIPTION
This fixes a corner case where running the Kubernetes version of the site would queue dataset tasks for workers which did not exist if you had less than the default of 16 dataset workers.