### PR TITLE
Add missing schedulers to helm deployment

### DIFF
--- a/helm/.gitignore
+++ b/helm/.gitignore
@@ -1,3 +1,3 @@
 openneuro/charts
 values.yaml
-secrets.yaml
+secrets*.yaml

--- a/helm/openneuro/Chart.yaml
+++ b/helm/openneuro/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: openneuro
-version: 1.0.1
+version: 1.0.2
 description: OpenNeuro production deployment chart
 home: https://openneuro.org
 sources:

--- a/helm/openneuro/templates/api-deployment.yaml
+++ b/helm/openneuro/templates/api-deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: {{ .Release.Name }}-api
   labels:
-    app: openneuro-api
+    app: {{ .Release.Name }}-api
     chart: '{{ .Chart.Name }}-{{ .Chart.Version }}'
     release: '{{ .Release.Name }}'
     heritage: '{{ .Release.Service }}'

--- a/helm/openneuro/templates/api-deployment.yaml
+++ b/helm/openneuro/templates/api-deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: {{ .Release.Name }}-api
   labels:
-    app: {{ .Release.Name }}-api
+    app: '{{ .Release.Name }}-api'
     chart: '{{ .Chart.Name }}-{{ .Chart.Version }}'
     release: '{{ .Release.Name }}'
     heritage: '{{ .Release.Service }}'

--- a/helm/openneuro/templates/beat-scheduler-deployment.yaml
+++ b/helm/openneuro/templates/beat-scheduler-deployment.yaml
@@ -1,0 +1,33 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-beat-scheduler
+  labels:
+    app: openneuro-api
+    chart: '{{ .Chart.Name }}-{{ .Chart.Version }}'
+    release: '{{ .Release.Name }}'
+    heritage: '{{ .Release.Service }}'
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}-beat-scheduler
+  template:
+    metadata:
+      labels:
+        app: {{ .Release.Name }}-beat-scheduler
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+    spec:
+      containers:
+      - name: {{ .Release.Name }}-beat-scheduler
+        image: 'openneuro/datalad-service:v{{ .Chart.AppVersion }}'
+        command:
+          - /beat-scheduler
+        envFrom:
+        - configMapRef:
+            name: {{ .Release.Name }}-configmap
+        - secretRef:
+            name: {{ .Release.Name }}-secret
+

--- a/helm/openneuro/templates/beat-scheduler-deployment.yaml
+++ b/helm/openneuro/templates/beat-scheduler-deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: {{ .Release.Name }}-beat-scheduler
   labels:
-    app: openneuro-api
+    app: '{{ .Release.Name }}-beat-scheduler'
     chart: '{{ .Chart.Name }}-{{ .Chart.Version }}'
     release: '{{ .Release.Name }}'
     heritage: '{{ .Release.Service }}'

--- a/helm/openneuro/templates/publish-worker-deployment.yaml
+++ b/helm/openneuro/templates/publish-worker-deployment.yaml
@@ -1,17 +1,21 @@
 apiVersion: apps/v1
-kind: StatefulSet
+kind: Deployment
 metadata:
   name: {{ .Release.Name }}-publish-worker
+  labels:
+    app: openneuro-api
+    chart: '{{ .Chart.Name }}-{{ .Chart.Version }}'
+    release: '{{ .Release.Name }}'
+    heritage: '{{ .Release.Service }}'
 spec:
+  replicas: 1
   selector:
     matchLabels:
-      app: {{ .Release.Name }}-publish-worker # has to match .spec.template.metadata.labels
-  serviceName: "publish-worker"
-  replicas: 1
+      app: {{ .Release.Name }}-publish-worker
   template:
     metadata:
       labels:
-        app: {{ .Release.Name }}-publish-worker # has to match .spec.selector.matchLabels
+        app: {{ .Release.Name }}-publish-worker
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}

--- a/helm/openneuro/templates/publish-worker-deployment.yaml
+++ b/helm/openneuro/templates/publish-worker-deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: {{ .Release.Name }}-publish-worker
   labels:
-    app: openneuro-api
+    app: '{{ .Release.Name }}-publish-worker'
     chart: '{{ .Chart.Name }}-{{ .Chart.Version }}'
     release: '{{ .Release.Name }}'
     heritage: '{{ .Release.Service }}'

--- a/helm/openneuro/templates/publish-worker-stateful-set.yaml
+++ b/helm/openneuro/templates/publish-worker-stateful-set.yaml
@@ -1,0 +1,35 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ .Release.Name }}-publish-worker
+spec:
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}-publish-worker # has to match .spec.template.metadata.labels
+  serviceName: "publish-worker"
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: {{ .Release.Name }}-publish-worker # has to match .spec.selector.matchLabels
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+    spec:
+      volumes:
+      - name: datasets
+        persistentVolumeClaim:
+          claimName: {{ .Release.Name }}-datasets
+      containers:
+      - name: {{ .Release.Name }}-publish-worker
+        image: 'openneuro/datalad-service:v{{ .Chart.AppVersion }}'
+        command:
+          - /publish-worker
+        envFrom:
+        - configMapRef:
+            name: {{ .Release.Name }}-configmap
+        - secretRef:
+            name: {{ .Release.Name }}-secret
+        volumeMounts:
+        - name: datasets
+          mountPath: /datalad


### PR DESCRIPTION
This starts the remote audit on the new hosting setup and fixes the missing publish worker that exports data to S3.