### PR TITLE
Update snapshot draft pointer

### DIFF
--- a/packages/openneuro-server/datalad/__tests__/snapshots.spec.js
+++ b/packages/openneuro-server/datalad/__tests__/snapshots.spec.js
@@ -8,7 +8,9 @@ import config from '../../config.js'
 jest.mock('superagent')
 jest.mock('../../libs/redis.js')
 // Mock draft files calls
-jest.mock('../draft.js')
+jest.mock('../draft.js', () => ({
+  updateDatasetRevision: () => () => Promise.resolve(),
+}))
 
 describe('snapshot model operations', () => {
   describe('createSnapshot()', () => {

--- a/packages/openneuro-server/datalad/dataset.js
+++ b/packages/openneuro-server/datalad/dataset.js
@@ -297,9 +297,8 @@ export const commitFiles = (datasetId, user) => {
     .set('Accept', 'application/json')
     .then(res => {
       gitRef = res.body.ref
-      return gitRef
+      return updateDatasetRevision(datasetId, gitRef).then(() => gitRef)
     })
-    .then(updateDatasetRevision(datasetId))
 }
 
 /**

--- a/packages/openneuro-server/datalad/dataset.js
+++ b/packages/openneuro-server/datalad/dataset.js
@@ -21,7 +21,6 @@ import Star from '../models/stars.js'
 import Analytics from '../models/analytics.js'
 import { trackAnalytics } from './analytics.js'
 import { datasetsConnection } from './pagination.js'
-import publishDraftUpdate from '../graphql/utils/publish-draft-update.js'
 const c = mongo.collections
 const uri = config.datalad.uri
 
@@ -301,10 +300,6 @@ export const commitFiles = (datasetId, user) => {
       return gitRef
     })
     .then(updateDatasetRevision(datasetId))
-    .then(gitRef => {
-      publishDraftUpdate(datasetId, gitRef)
-      return gitRef
-    })
 }
 
 /**

--- a/packages/openneuro-server/datalad/draft.js
+++ b/packages/openneuro-server/datalad/draft.js
@@ -6,7 +6,7 @@ import mongo from '../libs/mongo.js'
 import { redis } from '../libs/redis.js'
 import config from '../config.js'
 import { addFileUrl } from './utils.js'
-
+import publishDraftUpdate from '../graphql/utils/publish-draft-update.js'
 const uri = config.datalad.uri
 
 const draftFilesKey = datasetId => {
@@ -58,6 +58,7 @@ export const updateDatasetRevision = datasetId => gitRef => {
       // Remove the now invalid draft files cache
       return expireDraftFiles(datasetId)
     })
+    .then(() => publishDraftUpdate(datasetId, gitRef))
 }
 
 export const draftPartialKey = datasetId => {

--- a/packages/openneuro-server/datalad/draft.js
+++ b/packages/openneuro-server/datalad/draft.js
@@ -45,7 +45,7 @@ export const getDraftFiles = async (datasetId, options = {}) => {
   })
 }
 
-export const updateDatasetRevision = datasetId => gitRef => {
+export const updateDatasetRevision = (datasetId, gitRef) => {
   /**
    * Update the revision pointer in a draft on changes
    */

--- a/packages/openneuro-server/datalad/snapshots.js
+++ b/packages/openneuro-server/datalad/snapshots.js
@@ -118,7 +118,7 @@ export const createSnapshot = async (
       }
 
       // Update the draft status in case any changes were made (DOI, License)
-      await updateDatasetRevision(datasetId)(body.hexsha)
+      await updateDatasetRevision(datasetId, body.hexsha)
 
       return (
         createSnapshotMetadata(datasetId, tag, body.hexsha, body.created)

--- a/packages/openneuro-server/datalad/snapshots.js
+++ b/packages/openneuro-server/datalad/snapshots.js
@@ -16,6 +16,7 @@ import { generateDataladCookie } from '../libs/authentication/jwt'
 import notifications from '../libs/notifications'
 import Snapshot from '../models/snapshot.js'
 import { trackAnalytics } from './analytics.js'
+import { updateDatasetRevision } from './draft.js'
 
 const c = mongo.collections
 const uri = config.datalad.uri
@@ -115,6 +116,9 @@ export const createSnapshot = async (
         // Return the promise so queries won't block
         body.files = getFiles(datasetId, body.hexsha)
       }
+
+      // Update the draft status in case any changes were made (DOI, License)
+      await updateDatasetRevision(datasetId)(body.hexsha)
 
       return (
         createSnapshotMetadata(datasetId, tag, body.hexsha, body.created)


### PR DESCRIPTION
This prevents the draft pointer from getting out of sync when snapshot creation generates intermediate commits.