### PR TITLE
Helm: Mount GitHub SSH key in publish worker

### DIFF
--- a/helm/openneuro/Chart.yaml
+++ b/helm/openneuro/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: openneuro
-version: 1.0.3
+version: 1.0.4
 description: OpenNeuro production deployment chart
 home: https://openneuro.org
 sources:

--- a/helm/openneuro/templates/publish-worker-deployment.yaml
+++ b/helm/openneuro/templates/publish-worker-deployment.yaml
@@ -24,6 +24,12 @@ spec:
       - name: datasets
         persistentVolumeClaim:
           claimName: {{ .Release.Name }}-datasets
+      - name: ssh-key
+        secret:
+          secretName: {{ .Release.Name }}-ssh-key
+          items:
+          - key: datalad-key
+            path: datalad-key
       containers:
       - name: {{ .Release.Name }}-publish-worker
         image: 'openneuro/datalad-service:v{{ .Chart.AppVersion }}'
@@ -37,3 +43,6 @@ spec:
         volumeMounts:
         - name: datasets
           mountPath: /datalad
+        - name: ssh-key
+          mountPath: /datalad-key
+          subPath: datalad-key


### PR DESCRIPTION
This adds the ssh key mount to the correct deployment for automated pushes to GitHub.