### PR TITLE
Fix missing draft version for partial datasets

### DIFF
--- a/packages/openneuro-app/src/scripts/datalad/dataset/__tests__/__snapshots__/left-siderbar.spec.jsx.snap
+++ b/packages/openneuro-app/src/scripts/datalad/dataset/__tests__/__snapshots__/left-siderbar.spec.jsx.snap
@@ -5,7 +5,23 @@ exports[`LeftSidebar component SidebarRow renders draft version correctly 1`] = 
 exports[`LeftSidebar component SidebarRow renders snapshot version correctly 1`] = `undefined`;
 
 exports[`LeftSidebar component renders with basic props 1`] = `
-<Route>
-  <Component />
-</Route>
+<div
+  className="left-sidebar"
+>
+  <span
+    className="slide"
+  >
+    <div
+      className="snapshot-select"
+      role="presentation"
+    >
+      <span>
+        <h3>
+          Versions
+        </h3>
+        <ul />
+      </span>
+    </div>
+  </span>
+</div>
 `;

--- a/packages/openneuro-app/src/scripts/datalad/dataset/__tests__/left-siderbar.spec.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/dataset/__tests__/left-siderbar.spec.jsx
@@ -1,21 +1,63 @@
 import React from 'react'
 import { shallow } from 'enzyme'
-import LeftSidebar, { SidebarRow } from '../left-sidebar.jsx'
+import { LeftSidebar, SidebarRow } from '../left-sidebar.jsx'
+import cookies from '../../../utils/cookies.js'
 
 const fixedDate = new Date('2019-04-02T19:56:41.222Z')
+const mockLocation = { pathname: '/dataset/ds000001' }
 
 describe('LeftSidebar component', () => {
   it('renders with basic props', () => {
+    const testDataset = {
+      permissions: [],
+      draft: {
+        partial: false,
+      },
+    }
     expect(
       shallow(
         <LeftSidebar
+          dataset={testDataset}
           datasetId="ds000001"
           draftModified={fixedDate}
           snapshots={[]}
-          location="/dataset/ds000001"
+          location={mockLocation}
         />,
       ),
     ).toMatchSnapshot()
+  })
+  it('renders the draft when dataset.draft.partial is true', () => {
+    // Set admin token to enable edit access
+    cookies.set(
+      'accessToken',
+      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJhZG1pbiI6dHJ1ZX0.F-cvL2RcfQhUtCavIM7q7zYE8drmj2LJk0JRkrS6He4',
+    )
+    const testDataset = {
+      permissions: [],
+      draft: {
+        partial: true,
+      },
+    }
+    const wrapper = shallow(
+      <LeftSidebar
+        dataset={testDataset}
+        datasetId="ds000001"
+        draftModified={fixedDate}
+        snapshots={[]}
+        location={mockLocation}
+      />,
+    )
+    // Check that a SidebarRow is rendered
+    expect(wrapper.find('SidebarRow')).toHaveLength(1)
+    // Check that the first sidebar row is "draft" if the user can edit it
+    expect(
+      wrapper
+        .find('SidebarRow')
+        .first()
+        .props().version,
+    ).toBe('Draft')
+    // Cleanup cookie for other tests
+    cookies.remove('accessToken')
   })
   describe('SidebarRow', () => {
     it('renders draft version correctly', () => {

--- a/packages/openneuro-app/src/scripts/datalad/dataset/left-sidebar.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/dataset/left-sidebar.jsx
@@ -45,7 +45,7 @@ SidebarRow.propTypes = {
   modified: PropTypes.oneOfType([PropTypes.string, PropTypes.instanceOf(Date)]),
 }
 
-const LeftSidebar = ({
+export const LeftSidebar = ({
   dataset,
   datasetId,
   draftModified,

--- a/packages/openneuro-app/src/scripts/datalad/dataset/left-sidebar.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/dataset/left-sidebar.jsx
@@ -55,9 +55,8 @@ export const LeftSidebar = ({
   const active = snapshotVersion(location) || 'draft'
   const user = getProfile()
   const hasEdit =
-    ((user && user.admin) ||
-      hasEditPermissions(dataset.permissions, user && user.sub)) &&
-    !dataset.draft.partial
+    (user && user.admin) ||
+    hasEditPermissions(dataset.permissions, user && user.sub)
   return (
     <div className="left-sidebar">
       <span className="slide">


### PR DESCRIPTION
This show allow you to get to the draft page for any dataset affected by #1222. Added test coverage for this situation and fixed the basic snapshot test which was not working for the LeftSidebar component.