### PR TITLE
Fix partial drafts always causing a redirect

### DIFF
--- a/packages/openneuro-app/src/scripts/datalad/routes/dataset-content.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/routes/dataset-content.jsx
@@ -52,9 +52,8 @@ HasBeenPublished.propTypes = {
 const DatasetContent = ({ dataset }) => {
   const user = getProfile()
   const hasEdit =
-    ((user && user.admin) ||
-      hasEditPermissions(dataset.permissions, user && user.sub)) &&
-    !dataset.draft.partial
+    (user && user.admin) ||
+    hasEditPermissions(dataset.permissions, user && user.sub)
   return (
     <>
       <LoggedIn>


### PR DESCRIPTION
Follow up to #1238 - the draft button was visible but this redirect would always take you to a snapshot page.