### PR TITLE
Make sure partial state cache is cleared after commitFiles

### DIFF
--- a/packages/openneuro-server/datalad/dataset.js
+++ b/packages/openneuro-server/datalad/dataset.js
@@ -297,6 +297,8 @@ export const commitFiles = (datasetId, user) => {
     .set('Accept', 'application/json')
     .then(res => {
       gitRef = res.body.ref
+      // Always remove the partial key when a commit is successfully made
+      redis.del(draftPartialKey(datasetId))
       return updateDatasetRevision(datasetId, gitRef).then(() => gitRef)
     })
 }


### PR DESCRIPTION
This fixes a regression where commitFiles (which is how you get out of a partial dataset state) would not clear the cache key, leaving your dataset marked as "incomplete" when it really isn't.