### PR TITLE
Filter out private datasets from participant count query

### DIFF
--- a/packages/openneuro-server/graphql/resolvers/snapshots.js
+++ b/packages/openneuro-server/graphql/resolvers/snapshots.js
@@ -24,6 +24,19 @@ export const snapshot = (obj, { datasetId, tag }, context) => {
 export const participantCount = async () => {
   const aggregateResult = await SnapshotModel.aggregate([
     {
+      $lookup: {
+        from: 'datasets',
+        localField: 'datasetId',
+        foreignField: 'id',
+        as: 'dataset',
+      },
+    },
+    {
+      $match: {
+        'dataset.public': true,
+      },
+    },
+    {
       $sort: {
         created: -1,
       },


### PR DESCRIPTION
The participants count is inflated by some unpublished data, this restricts the aggregation to only public datasets.