### PR TITLE
Cache front page query for up to 24 hours

### DIFF
--- a/packages/openneuro-server/graphql/schema.js
+++ b/packages/openneuro-server/graphql/schema.js
@@ -41,7 +41,7 @@ const typeDefs = `
     # Get a list of users
     users: [User]
     # Get the total number of dataset participants
-    participantCount: Int
+    participantCount: Int @cacheControl(maxAge: 86400, scope: PUBLIC)
     # Request one snapshot
     snapshot(datasetId: ID!, tag: String!): Snapshot
     # Determine if a dataset is partially uploaded


### PR DESCRIPTION
Fixes #1256 by allowing the server and client to cache this field for up to one day.