### PR TITLE
Add sitemap route to Kubernetes deployment

### DIFF
--- a/helm/openneuro/templates/ingress.yaml
+++ b/helm/openneuro/templates/ingress.yaml
@@ -22,6 +22,10 @@ spec:
             backend:
               serviceName: {{ .Release.Name }}-api
               servicePort: 8111
+          - path: /sitemap.xml
+            backend:
+              serviceName: {{ .Release.Name }}-api
+              servicePort: 8111
           - path: /*
             backend:
               serviceName: {{ .Release.Name }}-web

--- a/packages/openneuro-server/app.js
+++ b/packages/openneuro-server/app.js
@@ -16,6 +16,7 @@ import bodyParser from 'body-parser'
 import cookieParser from 'cookie-parser'
 import * as jwt from './libs/authentication/jwt.js'
 import * as auth from './libs/authentication/states.js'
+import { sitemapHandler } from './handlers/sitemap.js'
 import { setupPassportAuth } from './libs/authentication/passport.js'
 
 // test flag disables Sentry for tests
@@ -40,7 +41,7 @@ export default test => {
   app.use(bodyParser.json({ limit: '50mb' }))
 
   // routing ---------------------------------------------------------
-
+  app.use('/sitemap.xml', sitemapHandler)
   app.use(config.apiPrefix, routes)
 
   // error handling --------------------------------------------------\


### PR DESCRIPTION
Recreates the nginx /sitemap.xml route for the new hosting setup.