### PR TITLE
581 format validator output

### DIFF
--- a/packages/openneuro-cli/src/actions.js
+++ b/packages/openneuro-cli/src/actions.js
@@ -23,7 +23,7 @@ export const login = () => {
       type: 'list',
       name: 'url',
       message: 'Choose an OpenNeuro instance to use.',
-      choices: ['https://openneuro.org/', 'https://openneuro.dev.sqm.io/'],
+      choices: ['https://openneuro.org/', 'https://openneuro.staging.sqm.io/'],
       default: 'https://openneuro.org/',
     })
     .then(async answers =>

--- a/packages/openneuro-cli/src/upload.js
+++ b/packages/openneuro-cli/src/upload.js
@@ -28,12 +28,17 @@ const fatalError = err => {
 }
 
 /**
- * Runs validation and exits if an error is encountered
+ * Runs validation, logs summary or exits if an error is encountered
  * @param {string} dir Directory to validate
  * @param {object} validatorOptions Options passed to the validator
  */
 export const validation = (dir, validatorOptions) => {
-  return validatePromise(dir, validatorOptions).catch(fatalError)
+  return validatePromise(dir, validatorOptions)
+    .then(function({ summary }) {
+      // eslint-disable-next-line no-console
+      console.log({ summary })
+    })
+    .catch(fatalError)
 }
 
 /**

--- a/packages/openneuro-cli/src/upload.js
+++ b/packages/openneuro-cli/src/upload.js
@@ -2,6 +2,7 @@ import { inspect } from 'util'
 import { files } from 'openneuro-client'
 import validate from 'bids-validator'
 import { getFileTree, generateChanges } from './files'
+import consoleFormat from 'bids-validator/utils/consoleFormat'
 
 /**
  * BIDS validator promise wrapper
@@ -15,7 +16,7 @@ const validatePromise = (dir, options = {}) => {
       if (errors.length + warnings.length === 0) {
         resolve({ summary })
       } else {
-        reject({ errors, warnings })
+        reject(consoleFormat.issues({ errors, warnings }))
       }
     })
   })
@@ -36,7 +37,7 @@ export const validation = (dir, validatorOptions) => {
   return validatePromise(dir, validatorOptions)
     .then(function({ summary }) {
       // eslint-disable-next-line no-console
-      console.log({ summary })
+      console.log(consoleFormat.summary(summary))
     })
     .catch(fatalError)
 }


### PR DESCRIPTION
**Abstract:** The outputs on the CLI tool are now formatted. Error outputs point the user to the specific files causing the failed validation (in the stead of the less-than-helpful "`[array]`" left unpacked and inaccessible). A broken URL has been updated.
***
I've implemented three changes, as follows:

**(1)** The staging URL that the OpenNeuro CLI points to was deprecated; it was being output to the user. I've updated it to its current, live incarnation.

I've imported the `consoleFormat` methods (already exposed given `bids-validator` is a dependency of OpenNeuro) into the uploads script. These methods were called to:

**(2)** format the summary output upon successful validation of a dataset upload
**(3)** format the errors, warnings output upon failed validation of dataset upload