### PR TITLE
Avoid loading draft files when viewing snapshot routes

### DIFF
--- a/packages/openneuro-app/src/scripts/datalad/dataset/__tests__/__snapshots__/dataset-query.spec.jsx.snap
+++ b/packages/openneuro-app/src/scripts/datalad/dataset/__tests__/__snapshots__/dataset-query.spec.jsx.snap
@@ -6,6 +6,7 @@ exports[`DatasetQuery component renders with common params 1`] = `
 >
   <DatasetQueryHook
     datasetId="ds000001"
+    draft={true}
   />
 </ErrorBoundaryAssertionFailureException>
 `;

--- a/packages/openneuro-app/src/scripts/datalad/dataset/dataset-query-fragments.js
+++ b/packages/openneuro-app/src/scripts/datalad/dataset/dataset-query-fragments.js
@@ -18,11 +18,6 @@ export const DRAFT_FRAGMENT = gql`
         Funding
         ReferencesAndLinks
       }
-      files {
-        id
-        filename
-        size
-      }
       summary {
         modalities
         sessions
@@ -37,6 +32,20 @@ export const DRAFT_FRAGMENT = gql`
         size
         totalFiles
         dataProcessed
+      }
+    }
+  }
+`
+
+export const DRAFT_FILES_FRAGMENT = gql`
+  fragment DatasetDraftFiles on Dataset {
+    id
+    draft {
+      id
+      files {
+        id
+        filename
+        size
       }
     }
   }

--- a/packages/openneuro-app/src/scripts/datalad/dataset/dataset-query.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/dataset/dataset-query.jsx
@@ -14,7 +14,6 @@ import ErrorBoundary, {
 
 /**
  * Generate the dataset page query
- * @param {number} commentDepth How many levels to recurse for comments
  */
 export const getDatasetPage = gql`
   query dataset($datasetId: ID!) {
@@ -51,16 +50,56 @@ export const getDatasetPage = gql`
 `
 
 /**
+ * Add files fragment for draft route
+ */
+export const getDraftPage = gql`
+  query dataset($datasetId: ID!) {
+    dataset(id: $datasetId) {
+      id
+      created
+      public
+      following
+      starred
+      ...DatasetDraft
+      ...DatasetDraftFiles
+      ...DatasetPermissions
+      ...DatasetSnapshots
+      ...DatasetIssues
+      ...DatasetMetadata
+      ...DatasetComments
+      uploader {
+        id
+        name
+        email
+      }
+      analytics {
+        downloads
+        views
+      }
+      onBrainlife
+    }
+  }
+  ${DatasetQueryFragments.DRAFT_FRAGMENT}
+  ${DatasetQueryFragments.DRAFT_FILES_FRAGMENT}
+  ${DatasetQueryFragments.PERMISSION_FRAGMENT}
+  ${DatasetQueryFragments.DATASET_SNAPSHOTS}
+  ${DatasetQueryFragments.DATASET_ISSUES}
+  ${DatasetQueryFragments.DATASET_METADATA}
+  ${DATASET_COMMENTS}
+`
+
+/**
  * Query to load and render dataset page - most dataset loading is done here
  * @param {Object} props
  * @param {Object} props.datasetId Accession number / id for dataset to query
+ * @param {Object} props.draft Is this the draft page?
  */
-export const DatasetQueryHook = ({ datasetId }) => {
+export const DatasetQueryHook = ({ datasetId, draft }) => {
   const {
     data: { dataset },
     loading,
     error,
-  } = useQuery(getDatasetPage, {
+  } = useQuery(draft ? getDraftPage : getDatasetPage, {
     variables: { datasetId },
   })
   if (loading) {
@@ -88,10 +127,14 @@ DatasetQueryHook.propTypes = {
  * Routing wrapper for dataset query
  * @param {Object} props
  * @param {Object} props.match React router match object
+ * @param {Object} props.draft Is this the draft page?
  */
 const DatasetQuery = ({ match }) => (
   <ErrorBoundaryAssertionFailureException subject={'error in dataset query'}>
-    <DatasetQueryHook datasetId={match.params.datasetId} />
+    <DatasetQueryHook
+      datasetId={match.params.datasetId}
+      draft={!match.params.snapshotId}
+    />
   </ErrorBoundaryAssertionFailureException>
 )
 

--- a/packages/openneuro-app/src/scripts/datalad/dataset/dataset.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/dataset/dataset.jsx
@@ -1,21 +1,21 @@
 import React from 'react'
-import { Route } from 'react-router-dom'
+import { Route, Switch } from 'react-router-dom'
 import DatasetQuery from './dataset-query.jsx'
 
 const Dataset = () => {
   return (
-    <div>
-      <Route
-        name="datalad-dataset"
-        path="/datasets/:datasetId"
-        component={DatasetQuery}
-      />
+    <Switch>
       <Route
         name="datalad-snapshot"
-        path="/datasets/:datasetId/version/:snapshotId"
+        path="/datasets/:datasetId/versions/:snapshotId"
         component={DatasetQuery}
       />
-    </div>
+      <Route
+        name="datalad-dataset"
+        path="/datasets/:datasetId/"
+        component={DatasetQuery}
+      />
+    </Switch>
   )
 }
 


### PR DESCRIPTION
The first commit here fixes a long standing bug where the snapshot page route was unused. Luckily we had nothing that depended on this until now :smile:

The second makes the draft files fragment conditional on the route entered by choosing the appropriate version of the query depending on whether the draft or snapshot route is entered. This nicely loads the draft once if you enter the page and then switch to a snapshot, but skips loading the draft if you enter via the snapshot. Going from snapshot -> draft now makes the extra query to obtain the draft files.