### PR TITLE
fix share functionality

### DIFF
--- a/packages/openneuro-app/src/scripts/datalad/routes/share.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/routes/share.jsx
@@ -110,7 +110,7 @@ const Share = ({ datasetId, permissions }) => {
             <ShareDataset
               datasetId={datasetId}
               userEmail={userEmail}
-              access={access}
+              metadata={access}
               done={() => setUserEmail('')}
             />
           </div>


### PR DESCRIPTION
renamed prop being passed in to ShareDataset so as to expose the level variable being passed into its mutation

note: resubmitted this PR as a branch on the actual repo (as opposed to my fork); nothing else has changed