### PR TITLE
1331 responsive homepage

### DIFF
--- a/packages/openneuro-app/src/sass/crn_app/_elements-wrappers.scss
+++ b/packages/openneuro-app/src/sass/crn_app/_elements-wrappers.scss
@@ -52,7 +52,8 @@ body {
     font-family: $font-family-cabin;
     font-family: var(--font-family-cabin);
     letter-spacing: .03em;
-    background: $e5;
+    background: $white;
+    display: flex;
 }
 
 .main {

--- a/packages/openneuro-app/src/sass/crn_app/_elements-wrappers.scss
+++ b/packages/openneuro-app/src/sass/crn_app/_elements-wrappers.scss
@@ -52,9 +52,16 @@ body {
     font-family: $font-family-cabin;
     font-family: var(--font-family-cabin);
     letter-spacing: .03em;
-    background: $white;
-    display: flex;
+    background: $e5;
 }
+
+@media only screen and (max-width: 765px) {
+    body{
+        background: $white;
+        display: flex;
+    }
+}
+
 
 .main {
     display: flex;

--- a/packages/openneuro-app/src/sass/crn_app/_frontPage.scss
+++ b/packages/openneuro-app/src/sass/crn_app/_frontPage.scss
@@ -471,6 +471,12 @@
         }
     }
 }
+// limits num of <li> items that populate the browse containers on mobile
+@media ( max-width: 765px) { 
+    .row > div > div > div:nth-child(n + 5) {
+        display: none;
+    }
+}
 
 @media only screen and (max-width: 765px) {
     .mate-slide{

--- a/packages/openneuro-app/src/sass/crn_app/_frontPage.scss
+++ b/packages/openneuro-app/src/sass/crn_app/_frontPage.scss
@@ -472,6 +472,12 @@
     }
 }
 
+@media only screen and (max-width: 765px) {
+    .mate-slide{
+    border-bottom: inset #009b76;
+    }
+}
+
 .mate-analyses-header {
     margin-bottom: 10px;
 }

--- a/packages/openneuro-app/src/sass/crn_app/_frontPage.scss
+++ b/packages/openneuro-app/src/sass/crn_app/_frontPage.scss
@@ -472,7 +472,7 @@
     }
 }
 // limits num of <li> items that populate the browse containers on mobile
-@media ( max-width: 765px) { 
+@media only screen and  ( max-width: 765px) { 
     .row > div > div > div:nth-child(n + 5) {
         display: none;
     }


### PR DESCRIPTION
These changes make the front page responsive -> the containers are now flex and the gray offset on the right side of the page is now gone. I've also added a media query that draws a small inset border between the green "recent activity" cards; via mobile, they now appear as two discrete entities and the typographic hierarchy of the headers remains apparent (whereas before, this emphasis was lost on mobile). 

Last, I've added a media query that works in concert with the inset border -> this styling limits the prepopulated 'top datasets' and 'most active' lists to 3 items on mobile (as opposed to 5). This makes the vertical height of the view a bit shorter and conserves some real estate for the mobile view.