### PR TITLE
Front page error handling

### DIFF
--- a/packages/openneuro-app/src/scripts/front-page/__tests__/front-page-top-datasets.spec.jsx
+++ b/packages/openneuro-app/src/scripts/front-page/__tests__/front-page-top-datasets.spec.jsx
@@ -1,10 +1,27 @@
 import React from 'react'
 import { shallow } from 'enzyme'
-import FrontPageTopDatasets from '../front-page-top-datasets.jsx'
+import FrontPageTopDatasets, {
+  FrontPageTopResult,
+} from '../front-page-top-datasets.jsx'
 
 describe('FrontPageTopDatasets', () => {
   it('renders container correctly', () => {
     const wrapper = shallow(<FrontPageTopDatasets />)
     expect(wrapper).toMatchSnapshot()
+  })
+  describe('FrontPageTopResult', () => {
+    it('does not crash with null query results', () => {
+      const fakeQuery = Symbol('not a real query')
+      const renderFrontPageTopResult = () => {
+        shallow(
+          FrontPageTopResult(fakeQuery)({
+            loading: false,
+            error: false,
+            data: {},
+          }),
+        )
+      }
+      expect(renderFrontPageTopResult).not.toThrowError()
+    })
   })
 })

--- a/packages/openneuro-app/src/scripts/front-page/front-page-top-datasets.jsx
+++ b/packages/openneuro-app/src/scripts/front-page/front-page-top-datasets.jsx
@@ -160,7 +160,9 @@ const FrontPageTopResult = query => ({ loading, error, data }) => {
 }
 
 const FrontPageTopQuery = ({ query }) => (
-  <Query query={query}>{FrontPageTopResult(query)}</Query>
+  <Query query={query} errorPolicy="ignore">
+    {FrontPageTopResult(query)}
+  </Query>
 )
 
 FrontPageTopQuery.propTypes = {

--- a/packages/openneuro-app/src/scripts/front-page/front-page-top-datasets.jsx
+++ b/packages/openneuro-app/src/scripts/front-page/front-page-top-datasets.jsx
@@ -144,8 +144,8 @@ FrontPageTopRecent.propTypes = {
   datasets: PropTypes.array,
 }
 
-const FrontPageTopResult = query => ({ loading, error, data }) => {
-  if (error || data.datasets === null) {
+export const FrontPageTopResult = query => ({ loading, error, data }) => {
+  if (error || data.datasets == null) {
     Sentry.captureException(error)
     return <div>Failed to load top datasets, please try again later.</div>
   } else if (loading) {


### PR DESCRIPTION
Two fixes for front page component crashes in this branch:

1. If a dataset has no snapshot but is a result in the front page query, this would throw an error and return no results. Changing the error policy to ignore improves things by simply skipping the one erroring result.
1. With the default error policy or if all results are invalid, the component responsible did not correctly check that the query result it received was empty. The null case worked but other failing results are not strictly equal to null. Added a unit test for this and change the comparison to throw the error state for the expected failure cases.