### PR TITLE
Fix inverted logic for browser download service worker check

### DIFF
--- a/packages/openneuro-app/src/scripts/sw.js
+++ b/packages/openneuro-app/src/scripts/sw.js
@@ -30,7 +30,7 @@ self.addEventListener('fetch', event => {
     if (
       url.pathname.startsWith('/crn') &&
       url.pathname.endsWith('download') &&
-      url.searchParams.get('skip-bundle')
+      url.searchParams.get('skip-bundle') !== null
     ) {
       // Catch any aggregate download requests
       return event.respondWith(bundleResponse(url))


### PR DESCRIPTION
This check was inverted, so browsers without native file enabled were getting download metadata instead of bundling.