### PR TITLE
Helm: Redirect base application domain from http to https

### DIFF
--- a/helm/openneuro/templates/ingress.yaml
+++ b/helm/openneuro/templates/ingress.yaml
@@ -10,10 +10,16 @@ metadata:
     alb.ingress.kubernetes.io/certificate-arn: {{ .Values.certifcateArn }}
     alb.ingress.kubernetes.io/target-type: ip
     alb.ingress.kubernetes.io/healthcheck-path: /crn/
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS":443}]'
+    alb.ingress.kubernetes.io/actions.ssl-redirect: '{"Type": "redirect", "RedirectConfig": { "Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_301"}}'
 spec:
   rules:
     - http:
         paths:
+          - path: /*
+            backend:
+              serviceName: ssl-redirect
+              servicePort: use-annotation
           - path: /graphql-subscriptions
             backend:
               serviceName: {{ .Release.Name }}-api

--- a/helm/openneuro/templates/ingress.yaml
+++ b/helm/openneuro/templates/ingress.yaml
@@ -11,7 +11,7 @@ metadata:
     alb.ingress.kubernetes.io/target-type: ip
     alb.ingress.kubernetes.io/healthcheck-path: /crn/
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS":443}]'
-    alb.ingress.kubernetes.io/actions.ssl-redirect: '{"Type": "redirect", "RedirectConfig": { "Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_301"}}'
+    alb.ingress.kubernetes.io/actions.ssl-redirect: '{"Type": "redirect", "RedirectConfig": { "Host": "openneuro.org", "Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_301"}}'
 spec:
   rules:
     - http:

--- a/helm/openneuro/values-production.yaml
+++ b/helm/openneuro/values-production.yaml
@@ -14,7 +14,7 @@ freshDeskUrl: https://openneuro.freshdesk.com/widgets/feedback_widget/new?&widge
 googleTrackingId: UA-100754266-2
 
 # AWS TLS Certificate ARN
-certifcateArn: "arn:aws:acm:us-east-1:488777458602:certificate/2b4af116-1acd-447d-b33b-6e25219293a3"
+certifcateArn: "arn:aws:acm:us-east-1:488777458602:certificate/7a4fa0e4-aee0-481b-82ee-dbde4c10c227"
 
 # Dataset worker parallelism
 dataladWorkers: 16


### PR DESCRIPTION
This fixes a missing response on port 80 if the original request comes from a client without HSTS set.

Fixes #1421 (sort of)