### PR TITLE
Don't auto-expand all subdirs to reduce performance issues rendering

### DIFF
--- a/packages/openneuro-app/src/scripts/file-tree/__tests__/__snapshots__/file-tree.spec.jsx.snap
+++ b/packages/openneuro-app/src/scripts/file-tree/__tests__/__snapshots__/file-tree.spec.jsx.snap
@@ -11,7 +11,7 @@ exports[`FileTree component renders with default props 1`] = `
         onClick={[Function]}
       >
         <i
-          className="type-icon fa fa-folder-open"
+          className="type-icon fa fa-folder"
         />
          
         <Styled(span)>
@@ -20,7 +20,7 @@ exports[`FileTree component renders with default props 1`] = `
           />
         </Styled(span)>
         <i
-          className="accordion-icon fa fa-caret-up"
+          className="accordion-icon fa fa-caret-down"
         />
       </button>
       <Styled(div)

--- a/packages/openneuro-app/src/scripts/file-tree/__tests__/file-tree.spec.jsx
+++ b/packages/openneuro-app/src/scripts/file-tree/__tests__/file-tree.spec.jsx
@@ -33,12 +33,6 @@ describe('FileTree component', () => {
       wrapper
         .find('button.btn-file-folder > i.type-icon')
         .hasClass('fa-folder-open'),
-    ).toBe(true)
-    wrapper.find('button').simulate('click')
-    expect(
-      wrapper
-        .find('button.btn-file-folder > i.type-icon')
-        .hasClass('fa-folder-open'),
     ).toBe(false)
     wrapper.find('button').simulate('click')
     expect(
@@ -46,6 +40,12 @@ describe('FileTree component', () => {
         .find('button.btn-file-folder > i.type-icon')
         .hasClass('fa-folder-open'),
     ).toBe(true)
+    wrapper.find('button').simulate('click')
+    expect(
+      wrapper
+        .find('button.btn-file-folder > i.type-icon')
+        .hasClass('fa-folder-open'),
+    ).toBe(false)
   })
   describe('sortByFilename()', () => {
     it('sorts the expected filename properties', () => {

--- a/packages/openneuro-app/src/scripts/file-tree/file-tree.jsx
+++ b/packages/openneuro-app/src/scripts/file-tree/file-tree.jsx
@@ -15,6 +15,8 @@ export const sortByName = (a, b) => a.name.localeCompare(b.name)
 
 export const unescapePath = path => path.replace(/:/g, '/')
 
+const isTopLevel = dir => !dir.path.includes(':')
+
 const FileTree = ({
   datasetId,
   snapshotTag = null,
@@ -23,7 +25,7 @@ const FileTree = ({
   files = [],
   directories = [],
   editMode = false,
-  defaultExpanded = true,
+  defaultExpanded = false,
 }) => {
   const [expanded, setExpanded] = useState(defaultExpanded)
   const previous = usePrevious(expanded)
@@ -91,6 +93,7 @@ const FileTree = ({
                       datasetId={datasetId}
                       snapshotTag={snapshotTag}
                       editMode={editMode}
+                      defaultExpanded={isTopLevel(dir)}
                       {...dir}
                     />
                   </li>


### PR DESCRIPTION
This mitigates the performance issue in #1425 but we may still want to disable the animation in some cases.