### PR TITLE
prettify metadata age field

### DIFF
--- a/packages/openneuro-app/src/scripts/datalad/mutations/metadata-form.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/mutations/metadata-form.jsx
@@ -197,7 +197,7 @@ const metadataFields = hasEdit => {
     },
     {
       key: 'ages',
-      label: 'Subject Ages',
+      label: 'Subject Age(s)',
       // text input because field is read-only
       Component: TextInput,
       additionalProps: {

--- a/packages/openneuro-app/src/scripts/datalad/mutations/metadata-form.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/mutations/metadata-form.jsx
@@ -198,11 +198,20 @@ const metadataFields = hasEdit => {
     {
       key: 'ages',
       label: 'Subject Ages',
-      Component: TextArrayInput,
+      // text input because field is read-only
+      Component: TextInput,
       additionalProps: {
         disabled: true,
         annotated: true,
         required: false,
+      },
+      transformValue: value => {
+        if (Array.isArray(value)) {
+          const ages = value.filter(x => x)
+          if (ages.length === 0) return 'N/A'
+          else if (ages.length === 1) return ages[0]
+          else return `${Math.min(...ages)} - ${Math.max(...ages)}`
+        } else if (value === undefined) return 'N/A'
       },
     },
     {
@@ -250,11 +259,11 @@ const MetadataForm = ({ values, onChange, hideDisabled, hasEdit }) => (
         // remove disabled fields when hideDisabled is true
         field => !(hideDisabled && field.additionalProps.disabled),
       )
-      .map(({ key, label, Component, additionalProps }, i) => (
+      .map(({ key, label, Component, additionalProps, transformValue }, i) => (
         <Component
           name={key}
           label={label}
-          value={values[key]}
+          value={transformValue ? transformValue(values[key]) : values[key]}
           onChange={onChange}
           {...additionalProps}
           key={i}


### PR DESCRIPTION
Age metadata is structured as either a number[] or is undefined. Undefined data or an array with no elements are now displayed as "N/A" and multiple ages are reduced to a range "least - greatest".