### PR TITLE
Mark latestSnapshot and DatasetEdge.node as required fields

### DIFF
--- a/packages/openneuro-app/src/scripts/front-page/front-page-top-datasets.jsx
+++ b/packages/openneuro-app/src/scripts/front-page/front-page-top-datasets.jsx
@@ -151,10 +151,12 @@ export const FrontPageTopResult = query => ({ loading, error, data }) => {
     Sentry.captureException(error)
     return <div>Failed to load top datasets, please try again later.</div>
   } else {
+    // Remove any edges which could not be loaded
+    const edges = data.datasets.edges.filter(dataset => dataset !== null)
     if (query === TOP_VIEWED) {
-      return <FrontPageTopActive datasets={data.datasets.edges} />
+      return <FrontPageTopActive datasets={edges} />
     } else if (query === RECENTLY_PUBLISHED) {
-      return <FrontPageTopRecent datasets={data.datasets.edges} />
+      return <FrontPageTopRecent datasets={edges} />
     }
   }
 }

--- a/packages/openneuro-server/graphql/schema.js
+++ b/packages/openneuro-server/graphql/schema.js
@@ -233,7 +233,7 @@ const typeDefs = `
   # One connected dataset
   type DatasetEdge {
     # Connected dataset
-    node: Dataset
+    node: Dataset!
     # Pagination cursor
     cursor: String!
   }
@@ -247,7 +247,7 @@ const typeDefs = `
     draft: Draft
     snapshots: [Snapshot]
     # Newest snapshot
-    latestSnapshot: Snapshot
+    latestSnapshot: Snapshot!
     permissions: [Permission]
     analytics: Analytic
     stars: [Star]


### PR DESCRIPTION
This lets Apollo mark invalid query rows as errored and then we filter them out from display on the front page. Avoids top dataset component crashes without removing all results when one fails.