### PR TITLE
Add test for loading state behavior on admin users route

### DIFF
--- a/packages/openneuro-app/src/scripts/admin/__tests__/admin.users.spec.jsx
+++ b/packages/openneuro-app/src/scripts/admin/__tests__/admin.users.spec.jsx
@@ -1,0 +1,15 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import { UsersQueryResult } from '../admin.users.jsx'
+
+describe('Admin users tab', () => {
+  describe('UsersQueryResult component', () => {
+    it('should not crash in a loading state', () => {
+      expect(() => {
+        shallow(
+          <UsersQueryResult loading={true} data={null} refetch={jest.fn()} />,
+        )
+      }).not.toThrowError()
+    })
+  })
+})

--- a/packages/openneuro-app/src/scripts/admin/admin.users.jsx
+++ b/packages/openneuro-app/src/scripts/admin/admin.users.jsx
@@ -51,16 +51,24 @@ export const SET_BLOCKED = gql`
   ${USER_FRAGMENT}
 `
 
-const UsersQuery = () => <Query query={GET_USERS}>{UsersQueryResult}</Query>
+export const UsersQuery = () => (
+  <Query query={GET_USERS}>{UsersQueryResult}</Query>
+)
 
-const UsersQueryResult = ({ loading, data, refetch }) => {
-  return <Users loading={loading} users={data.users || []} refetch={refetch} />
+export const UsersQueryResult = ({ loading, data, refetch }) => {
+  if (loading) {
+    return <Spinner active message="Loading users" />
+  } else {
+    return (
+      <Users loading={loading} users={data.users || []} refetch={refetch} />
+    )
+  }
 }
 
 UsersQueryResult.propTypes = {
   loading: PropTypes.bool,
   data: PropTypes.object,
-  refetch: PropTypes.function,
+  refetch: PropTypes.func,
 }
 
 class Users extends React.Component {


### PR DESCRIPTION
This previously seems to have been working due to the fallback on rendering zero users. This adds a test for the loading state and displays a spinner while data is loading.