### PR TITLE
Add resolvers for Snapshot type fields

### DIFF
--- a/packages/openneuro-server/graphql/resolvers/snapshots.js
+++ b/packages/openneuro-server/graphql/resolvers/snapshots.js
@@ -141,8 +141,20 @@ export const updateSnapshotFileUrls = (obj, { fileUrls }) => {
 }
 
 const Snapshot = {
-  analytics: snapshot => analytics(snapshot),
-  issues: snapshot => snapshotIssues(snapshot),
+  analytics: () => analytics,
+  issues: snapshotIssues,
+  description: snapshot =>
+    description(snapshot, {
+      datasetId: snapshot.datasetId,
+      tag: snapshot.tag,
+    }),
+  readme: snapshot =>
+    readme(snapshot, {
+      datasetId: snapshot.datasetId,
+      revision: snapshot.hexsha,
+    }),
+  files: (snapshot, { prefix }) =>
+    getFiles(snapshot.datasetId, snapshot.hexsha).then(filterFiles(prefix)),
 }
 
 export default Snapshot


### PR DESCRIPTION
This allows description, readme, and files to be resolved from the Snapshot type when returned anywhere our schema.

This is another fix broken out from the search work.