### PR TITLE
Apply myDatasets filter only if neither public or saved is set

### DIFF
--- a/packages/openneuro-app/src/scripts/datalad/dashboard/datasets/dataset-query.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/dashboard/datasets/dataset-query.jsx
@@ -173,7 +173,7 @@ const DatasetQuery = ({ public: isPublic, saved: isSaved }) => (
     query={getDatasets}
     variables={{
       filterBy: { public: isPublic, starred: isSaved },
-      myDatasets: !isPublic,
+      myDatasets: !(isPublic || isSaved),
     }}
     errorPolicy="all">
     {datasetQueryDisplay(isPublic, isSaved)}


### PR DESCRIPTION
Fixes a logic error where the saved dashboard also applies the myDatasets filter, which hides any starred datasets that are public but which you do not have permissions added for.