### PR TITLE
Raise openneuro-server default heap size to 1GB

### DIFF
--- a/packages/openneuro-server/Dockerfile
+++ b/packages/openneuro-server/Dockerfile
@@ -8,5 +8,7 @@ RUN apk add git make gcc g++ python --no-cache --update && \
   yarn install && \
   apk del make gcc g++ python
 
+ENV NODE_OPTIONS=--max_old_space_size=1024
+
 # start server
 CMD ["node", "/srv/index.js"]


### PR DESCRIPTION
This may help with out of memory issues seen recently on production.