### PR TITLE
update api endpoint

### DIFF
--- a/packages/openneuro-app/src/scripts/datalad/fragments/__tests__/__snapshots__/dataset-uploaded.spec.jsx.snap
+++ b/packages/openneuro-app/src/scripts/datalad/fragments/__tests__/__snapshots__/dataset-uploaded.spec.jsx.snap
@@ -2,6 +2,6 @@
 
 exports[`DatasetUploaded component renders with common props 1`] = `
 <h6>
-  uploaded by Tester on 2016-11-06 - about 3 years ago
+  uploaded by Tester on 2016-11-06 - over 3 years ago
 </h6>
 `;

--- a/packages/openneuro-server/graphql/resolvers/dataset.js
+++ b/packages/openneuro-server/graphql/resolvers/dataset.js
@@ -300,10 +300,10 @@ export const starred = (obj, _, { user }) =>
  */
 export const onBrainlife = async dataset => {
   try {
-    const url = `https://brainlife.io/api/warehouse/project?find={"openneuro.dataset_id":"${dataset.id}"}`
+    const url = `https://brainlife.io/api/warehouse/datalad/datasets?find={"path":{"$regex":"${dataset.id}$"}}`
     const res = await fetch(url)
     const body = await res.json()
-    return Boolean(body.count)
+    return body[0].path === `OpenNeuroDatasets/${dataset.id}`
   } catch (err) {
     return false
   }

--- a/packages/openneuro-server/graphql/resolvers/dataset.js
+++ b/packages/openneuro-server/graphql/resolvers/dataset.js
@@ -299,12 +299,12 @@ export const starred = (obj, _, { user }) =>
  * Is this dataset available on brainlife?
  */
 export const onBrainlife = async dataset => {
-  try {
-    const url = `https://brainlife.io/api/warehouse/datalad/datasets?find={"path":{"$regex":"${dataset.id}$"}}`
-    const res = await fetch(url)
-    const body = await res.json()
+  const url = `https://brainlife.io/api/warehouse/datalad/datasets?find={"path":{"$regex":"${dataset.id}$"}}`
+  const res = await fetch(url)
+  const body = await res.json()
+  if (Array.isArray(body)) {
     return body[0].path === `OpenNeuroDatasets/${dataset.id}`
-  } catch (err) {
+  } else {
     return false
   }
 }

--- a/packages/openneuro-server/graphql/resolvers/dataset.js
+++ b/packages/openneuro-server/graphql/resolvers/dataset.js
@@ -302,7 +302,7 @@ export const onBrainlife = async dataset => {
   const url = `https://brainlife.io/api/warehouse/datalad/datasets?find={"path":{"$regex":"${dataset.id}$"}}`
   const res = await fetch(url)
   const body = await res.json()
-  if (Array.isArray(body)) {
+  if (Array.isArray(body) && body.length) {
     return body[0].path === `OpenNeuroDatasets/${dataset.id}`
   } else {
     return false


### PR DESCRIPTION
Added array type check on returned JSON. Root structure of any given document being returned via the regex on the endpoint is type array, so it shouldn't vary...

All documents: https://brainlife.io/api/warehouse/datalad/datasets?find=