### PR TITLE
Refactor mutation permissions and add dataset admin flag check

### DIFF
--- a/packages/openneuro-server/graphql/__tests__/__snapshots__/permissions.spec.js.snap
+++ b/packages/openneuro-server/graphql/__tests__/__snapshots__/permissions.spec.js.snap
@@ -1,3 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`resolver permissions helpers checkDatasetAdmin() resolves to false for anonymous users 1`] = `"You do not have admin access to this dataset."`;
+
 exports[`resolver permissions helpers checkDatasetWrite() resolves to false for anonymous users 1`] = `"You do not have access to modify this dataset."`;

--- a/packages/openneuro-server/graphql/__tests__/permissions.spec.js
+++ b/packages/openneuro-server/graphql/__tests__/permissions.spec.js
@@ -1,8 +1,9 @@
 import {
   datasetReadQuery,
-  checkReadPermissionLevel,
-  checkWritePermissionLevel,
+  checkPermissionLevel,
+  states,
   checkDatasetWrite,
+  checkDatasetAdmin,
 } from '../permissions.js'
 
 describe('resolver permissions helpers', () => {
@@ -24,30 +25,34 @@ describe('resolver permissions helpers', () => {
       ).toHaveProperty('public', true)
     })
   })
-  describe('checkReadPermissionLevel()', () => {
+  describe('checkPermissionLevel(..., READ)', () => {
     it('returns false if no permission passed in', () => {
-      expect(checkReadPermissionLevel(null)).toBe(false)
+      expect(checkPermissionLevel(null, states.READ)).toBe(false)
     })
     it('returns true for valid read access level', () => {
-      expect(checkReadPermissionLevel({ level: 'admin' })).toBe(true)
-      expect(checkReadPermissionLevel({ level: 'ro' })).toBe(true)
+      expect(checkPermissionLevel({ level: 'admin' }, states.READ)).toBe(true)
+      expect(checkPermissionLevel({ level: 'ro' }, states.READ)).toBe(true)
     })
     it('returns false if an unexpected level is present', () => {
-      expect(checkReadPermissionLevel({ level: 'not-real' })).toBe(false)
+      expect(checkPermissionLevel({ level: 'not-real' }, states.READ)).toBe(
+        false,
+      )
     })
   })
-  describe('checkWritePermissionLevel()', () => {
+  describe('checkPermissionLevel(..., WRITE)', () => {
     it('returns false if no permission passed in', () => {
-      expect(checkWritePermissionLevel(null)).toBe(false)
+      expect(checkPermissionLevel(null, states.WRITE)).toBe(false)
     })
     it('returns true for admin', () => {
-      expect(checkWritePermissionLevel({ level: 'admin' })).toBe(true)
+      expect(checkPermissionLevel({ level: 'admin' }, states.WRITE)).toBe(true)
     })
     it('returns false for read only access', () => {
-      expect(checkWritePermissionLevel({ level: 'ro' })).toBe(false)
+      expect(checkPermissionLevel({ level: 'ro' }, states.WRITE)).toBe(false)
     })
     it('returns false if an unexpected level is present', () => {
-      expect(checkWritePermissionLevel({ level: 'not-real' })).toBe(false)
+      expect(checkPermissionLevel({ level: 'not-real' }, states.WRITE)).toBe(
+        false,
+      )
     })
   })
   describe('checkDatasetWrite()', () => {
@@ -59,6 +64,37 @@ describe('resolver permissions helpers', () => {
     it('resolves to true for admins', () => {
       return expect(
         checkDatasetWrite('ds000001', '1234', { admin: true }),
+      ).resolves.toBe(true)
+    })
+  })
+  describe('checkPermissionLevel(..., ADMIN)', () => {
+    it('returns false if no permission passed in', () => {
+      expect(checkPermissionLevel(null, states.ADMIN)).toBe(false)
+    })
+    it('returns true for admin', () => {
+      expect(checkPermissionLevel({ level: 'admin' }, states.ADMIN)).toBe(true)
+    })
+    it('returns false for read write access', () => {
+      expect(checkPermissionLevel({ level: 'rw' }, states.ADMIN)).toBe(false)
+    })
+    it('returns false for read only access', () => {
+      expect(checkPermissionLevel({ level: 'ro' }, states.ADMIN)).toBe(false)
+    })
+    it('returns false if an unexpected level is present', () => {
+      expect(checkPermissionLevel({ level: 'not-real' }, states.ADMIN)).toBe(
+        false,
+      )
+    })
+  })
+  describe('checkDatasetAdmin()', () => {
+    it('resolves to false for anonymous users', () => {
+      return expect(
+        checkDatasetAdmin('ds000001', null, null),
+      ).rejects.toThrowErrorMatchingSnapshot()
+    })
+    it('resolves to true for admins', () => {
+      return expect(
+        checkDatasetAdmin('ds000001', '1234', { admin: true }),
       ).resolves.toBe(true)
     })
   })

--- a/packages/openneuro-server/graphql/resolvers/permissions.js
+++ b/packages/openneuro-server/graphql/resolvers/permissions.js
@@ -1,5 +1,6 @@
 import mongo from '../../libs/mongo.js'
 import User from '../../models/user'
+import { checkDatasetAdmin } from '../permissions'
 import pubsub from '../pubsub.js'
 
 export const permissions = obj => {
@@ -9,7 +10,8 @@ export const permissions = obj => {
 /**
  * Update user permissions on a dataset
  */
-export const updatePermissions = async (obj, args) => {
+export const updatePermissions = async (obj, args, { user, userInfo }) => {
+  await checkDatasetAdmin(args.datasetId, user, userInfo)
   // get all users the the email specified by permissions arg
   let users = await User.find({ email: args.userEmail }).exec()
   let userPromises = users.map(user => {


### PR DESCRIPTION
This generalizes some of the resolver helpers we have for verifying permissions and includes the addition of a dataset admin check.