### PR TITLE
Cache README access

### DIFF
--- a/packages/openneuro-server/datalad/readme.js
+++ b/packages/openneuro-server/datalad/readme.js
@@ -1,23 +1,36 @@
 import config from '../config.js'
 import fetch from 'node-fetch'
 import { addFileString, commitFiles } from './dataset.js'
+import { redis } from '../libs/redis.js'
 
 export const readmeUrl = (datasetId, revision) => {
-  return `http://${
-    config.datalad.uri
-  }/datasets/${datasetId}/snapshots/${revision}/files/README`
+  return `http://${config.datalad.uri}/datasets/${datasetId}/snapshots/${revision}/files/README`
 }
 
-export const readme = (obj, { datasetId, revision }) => {
-  /** Why are we using fetch here instead of superagent?
-   * The backend guesses wrong at the MIME type so fetch lets us get the string
-   * without messing around with superagent parsers
-   *
-   * We may want to use less superagent anyways just to avoid library weight
-   */
-  return fetch(readmeUrl(datasetId, revision)).then(
-    res => (res.status === 200 ? res.text() : null),
-  )
+export const readmeKey = (datasetId, revision) =>
+  `openneuro:readme:${datasetId}:${revision}`
+
+export const readme = async (obj, { datasetId, revision }) => {
+  const key = readmeKey(datasetId, revision)
+  const data = await redis.get(key)
+  if (data) {
+    return data
+  } else {
+    /** Why are we using fetch here instead of superagent?
+     * The backend guesses wrong at the MIME type so fetch lets us get the string
+     * without messing around with superagent parsers
+     *
+     * We may want to use less superagent anyways just to avoid library weight
+     */
+    const readmeReq = await fetch(readmeUrl(datasetId, revision))
+    if (readmeReq.status === 200) {
+      const readmeContent = await readmeReq.text()
+      redis.set(key, readmeContent)
+      return readmeContent
+    } else {
+      return null
+    }
+  }
 }
 
 export const setReadme = (datasetId, readme, user) => {


### PR DESCRIPTION
This saves a lot of I/O time spent resolving the contents on disk for README files within snapshots. By caching this in Redis the cost is paid once per commit instead of once per access.