### PR TITLE
Fix incorrect key name for search results pagination

### DIFF
--- a/packages/openneuro-app/src/scripts/datalad/dashboard/datasets/dataset-tab.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/dashboard/datasets/dataset-tab.jsx
@@ -115,7 +115,7 @@ const DatasetTab = ({
     ) : (
       <ErrorBoundary error={error} subject={'error in dashboard dataset tab'}>
         <DatasetTabLoaded
-          datasets={data.datasets || data.search}
+          datasets={data.datasets}
           loadMoreRows={loadMoreRows}
           publicDashboard={publicDashboard}
         />

--- a/packages/openneuro-app/src/scripts/search/search-results.tsx
+++ b/packages/openneuro-app/src/scripts/search/search-results.tsx
@@ -6,7 +6,7 @@ import { datasetQueryDisplay } from '../datalad/dashboard/datasets/dataset-query
 
 const searchQuery = gql`
   query searchDatasets($q: String!, $cursor: String) {
-    search(q: $q, first: 25, after: $cursor) {
+    datasets: search(q: $q, first: 2, after: $cursor) {
       edges {
         node {
           id


### PR DESCRIPTION
This fixes a crash when loading paginated search results due to the different root key name (search vs datasets).