### PR TITLE
Add missing graphql-tag dependency to each package which requires it

### DIFF
--- a/packages/openneuro-app/package.json
+++ b/packages/openneuro-app/package.json
@@ -34,6 +34,7 @@
     "enzyme-to-json": "^3.3.5",
     "eslint": "^6.5.1",
     "graphql": "14.5.8",
+    "graphql-tag": "^2.10.3",
     "graphql-tools": "4.0.6",
     "jszip": "^3.1.5",
     "jwt-decode": "^2.2.0",

--- a/packages/openneuro-cli/package.json
+++ b/packages/openneuro-cli/package.json
@@ -20,6 +20,7 @@
     "commander": "^2.15.1",
     "esm": "^3.0.16",
     "find-config": "^1.0.0",
+    "graphql-tag": "^2.10.3",
     "inquirer": "^5.2.0",
     "mkdirp": "^0.5.1",
     "moment": "^2.22.2",

--- a/packages/openneuro-client/package.json
+++ b/packages/openneuro-client/package.json
@@ -19,6 +19,7 @@
     "esm": "^3.0.84",
     "form-data": "^2.5.0",
     "graphql": "14.5.8",
+    "graphql-tag": "^2.10.3",
     "graphql-tools": "4.0.6",
     "node-fetch": "^2.6.0",
     "semver": "^5.5.0",

--- a/packages/openneuro-indexer/package.json
+++ b/packages/openneuro-indexer/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@elastic/elasticsearch": "^7.5.0",
     "apollo-link-retry": "^2.2.15",
+    "graphql-tag": "^2.10.3",
     "ts-node": "^8.6.2",
     "typescript": "^3.7.5"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -8050,6 +8050,11 @@ graphql-tag@2.10.1, graphql-tag@^2.10.1, graphql-tag@^2.9.2:
   resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.10.1.tgz#10aa41f1cd8fae5373eaf11f1f67260a3cad5e02"
   integrity sha512-jApXqWBzNXQ8jYa/HLkZJaVw9jgwNqZkywa2zfFn16Iv1Zb7ELNHkJaXHR7Quvd5SIGsy6Ny7SUKATgnu05uEg==
 
+graphql-tag@^2.10.3:
+  version "2.10.3"
+  resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.10.3.tgz#ea1baba5eb8fc6339e4c4cf049dabe522b0edf03"
+  integrity sha512-4FOv3ZKfA4WdOKJeHdz6B3F/vxBLSgmBcGeAFPf4n1F64ltJUvOOerNj0rsJxONQGdhUMynQIvd6LzB+1J5oKA==
+
 graphql-tools@4.0.6:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/graphql-tools/-/graphql-tools-4.0.6.tgz#0e729e73db05ade3df10a2f92511be544972a844"


### PR DESCRIPTION
Looks like this probably regressed with the removal of apollo-boost, this adds graphql-tag to each package which uses it.

#1551 will address the linting to catch this error automatically.