### PR TITLE
Remove unused codecov dev dep from openneuro-server

### DIFF
--- a/packages/openneuro-server/package.json
+++ b/packages/openneuro-server/package.json
@@ -76,7 +76,6 @@
     "apollo": "^2.16.1",
     "apollo-link-schema": "^1.2.3",
     "babel-eslint": "^10.0.3",
-    "codecov": "^3.6.5",
     "eslint": "^4.18.1",
     "ioredis-mock": "^3.8.1",
     "jest": "^24.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5183,7 +5183,7 @@ code-point-at@^1.0.0:
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
   integrity sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=
 
-codecov@^3.0.0, codecov@^3.6.5:
+codecov@^3.0.0:
   version "3.6.5"
   resolved "https://registry.yarnpkg.com/codecov/-/codecov-3.6.5.tgz#d73ce62e8a021f5249f54b073e6f2d6a513f172a"
   integrity sha512-v48WuDMUug6JXwmmfsMzhCHRnhUf8O3duqXvltaYJKrO1OekZWpB/eH6iIoaxMl8Qli0+u3OxptdsBOYiD7VAQ==


### PR DESCRIPTION
Obsoletes #1546 since we don't use codecov in the server package directly.