### PR TITLE
Enable native file API origin trial

### DIFF
--- a/packages/openneuro-app/src/index.html
+++ b/packages/openneuro-app/src/index.html
@@ -6,6 +6,8 @@
     <meta http-equiv="expires" content="0" />
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta http-equiv="origin-trial" content="AvFv9hZMq0BpCBcjDWVkfJ++9Zi5wbNdLzcJ7NXWNCSxTcUVp0g5/Do7xj8Fkuiex0hZidgNK4QI4EPq3liKxQsAAABieyJvcmlnaW4iOiJodHRwczovL29wZW5uZXVyby5zdGFnaW5nLnNxbS5pbzo0NDMiLCJmZWF0dXJlIjoiTmF0aXZlRmlsZVN5c3RlbSIsImV4cGlyeSI6MTU4NTg5MTU3M30=" />
+    <meta http-equiv="origin-trial" content="AhRwGjErLVL6mCn6sbrSOZTZqZdEpZgZJzAK49A4/HSeSjIWLoNxgasXMkHb8fdGYHzZsp03kfx8W4iS8uP0Xg8AAABXeyJvcmlnaW4iOiJodHRwczovL29wZW5uZXVyby5vcmc6NDQzIiwiZmVhdHVyZSI6Ik5hdGl2ZUZpbGVTeXN0ZW0iLCJleHBpcnkiOjE1ODU4OTEyNjh9" />
     <title>OpenNeuro</title>
     <link id="favicon" rel="icon" type="image/png" href="/content/img/favicon.ico" />
     <link rel="preload" href="/crn/config.json" as="fetch" crossorigin>


### PR DESCRIPTION
This enables the native file API downloader for the primary OpenNeuro and staging domains.

To test this locally, you have to [override the setting since origin trials do not apply to localhost](https://web.dev/native-file-system/#enabling-via-chrome:flags). The feature is Chrome only but Firefox and users without this flag should get the existing client side bundle downloader.