### PR TITLE
Fix regression in Apollo Upload Client requests from CLI tool

### DIFF
--- a/packages/openneuro-client/src/__tests__/client.spec.js
+++ b/packages/openneuro-client/src/__tests__/client.spec.js
@@ -1,0 +1,18 @@
+import { createClient, middlewareAuthLink } from '../client.js'
+
+describe('API client', () => {
+  describe('createClient', () => {
+    it('setup a link given basic options', () => {
+      expect(() => {
+        createClient('http://does-not-exist-tld')
+      }).not.toThrowError()
+    })
+  })
+  describe('middlewareAuthLink()', () => {
+    it('creates an anonymous upload link given no getAuthorization option', () => {
+      expect(
+        middlewareAuthLink('http://does-not-exist-tld').constructor.name,
+      ).toBe('ApolloLink')
+    })
+  })
+})

--- a/packages/openneuro-client/src/client.js
+++ b/packages/openneuro-client/src/client.js
@@ -7,7 +7,7 @@ import { ApolloLink, split, Observable } from 'apollo-link'
 import { WebSocketLink } from 'apollo-link-ws'
 import { getMainDefinition } from 'apollo-utilities'
 import semver from 'semver'
-import * as FormData from 'form-data'
+import FormData from 'form-data'
 import * as files from './files'
 import * as datasets from './datasets'
 import * as snapshots from './snapshots'
@@ -69,7 +69,7 @@ const checkVersions = (serverVersion, clientVersion) => {
   }
 }
 
-const middlewareAuthLink = (uri, getAuthorization, fetch) => {
+export const middlewareAuthLink = (uri, getAuthorization, fetch) => {
   // We have to setup authLink to inject credentials here
   const httpUploadLink = createUploadLink({
     uri,


### PR DESCRIPTION
This fixes an openneuro-cli regression caused by the type fixes for openneuro-indexer. The FormData default import is required for createUploadLink to return a valid upload link.