### PR TITLE
Switch to worker-plugin from worker-loader.

### DIFF
--- a/packages/openneuro-app/package.json
+++ b/packages/openneuro-app/package.json
@@ -109,7 +109,7 @@
     "webpack-dev-server": "^3.1.9",
     "webpack-merge": "^4.1.4",
     "webpack-visualizer-plugin": "^0.1.11",
-    "worker-loader": "^2.0.0"
+    "worker-plugin": "^3.2.0"
   },
   "jest": {
     "setupFiles": [

--- a/packages/openneuro-app/src/scripts/workers/validate.js
+++ b/packages/openneuro-app/src/scripts/workers/validate.js
@@ -1,10 +1,9 @@
 import * as Comlink from 'comlink'
-import ValidateWorker from './validate.worker.js'
 
-async function init(files, options) {
-  const worker = new ValidateWorker()
+function init(files, options) {
+  const worker = new Worker('./validate.worker.js', { type: 'module' })
   const validate = Comlink.wrap(worker)
-  const output = await new Promise((resolve, reject) => {
+  return new Promise((resolve, reject) => {
     validate(
       files,
       options,
@@ -14,7 +13,6 @@ async function init(files, options) {
       }),
     )
   })
-  return output
 }
 
 export default init

--- a/packages/openneuro-app/webpack.common.js
+++ b/packages/openneuro-app/webpack.common.js
@@ -5,6 +5,7 @@ const CleanWebpackPlugin = require('clean-webpack-plugin')
 const MiniCssExtractPlugin = require('mini-css-extract-plugin')
 const CopyWebpackPlugin = require('copy-webpack-plugin')
 const ServiceWorkerWebpackPlugin = require('serviceworker-webpack-plugin')
+const WorkerPlugin = require('worker-plugin')
 
 module.exports = {
   context: path.resolve(__dirname, 'src'),
@@ -51,6 +52,7 @@ module.exports = {
     new MiniCssExtractPlugin({
       filename: 'style.css',
     }),
+    new WorkerPlugin(),
   ],
   module: {
     rules: [
@@ -74,10 +76,6 @@ module.exports = {
             },
           },
         ],
-      },
-      {
-        test: /\.worker\.js$/,
-        use: { loader: 'worker-loader' },
       },
       {
         test: /\.scss$/,

--- a/yarn.lock
+++ b/yarn.lock
@@ -10540,7 +10540,7 @@ loader-runner@^2.4.0:
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-2.4.0.tgz#ed47066bfe534d7e84c4c7b9998c2a75607d9357"
   integrity sha512-Jsmr89RcXGIwivFY21FcRrisYZfvLMTWx5kOLc+JTxtpBOG6xML0vzbc6SEQG2FO9/4Fc3wW4LVcB5DmGflaRw==
 
-loader-utils@1.2.3, loader-utils@^1.0.0, loader-utils@^1.0.1, loader-utils@^1.0.2, loader-utils@^1.1.0, loader-utils@^1.2.3:
+loader-utils@1.2.3, loader-utils@^1.0.1, loader-utils@^1.0.2, loader-utils@^1.1.0, loader-utils@^1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.2.3.tgz#1ff5dc6911c9f0a062531a4c04b609406108c2c7"
   integrity sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==
@@ -14264,7 +14264,7 @@ scheduler@^0.15.0:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
 
-schema-utils@^0.4.0, schema-utils@^0.4.2, schema-utils@^0.4.5:
+schema-utils@^0.4.2, schema-utils@^0.4.5:
   version "0.4.7"
   resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-0.4.7.tgz#ba74f597d2be2ea880131746ee17d0a093c68187"
   integrity sha512-v/iwU6wvwGK8HbU9yi3/nhGzP0yGSuhQMzL6ySiec1FSrZZDkhm4noOSWzrNFo/jEc+SJY6jRTwuwbSXJPDUnQ==
@@ -16494,13 +16494,12 @@ worker-farm@^1.7.0:
   dependencies:
     errno "~0.1.7"
 
-worker-loader@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/worker-loader/-/worker-loader-2.0.0.tgz#45fda3ef76aca815771a89107399ee4119b430ac"
-  integrity sha512-tnvNp4K3KQOpfRnD20m8xltE3eWh89Ye+5oj7wXEEHKac1P4oZ6p9oTj8/8ExqoSBnk9nu5Pr4nKfQ1hn2APJw==
+worker-plugin@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/worker-plugin/-/worker-plugin-3.2.0.tgz#ddae9f161b76fcbaacf8f54ecd037844584e43e7"
+  integrity sha512-W5nRkw7+HlbsEt3qRP6MczwDDISjiRj2GYt9+bpe8A2La00TmJdwzG5bpdMXhRt1qcWmwAvl1TiKaHRa+XDS9Q==
   dependencies:
-    loader-utils "^1.0.0"
-    schema-utils "^0.4.0"
+    loader-utils "^1.1.0"
 
 wrap-ansi@^2.0.0:
   version "2.1.0"


### PR DESCRIPTION
This uses standard worker creation syntax and fixes intermittent build issues we're seeing on master.