### PR TITLE
Remove publish worker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -99,18 +99,6 @@ services:
     env_file: ./config.env
     init: true
 
-  # publish-only celery worker
-  publish:
-    build: services/datalad
-    command:
-      - /publish-worker
-    volumes:
-      - ${PERSISTENT_DIR}/datalad:/datalad
-      - ./services/datalad/datalad_service:/datalad_service
-      - ./datalad-key:/datalad-key
-    env_file: ./config.env
-    init: true
-
   flower:
     image: openneuro/datalad-service:latest
     command:

--- a/services/datalad/Dockerfile
+++ b/services/datalad/Dockerfile
@@ -5,7 +5,6 @@ COPY Pipfile /Pipfile
 COPY Pipfile.lock /Pipfile.lock
 COPY datalad_service /datalad_service
 COPY dataset-worker /dataset-worker
-COPY publish-worker /publish-worker
 COPY beat-scheduler /beat-scheduler
 COPY get_docker_scale.py /get_docker_scale.py
 COPY ./ssh_config /root/.ssh/config

--- a/services/datalad/datalad_service/app.py
+++ b/services/datalad/datalad_service/app.py
@@ -1,7 +1,7 @@
 import falcon
 
 from datalad_service.common import raven
-from datalad_service.common.celery import app, publish_queue
+from datalad_service.common.celery import app, dataset_queue
 from datalad_service.tasks.audit import audit_datasets
 from datalad_service.datalad import DataladStore
 from datalad_service.handlers.dataset import DatasetResource
@@ -29,7 +29,7 @@ def create_app(annex_path):
     def schedule_celery_tasks(sender, **kwargs):
         """Run all periodic tasks."""
         sender.add_periodic_task(
-            60 * 15, audit_datasets.s(annex_path), queue=publish_queue())
+            60 * 15, audit_datasets.s(annex_path), queue=dataset_queue('publish'))
 
     api = falcon.API(middleware=AuthenticateMiddleware())
     api.router_options.converters['path'] = PathConverter

--- a/services/datalad/datalad_service/common/celery.py
+++ b/services/datalad/datalad_service/common/celery.py
@@ -16,10 +16,6 @@ def dataset_queue(dataset):
     return 'dataset-worker-{}'.format(dataset_hash(dataset))
 
 
-def publish_queue():
-    return 'publish-worker'
-
-
 def dataset_hash(key):
     """Return which worker for a given task."""
     return hash(key) % DATALAD_WORKERS

--- a/services/datalad/datalad_service/handlers/publish.py
+++ b/services/datalad/datalad_service/handlers/publish.py
@@ -1,7 +1,7 @@
 import falcon
 
 from datalad_service.common.user import get_user_info
-from datalad_service.common.celery import publish_queue
+from datalad_service.common.celery import dataset_queue
 from datalad_service.tasks.dataset import *
 from datalad_service.tasks.publish import migrate_to_bucket
 
@@ -15,16 +15,18 @@ class PublishResource(object):
 
     def on_post(self, req, resp, dataset):
         datalad = self.store.get_dataset(dataset)
-        queue = publish_queue()
-        publish = migrate_to_bucket.s(self.store.annex_path, dataset, cookies=req.cookies)
+        queue = dataset_queue(dataset)
+        publish = migrate_to_bucket.s(
+            self.store.annex_path, dataset, cookies=req.cookies)
         publish.apply_async(queue=queue)
         resp.media = {}
         resp.status = falcon.HTTP_OK
-    
+
     def on_delete(self, req, resp, dataset):
         datalad = self.store.get_dataset
-        queue = publish_queue()
-        publish = migrate_to_bucket.s(self.store.annex_path, dataset, cookies=req.cookies, realm='PRIVATE')
+        queue = dataset_queue(dataset)
+        publish = migrate_to_bucket.s(
+            self.store.annex_path, dataset, cookies=req.cookies, realm='PRIVATE')
         publish.apply_async(queue=queue)
         resp.media = {}
         resp.status = falcon.HTTP_OK

--- a/services/datalad/datalad_service/handlers/snapshots.py
+++ b/services/datalad/datalad_service/handlers/snapshots.py
@@ -4,7 +4,6 @@ import falcon
 from celery import chain
 
 from datalad_service.common.celery import dataset_queue
-from datalad_service.common.celery import publish_queue
 from datalad_service.tasks.dataset import create_snapshot
 from datalad_service.tasks.snapshots import get_snapshot, get_snapshots
 from datalad_service.tasks.files import get_files
@@ -50,7 +49,7 @@ class SnapshotResource(object):
 
         monitor_remote_configs.s(
             self.store.annex_path, dataset, snapshot).set(
-                queue=publish_queue()).apply_async()
+                queue=dataset_queue(dataset)).apply_async()
 
         created = create_snapshot(
             self.store.annex_path, dataset, snapshot, description_fields, snapshot_changes)

--- a/services/datalad/datalad_service/tasks/audit.py
+++ b/services/datalad/datalad_service/tasks/audit.py
@@ -3,7 +3,7 @@ import os
 import subprocess
 import random
 
-from datalad_service.common.celery import dataset_task, publish_queue
+from datalad_service.common.celery import dataset_task, dataset_queue
 from datalad_service.common.raven import client
 
 
@@ -14,7 +14,7 @@ def audit_datasets(store):
     # Randomize start time a bit to reduce risk of stampedes
     countdown = random.randint(1, 30)
     audit_remotes.apply_async(
-        (store.annex_path, dataset), queue=publish_queue(), countdown=countdown)
+        (store.annex_path, dataset), queue=dataset_queue(dataset), countdown=countdown)
 
 
 def fsck_remote(ds, remote):

--- a/services/datalad/dataset-worker
+++ b/services/datalad/dataset-worker
@@ -2,4 +2,4 @@
 # Example worker script for docker-compose
 WORKER_ID=$(python get_docker_scale.py)
 echo "Worker $WORKER_ID starting..."
-celery -A datalad_service.worker worker -Q dataset-worker-$WORKER_ID -l info -c 1
+celery -A datalad_service.worker worker -Q dataset-worker-$WORKER_ID -l info

--- a/services/datalad/publish-worker
+++ b/services/datalad/publish-worker
@@ -1,3 +1,0 @@
-#!/bin/bash
-echo "Publish worker starting..."
-celery -A datalad_service.worker worker -Q publish-worker -l info -c 4


### PR DESCRIPTION
This will remove the publish worker and merge its responsibilities into the dataset workers. To do this, workers now support running in concurrent mode. Each worker will run one task for each CPU core available to it and rely on disk based locking to prevent conflicts with publish tasks and edits.