### PR TITLE
Revert to git-annex 7.20191230 to fix exporttree regression

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,7 +166,7 @@ jobs:
           working_directory: ~/project/services/datalad
 
       # install git-annex
-      - run: curl http://ia600309.us.archive.org/26/items/git-annex-builds/SHA256E-s52708477--e5930f66a9b56a88de5dabe65964e9eb59bf34c0bbb6c9bb0305773d69852add.tar.gz | tar -xvz  && sudo mv git-annex.linux/* /usr/local/bin
+      - run: curl -L http://archive.org/download/git-annex-builds/SHA256E-s52844027--52257d8de278e4ecf94a971c716b7929f6d0e1fe6c5a65ed40b03f0964f9c85d.tar.gz | tar -xvz  && sudo mv git-annex.linux/* /usr/local/bin
 
       # run unit tests
       - run:

--- a/services/datalad/Dockerfile
+++ b/services/datalad/Dockerfile
@@ -10,7 +10,7 @@ COPY get_docker_scale.py /get_docker_scale.py
 COPY ./ssh_config /root/.ssh/config
 
 RUN apk --update add bash yarn git python py-pip openssl openssh ca-certificates py-openssl wget \
-  && wget -O git-annex-standalone-amd64.tar.gz http://ia600309.us.archive.org/26/items/git-annex-builds/SHA256E-s52708477--e5930f66a9b56a88de5dabe65964e9eb59bf34c0bbb6c9bb0305773d69852add.tar.gz \
+  && wget -O git-annex-standalone-amd64.tar.gz http://archive.org/download/git-annex-builds/SHA256E-s52844027--52257d8de278e4ecf94a971c716b7929f6d0e1fe6c5a65ed40b03f0964f9c85d.tar.gz \
   && tar -xvf git-annex-standalone-amd64.tar.gz \
   && rm git-annex-standalone-amd64.tar.gz \
   && mv git-annex.linux/* /usr/local/bin \


### PR DESCRIPTION
This reverts git-annex to an earlier version to fix a regression with the exporttree option preventing new remotes from being created. [It is fixed in later releases of git-annex](https://git-annex.branchable.com/bugs/git-annex__58___Unexpected_parameters__58___exporttree/) as well but until we can move to git-annex 8, there are no standalone builds to use for later releases.