### PR TITLE
Fix warning for autoenable=yes / no in current git-annex

### DIFF
--- a/services/datalad/datalad_service/common/s3.py
+++ b/services/datalad/datalad_service/common/s3.py
@@ -56,13 +56,12 @@ def generate_s3_annex_options(dataset, realm):
         public = getattr(datalad_service.config, 'DATALAD_S3_PUBLIC_ON_EXPORT')
         if public == 'yes':
             annex_options += [
-                'autoenable=yes',
+                'autoenable=true',
                 'publicurl=http://{}.s3.amazonaws.com/'.format(realm.s3_bucket),
             ]
     else:
         annex_options += [
-            'autoenable=no',
-            'publicurl=',
+            'autoenable=false',
             ]
         public = 'no'
     annex_options.append('public={}'.format(public))


### PR DESCRIPTION
This updates the autoenable argument format to match the current releases of git-annex. It looks like existing remotes with the old value work fine.