### PR TITLE
Fix missing directories in web downloads

### DIFF
--- a/packages/openneuro-server/handlers/download.js
+++ b/packages/openneuro-server/handlers/download.js
@@ -7,7 +7,7 @@ const DRAFT_FILES = `
       id
       draft {
         id
-        files {
+        files(prefix: null) {
           id
           filename
           size
@@ -22,7 +22,7 @@ const SNAPSHOT_FILES = `
   query snapshot($datasetId: ID!, $tag: String!) {
     snapshot(datasetId: $datasetId, tag: $tag) {
       id
-      files {
+      files(prefix: null) {
         id
         filename
         size


### PR DESCRIPTION
To avoid including mocked directory entries in downloads, we need to override the default prefix with null when serving download URLs directly.