### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,4 +32,4 @@ For example, you can restart the server container with `docker-compose restart s
 * [OpenNeuro server](packages/openneuro-server) - Node.js web backend.
 * [DataLad service](https://github.com/OpenNeuroOrg/datalad-service) - [DataLad](http://datalad.org/) microservice.
 * [bids-app-host](https://github.com/OpenNeuroOrg/bids-app-host) - Docker wrapper for cloud hosted job execution.
-* [bids-validator](https://github.com/INCF/bids-validator) - BIDS validation library.
+* [bids-validator](https://github.com/bids-standard/bids-validator) - BIDS validation library.


### PR DESCRIPTION
point to the new location of the bids-validator, at bids-standard rather than INCF