### PR TITLE
Fix error handling for Brainlife API failures

### DIFF
--- a/packages/openneuro-server/graphql/resolvers/dataset.js
+++ b/packages/openneuro-server/graphql/resolvers/dataset.js
@@ -300,12 +300,16 @@ export const starred = (obj, _, { user }) =>
  * Is this dataset available on brainlife?
  */
 export const onBrainlife = async dataset => {
-  const url = `https://brainlife.io/api/warehouse/datalad/datasets?find={"path":{"$regex":"${dataset.id}$"}}`
-  const res = await fetch(url)
-  const body = await res.json()
-  if (Array.isArray(body) && body.length) {
-    return body[0].path === `OpenNeuroDatasets/${dataset.id}`
-  } else {
+  try {
+    const url = `https://brainlife.io/api/warehouse/datalad/datasets?find={"path":{"$regex":"${dataset.id}$"}}`
+    const res = await fetch(url)
+    const body = await res.json()
+    if (Array.isArray(body) && body.length) {
+      return body[0].path === `OpenNeuroDatasets/${dataset.id}`
+    } else {
+      return false
+    }
+  } catch (err) {
     return false
   }
 }

--- a/packages/openneuro-server/graphql/schema.js
+++ b/packages/openneuro-server/graphql/schema.js
@@ -290,7 +290,7 @@ export const typeDefs = `
     # When was this dataset first made public?
     publishDate: DateTime
     # Is the dataset available for analysis on Brainlife?
-    onBrainlife: Boolean
+    onBrainlife: Boolean @cacheControl(maxAge: 10080, scope: PUBLIC)
     # Dataset Metadata
     metadata: Metadata
   }


### PR DESCRIPTION
I ran into this problem while testing a local copy of OpenNeuro. This isn't critical data to return, so this will catch the error and continue. Adding the cache control pragma should reduce how often we need to make these requests.

Fixes #1600