### PR TITLE
Switch to path prefix based bulk deletion

### DIFF
--- a/packages/openneuro-app/src/scripts/datalad/mutations/__tests__/__snapshots__/delete.spec.jsx.snap
+++ b/packages/openneuro-app/src/scripts/datalad/mutations/__tests__/__snapshots__/delete.spec.jsx.snap
@@ -119,13 +119,13 @@ exports[`DeleteDir mutation renders with common props 1`] = `
                     "kind": "Argument",
                     "name": Object {
                       "kind": "Name",
-                      "value": "files",
+                      "value": "path",
                     },
                     "value": Object {
                       "kind": "Variable",
                       "name": Object {
                         "kind": "Name",
-                        "value": "files",
+                        "value": "path",
                       },
                     },
                   },
@@ -173,7 +173,7 @@ exports[`DeleteDir mutation renders with common props 1`] = `
                   "kind": "NamedType",
                   "name": Object {
                     "kind": "Name",
-                    "value": "FileTree",
+                    "value": "String",
                   },
                 },
               },
@@ -181,7 +181,7 @@ exports[`DeleteDir mutation renders with common props 1`] = `
                 "kind": "Variable",
                 "name": Object {
                   "kind": "Name",
-                  "value": "files",
+                  "value": "path",
                 },
               },
             },
@@ -190,7 +190,7 @@ exports[`DeleteDir mutation renders with common props 1`] = `
       ],
       "kind": "Document",
       "loc": Object {
-        "end": 120,
+        "end": 115,
         "start": 0,
       },
     }

--- a/packages/openneuro-app/src/scripts/datalad/mutations/delete-dir.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/mutations/delete-dir.jsx
@@ -5,12 +5,12 @@ import { Mutation } from 'react-apollo'
 import WarnButton from '../../common/forms/warn-button.jsx'
 
 const DELETE_FILES = gql`
-  mutation deleteFiles($datasetId: ID!, $files: FileTree!) {
-    deleteFiles(datasetId: $datasetId, files: $files)
+  mutation deleteFiles($datasetId: ID!, $path: String!) {
+    deleteFiles(datasetId: $datasetId, path: $path)
   }
 `
 
-const DeleteDir = ({ datasetId, fileTree }) => (
+const DeleteDir = ({ datasetId, path }) => (
   <Mutation mutation={DELETE_FILES}>
     {deleteFiles => (
       <span className="delete-file">
@@ -23,7 +23,7 @@ const DeleteDir = ({ datasetId, fileTree }) => (
             deleteFiles({
               variables: {
                 datasetId,
-                files: fileTree,
+                path,
               },
             }).then(() => {
               cb()
@@ -37,7 +37,7 @@ const DeleteDir = ({ datasetId, fileTree }) => (
 
 DeleteDir.propTypes = {
   datasetId: PropTypes.string,
-  fileTree: PropTypes.object,
+  path: PropTypes.string,
 }
 
 export default DeleteDir

--- a/packages/openneuro-app/src/scripts/datalad/subscriptions/__tests__/files-subscription.spec.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/subscriptions/__tests__/files-subscription.spec.jsx
@@ -26,9 +26,8 @@ describe('deleteFilesReducer', () => {
       steak: 'sauce',
     }
     filesToDelete = [
-      { filename: 'deleted:file.txt' },
+      { filename: 'deleted' },
       { filename: 'another_deleted_file.txt' },
-      { filename: 'deleted:file:again:here' },
     ]
   })
   it('removes files from draft', () => {

--- a/packages/openneuro-app/src/scripts/datalad/subscriptions/files-subscription.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/subscriptions/files-subscription.jsx
@@ -27,10 +27,12 @@ const FILES_SUBSCRIPTION = gql`
  * @returns {Object} - updated version of draft
  */
 export const deleteFilesReducer = (files, draft) => {
-  const deleted = files.map(({ filename }) => filename.split(':').join('/'))
+  const pathMatch = files
+    .map(({ filename }) => filename.split(':').join('\\/'))
+    .join('|')
   return {
     ...draft,
-    files: draft.files.filter(file => !deleted.includes(file.filename)),
+    files: draft.files.filter(file => !file.filename.match(pathMatch)),
   }
 }
 

--- a/packages/openneuro-app/src/scripts/file-tree/file-tree.jsx
+++ b/packages/openneuro-app/src/scripts/file-tree/file-tree.jsx
@@ -52,10 +52,7 @@ const FileTree = ({
                 multiple>
                 <i className="fa fa-plus" /> Add Directory
               </UpdateFile>
-              <DeleteDir
-                datasetId={datasetId}
-                fileTree={{ name, path, files, directories }}
-              />
+              <DeleteDir datasetId={datasetId} path={path} />
             </span>
           )}
           <ul className="child-files">

--- a/packages/openneuro-server/datalad/dataset.js
+++ b/packages/openneuro-server/datalad/dataset.js
@@ -13,7 +13,7 @@ import * as subscriptions from '../handlers/subscriptions.js'
 import { generateDataladCookie } from '../libs/authentication/jwt'
 import { redis } from '../libs/redis.js'
 import { updateDatasetRevision, draftPartialKey } from './draft.js'
-import { fileUrl, getFileName } from './files.js'
+import { fileUrl, pathUrl, getFileName, encodeFilePath } from './files.js'
 import { getAccessionNumber } from '../libs/dataset.js'
 import Dataset from '../models/dataset.js'
 import Permission from '../models/permission.js'
@@ -371,10 +371,20 @@ export const commitFiles = (datasetId, user) => {
  * Delete an existing file in a dataset
  */
 export const deleteFile = (datasetId, path, file) => {
-  // Cannot use superagent 'request' due to inability to post streams
   const url = fileUrl(datasetId, path, file.name)
   const filename = getFileName(path, file.name)
   return request.del(url).then(() => filename)
+}
+
+/**
+ * Recursively delete a directory path within a dataset
+ */
+export const deletePath = (datasetId, path) => {
+  const url = pathUrl(datasetId, path)
+  return request
+    .del(url)
+    .query({ recursive: true })
+    .then(() => encodeFilePath(path))
 }
 
 /**

--- a/packages/openneuro-server/datalad/dataset.js
+++ b/packages/openneuro-server/datalad/dataset.js
@@ -370,20 +370,26 @@ export const commitFiles = (datasetId, user) => {
 /**
  * Delete an existing file in a dataset
  */
-export const deleteFile = (datasetId, path, file) => {
+export const deleteFile = (datasetId, path, file, user) => {
   const url = fileUrl(datasetId, path, file.name)
   const filename = getFileName(path, file.name)
-  return request.del(url).then(() => filename)
+  return request
+    .del(url)
+    .set('Cookie', generateDataladCookie(config)(user))
+    .set('Accept', 'application/json')
+    .then(() => filename)
 }
 
 /**
  * Recursively delete a directory path within a dataset
  */
-export const deletePath = (datasetId, path) => {
+export const deletePath = (datasetId, path, user) => {
   const url = pathUrl(datasetId, path)
   return request
     .del(url)
     .query({ recursive: true })
+    .set('Cookie', generateDataladCookie(config)(user))
+    .set('Accept', 'application/json')
     .then(() => encodeFilePath(path))
 }
 

--- a/packages/openneuro-server/datalad/files.js
+++ b/packages/openneuro-server/datalad/files.js
@@ -49,6 +49,17 @@ export const fileUrl = (datasetId, path, filename) => {
 }
 
 /**
+ * Generate path URL (such a directory or virtual path) for DataLad service
+ * @param {String} datasetId
+ * @param {String} path - Relative path for the file
+ */
+export const pathUrl = (datasetId, path) => {
+  const fileName = encodeFilePath(path)
+  const url = `http://${config.datalad.uri}/datasets/${datasetId}/files/${fileName}`
+  return url
+}
+
+/**
  * Get the faster object URL for a file
  * @param {string} datasetId - Dataset accession number
  * @param {string} objectId - Git object id, a sha1 hash for git objects or key for annexed files

--- a/packages/openneuro-server/graphql/resolvers/dataset.js
+++ b/packages/openneuro-server/graphql/resolvers/dataset.js
@@ -147,17 +147,6 @@ export const updateFiles = async (
 }
 
 /**
- * Delete a path within a dataset
- *
- * @param {string} datasetId
- * @param {string} path Single filename or directory path to remove recursively
- */
-export const deleteFilesPath = (datasetId, path) => {
-  // drafts just need something to invalidate client cache
-  return datalad.deletePath(datasetId, path)
-}
-
-/**
  * Delete files from a draft
  */
 export const deleteFiles = async (
@@ -167,7 +156,7 @@ export const deleteFiles = async (
 ) => {
   try {
     await checkDatasetWrite(datasetId, user, userInfo)
-    await deleteFilesPath(datasetId, path)
+    await datalad.deletePath(datasetId, path, userInfo)
     pubsub.publish('filesUpdated', {
       datasetId,
       filesUpdated: {
@@ -196,7 +185,7 @@ export const deleteFile = async (
   try {
     await checkDatasetWrite(datasetId, user, userInfo)
     const deletedFile = await datalad
-      .deleteFile(datasetId, path, { name: filename })
+      .deleteFile(datasetId, path, { name: filename }, userInfo)
       .then(filename => new UpdatedFile(filename))
     await datalad.commitFiles(datasetId, userInfo)
     pubsub.publish('filesUpdated', {

--- a/packages/openneuro-server/graphql/resolvers/draft.js
+++ b/packages/openneuro-server/graphql/resolvers/draft.js
@@ -7,6 +7,7 @@ import {
   getPartialStatus,
   updateDatasetRevision,
 } from '../../datalad/draft.js'
+import { checkDatasetWrite } from '../permissions.js'
 import { filterFiles } from '../../datalad/files.js'
 
 // A draft must have a dataset parent
@@ -26,12 +27,10 @@ export const partial = (obj, { datasetId }) => {
 /**
  * Mutation to move the draft HEAD reference forward or backward
  */
-export const updateRef = (obj, { datasetId, ref }, { userInfo }) => {
-  if (userInfo.admin) {
+export const updateRef = (obj, { datasetId, ref }, { user, userInfo }) => {
+  return checkDatasetWrite(datasetId, user, userInfo).then(() => {
     return updateDatasetRevision(datasetId, ref)
-  } else {
-    throw new Error('Access denied')
-  }
+  })
 }
 
 export const draft = obj => ({

--- a/packages/openneuro-server/graphql/resolvers/draft.js
+++ b/packages/openneuro-server/graphql/resolvers/draft.js
@@ -4,6 +4,8 @@ import { description } from './description.js'
 import { readme } from './readme.js'
 import { getDraftFiles, getPartialStatus } from '../../datalad/draft.js'
 import { filterFiles } from '../../datalad/files.js'
+import { updateDatasetRevision } from '../../datalad/draft.js'
+import Dataset from '../../models/dataset.js'
 
 // A draft must have a dataset parent
 const draftFiles = dataset => args => {
@@ -17,6 +19,17 @@ const draftFiles = dataset => args => {
  */
 export const partial = (obj, { datasetId }) => {
   return getPartialStatus(datasetId)
+}
+
+/**
+ * Mutation to move the draft HEAD reference forward or backward
+ */
+export const updateRef = async (obj, { datasetId, ref }, { userInfo }) => {
+  if (userInfo.admin) {
+    updateDatasetRevision(datasetId, ref)
+  } else {
+    throw new Error('Access denied')
+  }
 }
 
 export const draft = obj => ({

--- a/packages/openneuro-server/graphql/resolvers/draft.js
+++ b/packages/openneuro-server/graphql/resolvers/draft.js
@@ -2,10 +2,12 @@ import { summary } from './summary.js'
 import { issues } from './issues.js'
 import { description } from './description.js'
 import { readme } from './readme.js'
-import { getDraftFiles, getPartialStatus } from '../../datalad/draft.js'
+import {
+  getDraftFiles,
+  getPartialStatus,
+  updateDatasetRevision,
+} from '../../datalad/draft.js'
 import { filterFiles } from '../../datalad/files.js'
-import { updateDatasetRevision } from '../../datalad/draft.js'
-import Dataset from '../../models/dataset.js'
 
 // A draft must have a dataset parent
 const draftFiles = dataset => args => {
@@ -24,9 +26,9 @@ export const partial = (obj, { datasetId }) => {
 /**
  * Mutation to move the draft HEAD reference forward or backward
  */
-export const updateRef = async (obj, { datasetId, ref }, { userInfo }) => {
+export const updateRef = (obj, { datasetId, ref }, { userInfo }) => {
   if (userInfo.admin) {
-    updateDatasetRevision(datasetId, ref)
+    return updateDatasetRevision(datasetId, ref)
   } else {
     throw new Error('Access denied')
   }

--- a/packages/openneuro-server/graphql/resolvers/mutation.js
+++ b/packages/openneuro-server/graphql/resolvers/mutation.js
@@ -10,6 +10,7 @@ import {
   updatePublic,
   trackAnalytics,
 } from './dataset.js'
+import { updateRef } from './draft.js'
 import {
   createSnapshot,
   deleteSnapshot,
@@ -56,6 +57,7 @@ const Mutation = {
   editComment,
   subscribeToNewsletter,
   addMetadata,
+  updateRef,
 }
 
 export default Mutation

--- a/packages/openneuro-server/graphql/schema.js
+++ b/packages/openneuro-server/graphql/schema.js
@@ -92,8 +92,8 @@ export const typeDefs = `
     deleteSnapshot(datasetId: ID!, tag: String!): Boolean!
     # Add or update files in a draft - returns a new Draft
     updateFiles(datasetId: ID!, files: FileTree!): Draft
-    # delete files in a draft - returns a new Draft
-    deleteFiles(datasetId: ID!, files: FileTree!): Boolean
+    # Recursively delete a file or directory in a draft - returns true on success
+    deleteFiles(datasetId: ID!, path: String!): Boolean
     # delete one file based on path
     deleteFile(datasetId: ID!, path: String!, filename: String!): Boolean
     # Add or remove the public flag from a dataset
@@ -136,6 +136,8 @@ export const typeDefs = `
     subscribeToNewsletter(email: String!): Boolean
     # Upserts dataset metadata
     addMetadata(datasetId: ID!, metadata: MetadataInput!): Metadata
+    # Update draft reference pointer
+    updateRef(datasetId: ID!, ref: String!): Boolean
   }
 
   input SummaryInput {

--- a/packages/openneuro-server/graphql/utils/file.js
+++ b/packages/openneuro-server/graphql/utils/file.js
@@ -9,7 +9,7 @@ export const generateFileId = (filepath, size) => `${filepath}:${size}`
  * Creates a file object with an ApolloGQL cache-safe id.
  * @class
  * @param {string} filepath ':' delimited
- * @param {string|number} size
+ * @param {string|number} [size]
  */
 export function UpdatedFile(filepath, size) {
   /**

--- a/services/datalad/datalad_service/common/draft.py
+++ b/services/datalad/datalad_service/common/draft.py
@@ -13,15 +13,14 @@ def draft_revision_mutation(dataset_id, ref):
     }
 
 
-def update_head(store, dataset):
+def update_head(store, dataset, cookies=None):
     """Pass HEAD commit references back to OpenNeuro"""
     ds = store.get_dataset(dataset)
     ref = ds.repo.get_hexsha()
-    print('UPDATE REF TO ', ref)
     # We may want to detect if we need to run validation here?
     queue = dataset_queue(dataset)
     validate_dataset.s(dataset, ds.path, ref).apply_async(queue=queue)
     r = requests.post(url=GRAPHQL_ENDPOINT,
-                      json=draft_revision_mutation(dataset, ref))
+                      json=draft_revision_mutation(dataset, ref), cookies=cookies)
     if r.status_code != 200:
         raise Exception(r.text)

--- a/services/datalad/datalad_service/common/draft.py
+++ b/services/datalad/datalad_service/common/draft.py
@@ -1,0 +1,27 @@
+import requests
+
+from datalad_service.common.celery import dataset_queue
+from datalad_service.config import GRAPHQL_ENDPOINT
+from datalad_service.tasks.validator import validate_dataset
+
+
+def draft_revision_mutation(dataset_id, ref):
+    """Update the draft HEAD reference to an new git commit id (hexsha)."""
+    return {
+        'query': 'mutation ($datasetId: ID!, $ref: String!) { updateRef(datasetId: $datasetId, ref: $ref) }',
+        'variables': {'datasetId': dataset_id, 'ref': ref}
+    }
+
+
+def update_head(store, dataset):
+    """Pass HEAD commit references back to OpenNeuro"""
+    ds = store.get_dataset(dataset)
+    ref = ds.repo.get_hexsha()
+    print('UPDATE REF TO ', ref)
+    # We may want to detect if we need to run validation here?
+    queue = dataset_queue(dataset)
+    validate_dataset.s(dataset, ds.path, ref).apply_async(queue=queue)
+    r = requests.post(url=GRAPHQL_ENDPOINT,
+                      json=draft_revision_mutation(dataset, ref))
+    if r.status_code != 200:
+        raise Exception(r.text)

--- a/services/datalad/datalad_service/handlers/files.py
+++ b/services/datalad/datalad_service/handlers/files.py
@@ -140,10 +140,10 @@ class FilesResource(object):
                 # The recursive flag removes the entire tree in one commit
                 if 'recursive' in req.params and req.params['recursive'] != 'false':
                     remove = remove_recursive.apply_async(queue=queue, args=(self.annex_path, dataset), kwargs={
-                        'path': filename, 'name': name, 'email': email})
+                        'path': filename, 'name': name, 'email': email, 'cookies': req.cookies})
                 else:
                     remove = remove_files.apply_async(queue=queue, args=(self.annex_path, dataset), kwargs={
-                        'files': [filename], 'name': name, 'email': email})
+                        'files': [filename], 'name': name, 'email': email, 'cookies': req.cookies})
                 resp.media = media_dict
                 resp.status = falcon.HTTP_OK
             else:

--- a/services/datalad/datalad_service/tasks/files.py
+++ b/services/datalad/datalad_service/tasks/files.py
@@ -74,18 +74,18 @@ def get_untracked_files(store, dataset):
 
 
 @dataset_task
-def remove_files(store, dataset, files, name=None, email=None):
+def remove_files(store, dataset, files, name=None, email=None, cookies=None):
     ds = store.get_dataset(dataset)
     with CommitInfo(ds, name, email):
         for filename in files:
             ds.remove(filename, check=False)
-            update_head(store, dataset)
+            update_head(store, dataset, cookies)
 
 
 @dataset_task
-def remove_recursive(store, dataset, path, name=None, email=None):
+def remove_recursive(store, dataset, path, name=None, email=None, cookies=None):
     """Remove a path within a dataset recursively."""
     ds = store.get_dataset(dataset)
     with CommitInfo(ds, name, email):
         ds.remove(path, recursive=True, check=False)
-        update_head(store, dataset)
+        update_head(store, dataset, cookies=cookies)

--- a/services/datalad/datalad_service/tasks/files.py
+++ b/services/datalad/datalad_service/tasks/files.py
@@ -3,6 +3,7 @@ import os
 from datalad_service.common.annex import CommitInfo, get_repo_files
 from datalad_service.common.celery import dataset_task
 from datalad_service.common.celery import dataset_queue
+from datalad_service.common.draft import update_head
 from datalad_service.tasks.validator import validate_dataset
 
 
@@ -35,7 +36,6 @@ def unlock_files(store, dataset, files):
     ds = store.get_dataset(dataset)
     for filename in files:
         ds.unlock(filename)
-        
 
 
 @dataset_task
@@ -68,7 +68,8 @@ def get_untracked_files(store, dataset):
             size = os.path.getsize(path)
             # The id is just a composite of path/size for untracked files
             file_id = '{}:{}'.format(file_path, size)
-            fileMeta.append({'filename': file_path, 'size': size, 'id': file_id})
+            fileMeta.append(
+                {'filename': file_path, 'size': size, 'id': file_id})
     return fileMeta
 
 
@@ -78,3 +79,13 @@ def remove_files(store, dataset, files, name=None, email=None):
     with CommitInfo(ds, name, email):
         for filename in files:
             ds.remove(filename, check=False)
+            update_head(store, dataset)
+
+
+@dataset_task
+def remove_recursive(store, dataset, path, name=None, email=None):
+    """Remove a path within a dataset recursively."""
+    ds = store.get_dataset(dataset)
+    with CommitInfo(ds, name, email):
+        ds.remove(path, recursive=True, check=False)
+        update_head(store, dataset)

--- a/services/datalad/datalad_service/tasks/validator.py
+++ b/services/datalad/datalad_service/tasks/validator.py
@@ -2,8 +2,8 @@ import json
 import os
 import subprocess
 import requests
-from datalad_service.config import GRAPHQL_ENDPOINT
 
+from datalad_service.config import GRAPHQL_ENDPOINT
 from datalad_service.common.raven import client
 from datalad_service.common.celery import app
 


### PR DESCRIPTION
The original tree model was more flexible but we only really need to delete entire subtrees currently. This replaces the FileTree object with an array of paths which are recursively removed in each layer (React, server, backend service).