### PR TITLE
Ignore errors in the dataset access resolver for searches

### DIFF
--- a/packages/openneuro-app/src/scripts/search/search-results.tsx
+++ b/packages/openneuro-app/src/scripts/search/search-results.tsx
@@ -99,7 +99,7 @@ const SearchResultsQuery = (): React.SFC => {
       variables: {
         q: query,
       },
-      errorPolicy: 'all',
+      errorPolicy: 'ignore',
     }),
   )
 }


### PR DESCRIPTION
If you get a search result that you don't have permission to access, this will avoid the crash which hid other results.