### PR TITLE
Remove deleted datasets from search indexes.

### DIFF
--- a/packages/openneuro-server/src/graphql/resolvers/dataset-search.js
+++ b/packages/openneuro-server/src/graphql/resolvers/dataset-search.js
@@ -4,6 +4,15 @@ import { dataset } from './dataset'
 const elasticIndex = 'datasets'
 
 /**
+ * Remove a dataset from the index, used when deleting datasets to clean up
+ * unreachable index entries
+ * @param {string} id Dataset accession number id
+ * @returns {Promise}
+ */
+export const removeDatasetSearchDocument = id =>
+  elasticClient.delete({ id, index: elasticIndex })
+
+/**
  * Accepts an array of fields representing the sort order for the search
  * @param {Array<*>} sort
  * @returns {string}


### PR DESCRIPTION
This cleans up datasets from search indexes on deletion, preventing search queries from linking into datasets which no longer exist.