### PR TITLE
Enable native file API v2 for downloads

### DIFF
--- a/packages/openneuro-app/src/index.html
+++ b/packages/openneuro-app/src/index.html
@@ -6,8 +6,8 @@
     <meta http-equiv="expires" content="0" />
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta http-equiv="origin-trial" content="Apr/SwmDolSv3Rrn5U8VAIZ6w1dqXZEsmZCE1O5jzqy3qZjS230aJfZFs/jEtVPsDnAPtx/56Yhv2hFIpTVyMgcAAABXeyJvcmlnaW4iOiJodHRwczovL29wZW5uZXVyby5vcmc6NDQzIiwiZmVhdHVyZSI6Ik5hdGl2ZUZpbGVTeXN0ZW0iLCJleHBpcnkiOjE1ODkzMjc5OTl9" />
-    <meta http-equiv="origin-trial" content="AsJCOf/ipo/lGu178w5K+omjEsQQBFs/9V0XGYHzY0nOCPHjDgSgmUWtmeFyDTmpr6j4o4IeIRw07m1M+LkeUAgAAABieyJvcmlnaW4iOiJodHRwczovL29wZW5uZXVyby5zdGFnaW5nLnNxbS5pbzo0NDMiLCJmZWF0dXJlIjoiTmF0aXZlRmlsZVN5c3RlbSIsImV4cGlyeSI6MTU4OTMyNzk5OX0=" />
+    <meta http-equiv="origin-trial" content="AsKpocpVbl1jNiP78GEvJYnYkF8EOXv1QvNCWaAP4clN3ynEBjJlywcE+hJOgRNldAO2qpKFkN8XwV9D7r7N4woAAABYeyJvcmlnaW4iOiJodHRwczovL29wZW5uZXVyby5vcmc6NDQzIiwiZmVhdHVyZSI6Ik5hdGl2ZUZpbGVTeXN0ZW0yIiwiZXhwaXJ5IjoxNTkyODQ1NTk5fQ==" />
+    <meta http-equiv="origin-trial" content="ArNoaUPIKGYJuoo0JdVnfuWCFV3jOqAt8ODklLBaExQ0bxegn8zvwSBw7vSkA9F8VLB+WGm2YQLNXlFkCUoYJwkAAABjeyJvcmlnaW4iOiJodHRwczovL29wZW5uZXVyby5zdGFnaW5nLnNxbS5pbzo0NDMiLCJmZWF0dXJlIjoiTmF0aXZlRmlsZVN5c3RlbTIiLCJleHBpcnkiOjE1OTI4NDU1Nzh9" />
     <title>OpenNeuro</title>
     <link id="favicon" rel="icon" type="image/png" href="/content/img/favicon.ico" />
     <link rel="preload" href="/crn/config.json" as="fetch" crossorigin>

--- a/packages/openneuro-app/src/scripts/datalad/download/download-native.js
+++ b/packages/openneuro-app/src/scripts/datalad/download/download-native.js
@@ -45,16 +45,15 @@ export const downloadNative = (datasetId, snapshotTag) => async () => {
   try {
     // Open user selected directory
     const dirHandle = await window.chooseFileSystemEntries({
-      type: 'openDirectory',
+      type: 'open-directory',
     })
     for (const file of filesToDownload.files) {
       const fileHandle = await openFileTree(dirHandle, file.filename)
       // Skip files which are already complete
       if (fileHandle.size == file.size) continue
-      const writer = await fileHandle.createWriter()
-      const ff = await fetch(file.urls.pop())
-      await writer.write(0, await ff.arrayBuffer())
-      await writer.close()
+      const writable = await fileHandle.createWritable()
+      const { body } = await fetch(file.urls.pop())
+      await body.pipeTo(writable)
     }
     downloadCompleteToast(dirHandle.name)
   } catch (err) {


### PR DESCRIPTION
This updated the origin trial tokens to enable the v2 native file API with Chrome 83's release next week.

Requires Chrome 83 to test (beta channel currently).