### PR TITLE
Raise Celery concurrency to 2 -> 4. Disable cross worker heartbeats

### DIFF
--- a/services/datalad/dataset-worker
+++ b/services/datalad/dataset-worker
@@ -2,4 +2,4 @@
 # Example worker script for docker-compose
 WORKER_ID=$(python get_docker_scale.py)
 echo "Worker $WORKER_ID starting..."
-celery -A datalad_service.worker worker -Q dataset-worker-$WORKER_ID -l info
+celery -A datalad_service.worker worker -Q dataset-worker-$WORKER_ID -l info -c 4 --without-gossip --without-mingle --without-heartbeat


### PR DESCRIPTION
This should help performance in production as we seem to be using a significant chunk of our message bandwidth on cross worker heartbeat logic. Doubles the worker concurrency to reduce the chance of a blocked worker.