### PR TITLE
Workaround bad pipenv release until a fix is out

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -156,7 +156,7 @@ jobs:
       # Install codecov and pipenv
       - run:
           name: Install pipenv
-          command: pip install --user pipenv
+          command: pip install --user 'pipenv==2018.11.26'
           working_directory: ~/project/services/datalad
 
       # create venv and install dependencies

--- a/services/datalad/Dockerfile
+++ b/services/datalad/Dockerfile
@@ -15,7 +15,7 @@ RUN apk --update add bash yarn git python py-pip openssl openssh ca-certificates
   && rm git-annex-standalone-amd64.tar.gz \
   && mv git-annex.linux/* /usr/local/bin \
   && apk --update add --virtual build-dependencies libffi-dev openssl-dev python3-dev py3-pip build-base libxml2-dev libxslt-dev \
-  && pip install pipenv \
+  && pip install 'pipenv==2018.11.26' \
   && pipenv install --deploy --system \
   && apk del build-dependencies wget \
   && mkdir /datalad \


### PR DESCRIPTION
This installs the previously working release of pipenv for CI builds.