### PR TITLE
Update charts to support Kubernetes 1.16

### DIFF
--- a/helm/openneuro/Chart.yaml
+++ b/helm/openneuro/Chart.yaml
@@ -8,11 +8,11 @@ sources:
 appVersion: 3.14.3
 dependencies:
   - name: redis
-    version: 7.1.0
-    repository: https://kubernetes-charts.storage.googleapis.com/
+    version: 10.6.17
+    repository: https://charts.bitnami.com/bitnami
   - name: efs-provisioner
-    version: 0.3.7
+    version: 0.11.1
     repository: https://kubernetes-charts.storage.googleapis.com/
   - name: aws-alb-ingress-controller
-    version: 0.1.11
+    version: 1.0.0
     repository: https://kubernetes-charts-incubator.storage.googleapis.com/

--- a/helm/openneuro/requirements.lock
+++ b/helm/openneuro/requirements.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: redis
-  repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 7.1.0
+  repository: https://charts.bitnami.com/bitnami
+  version: 10.6.17
 - name: efs-provisioner
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 0.3.7
+  version: 0.11.1
 - name: aws-alb-ingress-controller
   repository: https://kubernetes-charts-incubator.storage.googleapis.com/
-  version: 0.1.11
-digest: sha256:53f37b16af475683f16dc74b0dd2118dafd8276e6deb510b1a104e152dbe1c9d
-generated: "2019-12-19T21:30:53.957756636-08:00"
+  version: 1.0.0
+digest: sha256:3ab7809ee83e0dc58779d9edd1605144bc8cd292f85b2992e75e425491117244
+generated: "2020-06-01T19:40:21.004685521-07:00"

--- a/helm/openneuro/values.yaml
+++ b/helm/openneuro/values.yaml
@@ -32,6 +32,7 @@ efs-provisioner:
     efsFileSystemId: fs-acb10b4f
     path: /pv
     storageClass:
+      name: efs
       reclaimPolicy: Retain
 
 # Load balancer / ingress config


### PR DESCRIPTION
This adds Kubernetes 1.16 support to our helm chart.