### PR TITLE
Update container images to use 12.18.0-alpine3.12 as base image.

### DIFF
--- a/packages/openneuro-app/Dockerfile
+++ b/packages/openneuro-app/Dockerfile
@@ -1,6 +1,6 @@
-FROM node:12.16.1-alpine AS app
+FROM node:12.18.0-alpine3.12 AS app
 
-RUN apk --no-cache --update add git make gcc g++ python
+RUN apk --no-cache --update add git
 
 ADD . /srv
 
@@ -8,7 +8,7 @@ ADD . /srv
 WORKDIR /srv
 
 # Build the frontend
-RUN yarn install --pure-lockfile && yarn bootstrap && apk del make gcc g++ python
+RUN yarn install --pure-lockfile && yarn bootstrap
 
 WORKDIR /srv/packages/openneuro-app
 

--- a/packages/openneuro-indexer/Dockerfile
+++ b/packages/openneuro-indexer/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.16.1-alpine as indexer
+FROM node:12.18.0-alpine3.12 as indexer
 
 ADD . /srv
 WORKDIR /srv

--- a/packages/openneuro-server/Dockerfile
+++ b/packages/openneuro-server/Dockerfile
@@ -1,11 +1,9 @@
-FROM node:12.16.1-alpine
+FROM node:12.18.0-alpine3.12
 
 # install server app
 ADD . /srv
 WORKDIR /srv
-RUN apk add curl git make gcc g++ python --no-cache --update && \
-  yarn install && \
-  apk del make gcc g++ python
+RUN apk add curl git --no-cache --update && yarn install
 
 HEALTHCHECK --interval=10s --retries=10 CMD curl -f 'http://localhost:8111' || exit 1
 


### PR DESCRIPTION
This also avoids the need for some native compilation during builds.