### PR TITLE
Add network aliases for datalad service running under docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,6 +79,11 @@ services:
     depends_on:
       - celery
     init: true
+    networks:
+      default:
+        aliases:
+          - datalad-0
+          - datalad-1
 
   # celery Python backend
   celery:


### PR DESCRIPTION
Fixes #1675 by adding in some hardcoded aliases for the first and second workers. This will need to be updated whenever the dev setup runs more than two workers.