### PR TITLE
Use git-annex whereis to obtain remote URL paths

### DIFF
--- a/packages/openneuro-server/src/datalad/files.js
+++ b/packages/openneuro-server/src/datalad/files.js
@@ -93,7 +93,7 @@ export const getFiles = (datasetId, hexsha) => {
         )
         .set('Accept', 'application/json')
         .then(({ body: { files } }) => {
-          const filesWithUrls = files.map(addFileUrl(datasetId))
+          const filesWithUrls = files.map(addFileUrl(datasetId, hexsha))
           redis.set(key, JSON.stringify(filesWithUrls))
           return filesWithUrls
         })

--- a/packages/openneuro-server/src/datalad/utils.js
+++ b/packages/openneuro-server/src/datalad/utils.js
@@ -1,29 +1,21 @@
 import config from '../config.js'
 
-export const addFileUrl = (datasetId, tag, externalFiles) => file => {
-  // This is a draft, files are local
-  const filePath = file.filename.replace(/\//g, ':')
-  if (tag) {
-    // Snapshot
-    const urls = []
-
-    // Published snapshot S3 URL
-    if (externalFiles) {
-      const match = externalFiles.filter(
-        fileObj => fileObj.filename === file.filename,
-      )
-      const matchedFile = match ? match.pop() : null
-      // If any matches are found, merge in the urls
-      if (matchedFile) urls.push(...matchedFile.urls)
-    } else {
-      // Backup URL for direct access
-      const fileUrl = `${config.url}${config.apiPrefix}datasets/${datasetId}/snapshots/${tag}/files/${filePath}`
-      urls.push(fileUrl)
-    }
-    return { ...file, urls }
+export const addFileUrl = (datasetId, tag) => file => {
+  // Skip files annotated with a URL from datalad service
+  if (file.urls.length > 0) {
+    return file
   } else {
-    // Dataset draft
-    const fileUrl = `${config.url}${config.apiPrefix}datasets/${datasetId}/files/${filePath}`
-    return { ...file, urls: [fileUrl] }
+    // This is a draft, files are local and no URLs defined
+    const filePath = file.filename.replace(/\//g, ':')
+    if (tag) {
+      // Snapshot
+      // Backup URL for direct access for private datasets
+      const fileUrl = `${config.url}${config.apiPrefix}datasets/${datasetId}/snapshots/${tag}/files/${filePath}`
+      return { ...file, urls: [fileUrl] }
+    } else {
+      // Dataset draft
+      const fileUrl = `${config.url}${config.apiPrefix}datasets/${datasetId}/files/${filePath}`
+      return { ...file, urls: [fileUrl] }
+    }
   }
 }

--- a/services/datalad/datalad_service/handlers/snapshots.py
+++ b/services/datalad/datalad_service/handlers/snapshots.py
@@ -43,9 +43,11 @@ class SnapshotResource(object):
         media = req.media
         description_fields = {}
         snapshot_changes = []
+        skip_publishing = False
         if media != None:
             description_fields = media.get('description_fields')
             snapshot_changes = media.get('snapshot_changes')
+            skip_publishing = media.get('skip_publishing')
 
         monitor_remote_configs.s(
             self.store.annex_path, dataset, snapshot).set(
@@ -59,9 +61,7 @@ class SnapshotResource(object):
             # Publish after response
             publish = publish_snapshot.s(
                 self.store.annex_path, dataset, snapshot, req.cookies)
-            skip_publishing = req.media != None and media.get(
-                'skip_publishing')
-            if not skip_publishing and skip_publishing is not None:
+            if not skip_publishing:
                 publish.apply_async(queue=queue)
         else:
             resp.media = {'error': 'tag already exists'}

--- a/services/datalad/datalad_service/tasks/publish.py
+++ b/services/datalad/datalad_service/tasks/publish.py
@@ -109,12 +109,6 @@ def migrate_to_bucket(store, dataset, cookies=None, realm='PUBLIC'):
     s3_remote = s3_sibling(ds, siblings, realm=realm)
     for tag in tags:
         publish_target(ds, realm.s3_remote, tag)
-        versions = s3_versions(ds, realm, tag)
-        if (len(versions)):
-            r = requests.post(
-                url=GRAPHQL_ENDPOINT, json=file_urls_mutation(dataset_id, tag, versions), cookies=cookies)
-            if r.status_code != 200:
-                raise Exception(r.text)
         # Public publishes to GitHub
         if realm == DatasetRealm.PUBLIC and DATALAD_GITHUB_EXPORTS_ENABLED:
             github_remote = github_sibling(ds, dataset_id, siblings)

--- a/services/datalad/datalad_service/tasks/publish.py
+++ b/services/datalad/datalad_service/tasks/publish.py
@@ -8,7 +8,7 @@ from datalad_service.config import DATALAD_GITHUB_PASS
 from datalad_service.config import DATALAD_GITHUB_EXPORTS_ENABLED
 from datalad_service.config import GRAPHQL_ENDPOINT
 import datalad_service.common.s3
-from datalad_service.common.s3 import DatasetRealm, s3_export, s3_versions, get_s3_realm
+from datalad_service.common.s3 import DatasetRealm, s3_export, get_s3_realm
 from datalad_service.common.celery import dataset_task, dataset_queue
 from datalad_service.common.s3 import validate_s3_config, update_s3_sibling
 
@@ -146,12 +146,6 @@ def publish_s3_async(store, dataset, snapshot, s3_remote, s3_bucket, cookies):
     """Actual S3 remote push. Can run on another queue, so it's its own task."""
     ds = store.get_dataset(dataset)
     publish_target(ds, s3_remote, snapshot)
-    versions = s3_versions(ds, s3_bucket, snapshot)
-    if (len(versions)):
-        r = requests.post(
-            url=GRAPHQL_ENDPOINT, json=file_urls_mutation(dataset, snapshot, versions), cookies=cookies)
-        if r.status_code != 200:
-            raise Exception(r.text)
 
 
 @dataset_task

--- a/services/datalad/tests/test_annex.py
+++ b/services/datalad/tests/test_annex.py
@@ -1,5 +1,5 @@
 from .dataset_fixtures import *
-from datalad_service.common.annex import create_file_obj, parse_ls_tree_line, read_ls_tree_line
+from datalad_service.common.annex import create_file_obj, parse_ls_tree_line, read_ls_tree_line, read_where_is_line
 
 expected_file_object = {
     'filename': 'dataset_description.json',
@@ -43,38 +43,42 @@ def test_parse_ls_tree_line_submodule():
 
 
 def test_get_ls_tree_line():
+    gitAnnexUrls = {}
     files = []
     symlinkFilenames = []
     symlinkObjects = []
     read_ls_tree_line("""100644 blob a786c385bd1812410d01177affb6ce834d85facd     459	dataset_description.json""",
-                      files, symlinkFilenames, symlinkObjects)
+                      gitAnnexUrls, files, symlinkFilenames, symlinkObjects)
     assert files == [
         {'filename': 'dataset_description.json',
          'id': '78dd92373749f62af23f3ae499b7a8ac33418fff',
          'key': 'a786c385bd1812410d01177affb6ce834d85facd',
-         'size': 459
+         'size': 459,
+         'urls': []
          }]
     assert symlinkFilenames == []
     assert symlinkObjects == []
 
 
 def test_get_ls_tree_line_ignored():
+    gitAnnexUrls = {}
     files = []
     symlinkFilenames = []
     symlinkObjects = []
     read_ls_tree_line("""100644 blob a786c385bd1812410d01177affb6ce834d85facd     459	.gitattributes""",
-                      files, symlinkFilenames, symlinkObjects)
+                      gitAnnexUrls, files, symlinkFilenames, symlinkObjects)
     assert files == []
     assert symlinkFilenames == []
     assert symlinkObjects == []
 
 
 def test_get_ls_tree_line_annexed():
+    gitAnnexUrls = {}
     files = []
     symlinkFilenames = []
     symlinkObjects = []
     read_ls_tree_line("""120000 blob 570cb4a3fd80de6e8491312c935bfe8029066361     141	derivatives/mriqc/reports/sub-01_ses-01_T1w.html""",
-                      files, symlinkFilenames, symlinkObjects)
+                      gitAnnexUrls, files, symlinkFilenames, symlinkObjects)
     assert files == []
     assert symlinkFilenames == [
         'derivatives/mriqc/reports/sub-01_ses-01_T1w.html']
@@ -82,11 +86,30 @@ def test_get_ls_tree_line_annexed():
 
 
 def test_get_ls_tree_line_submodule():
+    gitAnnexUrls = {}
     files = []
     symlinkFilenames = []
     symlinkObjects = []
     read_ls_tree_line("""160000 commit fcafd17fbfa44495c7f5f8a0777e5ab610b09500       -	code/facedistid_analysis""",
-                      files, symlinkFilenames, symlinkObjects)
+                      gitAnnexUrls, files, symlinkFilenames, symlinkObjects)
     assert files == []
     assert symlinkFilenames == []
     assert symlinkObjects == []
+
+
+def test_read_where_is_line():
+    gitAnnexUrls = {}
+    exampleAnnexedLine = """{"command":"whereis","note":"2 copies\\n\\t87fe6ba3-eb5e-4419-b7ce-839dd8fd1308 -- root@35763ede081b:/datalad/ds002002 [here]\\n \\tdd8cfd6d-a11e-419b-bbbc-35085d98051a -- [s3-PUBLIC]\\n\\ns3-PUBLIC: http://openneuro-datalad-public-nell-test.s3.amazonaws.com/ds002002/sub-01/anat/sub-01_T1w.nii.gz?versionId=yuHcJT5RxnjxNVuwEx3yq15oDrpb7H9z\\n","success":true,"untrusted":[],"key":"MD5E-s311112--bc8bbbacfd2ff823c2047ead1afec9b3.nii.gz","whereis":[{"here":true,"uuid":"87fe6ba3-eb5e-4419-b7ce-839dd8fd1308","urls":[],"description":"root@35763ede081b:/datalad/ds002002"},{"here":false,"uuid":"dd8cfd6d-a11e-419b-bbbc-35085d98051a","urls":["http://openneuro-datalad-public-nell-test.s3.amazonaws.com/ds002002/sub-01/anat/sub-01_T1w.nii.gz?versionId=yuHcJT5RxnjxNVuwEx3yq15oDrpb7H9z"],"description":"[s3-PUBLIC]"}],"file":null}"""
+    read_where_is_line(gitAnnexUrls, exampleAnnexedLine)
+    assert "MD5E-s311112--bc8bbbacfd2ff823c2047ead1afec9b3.nii.gz" in gitAnnexUrls
+    assert gitAnnexUrls["MD5E-s311112--bc8bbbacfd2ff823c2047ead1afec9b3.nii.gz"] == [
+        'http://openneuro-datalad-public-nell-test.s3.amazonaws.com/ds002002/sub-01/anat/sub-01_T1w.nii.gz?versionId=yuHcJT5RxnjxNVuwEx3yq15oDrpb7H9z']
+
+
+def test_read_where_is_line_git_file():
+    gitAnnexUrls = {}
+    exampleAnnexedLine = """{"command":"whereis","note":"1 copy\\n\\tdd8cfd6d-a11e-419b-bbbc-35085d98051a -- [s3-PUBLIC]\\n\\ns3-PUBLIC: http://openneuro-datalad-public-nell-test.s3.amazonaws.com/ds002002/T1w.json?versionId=65LPwCLmnBAOYlJ0WBW0itAo3ooGAw4j\\n","success":true,"untrusted":[],"key":"SHA1--b08aa0ec5b5e716479824859524a22140fb2af82","whereis":[{"here":false,"uuid":"dd8cfd6d-a11e-419b-bbbc-35085d98051a","urls":["http://openneuro-datalad-public-nell-test.s3.amazonaws.com/ds002002/T1w.json?versionId=65LPwCLmnBAOYlJ0WBW0itAo3ooGAw4j"],"description":"[s3-PUBLIC]"}],"file":null}"""
+    read_where_is_line(gitAnnexUrls, exampleAnnexedLine)
+    assert "SHA1--b08aa0ec5b5e716479824859524a22140fb2af82" in gitAnnexUrls
+    assert gitAnnexUrls["SHA1--b08aa0ec5b5e716479824859524a22140fb2af82"] == [
+        'http://openneuro-datalad-public-nell-test.s3.amazonaws.com/ds002002/T1w.json?versionId=65LPwCLmnBAOYlJ0WBW0itAo3ooGAw4j']

--- a/services/datalad/tests/test_files.py
+++ b/services/datalad/tests/test_files.py
@@ -100,13 +100,13 @@ def test_file_indexing(celery_app, client, new_dataset):
     assert all(f in response_content['files'] for f in [
         {'filename': 'dataset_description.json', 'size': 101,
             'id': '43502da40903d08b18b533f8897330badd6e1da3',
-            'key': '838d19644b3296cf32637bbdf9ae5c87db34842f'},
+            'key': '838d19644b3296cf32637bbdf9ae5c87db34842f', 'urls': []},
         {'filename': 'LICENSE', 'size': 8,
             'id': '8a6f5281317d8a8fb695d12c940b0ff7a7dee435',
-            'key': 'MD5E-s8--4d87586dfb83dc4a5d15c6cfa6f61e27'},
+            'key': 'MD5E-s8--4d87586dfb83dc4a5d15c6cfa6f61e27', 'urls': []},
         {'filename': 'sub-01/anat/sub-01_T1w.nii.gz',
             'id': '7fa0e07afaec0ff2cdf1bfc783596b4472df9b12',
-            'key': 'MD5E-s19--8149926e49b677a5ccecf1ad565acccf.nii.gz', 'size': 19}
+            'key': 'MD5E-s19--8149926e49b677a5ccecf1ad565acccf.nii.gz', 'size': 19, 'urls': []}
     ])
 
 
@@ -128,10 +128,10 @@ def test_empty_file(celery_app, client, new_dataset):
     # Check that all elements exist in both lists
     assert({'filename': 'LICENSE',
             'id': '5bfdc52581371bfa051fa76825a0e1b5e5c3b4bf',
-            'key': 'MD5E-s0--d41d8cd98f00b204e9800998ecf8427e', 'size': 0} in response_content['files'])
+            'key': 'MD5E-s0--d41d8cd98f00b204e9800998ecf8427e', 'size': 0, 'urls': []} in response_content['files'])
     assert({'filename': 'dataset_description.json',
             'id': '43502da40903d08b18b533f8897330badd6e1da3',
-            'key': '838d19644b3296cf32637bbdf9ae5c87db34842f', 'size': 101} in response_content['files'])
+            'key': '838d19644b3296cf32637bbdf9ae5c87db34842f', 'size': 101, 'urls': []} in response_content['files'])
 
 
 def test_duplicate_file_id(celery_app, client, new_dataset):

--- a/services/datalad/tests/test_snapshots.py
+++ b/services/datalad/tests/test_snapshots.py
@@ -17,9 +17,9 @@ def test_get_snapshot(client, celery_app):
     assert response.status == falcon.HTTP_OK
     assert result_doc['files'] == [
         {'filename': 'CHANGES', 'size': 41, 'id': '0daaa69260ab1f1fa8cfd0e17a4c1993d6d46e54',
-            'key': '63f4f8294caf64dccfedcb5300dee70e3fe3a7c5'},
+            'key': '63f4f8294caf64dccfedcb5300dee70e3fe3a7c5', 'urls': []},
         {'filename': 'dataset_description.json', 'id': '9c946a75b4c24c14e65d746b2ff295a904845aa3',
-            'key': '85b9ddf2bfaf1d9300d612dc29774a98cc1d5e25', 'size': 97}
+            'key': '85b9ddf2bfaf1d9300d612dc29774a98cc1d5e25', 'size': 97, 'urls': []}
     ] and \
         result_doc['tag'] == SNAPSHOT_ID and \
         result_doc['id'] == '{}:{}'.format(DATASET_ID, SNAPSHOT_ID)


### PR DESCRIPTION
This replaces the error prone method of crawling the buckets for S3 versions to return special remote paths.

Fallback URLs are still provided but they should only be used for private datasets with this change.