### PR TITLE
Prevent openneuro-cli from downloading all files at once

### DIFF
--- a/packages/openneuro-cli/src/download.js
+++ b/packages/openneuro-cli/src/download.js
@@ -41,15 +41,16 @@ export const getDownloadMetadata = (datasetId, tag) =>
     .get(downloadUrl(getUrl(), datasetId, tag))
     .set('Cookie', `accessToken=${getToken()}`)
 
-export const downloadFile = async (destination, filename, fileUrl) => {
+export const downloadFile = (destination, filename, fileUrl) => {
   const fullPath = path.join(destination, filename)
   // Create any needed parent dirs
   mkdirp.sync(path.dirname(fullPath))
   const writeStream = fs.createWriteStream(fullPath)
-  await request
+  const readStream = request
     .get(fileUrl)
     .set('Cookie', `accessToken=${getToken()}`)
     .pipe(writeStream)
+  return new Promise(resolve => readStream.on('finish', resolve))
 }
 
 export const getDownload = (destination, datasetId, tag) =>


### PR DESCRIPTION
Fixes openneuro-cli creating too many download requests at once. The superagent pipe here does not actually return a promise (just a thenable object), we need to wait for the finish event.