### PR TITLE
Download files without corrupting the dataset on HTTP errors.

### DIFF
--- a/packages/openneuro-cli/src/download.js
+++ b/packages/openneuro-cli/src/download.js
@@ -50,7 +50,7 @@ export const downloadFile = async (destination, filename, fileUrl) => {
     .get(fileUrl)
     .set('Cookie', `accessToken=${getToken()}`)
     .buffer(false)
-    .on('response', res => {
+    .parse((res, cb) => {
       // Stream data to the file.
       // We can't use request.pipe() directly because it
       // doesn't catch HTTP errors, meaning errors turn
@@ -60,10 +60,11 @@ export const downloadFile = async (destination, filename, fileUrl) => {
       // Instead we set stream content out manually.
       // https://github.com/visionmedia/superagent/issues/1575
 
-      // 'response' happens before superagent checks the
+      // this happens before superagent checks the
       // status code, so we need to check it ourselves.
-      if(request.Request.prototype._isResponseOK(res)) {
+      if(res.statusCode == 200) {
         res.on('data', chunk => { writeStream.write(chunk) })
+        res.on('end', () => { cb(null, undefined, null) })
       }
     })
 }

--- a/packages/openneuro-cli/src/download.js
+++ b/packages/openneuro-cli/src/download.js
@@ -62,9 +62,13 @@ export const downloadFile = async (destination, filename, fileUrl) => {
 
       // this happens before superagent checks the
       // status code, so we need to check it ourselves.
-      if(res.statusCode == 200) {
-        res.on('data', chunk => { writeStream.write(chunk) })
-        res.on('end', () => { cb(null, undefined, null) })
+      if (res.statusCode == 200) {
+        res.on('data', chunk => {
+          writeStream.write(chunk)
+        })
+        res.on('end', () => {
+          cb(null, undefined, null)
+        })
       }
     })
 }


### PR DESCRIPTION
superagent.request.pipe() was *too* convenient. It happily downloaded error pages in place of content.

Getting this working right was real complicated in the end, because superagent helpfully tries very very super hard to pre-parse everything for you and even hard-codes a special case for `application/json`. But when streaming I want it to do exactly none of that, so I had to subvert it slightly. See https://github.com/visionmedia/superagent/issues/1575 for details.

Maybe superagent can be convinced to make .pipe() throw exceptions on HTTP errors the way .then() does?

Fixes #1692.