### PR TITLE
CLI: Rework downloads to use node-fetch instead of superagent

### DIFF
--- a/packages/openneuro-cli/jest.setup.js
+++ b/packages/openneuro-cli/jest.setup.js
@@ -1,0 +1,2 @@
+import fetchMock from 'jest-fetch-mock'
+fetchMock.enableMocks()

--- a/packages/openneuro-cli/package.json
+++ b/packages/openneuro-cli/package.json
@@ -18,19 +18,22 @@
   "dependencies": {
     "bids-validator": "1.5.3",
     "commander": "^2.15.1",
+    "cross-fetch": "^3.0.5",
     "esm": "^3.0.16",
     "find-config": "^1.0.0",
     "graphql-tag": "^2.10.3",
     "inquirer": "^5.2.0",
     "mkdirp": "^0.5.1",
     "moment": "^2.22.2",
-    "openneuro-client": "^3.15.1",
-    "superagent": "^4.1.0"
+    "openneuro-client": "^3.15.1"
   },
   "scripts": {
     "openneuro": "node src/index.js"
   },
   "jest": {
+    "setupFiles": [
+      "./jest.setup.js"
+    ],
     "testEnvironment": "node",
     "collectCoverageFrom": [
       "**/*.js",
@@ -43,6 +46,7 @@
     ]
   },
   "devDependencies": {
+    "jest-fetch-mock": "^3.0.3",
     "metro-memory-fs": "^0.31.0"
   }
 }

--- a/packages/openneuro-cli/src/__mocks__/config.js
+++ b/packages/openneuro-cli/src/__mocks__/config.js
@@ -1,0 +1,3 @@
+export const getConfig = () => ({ apikey: 'mock', url: 'http://example.com' })
+export const getUrl = () => 'http://example.com'
+export const getToken = () => 'mock'

--- a/packages/openneuro-cli/src/__tests__/download.spec.js
+++ b/packages/openneuro-cli/src/__tests__/download.spec.js
@@ -1,4 +1,20 @@
-import { downloadUrl, checkDestination } from '../download.js'
+import {
+  downloadUrl,
+  checkDestination,
+  getDownloadMetadata,
+} from '../download.js'
+
+let errorSpy
+let dirSpy
+
+beforeEach(() => {
+  errorSpy = jest.spyOn(console, 'error').mockImplementation()
+  dirSpy = jest.spyOn(console, 'dir').mockImplementation()
+})
+afterEach(() => {
+  errorSpy.mockRestore()
+  dirSpy.mockRestore()
+})
 
 describe('download.js', () => {
   describe('downloadUrl()', () => {
@@ -16,6 +32,22 @@ describe('download.js', () => {
   describe('checkDestination()', () => {
     it('throws an error on existing directories', () => {
       expect(checkDestination('.')).toThrowErrorMatchingSnapshot()
+    })
+  })
+  describe('getDownloadMetadata()', () => {
+    it('fetches metdata on successful fetch', async () => {
+      fetch.mockResponseOnce(JSON.stringify({}))
+      await getDownloadMetadata('ds000testing', '1.0.0')
+      expect(fetch).toHaveBeenCalledTimes(1)
+    })
+    it('returns an error message on rejected fetch', async () => {
+      const testError = { testError: true }
+      fetch.mockReject(testError)
+      await getDownloadMetadata('ds000testing', '1.0.0')
+      expect(console.error).toHaveBeenCalledWith(
+        'Error starting download - please check your connection or try again later',
+      )
+      expect(console.dir).toHaveBeenCalledWith(testError)
     })
   })
 })

--- a/packages/openneuro-cli/src/__tests__/download.spec.js
+++ b/packages/openneuro-cli/src/__tests__/download.spec.js
@@ -4,6 +4,8 @@ import {
   getDownloadMetadata,
 } from '../download.js'
 
+jest.mock('../config.js')
+
 let errorSpy
 let dirSpy
 

--- a/packages/openneuro-cli/src/config.js
+++ b/packages/openneuro-cli/src/config.js
@@ -11,7 +11,12 @@ export const getConfig = () => {
 }
 
 export const readConfig = () => {
-  return fs.readFileSync(getConfig())
+  const config = getConfig()
+  if (config) {
+    return fs.readFileSync(config, 'utf8')
+  } else {
+    return JSON.stringify({})
+  }
 }
 
 /**

--- a/packages/openneuro-cli/src/download.js
+++ b/packages/openneuro-cli/src/download.js
@@ -1,7 +1,7 @@
+import 'cross-fetch/polyfill'
 import fs from 'fs'
 import path from 'path'
 import mkdirp from 'mkdirp'
-import request from 'superagent'
 import { getToken, getUrl } from './config.js'
 
 export const downloadUrl = (baseUrl, datasetId, tag) =>
@@ -36,24 +36,77 @@ export const testFile = (destination, filename, size) => {
   }
 }
 
-export const getDownloadMetadata = (datasetId, tag) =>
-  request
-    .get(downloadUrl(getUrl(), datasetId, tag))
-    .set('Cookie', `accessToken=${getToken()}`)
+const getFetchOptions = () => ({
+  headers: {
+    cookie: `accessToken=${getToken()}`,
+  },
+})
 
+const handleFetchReject = err => {
+  console.error(
+    'Error starting download - please check your connection or try again later',
+  )
+  console.dir(err)
+}
+
+/**
+ * Obtain the listing of files to download
+ * @param {string} datasetId
+ * @param {string} tag
+ */
+export const getDownloadMetadata = async (datasetId, tag) => {
+  try {
+    const response = await fetch(
+      downloadUrl(getUrl(), datasetId, tag),
+      getFetchOptions(),
+    )
+    if (response.status === 200) {
+      const body = await response.json()
+      return body
+    } else {
+      console.error(
+        `Error ${response.status} fetching download metadata - ${response.statusText}`,
+      )
+    }
+  } catch (err) {
+    handleFetchReject(err)
+  }
+}
+
+/**
+ * Download one file from a remote URL
+ * @param {string} destination Destination directory path
+ * @param {string} filename
+ * @param {string} fileUrl URL to download from
+ */
 export const downloadFile = async (destination, filename, fileUrl) => {
   const fullPath = path.join(destination, filename)
   // Create any needed parent dirs
   mkdirp.sync(path.dirname(fullPath))
   const writeStream = fs.createWriteStream(fullPath)
-  await request
-    .get(fileUrl)
-    .set('Cookie', `accessToken=${getToken()}`)
-    .pipe(writeStream)
+  try {
+    const response = await fetch(fileUrl, getFetchOptions())
+    if (response.status === 200) {
+      // Setup end/error handler with Promise interface
+      const responsePromise = new Promise((resolve, reject) => {
+        response.body.on('end', () => resolve())
+        response.body.on('error', err => reject(err))
+      })
+      // Start piping data
+      response.body.pipe(writeStream)
+      return responsePromise
+    } else {
+      console.error(
+        `Error ${response.status} fetching "${filename}" - ${response.statusText}`,
+      )
+    }
+  } catch (err) {
+    handleFetchReject(err)
+  }
 }
 
 export const getDownload = (destination, datasetId, tag) =>
-  getDownloadMetadata(datasetId, tag).then(async ({ body }) => {
+  getDownloadMetadata(datasetId, tag).then(async body => {
     checkDestination(destination)
     for (const file of body.files) {
       if (testFile(destination, file.filename, file.size)) {

--- a/packages/openneuro-cli/src/download.js
+++ b/packages/openneuro-cli/src/download.js
@@ -54,10 +54,10 @@ const handleFetchReject = err => {
  * @param {string} datasetId
  * @param {string} tag
  */
-export const getDownloadMetadata = async (datasetId, tag) => {
+export const getDownloadMetadata = async (config, datasetId, tag) => {
   try {
     const response = await fetch(
-      downloadUrl(getUrl(), datasetId, tag),
+      downloadUrl(getUrl(config), datasetId, tag),
       getFetchOptions(),
     )
     if (response.status === 200) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7959,7 +7959,7 @@ cookie@0.4.0:
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.0.tgz#beb437e7022b3b6d49019d088665303ebe9c14ba"
   integrity sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==
 
-cookiejar@^2.1.0, cookiejar@^2.1.2:
+cookiejar@^2.1.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/cookiejar/-/cookiejar-2.1.2.tgz#dd8a235530752f988f9a0844f3fc589e3111125c"
   integrity sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA==
@@ -8186,6 +8186,13 @@ cross-fetch@^3.0.4:
   dependencies:
     node-fetch "2.6.0"
     whatwg-fetch "3.0.0"
+
+cross-fetch@^3.0.5:
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.0.5.tgz#2739d2981892e7ab488a7ad03b92df2816e03f4c"
+  integrity sha512-FFLcLtraisj5eteosnX1gf01qYDCOc4fDy0+euOt8Kn9YBY2NtXL/pCoYPavw24NIQkQqm5ZOLsGD5Zzj0gyew==
+  dependencies:
+    node-fetch "2.6.0"
 
 cross-spawn-async@^2.1.8:
   version "2.2.5"
@@ -10977,7 +10984,7 @@ form-data@^2.2.0:
     combined-stream "^1.0.6"
     mime-types "^2.1.12"
 
-form-data@^2.3.1, form-data@^2.3.3, form-data@^2.5.0:
+form-data@^2.3.1, form-data@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.5.0.tgz#094ec359dc4b55e7d62e0db4acd76e89fe874d37"
   integrity sha512-WXieX3G/8side6VIqx44ablyULoGruSde5PNTxoUyo5CeyAMX6nVWUd0rgist/EuX655cjhUhTo1Fo3tRYqbcA==
@@ -14404,6 +14411,14 @@ jest-fetch-mock@^1.4.1:
   dependencies:
     cross-fetch "^2.2.2"
     promise-polyfill "^7.1.1"
+
+jest-fetch-mock@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/jest-fetch-mock/-/jest-fetch-mock-3.0.3.tgz#31749c456ae27b8919d69824f1c2bd85fe0a1f3b"
+  integrity sha512-Ux1nWprtLrdrH4XwE7O7InRY6psIi3GOsqNESJgMJ+M5cv4A8Lh7SN9d2V2kKRZ8ebAfcd1LNyZguAOb6JiDqw==
+  dependencies:
+    cross-fetch "^3.0.4"
+    promise-polyfill "^8.1.3"
 
 jest-get-type@^21.2.0:
   version "21.2.0"
@@ -18898,6 +18913,11 @@ promise-polyfill@^7.1.1:
   resolved "https://registry.yarnpkg.com/promise-polyfill/-/promise-polyfill-7.1.2.tgz#ab05301d8c28536301622d69227632269a70ca3b"
   integrity sha512-FuEc12/eKqqoRYIGBrUptCBRhobL19PS2U31vMNTfyck1FxPyMfgsXyW4Mav85y/ZN1hop3hOwRlUDok23oYfQ==
 
+promise-polyfill@^8.1.3:
+  version "8.1.3"
+  resolved "https://registry.yarnpkg.com/promise-polyfill/-/promise-polyfill-8.1.3.tgz#8c99b3cf53f3a91c68226ffde7bde81d7f904116"
+  integrity sha512-MG5r82wBzh7pSKDRa9y+vllNHz3e3d4CNj1PQE4BQYxLme0gKYYBm9YENq+UkEikyZ0XbiGWxYlVw3Rl9O/U8g==
+
 promise-retry@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/promise-retry/-/promise-retry-1.1.1.tgz#6739e968e3051da20ce6497fb2b50f6911df3d6d"
@@ -19131,7 +19151,7 @@ qs@^6.4.0:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.9.1.tgz#20082c65cb78223635ab1a9eaca8875a29bf8ec9"
   integrity sha512-Cxm7/SS/y/Z3MHWSxXb8lIFqgqBowP5JMlTUFyJN88y0SGQhVmZnqFK/PeuMX9LzUyWsqqhNxIyg0jlzq946yA==
 
-qs@^6.5.1, qs@^6.6.0:
+qs@^6.5.1:
   version "6.8.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.8.0.tgz#87b763f0d37ca54200334cd57bb2ef8f68a1d081"
   integrity sha512-tPSkj8y92PfZVbinY1n84i1Qdx75lZjMQYx9WZhnkofyxzw2r7Ho39G3/aEvSUdebxpnnM4LZJCtvE/Aq3+s9w==
@@ -22403,21 +22423,6 @@ superagent@^3.6.0, superagent@^3.8.2, superagent@^3.8.3:
     mime "^1.4.1"
     qs "^6.5.1"
     readable-stream "^2.3.5"
-
-superagent@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/superagent/-/superagent-4.1.0.tgz#c465c2de41df2b8d05c165cbe403e280790cdfd5"
-  integrity sha512-FT3QLMasz0YyCd4uIi5HNe+3t/onxMyEho7C3PSqmti3Twgy2rXT4fmkTz6wRL6bTF4uzPcfkUCa8u4JWHw8Ag==
-  dependencies:
-    component-emitter "^1.2.0"
-    cookiejar "^2.1.2"
-    debug "^4.1.0"
-    form-data "^2.3.3"
-    formidable "^1.2.0"
-    methods "^1.1.1"
-    mime "^2.4.0"
-    qs "^6.6.0"
-    readable-stream "^3.0.6"
 
 supertest@^3.0.0:
   version "3.4.2"


### PR DESCRIPTION
This replaces #1697 and reworks the CLI download process to add error handling and drop the dependency on superagent.