### PR TITLE
Handle unversioned S3 objects in parse_rmet_line

### DIFF
--- a/services/datalad/datalad_service/common/annex.py
+++ b/services/datalad/datalad_service/common/annex.py
@@ -105,15 +105,14 @@ def parse_remote_line(remoteLine,
 
 def parse_rmet_line(remote, rmetLine):
     """Read one rmet line and return a valid URL for this object"""
-    remoteContext, remoteData = rmetLine.split('V +')
-    slash = '' if remote['url'][-1] == '/' else '/'
-    if '#' in remoteData:
+    try:
+        remoteContext, remoteData = rmetLine.split('V +')
+        slash = '' if remote['url'][-1] == '/' else '/'
         s3version, path = remoteData.split('#')
         return '{}{}{}?versionId={}'.format(remote['url'], slash, path, s3version)
-    else:
-        # Handle unversioned data
-        path = remoteData
-        return '{}{}{}'.format(remote['url'], slash, path)
+    except ValueError:
+        # TODO - Log this error
+        return None
 
 
 def read_rmet_file(remote, catFile):

--- a/services/datalad/datalad_service/common/annex.py
+++ b/services/datalad/datalad_service/common/annex.py
@@ -106,9 +106,14 @@ def parse_remote_line(remoteLine,
 def parse_rmet_line(remote, rmetLine):
     """Read one rmet line and return a valid URL for this object"""
     remoteContext, remoteData = rmetLine.split('V +')
-    s3version, path = remoteData.split('#')
     slash = '' if remote['url'][-1] == '/' else '/'
-    return '{}{}{}?versionId={}'.format(remote['url'], slash, path, s3version)
+    if '#' in remoteData:
+        s3version, path = remoteData.split('#')
+        return '{}{}{}?versionId={}'.format(remote['url'], slash, path, s3version)
+    else:
+        # Handle unversioned data
+        path = remoteData
+        return '{}{}{}'.format(remote['url'], slash, path)
 
 
 def read_rmet_file(remote, catFile):


### PR DESCRIPTION
This affects a few older datasets, a fallback URL is served instead but we should handle the unversioned case.