### PR TITLE
openneuro-cli: Fix deprecated use of new Buffer(<string>)

### DIFF
--- a/packages/openneuro-cli/src/files.js
+++ b/packages/openneuro-cli/src/files.js
@@ -115,7 +115,7 @@ export const generateChanges = tree => {
 
   // Create readable stream from the CHANGES file we have
   const initialChangesStream = new stream.PassThrough()
-  initialChangesStream.end(new Buffer(initialChangesContent, 'utf-8'))
+  initialChangesStream.end(Buffer.from(initialChangesContent, 'utf-8'))
   initialChangesStream.path = 'CHANGES'
 
   // Add the readable stream to the root level files list (tree.files)


### PR DESCRIPTION
This is [safer](https://nodejs.org/ko/docs/guides/buffer-constructor-deprecation/) and avoids a Node warning during upload.