### PR TITLE
Infrastructure: Add documentation for Prometheus setup

### DIFF
--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -1,0 +1,31 @@
+---
+name: Kubernetes Monitoring
+route: monitoring
+---
+
+# Infrastructure Monitoring
+
+OpenNeuro is running Prometheus and Grafana for general monitoring and alerting. The Grafana dashboard is deployed at https://monitoring.openneuro.org and an account must be requested to access it.
+
+## Install
+
+A preconfigured secret is required for SMTP credentials.
+
+```shell
+kubectl --namespace monitoring create secret generic smtp-login --from-file=user=smtp-username.txt --from-file=password=smtp-password.txt
+```
+
+These services are deployed with the stable helm charts for Prometheus and Grafana.
+
+```shell
+helm --namespace monitoring install prometheus stable/prometheus
+helm --namespace monitoring install grafana stable/grafana -f helm/grafana.yaml
+```
+
+## Upgrades
+
+To apply new configuration or update a service, run helm upgrade.
+
+```shell
+helm --namespace monitoring upgrade grafana stable/grafana -f helm/grafana.yaml
+```

--- a/helm/grafana.yaml
+++ b/helm/grafana.yaml
@@ -1,0 +1,24 @@
+grafana.ini:
+  server:
+    root_url: https://monitoring.openneuro.org
+    domain: monitoring.openneuro.org
+  smtp:
+    enabled: true
+    host: smtp.mailgun.org:587
+    from_address: monitoring@mail.openneuro.org
+smtp:
+  existingSecret: mailgun-login
+persistence:
+  enabled: true
+  size: "50Gi"
+ingress:
+  enabled: true
+  path: /*
+  annotations:
+    kubernetes.io/ingress.class: alb
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/certificate-arn: "arn:aws:acm:us-west-2:488777458602:certificate/d95b9196-db39-4783-a667-19223290c067"
+    alb.ingress.kubernetes.io/target-type: ip
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":443}]'
+  hosts:
+    - monitoring.openneuro.org


### PR DESCRIPTION
Provides some high level docs and the base configuration minus secrets.