### PR TITLE
Fix missing readme content for snapshots

### DIFF
--- a/packages/openneuro-server/src/datalad/__tests__/utils.spec.js
+++ b/packages/openneuro-server/src/datalad/__tests__/utils.spec.js
@@ -1,0 +1,42 @@
+import { datasetOrSnapshot } from '../utils.js'
+
+describe('datasetOrSnapshot()', () => {
+  it('resolves a dataset object correctly', () => {
+    const dataset = {
+      id: 'ds000001',
+      revision: 'abcfdeg',
+      modified: new Date(),
+      draft: {
+        id: 'abcfdeg',
+      },
+    }
+    expect(datasetOrSnapshot(dataset)).toEqual({
+      datasetId: 'ds000001',
+      revision: 'abcfdeg',
+    })
+  })
+  it('resolves snapshot objects correctly', () => {
+    const snapshot = {
+      id: 'ds000001:1.0.0',
+      tag: '1.0.0',
+      hexsha: 'abcfdeg',
+      modified: new Date(),
+      files: [{ id: '1234', filename: 'dataset_description.json' }],
+    }
+    expect(datasetOrSnapshot(snapshot)).toEqual({
+      datasetId: 'ds000001',
+      revision: 'abcfdeg',
+    })
+  })
+  it('resolves the snapshot tag only corner case', () => {
+    const snapshot = {
+      id: 'ds000002:1.0.1',
+      tag: '1.0.1',
+      modified: new Date(),
+    }
+    expect(datasetOrSnapshot(snapshot)).toEqual({
+      datasetId: 'ds000002',
+      revision: '1.0.1',
+    })
+  })
+})

--- a/packages/openneuro-server/src/datalad/readme.js
+++ b/packages/openneuro-server/src/datalad/readme.js
@@ -3,6 +3,7 @@ import { addFileString, commitFiles } from './dataset'
 import { redis } from '../libs/redis'
 import CacheItem, { CacheType } from '../cache/item'
 import { getDatasetWorker } from '../libs/datalad-service'
+import { datasetOrSnapshot } from './utils.js'
 
 export const readmeUrl = (datasetId, revision) => {
   return `http://${getDatasetWorker(
@@ -10,9 +11,8 @@ export const readmeUrl = (datasetId, revision) => {
   )}/datasets/${datasetId}/snapshots/${revision}/files/README`
 }
 
-export const readme = async obj => {
-  const datasetId = obj.id
-  const revision = obj.revision || obj.tag
+export const readme = obj => {
+  const { datasetId, revision } = datasetOrSnapshot(obj)
   const cache = new CacheItem(redis, CacheType.readme, [
     datasetId,
     revision.substring(0, 7),

--- a/packages/openneuro-server/src/datalad/utils.js
+++ b/packages/openneuro-server/src/datalad/utils.js
@@ -19,3 +19,15 @@ export const addFileUrl = (datasetId, tag) => file => {
     }
   }
 }
+
+/**
+ * Helper for resolvers with dataset and snapshot parents
+ * @param {object} obj A snapshot or dataset parent object
+ */
+export function datasetOrSnapshot(obj) {
+  if ('tag' in obj) {
+    return { datasetId: obj.id.split(':')[0], revision: obj.hexsha || obj.tag }
+  } else {
+    return { datasetId: obj.id, revision: obj.revision }
+  }
+}


### PR DESCRIPTION
This is a regression introduced in #1729

The issue is the readme and description resolvers can both be called from either a dataset or snapshot context. There was different logic for handling this, breaking the readme version. This PR consolidates it to a function and adds some unit tests for the shared function.