### PR TITLE
Refactor upload API to use Falcon and enable for openneuro-cli

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -2,3 +2,4 @@ singleQuote: true
 jsxBracketSameLine: true
 semi: false
 trailingComma: all
+arrowParens: avoid

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 # docker compose versions
-version: '2.3'
+version: "2.3"
 
 # shared volumes
 volumes:
@@ -28,7 +28,7 @@ services:
       - webpack_cache:/webpack-cache
       - ./packages/openneuro-app/src:/srv/packages/openneuro-app/src
     ports:
-      - '8145:8145'
+      - "8145:8145"
 
   # crn node server
   server:
@@ -52,8 +52,6 @@ services:
     depends_on:
       - server
       - elasticsearch
-    extends:
-      service: nodejs
 
   content:
     image: ${CONTENT_IMAGE}
@@ -80,6 +78,24 @@ services:
       - ./services/datalad/datalad_service:/datalad_service
     env_file: ./config.env
     init: true
+    command:
+      [
+        "gunicorn",
+        "--bind",
+        "0.0.0.0:80",
+        "--reload",
+        "datalad_service.app:create_app('/datalad')",
+        "--workers",
+        "8",
+        "--worker-class",
+        "gevent",
+        "--timeout",
+        "60",
+        "--keep-alive",
+        "30",
+        "--log-level",
+        "debug",
+      ]
     networks:
       default:
         aliases:
@@ -94,9 +110,9 @@ services:
     volumes_from:
       - content
     ports:
-      - '80:80'
-      - '8110:8110'
-      - '9876:80'
+      - "80:80"
+      - "8110:8110"
+      - "9876:80"
     depends_on:
       - server
       - datalad
@@ -105,10 +121,10 @@ services:
     image: elasticsearch:7.5.1
     environment:
       discovery.type: single-node
-      cluster.routing.allocation.disk.threshold_enabled: 'true'
+      cluster.routing.allocation.disk.threshold_enabled: "true"
       cluster.routing.allocation.disk.watermark.flood_stage: 1gb
       cluster.routing.allocation.disk.watermark.low: 10gb
       cluster.routing.allocation.disk.watermark.high: 5gb
     ports:
-      - '9200:9200'
-      - '9300:9300'
+      - "9200:9200"
+      - "9300:9300"

--- a/nginx/nginx.dev.conf
+++ b/nginx/nginx.dev.conf
@@ -11,6 +11,17 @@ server {
     # Use a variable to allow for IP changes when a new container starts
     # https://www.nginx.com/blog/dns-service-discovery-nginx-plus/#domain-name-proxy_pass
     set $openneuro_server server;
+    set $datalad_service datalad;
+
+    location /uploads {
+        client_max_body_size 0;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header Connection "";
+        proxy_http_version 1.1;
+        proxy_request_buffering off;
+        proxy_pass http://$datalad_service:80;
+    }
 
     # crn-server proxy
     location /crn {

--- a/packages/openneuro-cli/package.json
+++ b/packages/openneuro-cli/package.json
@@ -16,7 +16,9 @@
     "openneuro": "./src/index.js"
   },
   "dependencies": {
+    "abort-controller": "^3.0.0",
     "bids-validator": "1.5.4",
+    "cli-progress": "^3.8.2",
     "commander": "^2.15.1",
     "cross-fetch": "^3.0.5",
     "esm": "^3.0.16",
@@ -24,7 +26,8 @@
     "graphql-tag": "^2.10.3",
     "inquirer": "^5.2.0",
     "mkdirp": "^0.5.1",
-    "openneuro-client": "^3.17.6"
+    "openneuro-client": "^3.17.6",
+    "node-fetch": "^2.6.0"
   },
   "scripts": {
     "openneuro": "node src/index.js"
@@ -46,6 +49,6 @@
   },
   "devDependencies": {
     "jest-fetch-mock": "^3.0.3",
-    "metro-memory-fs": "^0.31.0"
+    "metro-memory-fs": "0.61.0"
   }
 }

--- a/packages/openneuro-cli/src/__tests__/files.spec.js
+++ b/packages/openneuro-cli/src/__tests__/files.spec.js
@@ -1,83 +1,35 @@
+import os from 'os'
 import fs from 'fs'
 import path from 'path'
 import * as files from '../files'
 
 let tmpPath
-
-// Must be require for Jest's implementation
-jest.mock('fs', () => new (require('metro-memory-fs'))())
+const testFiles = ['test', 'test2', 'dir/test3', 'dir/dir2/test4', 'dir3/test5']
 
 describe('files.js', () => {
-  describe('getFileTree', () => {
+  describe('getFileTree()', () => {
     beforeEach(() => {
-      fs.reset()
-      tmpPath = '/testing'
+      tmpPath = fs.mkdtempSync(path.join(os.tmpdir(), 'openneuro-cli-tests'))
       // Some directory complexity to test against
-      fs.mkdirSync(tmpPath)
       fs.mkdirSync(path.join(tmpPath, 'dir'))
       fs.mkdirSync(path.join(tmpPath, 'dir/dir2'))
       fs.mkdirSync(path.join(tmpPath, 'dir3'))
-      const testFiles = [
-        'test',
-        'test2',
-        'dir/test3',
-        'dir/dir2/test4',
-        'dir3/test5',
-      ]
       for (const filePath of testFiles) {
         fs.writeFileSync(path.join(tmpPath, filePath), filePath)
       }
     })
-    it('should return a tree', done => {
-      files
-        .getFileTree(tmpPath, tmpPath, false)
-        .then(tree => {
-          expect(tree).toHaveProperty('files')
-          expect(tree.files).toHaveLength(2)
-          expect(tree).toHaveProperty('directories')
-          expect(tree.directories).toHaveLength(2)
-          expect(tree.directories[0]).toHaveProperty('directories')
-          expect(tree.directories[0].files).toHaveLength(1)
-        })
-        .then(done)
-    })
-    it('should include relative directory names at each node', done => {
-      files
-        .getFileTree(tmpPath, tmpPath, false)
-        .then(tree => {
-          expect(tree).toHaveProperty('name')
-          expect(tree.name).toBe('')
-          expect(tree.directories[0].name).toBe('dir')
-        })
-        .then(done)
+    it('should walk a tree successfully', async () => {
+      for await (const f of files.getFiles(tmpPath)) {
+        expect(testFiles).toContain(path.relative(tmpPath, f))
+      }
     })
   })
-  describe('fileProgress', () => {
-    it('returns a valid percentage', () => {
-      const progress = files.fileProgress(
-        { log: jest.fn() },
-        'test',
-        { bytesRead: 100 },
-        200,
-      )()
-      expect(progress.percentage).toBe(50)
-    })
-    it('returns a correct remainingBytes', () => {
-      const progress = files.fileProgress(
-        { log: jest.fn() },
-        'test',
-        { bytesRead: 100 },
-        200,
-      )()
-      expect(progress.remainingBytes).toBe(100)
-    })
-    it('formats status with all values', () => {
-      const mockConsole = { log: jest.fn() }
-      files.fileProgress(mockConsole, 'test', { bytesRead: 100 }, 200)()
-      expect(mockConsole.log).toHaveBeenCalled()
-      expect(mockConsole.log).toHaveBeenCalledWith(
-        'Transferring "test" - 50% complete (100 Bytes) remaining)',
-      )
+  describe('bytesToSize()', () => {
+    it('Returns correct output for various units', () => {
+      expect(files.bytesToSize(50)).toEqual('50 Bytes')
+      expect(files.bytesToSize(1024)).toEqual('1.0 KB')
+      expect(files.bytesToSize(65536)).toEqual('64.0 KB')
+      expect(files.bytesToSize(999999999999999)).toEqual('909.5 TB')
     })
   })
 })

--- a/packages/openneuro-cli/src/datasets.js
+++ b/packages/openneuro-cli/src/datasets.js
@@ -43,7 +43,7 @@ export const createDataset = (client, dir) => {
     .then(({ data }) => {
       const dsId = data.createDataset.id
       // eslint-disable-next-line no-console
-      console.log(`"${dsId}" created with label "${label}"`)
+      console.log(`"${dsId}" created`)
       return dsId
     })
 }

--- a/packages/openneuro-cli/src/files.js
+++ b/packages/openneuro-cli/src/files.js
@@ -1,124 +1,26 @@
-import fs from 'fs'
-import { createLazyReadStream } from './lazyReadStream.js'
+import { promises as fs } from 'fs'
 import path from 'path'
-import stream from 'stream'
-import { promisify } from 'util'
-import { debounce } from './utils'
 
-const readdir = promisify(fs.readdir)
-
-const bytesToSize = bytes => {
+export const bytesToSize = bytes => {
   const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB']
   if (bytes === 0) return 'n/a'
   const i = parseInt(String(Math.floor(Math.log(bytes) / Math.log(1024))), 10)
-  if (i === 0) return `${bytes} ${sizes[i]})`
+  if (i === 0) return `${bytes} ${sizes[i]}`
   return `${(bytes / 1024 ** i).toFixed(1)} ${sizes[i]}`
 }
 
-export const fileProgress = (console, relativePath, stream, size) => () => {
-  const percentage = Math.round(100 * (stream.bytesRead / size))
-  const remainingBytes = size - stream.bytesRead
-  const remaining = remainingBytes
-    ? `(${bytesToSize(remainingBytes)} remaining)`
-    : ''
-  console.log(
-    `Transferring "${relativePath}" - ${percentage}% complete ${remaining}`,
-  )
-  return { percentage, remainingBytes }
-}
-
-export const getFileTree = (
-  basepath,
-  root,
-  { remoteFiles, logging = true },
-) => {
-  return readdir(root).then(async contents => {
-    // Run stat for each file
-    const stats = contents.map(filePath => ({
-      filePath: path.join(root, filePath),
-      relativePath: path.join(path.relative(basepath, root), filePath),
-      stat: fs.statSync(path.join(root, filePath)),
-    }))
-    // Divide into files and directories
-    // Return streams for files, recurse for directories
-    // Ignores all other file types (we do not handle them)
-    return {
-      name: path.relative(basepath, root),
-      files: stats
-        .filter(({ stat, relativePath }) => {
-          // Only include files
-          if (stat.isFile()) {
-            // Remote file check enabled
-            if (remoteFiles) {
-              const remoteFile = remoteFiles.find(
-                rFile => rFile.filename === relativePath,
-              )
-              // File exists remotely
-              if (remoteFile) {
-                // File is the same size
-                if (remoteFile.size === stat.size) {
-                  if (logging) {
-                    // eslint-disable-next-line no-console
-                    console.log(`Skipping existing file - "${relativePath}"`)
-                  }
-                  // Skip existing files
-                  return false
-                }
-              }
-            }
-            // Include any other files
-            return true
-          } else {
-            // Skip directories
-            return false
-          }
-        })
-        .map(({ stat, filePath, relativePath }) => {
-          const stream = createLazyReadStream(filePath)
-          stream.pause()
-          if (logging) {
-            stream.on(
-              'data',
-              debounce(
-                fileProgress(console, relativePath, stream, stat.size),
-                500,
-              ),
-            )
-          }
-          return stream
-        }),
-      directories: await Promise.all(
-        // This is an array of each promise related to the next level in the tree
-        stats
-          .filter(({ stat }) => stat.isDirectory())
-          .map(({ filePath }) =>
-            getFileTree(basepath, filePath, { logging, remoteFiles }),
-          ),
-      ),
+/**
+ * Simplified generator walk of all files in a tree
+ * @param {string} dir
+ */
+export async function* getFiles(dir) {
+  const dirents = await fs.readdir(dir, { withFileTypes: true })
+  for (const dirent of dirents) {
+    const res = path.resolve(dir, dirent.name)
+    if (dirent.isDirectory()) {
+      yield* getFiles(res)
+    } else {
+      yield res
     }
-  })
-}
-
-export const generateChanges = tree => {
-  // Determine if the files list has a CHANGES file already
-  const hasChanges =
-    tree.files && tree.files.some(f => f.path.endsWith('CHANGES'))
-
-  // Do nothing if the file already exists
-  if (hasChanges) return tree
-
-  // Construct the initial content of the CHANGES file
-  const snapshotText = 'Initial snapshot'
-  const date = new Date().toISOString().substring(0, 10)
-  const versionString = '1.0.0'
-  const initialChangesContent = `\n${versionString}\t${date}\n\n\t- ${snapshotText}`
-
-  // Create readable stream from the CHANGES file we have
-  const initialChangesStream = new stream.PassThrough()
-  initialChangesStream.end(Buffer.from(initialChangesContent, 'utf-8'))
-  initialChangesStream.path = 'CHANGES'
-
-  // Add the readable stream to the root level files list (tree.files)
-  tree.files.push(initialChangesStream)
-  return tree
+  }
 }

--- a/packages/openneuro-cli/src/upload.js
+++ b/packages/openneuro-cli/src/upload.js
@@ -1,7 +1,14 @@
+import cliProgress from 'cli-progress'
+import path from 'path'
+import fetch from 'node-fetch'
+import inquirer from 'inquirer'
+import { AbortController } from 'abort-controller'
+import { createReadStream, promises as fs } from 'fs'
 import { inspect } from 'util'
-import { files } from 'openneuro-client'
+import { files, uploads } from 'openneuro-client'
 import validate from 'bids-validator'
-import { getFileTree, generateChanges } from './files'
+import { getFiles, bytesToSize } from './files'
+import { getUrl } from './config'
 import consoleFormat from 'bids-validator/utils/consoleFormat'
 
 /**
@@ -71,18 +78,127 @@ export const uploadTree = (client, datasetId) => tree => {
 }
 
 /**
- * Read and upload a dataset directory
+ * Calculate the diff and prepare an upload
  *
- * @param {Object} client - Initialized Apollo client to upload with
+ * @param {Object} client - Initialized Apollo client to call prepareUpload and finishUpload
  * @param {string} dir - Directory to upload
- * @param {Object} options - {datasetId: 'ds000001', delete: false, files: [paths, to, exclude]}
+ * @param {Object} options Query parameters for prepareUpload mutation
+ * @param {string} options.datasetId Accession number
+ * @param {Array<object>} options.remoteFiles An array of files available in HEAD, matching files are skipped
+ * @returns {Promise<Object>} prepareUpload mutation fields {id, token, files}
  */
-export const uploadDirectory = (client, dir, { datasetId, remoteFiles }) => {
-  return getFileTree(dir, dir, { remoteFiles })
-    .then(tree => {
-      tree = generateChanges(tree)
-      tree.files = files.sortFiles(tree.files)
-      return uploadTree(client, datasetId)(tree)
+export const prepareUpload = async (
+  client,
+  dir,
+  { datasetId, remoteFiles },
+) => {
+  const files = []
+  for await (const f of getFiles(dir)) {
+    const rel = path.relative(dir, f)
+    const remote = remoteFiles.find(remote => remote.filename === rel)
+    const { size } = await fs.stat(f)
+    if (remote) {
+      if (remote.size !== size) {
+        files.push({ filename: rel, path: f, size })
+      }
+    } else {
+      files.push({ filename: rel, path: f, size })
+    }
+  }
+  console.log(
+    '=======================================================================',
+  )
+  if (files.length < 12) {
+    console.log('Files to be uploaded:')
+    for (const f of files) {
+      console.log(`${f.filename} - ${bytesToSize(f.size)}`)
+    }
+  } else {
+    const totalSize = files.map(f => f.size).reduce((a, b) => a + b)
+    console.log(
+      `${files.length} files to be uploaded with a total size of ${bytesToSize(
+        totalSize,
+      )}`,
+    )
+  }
+  await inquirer.prompt({
+    type: 'confirm',
+    name: 'start',
+    message: 'Begin upload?',
+    default: true,
+  })
+  console.log(
+    '=======================================================================',
+  )
+  // Filter out local paths in mutation
+  const mutationFiles = files.map(f => ({ filename: f.filename, size: f.size }))
+  const { data } = await client.mutate({
+    mutation: uploads.prepareUpload,
+    variables: { datasetId, files: mutationFiles },
+  })
+  const id = data.prepareUpload.id
+  // eslint-disable-next-line no-console
+  console.log(`Starting a new upload (${id}) to dataset: '${datasetId}'`)
+  return {
+    id,
+    datasetId: data.prepareUpload.datasetId,
+    token: data.prepareUpload.token,
+    files,
+  }
+}
+
+/**
+ * Convert to URL compatible path
+ * @param {String} path
+ */
+export const encodeFilePath = path => {
+  return path.replace(new RegExp('/', 'g'), ':')
+}
+
+export const uploadFiles = async ({ id, datasetId, token, files }) => {
+  const uploadProgress = new cliProgress.SingleBar({
+    format:
+      datasetId + ' [{bar}] {percentage}% | ETA: {eta}s | {value}/{total}',
+    clearOnComplete: false,
+    hideCursor: true,
+  })
+  const rootUrl = getUrl()
+  uploadProgress.start(files.length, 0, {
+    speed: 'N/A',
+  })
+  for (const f of files) {
+    // http://localhost:9876/uploads/ds001024/0de963b9-1a2a-4bcc-af3c-fef0345780b0/dataset_description.json
+    const encodedFilePath = encodeFilePath(f.filename)
+    const fileUrl = `${rootUrl}uploads/${datasetId}/${id}/${encodedFilePath}`
+    const fileStream = createReadStream(f.path)
+    // This is needed to cancel the request in case of client errors
+    const controller = new AbortController()
+    fileStream.on('error', err => {
+      console.error(err)
+      controller.abort()
     })
-    .then(() => datasetId)
+    const response = await fetch(fileUrl, {
+      method: 'POST',
+      headers: {
+        cookie: `accessToken=${token}`,
+      },
+      body: fileStream,
+      signal: controller.signal,
+    })
+    if (response.status === 200) {
+      uploadProgress.increment()
+    } else {
+      uploadProgress.stop()
+      console.error(response)
+      throw new Error(`Failed to upload file "${f.filename}"`)
+    }
+  }
+  uploadProgress.stop()
+}
+
+export const finishUpload = (client, uploadId) => {
+  return client.mutate({
+    mutation: uploads.finishUpload,
+    variables: { uploadId: uploadId },
+  })
 }

--- a/packages/openneuro-client/src/client.js
+++ b/packages/openneuro-client/src/client.js
@@ -12,6 +12,7 @@ import * as files from './files'
 import * as datasets from './datasets'
 import * as snapshots from './snapshots'
 import * as users from './users'
+import * as uploads from './uploads'
 import datasetGenerator from './datasetGenerator.js'
 import { version } from '../package.json'
 
@@ -176,4 +177,12 @@ const createClient = (uri, options = {}) => {
   return new ApolloClient(apolloClientOptions)
 }
 
-export { files, datasets, snapshots, users, datasetGenerator, createClient }
+export {
+  files,
+  datasets,
+  snapshots,
+  users,
+  datasetGenerator,
+  createClient,
+  uploads,
+}

--- a/packages/openneuro-client/src/uploads.js
+++ b/packages/openneuro-client/src/uploads.js
@@ -1,0 +1,17 @@
+import gql from 'graphql-tag'
+
+export const prepareUpload = gql`
+  mutation prepareUpload($datasetId: ID!, $files: [UploadFile]!) {
+    prepareUpload(datasetId: $datasetId, files: $files) {
+      id
+      datasetId
+      token
+    }
+  }
+`
+
+export const finishUpload = gql`
+  mutation finishUpload($uploadId: ID!) {
+    finishUpload(uploadId: $uploadId)
+  }
+`

--- a/packages/openneuro-server/src/datalad/upload.js
+++ b/packages/openneuro-server/src/datalad/upload.js
@@ -1,0 +1,32 @@
+import fetch from 'node-fetch'
+import { getDatasetWorker } from '../libs/datalad-service'
+
+export const uploadUrl = (datasetId, uploadId) => {
+  return `http://${getDatasetWorker(
+    datasetId,
+  )}/datasets/${datasetId}/upload/${uploadId}`
+}
+
+/**
+ * Request datalad-service merge an upload into a draft
+ * @param {string} datasetId
+ * @param {string} uploadId
+ * @param {string} forwardToken Single use JWT for making the final commit
+ * @returns {Promise<object>}
+ */
+export const finishUploadRequest = async (
+  datasetId,
+  uploadId,
+  forwardToken,
+) => {
+  const response = await fetch(uploadUrl(datasetId, uploadId), {
+    method: 'POST',
+    body: JSON.stringify({}),
+    headers: {
+      cookie: `accessToken=${forwardToken}`,
+    },
+  })
+  if (response.status !== 200) {
+    throw new Error(`Finish upload request failed - ${response.statusText}`)
+  }
+}

--- a/packages/openneuro-server/src/graphql/resolvers/dataset.js
+++ b/packages/openneuro-server/src/graphql/resolvers/dataset.js
@@ -136,7 +136,7 @@ export const updateFiles = async (
     const snapshot = await Snapshot.findOne({
       datasetId,
     }).exec()
-    if (!snapshot) await createSnapshot(datasetId, '1.0.0', user)
+    if (!snapshot) await createSnapshot(datasetId, '1.0.0', userInfo)
     pubsub.publish('filesUpdated', {
       datasetId,
       filesUpdated: {

--- a/packages/openneuro-server/src/graphql/resolvers/mutation.js
+++ b/packages/openneuro-server/src/graphql/resolvers/mutation.js
@@ -24,6 +24,7 @@ import { updateReadme } from './readme.js'
 import { addComment, editComment, deleteComment } from './comment.js'
 import { subscribeToNewsletter } from './newsletter'
 import { addMetadata } from './metadata.js'
+import { prepareUpload, finishUpload } from './upload.js'
 
 const Mutation = {
   createDataset,
@@ -54,6 +55,8 @@ const Mutation = {
   subscribeToNewsletter,
   addMetadata,
   updateRef,
+  prepareUpload,
+  finishUpload,
 }
 
 export default Mutation

--- a/packages/openneuro-server/src/graphql/resolvers/upload.js
+++ b/packages/openneuro-server/src/graphql/resolvers/upload.js
@@ -1,0 +1,56 @@
+import Upload from '../../models/upload.js'
+import { checkDatasetWrite } from '../permissions.js'
+import { generateUploadToken } from '../../libs/authentication/jwt.js'
+import { finishUploadRequest } from '../../datalad/upload.js'
+
+/**
+ * Track initial state for a new upload
+ *
+ * This allocates a token and stores the list of expected files and sizes allowing for final validation
+ * @param {object} obj Parent object or null
+ * @param {object} arguments Resolver arguments
+ * @param {string} arguments.datasetId Accession number string
+ * @param {object} context Resolver context
+ * @param {string} context.user User id
+ * @param {object} context.userInfo Decoded userInfo from token
+ */
+export async function prepareUpload(
+  obj,
+  { datasetId, files },
+  { user, userInfo },
+) {
+  await checkDatasetWrite(datasetId, user, userInfo)
+  const upload = new Upload({ datasetId, files })
+  await upload.save()
+  const token = generateUploadToken(userInfo, datasetId)
+  const UploadMetadata = {
+    ...upload.toObject(),
+    token,
+  }
+  return UploadMetadata
+}
+
+/**
+ * Complete an upload by committing the files to the dataset and advancing the draft revision pointer
+ *
+ * Forwards this request to datalad-service
+ * @param {object} obj Parent object or null
+ * @param {object} arguments Resolver arguments
+ * @param {string} arguments.id Upload id to finish (originally returned by prepareUpload)
+ * @param {object} context Resolver context
+ * @param {string} context.user User id
+ * @param {object} context.userInfo Decoded userInfo from token
+ */
+export async function finishUpload(obj, { uploadId }, { user, userInfo }) {
+  const upload = await Upload.findOne({ id: uploadId })
+  const datasetId = upload.datasetId
+  await checkDatasetWrite(datasetId, user, userInfo)
+  await finishUploadRequest(
+    datasetId,
+    uploadId,
+    generateUploadToken(userInfo, datasetId, 600),
+  )
+  upload.complete = true
+  await upload.save()
+  return upload.complete
+}

--- a/packages/openneuro-server/src/graphql/schema.js
+++ b/packages/openneuro-server/src/graphql/schema.js
@@ -148,6 +148,15 @@ export const typeDefs = `
     addMetadata(datasetId: ID!, metadata: MetadataInput!): Metadata
     # Update draft reference pointer
     updateRef(datasetId: ID!, ref: String!): Boolean
+    # Start an upload
+    prepareUpload(datasetId: ID!, files: [UploadFile]): UploadMetadata
+    # Add files from a completed upload to the dataset draft
+    finishUpload(uploadId: ID!): Boolean
+  }
+
+  input UploadFile {
+    filename: String!
+    size: BigInt!
   }
 
   input SummaryInput {
@@ -277,6 +286,22 @@ export const typeDefs = `
     datasetId: ID
   }
 
+  # Client metadata needed to complete an upload
+  type UploadMetadata {
+    # Unique identifier for this upload
+    id: ID!
+    # Dataset associated with this upload
+    datasetId: ID!
+    # File status
+    files: [DatasetFile]
+    # Is this a complete upload (do we allow a resume or not?)
+    complete: Boolean!
+    # Estimated size in bytes (this is just used for progress display and can be inaccurate)
+    estimatedSize: BigInt
+    # On the first request, this token is returned to allow uploads into this upload bucket
+    token: String
+  }
+
   # Top level dataset, one draft and many snapshots
   type Dataset {
     id: ID!
@@ -327,6 +352,8 @@ export const typeDefs = `
     description: Description
     # Dataset README
     readme: String
+    # Uploads in progress or recently completed
+    uploads: [UploadMetadata]
   }
 
   # Tagged snapshot of a draft

--- a/packages/openneuro-server/src/libs/datalad-service.js
+++ b/packages/openneuro-server/src/libs/datalad-service.js
@@ -13,12 +13,18 @@ export function hashDatasetToRange(dataset, range) {
 }
 
 /**
+ * Obtain the statefulset or replica worker number for a dataset
+ * @param {string} dataset Accession number string - e.g. ds000001
+ * @returns {number}
+ */
+export function getDatasetEndpoint(dataset) {
+  return hashDatasetToRange(dataset, parseInt(config.datalad.workers))
+}
+
+/**
  * Find the statefulset or replica URL for a given dataset
  * @param {string} dataset
  */
 export function getDatasetWorker(dataset) {
-  return `${config.datalad.uri}-${hashDatasetToRange(
-    dataset,
-    parseInt(config.datalad.workers),
-  )}`
+  return `${config.datalad.uri}-${getDatasetEndpoint(dataset)}`
 }

--- a/packages/openneuro-server/src/models/upload.js
+++ b/packages/openneuro-server/src/models/upload.js
@@ -1,0 +1,19 @@
+import uuid from 'uuid'
+import mongoose from 'mongoose'
+
+/**
+ * Track state for uploads in progress
+ *
+ * newFiles excludes files in existing commits, as those are handled by other resolvers
+ */
+const uploadSchema = new mongoose.Schema({
+  id: { type: String, required: true, default: uuid.v4 },
+  datasetId: { type: String, required: true },
+  files: Array,
+  estimatedSize: Number,
+  complete: { type: Boolean, default: false, required: true },
+})
+
+const Upload = mongoose.model('Upload', uploadSchema)
+
+export default Upload

--- a/services/datalad/Dockerfile
+++ b/services/datalad/Dockerfile
@@ -22,4 +22,6 @@ RUN apk --update add bash yarn git python3 py3-pip openssl openssh ca-certificat
   && chmod 600 /root/.ssh/config \
   && yarn
 
+ENV LOCPATH=""
+
 CMD ["gunicorn", "--bind", "0.0.0.0:80", "--reload", "datalad_service.app:create_app('/datalad')", "--workers", "8", "--worker-class", "gevent", "--timeout", "60", "--keep-alive", "30"]

--- a/services/datalad/datalad_service/common/draft.py
+++ b/services/datalad/datalad_service/common/draft.py
@@ -12,13 +12,12 @@ def draft_revision_mutation(dataset_id, ref):
     }
 
 
-def update_head(store, dataset, cookies=None):
+def update_head(ds, dataset_id, cookies=None):
     """Pass HEAD commit references back to OpenNeuro"""
-    ds = store.get_dataset(dataset)
     ref = ds.repo.get_hexsha()
     # We may want to detect if we need to run validation here?
-    validate_dataset(dataset, ds.path, ref)
+    validate_dataset(dataset_id, ds.path, ref)
     r = requests.post(url=GRAPHQL_ENDPOINT,
-                      json=draft_revision_mutation(dataset, ref), cookies=cookies)
+                      json=draft_revision_mutation(dataset_id, ref), cookies=cookies)
     if r.status_code != 200:
         raise Exception(r.text)

--- a/services/datalad/datalad_service/datalad.py
+++ b/services/datalad/datalad_service/datalad.py
@@ -16,3 +16,7 @@ class DataladStore(object):
     def get_dataset_path(self, name):
         return path.join(self.annex_path, name)
 
+    def get_upload_path(self, dataset, upload):
+        prefix_a = upload[0:2]
+        prefix_b = upload[2:4]
+        return path.join(self.annex_path, 'uploads', dataset, prefix_a, prefix_b, upload)

--- a/services/datalad/datalad_service/handlers/upload.py
+++ b/services/datalad/datalad_service/handlers/upload.py
@@ -1,0 +1,42 @@
+import glob
+import logging
+import os
+import shutil
+
+import falcon
+import gevent
+import sentry_sdk
+
+from datalad_service.common.user import get_user_info
+from datalad_service.common.draft import update_head
+from datalad_service.common.annex import CommitInfo
+
+
+class UploadResource(object):
+    def __init__(self, store):
+        self.store = store
+        self.logger = logging.getLogger('datalad_service.' + __name__)
+
+    def _finish_upload(self, dataset_id, upload, name, email, cookies):
+        try:
+            ds = self.store.get_dataset(dataset_id)
+            with CommitInfo(ds, name, email):
+                upload_path = self.store.get_upload_path(dataset_id, upload)
+                unlock_files = [os.path.relpath(filename, start=upload_path) for filename in glob.iglob(
+                    upload_path + '**/**', recursive=True) if os.path.islink(os.path.join(ds.path, os.path.relpath(filename, start=upload_path)))]
+                ds.unlock(unlock_files)
+                shutil.copytree(upload_path, ds.path, dirs_exist_ok=True)
+                shutil.rmtree(upload_path)
+                ds.save(unlock_files)
+                update_head(ds, dataset_id, cookies)
+        except:
+            self.logger.exception('Dataset upload could not be finalized')
+            sentry_sdk.capture_exception()
+
+    def on_post(self, req, resp, dataset, upload):
+        """Copy uploaded data into dataset"""
+        name, email = get_user_info(req)
+        gevent.spawn(self._finish_upload, dataset,
+                     upload, name, email, req.cookies)
+        resp.media = {}
+        resp.status = falcon.HTTP_OK

--- a/services/datalad/datalad_service/handlers/upload_file.py
+++ b/services/datalad/datalad_service/handlers/upload_file.py
@@ -1,0 +1,70 @@
+import os
+import logging
+
+import falcon
+
+from datalad_service.common.user import get_user_info
+from datalad_service.handlers.upload import UploadResource
+
+
+class UploadFileResource(UploadResource):
+    # Chunk size is aligned with filesystem block size to obtain the fastest write speed
+    _CHUNK_SIZE_BYTES = 16384
+
+    def __init__(self, store):
+        self.store = store
+        self.logger = logging.getLogger('datalad_service.' + __name__)
+
+    def _check_access(self, req, dataset, upload):
+        user = 'user' in req.context and req.context['user'] or None
+        # Check that this request includes the correct token
+        if user != None and 'dataset:upload' in user['scopes'] and user['dataset'] == dataset:
+            return True
+        else:
+            return False
+
+    def _handle_failed_access(self, req, resp):
+        """Attach errors to the resp if auth failed."""
+        user = 'user' in req.context and req.context['user'] or None
+        # No user = unauthorized, otherwise token is present with the wrong scope/grant
+        if user == None:
+            resp.media = {'error': 'Authentication required for uploads'}
+            resp.status = falcon.HTTP_UNAUTHORIZED
+        else:
+            resp.media = {
+                'error': 'You do not have permission to access this dataset'}
+            resp.status = falcon.HTTP_FORBIDDEN
+
+    def _update_file(self, path, stream):
+        """Update a file on disk with a path and source stream."""
+        with open(path, 'wb') as new_file:
+            # Stream file to disk
+            while True:
+                chunk = stream.read(self._CHUNK_SIZE_BYTES)
+                if not chunk:
+                    break
+                new_file.write(chunk)
+
+    def on_post(self, req, resp, dataset, upload, filename):
+        # Check that this request includes the correct token
+        if self._check_access(req, dataset, upload):
+            upload_path = self.store.get_upload_path(dataset, upload)
+            # Save one file
+            file_path = os.path.join(upload_path, filename)
+            # Make any missing parent directories
+            os.makedirs(os.path.dirname(file_path), exist_ok=True)
+            self._update_file(file_path, req.stream)
+            resp.media = {}
+            resp.status = falcon.HTTP_OK
+        else:
+            self._handle_failed_access(req, resp)
+
+    def on_get(self, req, resp, dataset, upload):
+        """Return the current upload state, files and sizes."""
+        if self._check_access(req, dataset, upload):
+            upload_path = self.store.get_upload_path(dataset, upload)
+            uploaded_files = os.listdir(upload_path)
+            resp.status = falcon.HTTP_OK
+            resp.media = {"files": uploaded_files}
+        else:
+            self._handle_failed_access(req, resp)

--- a/services/datalad/datalad_service/middleware/auth.py
+++ b/services/datalad/datalad_service/middleware/auth.py
@@ -21,13 +21,17 @@ class AuthenticateMiddleware(object):
                     cookies['accessToken'], key=os.environ['JWT_SECRET'])
                 with configure_scope() as scope:
                     sentry_user = req.context['user'].copy()
-                    sentry_user['id'] = sentry_user['sub']
+                    try:
+                        sentry_user['id'] = sentry_user['sub']
+                    except KeyError:
+                        raise Exception(sentry_user)
                     del(sentry_user['sub'])
                     scope.user = sentry_user
             except:
                 req.context['user'] = None
                 with configure_scope() as scope:
                     scope.user = None
+                raise
         else:
             with configure_scope() as scope:
                 scope.user = None

--- a/services/datalad/datalad_service/tasks/files.py
+++ b/services/datalad/datalad_service/tasks/files.py
@@ -72,7 +72,7 @@ def remove_files(store, dataset, files, name=None, email=None, cookies=None):
     with CommitInfo(ds, name, email):
         for filename in files:
             ds.remove(filename, check=False)
-            update_head(store, dataset, cookies)
+            update_head(ds, dataset, cookies)
 
 
 def remove_recursive(store, dataset, path, name=None, email=None, cookies=None):
@@ -80,4 +80,4 @@ def remove_recursive(store, dataset, path, name=None, email=None, cookies=None):
     ds = store.get_dataset(dataset)
     with CommitInfo(ds, name, email):
         ds.remove(path, recursive=True, check=False)
-        update_head(store, dataset, cookies)
+        update_head(ds, dataset, cookies)

--- a/services/datalad/datalad_service/tasks/validator.py
+++ b/services/datalad/datalad_service/tasks/validator.py
@@ -27,7 +27,7 @@ def validate_dataset_sync(dataset_path, ref):
             ['./node_modules/.bin/bids-validator', '--json', dataset_path], stdout=subprocess.PIPE, timeout=300)
         return json.loads(process.stdout)
     except subprocess.TimeoutExpired:
-        sentry_sdk.captureException()
+        sentry_sdk.capture_exception()
 
 
 def summary_mutation(dataset_id, ref, validator_output):

--- a/services/datalad/tests/dataset_fixtures.py
+++ b/services/datalad/tests/dataset_fixtures.py
@@ -130,8 +130,13 @@ def no_init_remote(monkeypatch):
                         "create_sibling_github", mock_publish)
 
 
+@pytest.fixture(autouse=True)
+def mock_jwt_secret(monkeypatch):
+    monkeypatch.setenv('JWT_SECRET', 'test-secret-please-ignore')
+
+
 @pytest.fixture
-def client(datalad_store):
+def client(datalad_store, monkeypatch):
     return testing.TestClient(create_app(datalad_store.annex_path))
 
 

--- a/services/datalad/tests/test_upload.py
+++ b/services/datalad/tests/test_upload.py
@@ -1,0 +1,27 @@
+import falcon
+from falcon import testing
+
+from .dataset_fixtures import *
+
+
+def test_upload_file_no_auth(client):
+    ds_id = 'ds000001'
+    upload_id = '5da16a13-6028-4a53-808e-e828f5f280e5'
+    file_data = 'Test dataset README'
+    response = client.simulate_post(
+        '/uploads/{}/{}/README'.format(ds_id, upload_id), body=file_data)
+    assert response.status == falcon.HTTP_UNAUTHORIZED
+
+
+def test_upload_file(client, datalad_store):
+    ds_id = 'ds000001'
+    upload_id = '5da16a13-6028-4a53-808e-e828f5f280e5'
+    file_data = 'Test dataset README for new upload'
+    response = client.simulate_post(
+        '/uploads/{}/{}/README'.format(ds_id, upload_id), body=file_data, headers={'cookie': 'accessToken=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJmZDQ0ZjVjNS1iMjFiLTQyMGItOTU1NS1hZjg1NmVmYzk0NTIiLCJlbWFpbCI6Im5lbGxAc3F1aXNoeW1lZGlhLmNvbSIsInByb3ZpZGVyIjoiZ29vZ2xlIiwibmFtZSI6Ik5lbGwgSGFyZGNhc3RsZSIsImFkbWluIjp0cnVlLCJzY29wZXMiOlsiZGF0YXNldDp1cGxvYWQiXSwiZGF0YXNldCI6ImRzMDAwMDAxIiwiaWF0IjoxNTk2NTU4MTU0LCJleHAiOjE1OTcxNjI5NTR9.mx01qqsVEy2hoIXt4LIQHB2RfVOnelaTy23TwXHwMyA'})
+    assert response.status == falcon.HTTP_OK
+    readme_path = os.path.join(
+        datalad_store.get_upload_path(ds_id, upload_id), 'README')
+    # Check for the file in the upload bucket
+    with open(readme_path) as f:
+        assert f.read() == file_data

--- a/yarn.lock
+++ b/yarn.lock
@@ -4627,6 +4627,13 @@ abbrev@1:
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
   integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
 
+abort-controller@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/abort-controller/-/abort-controller-3.0.0.tgz#eaf54d53b62bae4138e809ca225c8439a6efb392"
+  integrity sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==
+  dependencies:
+    event-target-shim "^5.0.0"
+
 accepts@^1.3.5, accepts@^1.3.7, accepts@~1.3.4, accepts@~1.3.5, accepts@~1.3.7:
   version "1.3.7"
   resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.7.tgz#531bc726517a3b2b41f850021c6cc15eaab507cd"
@@ -7222,6 +7229,14 @@ cli-cursor@^3.1.0:
   integrity sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==
   dependencies:
     restore-cursor "^3.1.0"
+
+cli-progress@^3.8.2:
+  version "3.8.2"
+  resolved "https://registry.yarnpkg.com/cli-progress/-/cli-progress-3.8.2.tgz#abaf1fc6d6401351f16f068117a410554a0eb8c7"
+  integrity sha512-qRwBxLldMSfxB+YGFgNRaj5vyyHe1yMpVeDL79c+7puGujdKJHQHydgqXDcrkvQgJ5U/d3lpf6vffSoVVUftVQ==
+  dependencies:
+    colors "^1.1.2"
+    string-width "^4.2.0"
 
 cli-spinners@^0.1.2:
   version "0.1.2"
@@ -10294,6 +10309,11 @@ event-source-polyfill@^1.0.12:
   version "1.0.12"
   resolved "https://registry.yarnpkg.com/event-source-polyfill/-/event-source-polyfill-1.0.12.tgz#38546c4fee76dcadae2560185610ae46c5a39520"
   integrity sha512-WjOTn0LIbaN08z/8gNt3GYAomAdm6cZ2lr/QdvhTTEipr5KR6lds2ziUH+p/Iob4Lk6NClKhwPOmn1NjQEcJCg==
+
+event-target-shim@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/event-target-shim/-/event-target-shim-5.0.1.tgz#5d4d3ebdf9583d63a5333ce2deb7480ab2b05789"
+  integrity sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==
 
 eventemitter3@^3.0.0, eventemitter3@^3.1.0:
   version "3.1.2"
@@ -16212,10 +16232,10 @@ methods@^1.1.1, methods@^1.1.2, methods@~1.1.2:
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
   integrity sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=
 
-metro-memory-fs@^0.31.0:
-  version "0.31.0"
-  resolved "https://registry.yarnpkg.com/metro-memory-fs/-/metro-memory-fs-0.31.0.tgz#71c251b5b4592a9c70a1f452bac758ba6d0ffc36"
-  integrity sha512-sxpGqo4eE1l5hj9YUGaA7Zet1leb6IafNSzgI2NCuK6rUs8I9znEErCFZXLs4Fmq0LzW2suK21oaSDoNT+Ulwg==
+metro-memory-fs@0.61.0:
+  version "0.61.0"
+  resolved "https://registry.yarnpkg.com/metro-memory-fs/-/metro-memory-fs-0.61.0.tgz#31a2ddc9a9cadd5d8f147b57e0cc4a11a0f96203"
+  integrity sha512-0YN95SMYExvZALvFp6gdaK9FVyYlpQEMD6J8USNGOL3SZxRvZLlYrxhw2TMdPVP3eQg27GQYT1tc2r7dGZuUIg==
 
 microevent.ts@~0.1.1:
   version "0.1.1"


### PR DESCRIPTION
This is missing some resume functionality still even though the server side is implemented. The client needs a few fixes before this is ready for review. Depends on #1747 as well.

The main change here is dropping the Upload scalar (though it is maintained for backwards compatibility in openneuro-server in this PR) as the primary way to upload files. Instead the client requests temporary credentials and makes a regular POST for each file. This works fine with HTTP/1.1 and the local dev environment uses 1.1 but the real improvement is seen using HTTP/2 via the ALB. HTTP/2 pipelining makes this approach much more reliable and saves significant overhead for the client with maintaining thousands of connections. Behind the load balancer, the HTTP/1.1 backend works but a good future improvement would be to natively support HTTP/2 when our dependencies all support it (Falcon 3.0 is working on it) to also reduce this connection overhead behind the load balancer.

Client uploads are written to a temporary path in the same filesystem and then a copy and commit is made once the client signals it has finished uploading files. The server stores a list to validate that the same set of files is present but does not yet actually perform the validation.