### PR TITLE
Add an endpoint field to prepareUpload to coordinate ingress -> worker mapping

### DIFF
--- a/packages/openneuro-cli/src/upload.js
+++ b/packages/openneuro-cli/src/upload.js
@@ -144,6 +144,7 @@ export const prepareUpload = async (
     datasetId: data.prepareUpload.datasetId,
     token: data.prepareUpload.token,
     files,
+    endpoint: data.prepareUpload.endpoint,
   }
 }
 
@@ -155,7 +156,13 @@ export const encodeFilePath = path => {
   return path.replace(new RegExp('/', 'g'), ':')
 }
 
-export const uploadFiles = async ({ id, datasetId, token, files }) => {
+export const uploadFiles = async ({
+  id,
+  datasetId,
+  token,
+  files,
+  endpoint,
+}) => {
   const uploadProgress = new cliProgress.SingleBar({
     format:
       datasetId + ' [{bar}] {percentage}% | ETA: {eta}s | {value}/{total}',
@@ -167,9 +174,9 @@ export const uploadFiles = async ({ id, datasetId, token, files }) => {
     speed: 'N/A',
   })
   for (const f of files) {
-    // http://localhost:9876/uploads/ds001024/0de963b9-1a2a-4bcc-af3c-fef0345780b0/dataset_description.json
+    // http://localhost:9876/uploads/0/ds001024/0de963b9-1a2a-4bcc-af3c-fef0345780b0/dataset_description.json
     const encodedFilePath = encodeFilePath(f.filename)
-    const fileUrl = `${rootUrl}uploads/${datasetId}/${id}/${encodedFilePath}`
+    const fileUrl = `${rootUrl}uploads/${endpoint}/${datasetId}/${id}/${encodedFilePath}`
     const fileStream = createReadStream(f.path)
     // This is needed to cancel the request in case of client errors
     const controller = new AbortController()

--- a/packages/openneuro-client/src/uploads.js
+++ b/packages/openneuro-client/src/uploads.js
@@ -6,6 +6,7 @@ export const prepareUpload = gql`
       id
       datasetId
       token
+      endpoint
     }
   }
 `

--- a/packages/openneuro-server/src/graphql/resolvers/upload.js
+++ b/packages/openneuro-server/src/graphql/resolvers/upload.js
@@ -2,6 +2,7 @@ import Upload from '../../models/upload.js'
 import { checkDatasetWrite } from '../permissions.js'
 import { generateUploadToken } from '../../libs/authentication/jwt.js'
 import { finishUploadRequest } from '../../datalad/upload.js'
+import { getDatasetEndpoint } from '../../libs/datalad-service.js'
 
 /**
  * Track initial state for a new upload
@@ -26,6 +27,7 @@ export async function prepareUpload(
   const UploadMetadata = {
     ...upload.toObject(),
     token,
+    endpoint: getDatasetEndpoint(datasetId),
   }
   return UploadMetadata
 }

--- a/packages/openneuro-server/src/graphql/schema.js
+++ b/packages/openneuro-server/src/graphql/schema.js
@@ -300,6 +300,8 @@ export const typeDefs = `
     estimatedSize: BigInt
     # On the first request, this token is returned to allow uploads into this upload bucket
     token: String
+    # An endpoint index used to identify the backend responsible for these files
+    endpoint: Int
   }
 
   # Top level dataset, one draft and many snapshots

--- a/services/datalad/datalad_service/app.py
+++ b/services/datalad/datalad_service/app.py
@@ -85,7 +85,7 @@ def create_app(annex_path):
         '/datasets/{dataset}/upload/{upload}', dataset_upload
     )
     api.add_route(
-        '/uploads/{dataset}/{upload}/{filename:path}', dataset_upload_file
+        '/uploads/{worker}/{dataset}/{upload}/{filename:path}', dataset_upload_file
     )
 
     return api

--- a/services/datalad/datalad_service/handlers/upload_file.py
+++ b/services/datalad/datalad_service/handlers/upload_file.py
@@ -45,7 +45,7 @@ class UploadFileResource(UploadResource):
                     break
                 new_file.write(chunk)
 
-    def on_post(self, req, resp, dataset, upload, filename):
+    def on_post(self, req, resp, worker, dataset, upload, filename):
         # Check that this request includes the correct token
         if self._check_access(req, dataset, upload):
             upload_path = self.store.get_upload_path(dataset, upload)
@@ -59,7 +59,7 @@ class UploadFileResource(UploadResource):
         else:
             self._handle_failed_access(req, resp)
 
-    def on_get(self, req, resp, dataset, upload):
+    def on_get(self, req, resp, worker, dataset, upload):
         """Return the current upload state, files and sizes."""
         if self._check_access(req, dataset, upload):
             upload_path = self.store.get_upload_path(dataset, upload)

--- a/services/datalad/tests/test_upload.py
+++ b/services/datalad/tests/test_upload.py
@@ -9,7 +9,7 @@ def test_upload_file_no_auth(client):
     upload_id = '5da16a13-6028-4a53-808e-e828f5f280e5'
     file_data = 'Test dataset README'
     response = client.simulate_post(
-        '/uploads/{}/{}/README'.format(ds_id, upload_id), body=file_data)
+        '/uploads/1/{}/{}/README'.format(ds_id, upload_id), body=file_data)
     assert response.status == falcon.HTTP_UNAUTHORIZED
 
 
@@ -18,7 +18,7 @@ def test_upload_file(client, datalad_store):
     upload_id = '5da16a13-6028-4a53-808e-e828f5f280e5'
     file_data = 'Test dataset README for new upload'
     response = client.simulate_post(
-        '/uploads/{}/{}/README'.format(ds_id, upload_id), body=file_data, headers={'cookie': 'accessToken=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJmZDQ0ZjVjNS1iMjFiLTQyMGItOTU1NS1hZjg1NmVmYzk0NTIiLCJlbWFpbCI6Im5lbGxAc3F1aXNoeW1lZGlhLmNvbSIsInByb3ZpZGVyIjoiZ29vZ2xlIiwibmFtZSI6Ik5lbGwgSGFyZGNhc3RsZSIsImFkbWluIjp0cnVlLCJzY29wZXMiOlsiZGF0YXNldDp1cGxvYWQiXSwiZGF0YXNldCI6ImRzMDAwMDAxIiwiaWF0IjoxNTk2NTU4MTU0LCJleHAiOjE1OTcxNjI5NTR9.mx01qqsVEy2hoIXt4LIQHB2RfVOnelaTy23TwXHwMyA'})
+        '/uploads/1/{}/{}/README'.format(ds_id, upload_id), body=file_data, headers={'cookie': 'accessToken=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJmZDQ0ZjVjNS1iMjFiLTQyMGItOTU1NS1hZjg1NmVmYzk0NTIiLCJlbWFpbCI6Im5lbGxAc3F1aXNoeW1lZGlhLmNvbSIsInByb3ZpZGVyIjoiZ29vZ2xlIiwibmFtZSI6Ik5lbGwgSGFyZGNhc3RsZSIsImFkbWluIjp0cnVlLCJzY29wZXMiOlsiZGF0YXNldDp1cGxvYWQiXSwiZGF0YXNldCI6ImRzMDAwMDAxIiwiaWF0IjoxNTk2NTU4MTU0LCJleHAiOjE1OTcxNjI5NTR9.mx01qqsVEy2hoIXt4LIQHB2RfVOnelaTy23TwXHwMyA'})
     assert response.status == falcon.HTTP_OK
     readme_path = os.path.join(
         datalad_store.get_upload_path(ds_id, upload_id), 'README')


### PR DESCRIPTION
This simplifies the routing needed to forward file upload requests to the correct backend. See #1762 for the Kubernetes half of this.