### PR TITLE
Fix missing robots.txt

### DIFF
--- a/packages/openneuro-app/nginx.conf
+++ b/packages/openneuro-app/nginx.conf
@@ -9,6 +9,10 @@ server {
   gzip_types text/html application/json text/css;
 
   root /srv/app/dist;
+
+  # Return a well formed robots.txt
+  location /robots.txt {return 200 "User-agent: *\nAllow: /\n";}
+
   location /index.html {
     add_header Cache-Control 'no-cache';
   }


### PR DESCRIPTION
This serves robots.txt inline from the web container. Looks like this was missed when we originally moved over to the current load balancer setup.