### PR TITLE
Helm: Move ALB health checks into services

### DIFF
--- a/helm/openneuro/templates/api-service.yaml
+++ b/helm/openneuro/templates/api-service.yaml
@@ -7,6 +7,8 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  annotations:
+    alb.ingress.kubernetes.io/healthcheck-path: /crn/
 spec:
   ports:
   - port: 8111

--- a/helm/openneuro/templates/datalad-worker-service.yaml
+++ b/helm/openneuro/templates/datalad-worker-service.yaml
@@ -4,6 +4,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ $relname }}-dataset-worker-{{ . }}
+  annotations:
+    alb.ingress.kubernetes.io/healthcheck-path: /heartbeat
 spec:
   selector:
     statefulset.kubernetes.io/pod-name: {{ $relname }}-dataset-worker-{{ . }}

--- a/helm/openneuro/templates/ingress.yaml
+++ b/helm/openneuro/templates/ingress.yaml
@@ -9,7 +9,6 @@ metadata:
     alb.ingress.kubernetes.io/scheme: internet-facing
     alb.ingress.kubernetes.io/certificate-arn: {{ .Values.certifcateArn }}
     alb.ingress.kubernetes.io/target-type: ip
-    alb.ingress.kubernetes.io/healthcheck-path: /crn/
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS":443}]'
     alb.ingress.kubernetes.io/actions.ssl-redirect: '{"Type": "redirect", "RedirectConfig": {"Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_301"}}'
     alb.ingress.kubernetes.io/actions.www-redirect: '{"Type": "redirect", "RedirectConfig": {"Host": "{{ .Values.hostname }}", "Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_301"}}'

--- a/helm/openneuro/templates/web-service.yaml
+++ b/helm/openneuro/templates/web-service.yaml
@@ -7,6 +7,8 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  annotations:
+    alb.ingress.kubernetes.io/healthcheck-path: /
 spec:
   ports:
   - port: 80


### PR DESCRIPTION
Looks like we've never had passing health checks for the ALB configuration and things have worked only because the load balancer falls back to unhealthy endpoints if zero healthy ones are available. That has the consequence that a broken endpoint can end up in the rotation temporarily and handle a significant amount of traffic. Moving the checks to the service definition that actually handles them allows the alb-ingress-controller to create more target groups that represent the underlying services correctly and define the checks per service. This way if there is a down service, it will automatically leave the rotation and we have one check for each underlying endpoint (datalad service, GraphQL API, and static content).

This is deployed on staging for review.