### PR TITLE
API: Participant count fix to return latest valid snapshot

### DIFF
--- a/packages/openneuro-server/src/graphql/resolvers/snapshots.js
+++ b/packages/openneuro-server/src/graphql/resolvers/snapshots.js
@@ -45,7 +45,7 @@ export const participantCount = async () => {
     },
     {
       $sort: {
-        created: -1,
+        created: 1,
       },
     },
     {


### PR DESCRIPTION
This was returning earliest valid snapshot. See #1270 