### PR TITLE
Helm: Add elastic-apm-server

### DIFF
--- a/helm/openneuro/Chart.yaml
+++ b/helm/openneuro/Chart.yaml
@@ -13,3 +13,6 @@ dependencies:
   - name: aws-alb-ingress-controller
     version: 1.0.0
     repository: https://kubernetes-charts-incubator.storage.googleapis.com/
+  - name: apm-server
+    version: 7.9.0
+    repository: https://helm.elastic.co

--- a/helm/openneuro/requirements.lock
+++ b/helm/openneuro/requirements.lock
@@ -5,5 +5,8 @@ dependencies:
 - name: aws-alb-ingress-controller
   repository: https://kubernetes-charts-incubator.storage.googleapis.com/
   version: 1.0.0
-digest: sha256:c3573f9eacafef670c523bee58a686aa3455205d007534e1cd4ce13c0d00999b
-generated: "2020-06-06T21:24:16.481015609-07:00"
+- name: apm-server
+  repository: https://helm.elastic.co
+  version: 7.9.0
+digest: sha256:f90c303d40dcf002907179598ef0f1fda76b2edbc560f838910051aa9a2c21ab
+generated: "2020-08-21T14:22:28.124302759-07:00"

--- a/helm/openneuro/templates/secret.yaml
+++ b/helm/openneuro/templates/secret.yaml
@@ -38,3 +38,5 @@ stringData:
   MONGO_URL: {{ required "MONGO_URL with credentials is required" .Values.secrets.mongo.MONGO_URL | quote }}
   ENGINE_API_KEY: {{ .Values.secrets.apollo.ENGINE_API_KEY | quote }}
   ELASTICSEARCH_CONNECTION: {{ .Values.secrets.elasticsearch.ELASTICSEARCH_CONNECTION | quote }}
+  ELASTICSEARCH_CLOUD_ID: {{ .Values.secrets.elasticsearch.ELASTICSEARCH_CLOUD_ID | quote }}
+  ELASTICSEARCH_CLOUD_AUTH: {{ .Values.secrets.elasticsearch.ELASTICSEARCH_CLOUD_AUTH | quote }}

--- a/helm/openneuro/values-production.yaml
+++ b/helm/openneuro/values-production.yaml
@@ -89,3 +89,16 @@ redis:
       requests:
         cpu: "500m"
         memory: "4Gi"
+
+apm-server:
+  apmConfig:
+    apm-server.yml: |
+      apm-server:
+        host: "0.0.0.0:8200"
+      queue: {}
+      cloud:
+        id: "${ELASTICSEARCH_CLOUD_ID}"
+        auth: "${ELASTICSEARCH_CLOUD_AUTH}"
+  envFrom:
+    - secretRef:
+        name: openneuro-prod-secret

--- a/helm/openneuro/values.yaml
+++ b/helm/openneuro/values.yaml
@@ -82,3 +82,16 @@ redis:
       requests:
         cpu: '125m'
         memory: '1.5Gi'
+
+apm-server:
+  apmConfig:
+    apm-server.yml: |
+      apm-server:
+        host: "0.0.0.0:8200"
+      queue: {}
+      cloud:
+        id: "${ELASTICSEARCH_CLOUD_ID}"
+        auth: "${ELASTICSEARCH_CLOUD_AUTH}"
+  envFrom:
+    - secretRef:
+        name: openneuro-staging-secret


### PR DESCRIPTION
This deploys elastic-apm-server, which is required to configure the agents in #1749 