### PR TITLE
Ignore dev environments for elastic-apm and add version/environment info

### DIFF
--- a/packages/openneuro-app/src/scripts/client.jsx
+++ b/packages/openneuro-app/src/scripts/client.jsx
@@ -11,9 +11,16 @@ import * as GoogleAnalytics from 'react-ga'
 if (module.hot) module.hot.accept()
 
 loadConfig().then(config => {
-  initApm({
-    serverUrl: `${config.url}/apm`,
-  })
+  if (
+    config.sentry.environment === 'production' ||
+    config.sentry.environment === 'staging'
+  ) {
+    initApm({
+      serverUrl: `${config.url}/apm`,
+      serviceVersion: packageJson.version,
+      environment: config.sentry.environment,
+    })
+  }
 
   GoogleAnalytics.initialize(config.analytics.trackingId)
 


### PR DESCRIPTION
This improves the elastic-apm configuration with version info and disables it when running locally.