### PR TITLE
Avoid caching 404 file requests for snapshot tags

### DIFF
--- a/packages/openneuro-server/src/datalad/files.js
+++ b/packages/openneuro-server/src/datalad/files.js
@@ -87,7 +87,14 @@ export const getFiles = (datasetId, hexsha) => {
         )}/datasets/${datasetId}/snapshots/${hexsha}/files`,
       )
       .set('Accept', 'application/json')
-      .then(({ body: { files } }) => files.map(addFileUrl(datasetId, hexsha))),
+      .then(response => {
+        if (response.status === 200) {
+          const {
+            body: { files },
+          } = response
+          return files.map(addFileUrl(datasetId, hexsha))
+        }
+      }),
   )
 }
 

--- a/packages/openneuro-server/src/datalad/snapshots.js
+++ b/packages/openneuro-server/src/datalad/snapshots.js
@@ -140,6 +140,8 @@ const announceNewSnapshot = async (snapshot, datasetId, user) => {
  * @param {String} datasetId - Dataset ID string
  * @param {String} tag - Snapshot identifier and git tag
  * @param {Object} user - User object that has made the snapshot request
+ * @param {Object} descriptionFieldUpdates - Key/value pairs to update dataset_description.json
+ * @param {Array<string>} snapshotChanges - Array of changes to inject into CHANGES file
  * @returns {Promise} - resolves when tag is created
  */
 export const createSnapshot = async (


### PR DESCRIPTION
This should fix the issue in #1752 but I don't have a full reproduction case to be totally sure about it. This prevents a bug where the snapshot file tree is requested before the snapshot is created, leaving an empty cache which breaks the actual snapshot creation step.