### PR TITLE
CLI: Improve command line help documentation for subcommands

### DIFF
--- a/packages/openneuro-cli/src/cli.js
+++ b/packages/openneuro-cli/src/cli.js
@@ -13,6 +13,14 @@ function makeRed(txt) {
 
 commander.version(packageJson.version).description(packageJson.description)
 
+commander.on('--help', () => {
+  console.log('')
+  console.log(
+    'See additional options for each command with "openneuro [command] --help". Example:',
+  )
+  console.log('  $ openneuro upload --help')
+})
+
 commander
   .command('login')
   .alias('l')


### PR DESCRIPTION
Adds some extra help text:

<pre><code>Usage: openneuro [options] [command]

OpenNeuro command line uploader / editor.

Options:
  -V, --version                                   output the version number
  -h, --help                                      output usage information

Commands:
  login|l                                         Setup authentication with OpenNeuro
  upload|u [options] <dir>                        Upload or sync a dataset (if a accession number is provided)
  download|d [options] <datasetId> <destination>  Download a dataset draft or snapshot. If neither is specified, will prompt with available snapshots.

<b>See additional options for each command with "openneuro [command] --help". Example:
  $ openneuro upload --help</b>
</pre></code>