### PR TITLE
Delete dataset improvements

### DIFF
--- a/packages/openneuro-app/src/scripts/datalad/dataset/dataset-main.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/dataset/dataset-main.jsx
@@ -2,17 +2,17 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import DatasetRoutes from '../routes/dataset-routes.jsx'
 import Comments from './comments.jsx'
-import ErrorBoundary from '../../errors/errorBoundary.jsx'
+import { ErrorBoundaryDeletePageException } from '../../errors/errorBoundary.jsx'
 import DatasetQueryContext from './dataset-query-context.js'
 
 const DatasetMain = ({ dataset }) => {
   return (
     <>
-      <ErrorBoundary>
+      <ErrorBoundaryDeletePageException>
         <DatasetQueryContext.Consumer>
           {({ error }) => <DatasetRoutes dataset={dataset} error={error} />}
         </DatasetQueryContext.Consumer>
-      </ErrorBoundary>
+      </ErrorBoundaryDeletePageException>
       <Comments
         datasetId={dataset.id}
         uploader={dataset.uploader}

--- a/packages/openneuro-app/src/scripts/datalad/dataset/delete-page.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/dataset/delete-page.jsx
@@ -1,0 +1,88 @@
+import React, { useState } from 'react'
+import { PropTypes } from 'prop-types'
+import { withRouter } from 'react-router-dom'
+import DeleteDatasetForm from '../mutations/delete-dataset-form.jsx'
+import DeleteDataset from '../mutations/delete.jsx'
+import LoggedIn from '../../authentication/logged-in.jsx'
+import { hasEditPermissions, getProfile } from '../../authentication/profile.js'
+import styled from '@emotion/styled'
+
+const Container = styled.div({
+  display: 'flex',
+  flexDirection: 'column',
+})
+
+const WarningNote = styled.div({
+  color: 'red',
+  display: 'flex',
+
+  i: {
+    marginRight: '0.5rem',
+  },
+})
+
+const DeletePage = ({ dataset, returnToDataset, history, location }) => {
+  const [values, setValues] = useState({
+    reason: '',
+    redirect: '',
+  })
+  const handleInputChange = (name, value) => {
+    const newValues = {
+      ...values,
+      [name]: value,
+    }
+    setValues(newValues)
+  }
+  const user = getProfile()
+  const submitPath = location.state && location.state.submitPath
+  const hasEdit =
+    (user && user.admin) ||
+    hasEditPermissions(dataset.permissions, user && user.sub)
+
+  return (
+    <Container>
+      <header className="col-xs-12">
+        <h1>Delete Dataset</h1>
+        <hr />
+      </header>
+      <DeleteDatasetForm
+        values={values}
+        onChange={handleInputChange}
+        hideDisabled={false}
+        hasEdit={hasEdit}
+      />
+      <WarningNote className="col-xs-6">
+        <i className="fa fa-asterisk" />
+        <p>
+          Warning: this action will permanently remove this dataset along with
+          associated snapshots.
+        </p>
+      </WarningNote>
+      <div className="col-xs-12 dataset-form-controls">
+        <div className="col-xs-12 modal-actions">
+          <button className="btn-admin-blue" onClick={returnToDataset}>
+            Return to Dataset
+          </button>
+          {hasEdit && (
+            <LoggedIn>
+              <DeleteDataset
+                datasetId={dataset.id}
+                metadata={values}
+                done={() => submitPath && history.push(submitPath)}
+              />
+            </LoggedIn>
+          )}
+        </div>
+      </div>
+    </Container>
+  )
+}
+
+DeletePage.propTypes = {
+  dataset: PropTypes.object,
+  returnToDataset: PropTypes.function,
+  history: PropTypes.object,
+  location: PropTypes.object,
+}
+
+export default withRouter(DeletePage)

--- a/packages/openneuro-app/src/scripts/datalad/fragments/dataset-tools.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/fragments/dataset-tools.jsx
@@ -3,13 +3,18 @@ import PropTypes from 'prop-types'
 import { withRouter } from 'react-router-dom'
 import snapshotVersion from '../snapshotVersion.js'
 import WarnButton from '../../common/forms/warn-button.jsx'
-import DeleteDataset from '../mutations/delete.jsx'
 import FollowDataset from '../mutations/follow.jsx'
 import StarDataset from '../mutations/star.jsx'
 import ShareDatasetLink from '../fragments/share-dataset-button.jsx'
 import DatasetMetadata from './metadata-tool.jsx'
 import LoggedIn from '../../authentication/logged-in.jsx'
 import useMedia from '../../mobile/media-hook.jsx'
+import DeletePage from '../dataset/delete-page.jsx'
+import {
+  Overlay,
+  ModalContainer,
+  ExitButton,
+} from '../../styles/support-modal.jsx'
 
 /**
  * Immediate redirect to a dataset or snapshot route
@@ -33,6 +38,7 @@ const DatasetTools = ({ dataset, location, history }) => {
   // TODO - disable if you lack write access to the draft
   const edit = snapshot ? false : true
   const isMobile = useMedia('(max-width: 765px) ')
+  const [showDeleteModal, setShowDeleteModal] = React.useState(false)
   return (
     <div className="col-xs-12 dataset-tools-wrap">
       <div className="tools clearfix">
@@ -51,7 +57,13 @@ const DatasetTools = ({ dataset, location, history }) => {
             )}
           </div>
           <div role="presentation" className="tool">
-            {edit && <DeleteDataset datasetId={dataset.id} />}
+            <span>
+              <button
+                className="btn-warn-component warning"
+                onClick={() => setShowDeleteModal(true)}>
+                <i className="fa fa-trash" />
+              </button>
+            </span>
           </div>
           <div role="presentation" className="tool">
             {edit && (
@@ -74,7 +86,6 @@ const DatasetTools = ({ dataset, location, history }) => {
                 warn={false}
                 action={cb => {
                   toolRedirect(history, rootPath, 'snapshot')
-                  cb()
                 }}
               />
             )}
@@ -98,6 +109,19 @@ const DatasetTools = ({ dataset, location, history }) => {
           <DatasetMetadata datasetId={dataset.id} metadata={dataset.metadata} />
         </div>
       </div>
+      {showDeleteModal && (
+        <Overlay>
+          <ModalContainer>
+            <ExitButton onClick={() => setShowDeleteModal(false)}>
+              &times;
+            </ExitButton>
+            <DeletePage
+              dataset={dataset}
+              returnToDataset={() => setShowDeleteModal(false)}
+            />
+          </ModalContainer>
+        </Overlay>
+      )}
     </div>
   )
 }

--- a/packages/openneuro-app/src/scripts/datalad/mutations/__tests__/__snapshots__/delete.spec.jsx.snap
+++ b/packages/openneuro-app/src/scripts/datalad/mutations/__tests__/__snapshots__/delete.spec.jsx.snap
@@ -33,6 +33,34 @@ exports[`DeleteDataset mutation renders with common props 1`] = `
                       },
                     },
                   },
+                  Object {
+                    "kind": "Argument",
+                    "name": Object {
+                      "kind": "Name",
+                      "value": "reason",
+                    },
+                    "value": Object {
+                      "kind": "Variable",
+                      "name": Object {
+                        "kind": "Name",
+                        "value": "reason",
+                      },
+                    },
+                  },
+                  Object {
+                    "kind": "Argument",
+                    "name": Object {
+                      "kind": "Name",
+                      "value": "redirect",
+                    },
+                    "value": Object {
+                      "kind": "Variable",
+                      "name": Object {
+                        "kind": "Name",
+                        "value": "redirect",
+                      },
+                    },
+                  },
                 ],
                 "directives": Array [],
                 "kind": "Field",
@@ -67,12 +95,50 @@ exports[`DeleteDataset mutation renders with common props 1`] = `
                 },
               },
             },
+            Object {
+              "defaultValue": undefined,
+              "directives": Array [],
+              "kind": "VariableDefinition",
+              "type": Object {
+                "kind": "NamedType",
+                "name": Object {
+                  "kind": "Name",
+                  "value": "String",
+                },
+              },
+              "variable": Object {
+                "kind": "Variable",
+                "name": Object {
+                  "kind": "Name",
+                  "value": "reason",
+                },
+              },
+            },
+            Object {
+              "defaultValue": undefined,
+              "directives": Array [],
+              "kind": "VariableDefinition",
+              "type": Object {
+                "kind": "NamedType",
+                "name": Object {
+                  "kind": "Name",
+                  "value": "String",
+                },
+              },
+              "variable": Object {
+                "kind": "Variable",
+                "name": Object {
+                  "kind": "Name",
+                  "value": "redirect",
+                },
+              },
+            },
           ],
         },
       ],
       "kind": "Document",
       "loc": Object {
-        "end": 69,
+        "end": 143,
         "start": 0,
       },
     }

--- a/packages/openneuro-app/src/scripts/datalad/mutations/delete-dataset-form.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/mutations/delete-dataset-form.jsx
@@ -1,0 +1,74 @@
+import React from 'react'
+import { PropTypes } from 'prop-types'
+import TextInput from '../fragments/text-input.jsx'
+import SelectInput from '../fragments/select-input.jsx'
+import styled from '@emotion/styled'
+
+const Form = styled.form({
+  minWidth: '40rem',
+  margin: '10px 0',
+})
+
+const fields = hasEdit => {
+  const fields = [
+    {
+      key: 'reason',
+      label: 'Reason',
+      Component: SelectInput,
+      additionalProps: {
+        options: [
+          { value: 'subject privacy' },
+          { value: 'duplicate dataset' },
+          { value: 'abuse of service', admin: true },
+        ],
+        showOptionOther: true,
+        required: false,
+      },
+    },
+    {
+      key: 'redirect',
+      label: 'Superseded by (URL)',
+      Component: TextInput,
+      additionalProps: {
+        required: false,
+      },
+    },
+  ]
+  return hasEdit
+    ? fields
+    : fields.map(field => {
+        field.additionalProps.disabled = true
+        return field
+      })
+}
+
+const DeleteDatasetForm = ({ values, onChange, hasEdit }) => (
+  <Form id="metadata-form" className="col-xs-6">
+    {fields(hasEdit).map(
+      (
+        { key, label, hoverText, Component, additionalProps, transformValue },
+        i,
+      ) => (
+        <Component
+          name={key}
+          label={label}
+          hoverText={hoverText}
+          value={transformValue ? transformValue(values[key]) : values[key]}
+          onChange={onChange}
+          {...additionalProps}
+          key={i}
+        />
+      ),
+    )}
+  </Form>
+)
+
+DeleteDatasetForm.propTypes = {
+  keyLabelMap: PropTypes.object,
+  values: PropTypes.object,
+  onChange: PropTypes.func,
+  hideDisabled: PropTypes.bool,
+  hasEdit: PropTypes.bool,
+}
+
+export default DeleteDatasetForm

--- a/packages/openneuro-app/src/scripts/datalad/mutations/delete.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/mutations/delete.jsx
@@ -1,30 +1,55 @@
 import React from 'react'
+import { withRouter } from 'react-router-dom'
 import PropTypes from 'prop-types'
 import gql from 'graphql-tag'
 import { Mutation } from 'react-apollo'
-import WarnButton from '../../common/forms/warn-button.jsx'
 
 const DELETE_DATASET = gql`
-  mutation deleteDataset($id: ID!) {
-    deleteDataset(id: $id)
+  mutation deleteDataset($id: ID!, $reason: String, $redirect: String) {
+    deleteDataset(id: $id, reason: $reason, redirect: $redirect)
   }
 `
 
-const DeleteDataset = ({ datasetId }) => (
-  <Mutation mutation={DELETE_DATASET}>
-    {deleteDataset => (
-      <WarnButton
-        tooltip="Delete Dataset"
-        icon="fa-trash"
-        warn={true}
-        action={cb => deleteDataset({ variables: { id: datasetId } }).then(cb)}
-      />
-    )}
-  </Mutation>
-)
+const DeleteDataset = ({ datasetId, metadata }) => {
+  const [warn, setWarn] = React.useState(false)
+  const handleClick = deleteDataset => () => {
+    if (!warn) setWarn(true)
+    else deleteDataset()
+  }
+
+  return (
+    <Mutation mutation={DELETE_DATASET}>
+      {deleteDataset => (
+        <span>
+          <button
+            className="btn-admin-blue"
+            style={{ color: warn ? 'red' : null }}
+            onClick={handleClick(async () => {
+              await deleteDataset({
+                variables: {
+                  id: datasetId,
+                  reason: metadata.reason,
+                  redirect: metadata.redirect,
+                },
+              })
+              console.log('pre redirect')
+              window.location.replace(
+                `${window.location.origin}/dashboard/datasets`,
+              )
+              console.log('post redirect')
+            })}>
+            <i className="fa fa-trash" />
+            {warn ? ' Confirm Delete' : ' Delete Dataset'}
+          </button>
+        </span>
+      )}
+    </Mutation>
+  )
+}
 
 DeleteDataset.propTypes = {
   datasetId: PropTypes.string,
+  metadata: PropTypes.object,
 }
 
 export default DeleteDataset

--- a/packages/openneuro-app/src/scripts/datalad/mutations/delete.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/mutations/delete.jsx
@@ -32,11 +32,9 @@ const DeleteDataset = ({ datasetId, metadata }) => {
                   redirect: metadata.redirect,
                 },
               })
-              console.log('pre redirect')
               window.location.replace(
                 `${window.location.origin}/dashboard/datasets`,
               )
-              console.log('post redirect')
             })}>
             <i className="fa fa-trash" />
             {warn ? ' Confirm Delete' : ' Delete Dataset'}

--- a/packages/openneuro-app/src/scripts/datalad/routes/dataset-routes.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/routes/dataset-routes.jsx
@@ -9,6 +9,7 @@ import Share from './manage-permissions.jsx'
 import Snapshot from './snapshot.jsx'
 import FileDisplay from './file-display.jsx'
 import AddMetadata from '../mutations/add-metadata.jsx'
+import DeletePage from '../dataset/delete-page.jsx'
 
 const stubComponent = () => null
 
@@ -120,6 +121,12 @@ const DatasetRoutes = ({ dataset, error }) => {
         exact
         path="/datasets/:datasetId/metadata"
         component={() => <AddMetadata dataset={dataset} />}
+      />
+      <Route
+        name="delete"
+        exact
+        path="/datasets/:datasetId/delete"
+        component={() => <DeletePage dataset={dataset} />}
       />
     </Switch>
   )

--- a/packages/openneuro-app/src/scripts/datalad/subscriptions/useDatasetDeletedSubscription.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/subscriptions/useDatasetDeletedSubscription.jsx
@@ -22,7 +22,7 @@ export const datasetDeletedToast = (datasetId, name = datasetId) => {
   toast.warn(
     <ToastContent
       title="Deleting Dataset"
-      body={`Dataset "${name}" is being removed. Subscribers will recieve an email upon success.`}
+      body={`Dataset "${name}" is being removed.`}
     />,
   )
 }

--- a/packages/openneuro-app/src/scripts/datalad/subscriptions/useDatasetDeletedSubscription.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/subscriptions/useDatasetDeletedSubscription.jsx
@@ -19,10 +19,10 @@ const useDatasetDeletedSubscription = (datasetIds, cb) => {
 }
 
 export const datasetDeletedToast = (datasetId, name = datasetId) => {
-  toast.success(
+  toast.warn(
     <ToastContent
-      title="Dataset Deleted"
-      body={`Dataset "${name}" has been removed.`}
+      title="Deleting Dataset"
+      body={`Dataset "${name}" is being removed. Subscribers will recieve an email upon success.`}
     />,
   )
 }

--- a/packages/openneuro-app/src/scripts/errors/errorBoundary.jsx
+++ b/packages/openneuro-app/src/scripts/errors/errorBoundary.jsx
@@ -91,6 +91,28 @@ class ErrorBoundaryAssertionFailureException extends ErrorBoundary {
   }
 }
 
+// specific use case
+// ignore error in apollo lib
+class ErrorBoundaryDeletePageException extends ErrorBoundary {
+  constructor(props) {
+    super(props)
+  }
+
+  static getDerivedStateFromError(error) {
+    return getDerivedStateFromErrorOnCondition(
+      error,
+      // ErrorBoundary not triggered for "assertion failure"
+      () => {
+        const throwError = !/^\/datasets\/ds\d{6}\/delete$/.test(
+          window.location.pathname,
+        )
+        console.log(throwError)
+        return throwError
+      },
+    )
+  }
+}
+
 ErrorBoundaryAssertionFailureException.propTypes = {
   children: PropTypes.oneOfType([
     PropTypes.arrayOf(PropTypes.node),
@@ -99,5 +121,8 @@ ErrorBoundaryAssertionFailureException.propTypes = {
   errorMessage: PropTypes.string,
 }
 
-export { ErrorBoundaryAssertionFailureException }
+export {
+  ErrorBoundaryAssertionFailureException,
+  ErrorBoundaryDeletePageException,
+}
 export default ErrorBoundary

--- a/packages/openneuro-app/src/scripts/errors/freshdeskInterface.jsx
+++ b/packages/openneuro-app/src/scripts/errors/freshdeskInterface.jsx
@@ -4,7 +4,7 @@ import {
   Overlay,
   ModalContainer,
   ExitButton,
-} from '../../scripts/styles/support-modal.jsx'
+} from '../styles/support-modal.jsx'
 import PropTypes from 'prop-types'
 
 const FreshdeskInterface = props => {

--- a/packages/openneuro-client/src/datasets.js
+++ b/packages/openneuro-client/src/datasets.js
@@ -224,8 +224,8 @@ export const createDataset = gql`
 `
 
 export const deleteDataset = gql`
-  mutation deleteDataset($id: ID!) {
-    deleteDataset(id: $id)
+  mutation deleteDataset($id: ID!, $reason: String, $redirect: String) {
+    deleteDataset(id: $id, reason: $reason, redirect: $redirect)
   }
 `
 

--- a/packages/openneuro-server/src/graphql/resolvers/publish.js
+++ b/packages/openneuro-server/src/graphql/resolvers/publish.js
@@ -11,7 +11,7 @@ export const publishDataset = (obj, { datasetId }, { user, userInfo }) => {
     const uri = `${getDatasetWorker(datasetId)}/datasets/${datasetId}/publish`
     return await request
       .post(uri)
-      .set('Cookie', generateDataladCookie(config)(user))
+      .set('Cookie', generateDataladCookie(config)(userInfo))
       .then(() => true)
   })
 }

--- a/packages/openneuro-server/src/graphql/schema.js
+++ b/packages/openneuro-server/src/graphql/schema.js
@@ -95,7 +95,7 @@ export const typeDefs = `
     # Create a new dataset container and repository
     createDataset(label: String!): Dataset
     # Deletes a dataset and all associated snapshots
-    deleteDataset(id: ID!): Boolean
+    deleteDataset(id: ID!, reason: String, redirect: String): Boolean
     # Tag the current draft
     createSnapshot(datasetId: ID!, tag: String!, changes: [String!]): Snapshot
     # Remove a tag from the dataset

--- a/packages/openneuro-server/src/models/deletion.js
+++ b/packages/openneuro-server/src/models/deletion.js
@@ -1,0 +1,15 @@
+import mongoose from 'mongoose'
+
+const deletion = new mongoose.Schema(
+  {
+    datasetId: String, // OpenNeuro id
+    user: { _id: String },
+    reason: String,
+    redirect: String,
+  },
+  { timestamps: { createdAt: 'created_at' } },
+)
+
+const Deletion = mongoose.model('Deletion', deletion)
+
+export default Deletion

--- a/services/datalad/Pipfile
+++ b/services/datalad/Pipfile
@@ -23,10 +23,8 @@ gunicorn = "*"
 gevent = "*"
 elastic-apm = "*"
 falcon-elastic-apm = "*"
+sentry-sdk = {extras = [ "falcon",],version = "==0.16.1"}
+boto3 = "*"
 
 [requires]
 python_version = "3.8"
-
-[packages.sentry-sdk]
-extras = [ "falcon",]
-version = "==0.16.1"

--- a/services/datalad/Pipfile.lock
+++ b/services/datalad/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "18fc197f0fb1406e97da8aa69f362e8c71eb4809611dc22dd79663dabff9e8c7"
+            "sha256": "27a31db9ef13591561db4aa06e77637ac805877bb5acd93cecdadc271f53f612"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -18,7 +18,6 @@
     "default": {
         "annexremote": {
             "hashes": [
-                "sha256:41a768d5a65bea37e65db6ed0489f76f9adaaf930eb8a8a83d2b95ef7675fa34",
                 "sha256:8fab823c3a6588fa35b5bc72870ddb260799b36ccf9715911e8dd7abfca7382a"
             ],
             "version": "==1.4.3"
@@ -37,6 +36,21 @@
             ],
             "version": "==2.49.0"
         },
+        "boto3": {
+            "hashes": [
+                "sha256:44073b1b1823ffc9edcf9027afbca908dad6bd5000f512ca73f929f6a604ae24",
+                "sha256:888be45e289ba56c4e47cfae5d6b08f097bc981d077fbe6521a6d3dc7a4d757e"
+            ],
+            "index": "pypi",
+            "version": "==1.15.1"
+        },
+        "botocore": {
+            "hashes": [
+                "sha256:6bdf60281c2e80360fe904851a1a07df3dcfe066fe88dc7fba2b5e626ac05c8c",
+                "sha256:d6bdf51c8880aa9974e6b61d2f7d9d1debe407287e2e9e60f36c789fe8ba6790"
+            ],
+            "version": "==1.18.1"
+        },
         "certifi": {
             "hashes": [
                 "sha256:5930595817496dd21bb8dc35dad090f1c2cd0adfaf21204bf6732ca5d8ee34d3",
@@ -44,80 +58,12 @@
             ],
             "version": "==2020.6.20"
         },
-        "cffi": {
-            "hashes": [
-                "sha256:005f2bfe11b6745d726dbb07ace4d53f057de66e336ff92d61b8c7e9c8f4777d",
-                "sha256:03d3d238cc6c636a01cf55b9b2e1b6531a7f2f4103fabb5a744231582e68ecc7",
-                "sha256:09e96138280241bd355cd585148dec04dbbedb4f46128f340d696eaafc82dd7b",
-                "sha256:0b1ad452cc824665ddc682400b62c9e4f5b64736a2ba99110712fdee5f2505c4",
-                "sha256:0ef488305fdce2580c8b2708f22d7785ae222d9825d3094ab073e22e93dfe51f",
-                "sha256:15f351bed09897fbda218e4db5a3d5c06328862f6198d4fb385f3e14e19decb3",
-                "sha256:22399ff4870fb4c7ef19fff6eeb20a8bbf15571913c181c78cb361024d574579",
-                "sha256:23e5d2040367322824605bc29ae8ee9175200b92cb5483ac7d466927a9b3d537",
-                "sha256:2791f68edc5749024b4722500e86303a10d342527e1e3bcac47f35fbd25b764e",
-                "sha256:2f9674623ca39c9ebe38afa3da402e9326c245f0f5ceff0623dccdac15023e05",
-                "sha256:3363e77a6176afb8823b6e06db78c46dbc4c7813b00a41300a4873b6ba63b171",
-                "sha256:3b8eaf915ddc0709779889c472e553f0d3e8b7bdf62dab764c8921b09bf94522",
-                "sha256:3cb3e1b9ec43256c4e0f8d2837267a70b0e1ca8c4f456685508ae6106b1f504c",
-                "sha256:485d029815771b9fe4fa7e1c304352fe57df6939afe835dfd0182c7c13d5e92e",
-                "sha256:4d7c26bfc1ea9f92084a1d75e11999e97b62d63128bcc90c3624d07813c52808",
-                "sha256:529c4ed2e10437c205f38f3691a68be66c39197d01062618c55f74294a4a4828",
-                "sha256:52bf29af05344c95136df71716bb60508bbd217691697b4307dcae681612db9f",
-                "sha256:5d9a7dc7cf8b1101af2602fe238911bcc1ac36d239e0a577831f5dac993856e9",
-                "sha256:6642f15ad963b5092d65aed022d033c77763515fdc07095208f15d3563003869",
-                "sha256:85ba797e1de5b48aa5a8427b6ba62cf69607c18c5d4eb747604b7302f1ec382d",
-                "sha256:8f0f1e499e4000c4c347a124fa6a27d37608ced4fe9f7d45070563b7c4c370c9",
-                "sha256:a624fae282e81ad2e4871bdb767e2c914d0539708c0f078b5b355258293c98b0",
-                "sha256:b0358e6fefc74a16f745afa366acc89f979040e0cbc4eec55ab26ad1f6a9bfbc",
-                "sha256:bbd2f4dfee1079f76943767fce837ade3087b578aeb9f69aec7857d5bf25db15",
-                "sha256:bf39a9e19ce7298f1bd6a9758fa99707e9e5b1ebe5e90f2c3913a47bc548747c",
-                "sha256:c150eaa3dadbb2b5339675b88d4573c1be3cb6f2c33a6c83387e10cc0bf05bd3",
-                "sha256:c2a33558fdbee3df370399fe1712d72464ce39c66436270f3664c03f94971aff",
-                "sha256:c687778dda01832555e0af205375d649fa47afeaeeb50a201711f9a9573323b8",
-                "sha256:cc75f58cdaf043fe6a7a6c04b3b5a0e694c6a9e24050967747251fb80d7bce0d",
-                "sha256:d80998ed59176e8cba74028762fbd9b9153b9afc71ea118e63bbf5d4d0f9552b",
-                "sha256:de31b5164d44ef4943db155b3e8e17929707cac1e5bd2f363e67a56e3af4af6e",
-                "sha256:e66399cf0fc07de4dce4f588fc25bfe84a6d1285cc544e67987d22663393926d",
-                "sha256:f0620511387790860b249b9241c2f13c3a80e21a73e0b861a2df24e9d6f56730",
-                "sha256:f4eae045e6ab2bb54ca279733fe4eb85f1effda392666308250714e01907f394",
-                "sha256:f92cdecb618e5fa4658aeb97d5eb3d2f47aa94ac6477c6daf0f306c5a3b9e6b1",
-                "sha256:f92f789e4f9241cd262ad7a555ca2c648a98178a953af117ef7fad46aa1d5591"
-            ],
-            "version": "==1.14.3"
-        },
         "chardet": {
             "hashes": [
                 "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae",
                 "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
             ],
             "version": "==3.0.4"
-        },
-        "cryptography": {
-            "hashes": [
-                "sha256:10c9775a3f31610cf6b694d1fe598f2183441de81cedcf1814451ae53d71b13a",
-                "sha256:180c9f855a8ea280e72a5d61cf05681b230c2dce804c48e9b2983f491ecc44ed",
-                "sha256:247df238bc05c7d2e934a761243bfdc67db03f339948b1e2e80c75d41fc7cc36",
-                "sha256:26409a473cc6278e4c90f782cd5968ebad04d3911ed1c402fc86908c17633e08",
-                "sha256:2a27615c965173c4c88f2961cf18115c08fedfb8bdc121347f26e8458dc6d237",
-                "sha256:2e26223ac636ca216e855748e7d435a1bf846809ed12ed898179587d0cf74618",
-                "sha256:321761d55fb7cb256b771ee4ed78e69486a7336be9143b90c52be59d7657f50f",
-                "sha256:4005b38cd86fc51c955db40b0f0e52ff65340874495af72efabb1bb8ca881695",
-                "sha256:4b9e96543d0784acebb70991ebc2dbd99aa287f6217546bb993df22dd361d41c",
-                "sha256:548b0818e88792318dc137d8b1ec82a0ab0af96c7f0603a00bb94f896fbf5e10",
-                "sha256:725875681afe50b41aee7fdd629cedbc4720bab350142b12c55c0a4d17c7416c",
-                "sha256:7a63e97355f3cd77c94bd98c59cb85fe0efd76ea7ef904c9b0316b5bbfde6ed1",
-                "sha256:94191501e4b4009642be21dde2a78bd3c2701a81ee57d3d3d02f1d99f8b64a9e",
-                "sha256:969ae512a250f869c1738ca63be843488ff5cc031987d302c1f59c7dbe1b225f",
-                "sha256:9f734423eb9c2ea85000aa2476e0d7a58e021bc34f0a373ac52a5454cd52f791",
-                "sha256:b45ab1c6ece7c471f01c56f5d19818ca797c34541f0b2351635a5c9fe09ac2e0",
-                "sha256:cc6096c86ec0de26e2263c228fb25ee01c3ff1346d3cfc219d67d49f303585af",
-                "sha256:dc3f437ca6353979aace181f1b790f0fc79e446235b14306241633ab7d61b8f8",
-                "sha256:e7563eb7bc5c7e75a213281715155248cceba88b11cb4b22957ad45b85903761",
-                "sha256:e7dad66a9e5684a40f270bd4aee1906878193ae50a4831922e454a2a457f1716",
-                "sha256:eb80a288e3cfc08f679f95da72d2ef90cb74f6d8a8ba69d2f215c5e110b2ca32",
-                "sha256:fa7fbcc40e2210aca26c7ac8a39467eae444d90a2c346cbcffd9133a166bcc67"
-            ],
-            "version": "==3.1"
         },
         "datalad": {
             "hashes": [
@@ -323,13 +269,12 @@
             ],
             "version": "==0.1.13"
         },
-        "jeepney": {
+        "jmespath": {
             "hashes": [
-                "sha256:3479b861cc2b6407de5188695fa1a8d57e5072d7059322469b62628869b8e36e",
-                "sha256:d6c6b49683446d2407d2fe3acb7a368a77ff063f9182fe427da15d622adc24cf"
+                "sha256:b85d0567b8666149a93172712e68920734333c0ce7e89b78b3e987f71e5ed4f9",
+                "sha256:cdf6525904cc597730141d61b36f2e4b8ecc257c420fa2f4549bac2c2d0cb72f"
             ],
-            "markers": "sys_platform == 'linux'",
-            "version": "==0.4.3"
+            "version": "==0.10.0"
         },
         "jsmin": {
             "hashes": [
@@ -388,13 +333,6 @@
             ],
             "version": "==1.12"
         },
-        "pycparser": {
-            "hashes": [
-                "sha256:2d475327684562c3a96cc71adf7dc8c4f0565175cf86b6d7a404ff4c771f15f0",
-                "sha256:7582ad22678f0fcd81102833f60ef8d0e57288b6b5fb00323d101be910e35705"
-            ],
-            "version": "==2.20"
-        },
         "pygithub": {
             "hashes": [
                 "sha256:776befaddab9d8fddd525d52a6ca1ac228cf62b5b1e271836d766f4925e1452e",
@@ -409,6 +347,13 @@
             ],
             "index": "pypi",
             "version": "==1.7.1"
+        },
+        "python-dateutil": {
+            "hashes": [
+                "sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c",
+                "sha256:75bb3f31ea686f1197762692a9ee6a7550b59fc6ca3a1f4b5d7e32fb98e2da2a"
+            ],
+            "version": "==2.8.1"
         },
         "redis": {
             "hashes": [
@@ -426,15 +371,17 @@
             "index": "pypi",
             "version": "==2.24.0"
         },
-        "secretstorage": {
+        "s3transfer": {
             "hashes": [
-                "sha256:15da8a989b65498e29be338b3b279965f1b8f09b9668bd8010da183024c8bff6",
-                "sha256:b5ec909dde94d4ae2fa26af7c089036997030f0cf0a5cb372b4cccabd81c143b"
+                "sha256:2482b4259524933a022d59da830f51bd746db62f047d6eb213f2f8855dcb8a13",
+                "sha256:921a37e2aefc64145e7b73d50c71bb4f26f46e4c9f414dc648c6245ff92cf7db"
             ],
-            "markers": "sys_platform == 'linux'",
-            "version": "==3.1.2"
+            "version": "==0.3.3"
         },
         "sentry-sdk": {
+            "extras": [
+                "falcon"
+            ],
             "hashes": [
                 "sha256:2f023ff348359ec5f0b73a840e8b08e6a8d3b2613a98c57d11c222ef43879237",
                 "sha256:380a280cfc7c4ade5912294e6d9aa71ce776b5fca60a3782e9331b0bcd2866bf"
@@ -518,6 +465,7 @@
                 "sha256:91056c15fa70756691db97756772bb1eb9678fa585d9184f24534b100dc60f4a",
                 "sha256:e7983572181f5e1522d9c98453462384ee92a0be7fac5f1413a1e35c56cc0461"
             ],
+            "markers": "python_version != '3.4'",
             "version": "==1.25.10"
         },
         "whoosh": {
@@ -536,10 +484,10 @@
         },
         "zope.event": {
             "hashes": [
-                "sha256:69c27debad9bdacd9ce9b735dad382142281ac770c4a432b533d6d65c4614bcf",
-                "sha256:d8e97d165fd5a0997b45f5303ae11ea3338becfe68c401dd88ffd2113fe5cae7"
+                "sha256:2666401939cdaa5f4e0c08cf7f20c9b21423b95e88f4675b1443973bdb080c42",
+                "sha256:5e76517f5b9b119acf37ca8819781db6c16ea433f7e2062c4afc2b6fbedb1330"
             ],
-            "version": "==4.4"
+            "version": "==4.5.0"
         },
         "zope.interface": {
             "hashes": [
@@ -612,8 +560,7 @@
         "codecov": {
             "hashes": [
                 "sha256:24545847177a893716b3455ac5bfbafe0465f38d4eb86ea922c09adc7f327e65",
-                "sha256:355fc7e0c0b8a133045f0d6089bde351c845e7b52b99fec5903b4ea3ab5f6aab",
-                "sha256:7877f68effde3c2baadcff807a5d13f01019a337f9596eece0d64e57393adf3a"
+                "sha256:355fc7e0c0b8a133045f0d6089bde351c845e7b52b99fec5903b4ea3ab5f6aab"
             ],
             "index": "pypi",
             "version": "==2.1.9"
@@ -781,6 +728,7 @@
                 "sha256:91056c15fa70756691db97756772bb1eb9678fa585d9184f24534b100dc60f4a",
                 "sha256:e7983572181f5e1522d9c98453462384ee92a0be7fac5f1413a1e35c56cc0461"
             ],
+            "markers": "python_version != '3.4'",
             "version": "==1.25.10"
         }
     }

--- a/services/datalad/datalad_service/handlers/dataset.py
+++ b/services/datalad/datalad_service/handlers/dataset.py
@@ -45,7 +45,7 @@ class DatasetResource(object):
 
     def on_delete(self, req, resp, dataset):
         try:
-            delete_siblings(dataset)
+            delete_siblings(self.store, dataset)
             delete_dataset(self.store, dataset)
             resp.media = {}
             resp.status = falcon.HTTP_OK

--- a/services/datalad/datalad_service/handlers/dataset.py
+++ b/services/datalad/datalad_service/handlers/dataset.py
@@ -45,10 +45,16 @@ class DatasetResource(object):
 
     def on_delete(self, req, resp, dataset):
         try:
+            print('DELETE DATASET *****')
             delete_siblings(self.store, dataset)
+            print('SIBLINGS DONE *****')
             delete_dataset(self.store, dataset)
+            print('DATASET DONE *****')
             resp.media = {}
             resp.status = falcon.HTTP_OK
-        except:
+        except Exception as e:
+            print('<<<<<')
+            print(e)
+            print('<<<<<')
             resp.media = {'error': 'dataset not found'}
             resp.status = falcon.HTTP_NOT_FOUND

--- a/services/datalad/datalad_service/handlers/dataset.py
+++ b/services/datalad/datalad_service/handlers/dataset.py
@@ -5,7 +5,7 @@ import falcon
 from datalad_service.common.user import get_user_info
 from datalad_service.tasks.dataset import create_dataset
 from datalad_service.tasks.dataset import delete_dataset
-
+from datalad_service.tasks.publish import delete_siblings
 
 class DatasetResource(object):
 
@@ -45,6 +45,7 @@ class DatasetResource(object):
 
     def on_delete(self, req, resp, dataset):
         try:
+            delete_siblings(dataset)
             delete_dataset(self.store, dataset)
             resp.media = {}
             resp.status = falcon.HTTP_OK

--- a/services/datalad/datalad_service/handlers/dataset.py
+++ b/services/datalad/datalad_service/handlers/dataset.py
@@ -45,16 +45,10 @@ class DatasetResource(object):
 
     def on_delete(self, req, resp, dataset):
         try:
-            print('DELETE DATASET *****')
             delete_siblings(self.store, dataset)
-            print('SIBLINGS DONE *****')
             delete_dataset(self.store, dataset)
-            print('DATASET DONE *****')
             resp.media = {}
             resp.status = falcon.HTTP_OK
-        except Exception as e:
-            print('<<<<<')
-            print(e)
-            print('<<<<<')
+        except:
             resp.media = {'error': 'dataset not found'}
             resp.status = falcon.HTTP_NOT_FOUND

--- a/services/datalad/datalad_service/handlers/dataset.py
+++ b/services/datalad/datalad_service/handlers/dataset.py
@@ -1,6 +1,7 @@
 import os
 
 import falcon
+import gevent
 
 from datalad_service.common.user import get_user_info
 from datalad_service.tasks.dataset import create_dataset
@@ -44,9 +45,12 @@ class DatasetResource(object):
                 resp.status = falcon.HTTP_500
 
     def on_delete(self, req, resp, dataset):
+        def run_delete_tasks(store, dataset):
+            delete_siblings(store, dataset)
+            delete_dataset(store, dataset)
+
         try:
-            delete_siblings(self.store, dataset)
-            delete_dataset(self.store, dataset)
+            gevent.spawn(run_delete_tasks, self.store, dataset)
             resp.media = {}
             resp.status = falcon.HTTP_OK
         except:

--- a/services/datalad/datalad_service/tasks/publish.py
+++ b/services/datalad/datalad_service/tasks/publish.py
@@ -177,11 +177,11 @@ def delete_siblings(store, dataset_id):
     ds = store.get_dataset(dataset_id)
 
     siblings = ds.siblings()
-    delete_s3_sibling(dataset_id, siblings, DatasetRealm(1))
-    delete_s3_sibling(dataset_id, siblings, DatasetRealm(2))
+    delete_s3_sibling(dataset_id, siblings, DatasetRealm.PRIVATE)
+    delete_s3_sibling(dataset_id, siblings, DatasetRealm.PUBLIC)
 
     remotes = ds.repo.get_remotes()
-    if DatasetRealm(1).github_remote in remotes:
+    if DatasetRealm.PUBLIC.github_remote in remotes:
         delete_github_sibling(dataset_id)
 
     for remote in remotes:

--- a/services/datalad/datalad_service/tasks/publish.py
+++ b/services/datalad/datalad_service/tasks/publish.py
@@ -14,7 +14,7 @@ from datalad_service.common.s3 import DatasetRealm, s3_export, get_s3_realm
 from datalad_service.common.s3 import validate_s3_config, update_s3_sibling
 
 import boto3
-
+from github import Github
 
 def create_github_repo(dataset, repo_name):
     """Setup a github sibling / remote."""
@@ -160,8 +160,21 @@ def delete_s3_sibling(dataset, siblings, realm):
         client.delete_object(Bucket=realm.s3_bucket, Key=dataset.id)
 
 def delete_github_sibling(dataset):
-    # delete from github
-    pass
+    ses = Github(DATALAD_GITHUB_LOGIN, DATALAD_GITHUB_PASS)
+    org = ses.get_organizaton(DATALAD_GITHUB_ORG)
+    repos = org.get_repos()
+    try:
+        print('* * *')
+        print('* * *')
+        print('* * *')
+        print(f'deleting dataset {dataset.id}')
+        print('* * *')
+        print('* * *')
+        print('* * *')
+        r = next(r for r in repos if r.name == dataset.id)
+        r.delete()
+    except StopIteration:
+        raise Exception(f'Attempt to delete dataset {dataset.id} from GitHub failed, because dataset does not exist.')
 
 def delete_siblings(dataset):
     siblings = dataset.siblings()

--- a/services/datalad/datalad_service/tasks/publish.py
+++ b/services/datalad/datalad_service/tasks/publish.py
@@ -182,8 +182,8 @@ def delete_github_sibling(dataset_id):
     try:
         r = next(r for r in repos if r.name == dataset_id)
         r.delete()
-    except StopIteration:
-        raise Exception(f'Attempt to delete dataset {dataset_id} from GitHub has failed, because the dataset does not exist.')
+    except StopIteration as e:
+        raise Exception(f'Attempt to delete dataset {dataset_id} from GitHub has failed, because the dataset does not exist. ({e})')
 
 def delete_siblings(store, dataset_id):
     ds = store.get_dataset(dataset_id)


### PR DESCRIPTION
resolves #1577 and #1259 

# Major Changes
- Users deleting a dataset are prompted for a reason ("duplicate dataset", "abuse of service", or "Other" with custom input) for deletion and "Superseded by (URL)".
- Delete info is stored in mongo DB, including fields: datasetId, reason, redirect, user(_id), and a timestamp.
- When users delete a dataset, that dataset's siblings on github and S3 (Private and Public) are removed as well.