### PR TITLE
Don't reraise exception when error logging fails to find a user

### DIFF
--- a/services/datalad/datalad_service/middleware/auth.py
+++ b/services/datalad/datalad_service/middleware/auth.py
@@ -32,7 +32,6 @@ class AuthenticateMiddleware(object):
                 req.context['user'] = None
                 with configure_scope() as scope:
                     scope.user = None
-                raise
         else:
             with configure_scope() as scope:
                 scope.user = None


### PR DESCRIPTION
This was left in from debugging the uploader's interaction with tokens, which aborts the request before processing it when a token isn't provided. It should continue the request and log it without user information.