### PR TITLE
App: Fix uploader hang in Firefox waiting on service worker

### DIFF
--- a/packages/openneuro-app/src/scripts/uploader/file-upload.js
+++ b/packages/openneuro-app/src/scripts/uploader/file-upload.js
@@ -52,11 +52,11 @@ export async function uploadFiles({
     })
   })
 
-  // Verify the registration is ready
-  const swReg = await navigator.serviceWorker.ready
   // TODO - This is disabled due to Chrome bugs
   // eslint-disable-next-line no-constant-condition
   if ('BackgroundFetchManager' in self && false) {
+    // Verify the registration is ready
+    const swReg = await navigator.serviceWorker.ready
     // If there is parallelism, the browser will handle it
     const bgFetch = await swReg.backgroundFetch.fetch(uploadId, requests, {
       title: `${datasetId} upload`,


### PR DESCRIPTION
In Firefox the `await` call here hangs forever, this prevents uploads from progressing via the web uploader. The call is only useful in the background fetch variation, so I've moved it into that block despite it being disabled for now.