### PR TITLE
Avoid passing entire file list for prepareUpload to server

### DIFF
--- a/packages/openneuro-app/src/scripts/uploader/upload-mutation.js
+++ b/packages/openneuro-app/src/scripts/uploader/upload-mutation.js
@@ -19,10 +19,10 @@ export const createDataset = client => label => {
  * Create a dataset and update the label
  * @param {object} client Apollo client
  */
-export const prepareUpload = client => ({ datasetId, files }) => {
+export const prepareUpload = client => ({ datasetId, uploadId }) => {
   return client.mutate({
     mutation: uploads.prepareUpload,
-    variables: { datasetId, files },
+    variables: { datasetId, uploadId },
   })
 }
 

--- a/packages/openneuro-app/src/scripts/uploader/uploader.jsx
+++ b/packages/openneuro-app/src/scripts/uploader/uploader.jsx
@@ -9,7 +9,7 @@ import UploaderContext from './uploader-context.js'
 import FileSelect from '../common/forms/file-select.jsx'
 import { locationFactory } from './uploader-location.js'
 import * as mutation from './upload-mutation.js'
-import { datasets } from 'openneuro-client'
+import { datasets, uploads } from 'openneuro-client'
 import { withRouter } from 'react-router-dom'
 import { uploadFiles, getRelativePath } from './file-upload.js'
 import { UploadProgress } from './upload-progress.js'
@@ -255,10 +255,7 @@ export class UploadClient extends React.Component {
       },
     } = await mutation.prepareUpload(this.props.client)({
       datasetId: this.state.datasetId,
-      files: filesToUpload.map(f => ({
-        filename: getRelativePath(f),
-        size: f.size,
-      })),
+      uploadId: uploads.hashFileList(filesToUpload),
     })
 
     try {

--- a/packages/openneuro-cli/src/upload.js
+++ b/packages/openneuro-cli/src/upload.js
@@ -105,7 +105,7 @@ export const prepareUpload = async (
   const mutationFiles = files.map(f => ({ filename: f.filename, size: f.size }))
   const { data } = await client.mutate({
     mutation: uploads.prepareUpload,
-    variables: { datasetId, files: mutationFiles },
+    variables: { datasetId, uploadId: uploads.hashFileList(mutationFiles) },
   })
   const id = data.prepareUpload.id
   // eslint-disable-next-line no-console

--- a/packages/openneuro-client/src/__tests__/uploads.spec.js
+++ b/packages/openneuro-client/src/__tests__/uploads.spec.js
@@ -1,4 +1,12 @@
-import { uploadSize, uploadParallelism } from '../uploads.js'
+import { uploadSize, uploadParallelism, hashFileList } from '../uploads.js'
+
+// Quick Mock for browser File
+class File {
+  constructor(content, fileName) {
+    this.webkitRelativePath = '/' + fileName
+    this.size = content.length
+  }
+}
 
 describe('upload implementation', () => {
   describe('uploadSize()', () => {
@@ -43,6 +51,19 @@ describe('upload implementation', () => {
           211,
         ),
       ).toBe(2)
+    })
+  })
+  describe('hashFileList()', () => {
+    it('works for node.js file arrays', () => {
+      const fileList = [{ filename: 'dataset_description.json', size: 256 }]
+      expect(hashFileList(fileList)).toBe('191c26')
+    })
+    it('works for browser arrays of File objects', () => {
+      const fileList = [
+        new File('{"name": "Dataset"}', 'dataset_description.json'),
+        new File('mock dataset', 'README'),
+      ]
+      expect(hashFileList(fileList)).toBe('797ffbf2')
     })
   })
 })

--- a/packages/openneuro-client/src/uploads.js
+++ b/packages/openneuro-client/src/uploads.js
@@ -1,8 +1,8 @@
 import gql from 'graphql-tag'
 
 export const prepareUpload = gql`
-  mutation prepareUpload($datasetId: ID!, $files: [UploadFile]!) {
-    prepareUpload(datasetId: $datasetId, files: $files) {
+  mutation prepareUpload($datasetId: ID!, $uploadId: ID!) {
+    prepareUpload(datasetId: $datasetId, uploadId: $uploadId) {
       id
       datasetId
       token
@@ -38,6 +38,41 @@ export const decodeFilePath = path => {
  */
 export const uploadSize = files =>
   files.map(f => f.size).reduce((a, b) => a + b)
+
+/**
+ * Java hashcode implementation for browser and Node.js
+ * @param {string} str
+ */
+function hashCode(str) {
+  return str
+    .split('')
+    .reduce(
+      (prevHash, currVal) =>
+        ((prevHash << 5) - prevHash + currVal.charCodeAt(0)) | 0,
+      0,
+    )
+}
+
+/**
+ * Calculate a hash from a list of files to upload
+ * @param {Array<object>} files Files being uploaded
+ * @returns {string} Hex string identity hash
+ */
+export function hashFileList(files) {
+  return Math.abs(
+    hashCode(
+      files
+        .map(
+          f =>
+            `${'webkitRelativePath' in f ? f.webkitRelativePath : f.filename}:${
+              f.size
+            }`,
+        )
+        .sort()
+        .join(':'),
+    ),
+  ).toString(16)
+}
 
 /**
  * Determine parallelism based on Request list

--- a/packages/openneuro-server/src/graphql/resolvers/upload.js
+++ b/packages/openneuro-server/src/graphql/resolvers/upload.js
@@ -11,19 +11,20 @@ import { getDatasetEndpoint } from '../../libs/datalad-service.js'
  * @param {object} obj Parent object or null
  * @param {object} arguments Resolver arguments
  * @param {string} arguments.datasetId Accession number string
+ * @param {string} arguments.uploadId Client provided value to identify this upload
  * @param {object} context Resolver context
  * @param {string} context.user User id
  * @param {object} context.userInfo Decoded userInfo from token
  */
 export async function prepareUpload(
   obj,
-  { datasetId, files },
+  { datasetId, uploadId },
   { user, userInfo },
 ) {
   await checkDatasetWrite(datasetId, user, userInfo)
   const upload = await Upload.findOneAndUpdate(
-    { datasetId, files },
-    { datasetId, files },
+    { datasetId, id: uploadId },
+    { datasetId, id: uploadId },
     { new: true, upsert: true, setDefaultsOnInsert: true },
   )
   const token = generateUploadToken(userInfo, datasetId)

--- a/packages/openneuro-server/src/graphql/schema.js
+++ b/packages/openneuro-server/src/graphql/schema.js
@@ -149,7 +149,7 @@ export const typeDefs = `
     # Update draft reference pointer
     updateRef(datasetId: ID!, ref: String!): Boolean
     # Start an upload
-    prepareUpload(datasetId: ID!, files: [UploadFile]): UploadMetadata
+    prepareUpload(datasetId: ID!, uploadId: ID!): UploadMetadata
     # Add files from a completed upload to the dataset draft
     finishUpload(uploadId: ID!): Boolean
   }
@@ -292,8 +292,6 @@ export const typeDefs = `
     id: ID!
     # Dataset associated with this upload
     datasetId: ID!
-    # File status
-    files: [DatasetFile]
     # Is this a complete upload (do we allow a resume or not?)
     complete: Boolean!
     # Estimated size in bytes (this is just used for progress display and can be inaccurate)

--- a/packages/openneuro-server/src/models/upload.js
+++ b/packages/openneuro-server/src/models/upload.js
@@ -9,7 +9,6 @@ import mongoose from 'mongoose'
 const uploadSchema = new mongoose.Schema({
   id: { type: String, required: true, default: uuid.v4 },
   datasetId: { type: String, required: true },
-  files: Array,
   estimatedSize: Number,
   complete: { type: Boolean, default: false, required: true },
 })


### PR DESCRIPTION
Instead we hash it on the client or allow API clients to provide their own id to identify a particular upload.