### PR TITLE
DOC: Replace outdated URL to DataLad docs

### DIFF
--- a/packages/openneuro-app/src/scripts/datalad/download/download-datalad.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/download/download-datalad.jsx
@@ -33,7 +33,7 @@ const DownloadDataladInstructions = ({ datasetId, githubOrganization }) => (
     />
     <p>
       Check out{' '}
-      <a href="http://docs.datalad.org/en/latest/gettingstarted.html">
+      <a href="http://handbook.datalad.org/r.html?openneuro">
         getting started with DataLad
       </a>{' '}
       for more on how to use this download method.

--- a/packages/openneuro-app/src/scripts/front-page/front-page-collaborators.jsx
+++ b/packages/openneuro-app/src/scripts/front-page/front-page-collaborators.jsx
@@ -89,7 +89,7 @@ const Collaborators = () => (
             Read more about{' '}
             <a
               target="_blank"
-              href="http://datalad.org"
+              href="http://handbook.datalad.org/r.html?about"
               rel="noopener noreferrer">
               DataLad
             </a>


### PR DESCRIPTION
Hi! :wave:
When browsing OpenNeuro I noticed that most links to DataLad documentation link to its homepage at http://datalad.org or the developer docs at http://docs.datalad.org.
We have migrated almost all user documentation for DataLad to [handbook.datalad.org](http://handbook.datalad.org).

This PR replaces an outdated link that does not resolve anymore. As a suggestion, I have linked it to our ["overview of DataLad"](http://handbook.datalad.org/en/latest/intro/executive_summary.html#executive-summary) page, but I would be happy to add a small section "Downloading OpenNeuro datasets" to the handbook if you're fine with that. In that case, please let me know, and I'll update the PR soon.

If it is okay with you, I would also replace links to datalad.org with links to handbook.datalad.org. Once you give me a go, I can add those changes to this PR (if this is the correct repo to do this).
Thanks in advance!