### PR TITLE
Chrome 86 native file API updates

### DIFF
--- a/packages/openneuro-app/src/index.html
+++ b/packages/openneuro-app/src/index.html
@@ -6,8 +6,6 @@
     <meta http-equiv="expires" content="0" />
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta http-equiv="origin-trial" content="AmyPFwR0tBBGqzkALyIixvBrU52Da+EPmiUVBek8gTgALZz52o3yo60PUHqtda1mQHc1cuB256iqWU36J5c1rAEAAABYeyJvcmlnaW4iOiJodHRwczovL29wZW5uZXVyby5vcmc6NDQzIiwiZmVhdHVyZSI6Ik5hdGl2ZUZpbGVTeXN0ZW0yIiwiZXhwaXJ5IjoxNjAxNDIzOTk5fQ==" />
-    <meta http-equiv="origin-trial" content="AvBq594GmHFQGxKioxG6Qu/3lF6iCs4poqFufUYLWCL3MkUyrIazFfkr+7+q8Nlc10607k/oAr0L21RV9qh6QgoAAABjeyJvcmlnaW4iOiJodHRwczovL29wZW5uZXVyby5zdGFnaW5nLnNxbS5pbzo0NDMiLCJmZWF0dXJlIjoiTmF0aXZlRmlsZVN5c3RlbTIiLCJleHBpcnkiOjE2MDAzNzc1ODh9" />
     <title>OpenNeuro</title>
     <link id="favicon" rel="icon" type="image/png" href="/content/img/favicon.ico" />
     <link rel="preload" href="/crn/config.json" as="fetch" crossorigin>

--- a/packages/openneuro-app/src/scripts/datalad/download/__tests__/download-native.spec.js
+++ b/packages/openneuro-app/src/scripts/datalad/download/__tests__/download-native.spec.js
@@ -5,12 +5,14 @@ describe('dataset/download - native file API method', () => {
     it('iterates over directory to correct depth', async () => {
       const mockDirectoryHandle = {}
       const mockFile = Symbol('mockFile')
-      mockDirectoryHandle.getDirectory = jest.fn(() => mockDirectoryHandle)
-      mockDirectoryHandle.getFile = jest.fn(() => mockFile)
+      mockDirectoryHandle.getDirectoryHandle = jest.fn(
+        () => mockDirectoryHandle,
+      )
+      mockDirectoryHandle.getFileHandle = jest.fn(() => mockFile)
       expect(
         await openFileTree(mockDirectoryHandle, 'sub-01/anat/something.nii.gz'),
       ).toBe(mockFile)
-      expect(mockDirectoryHandle.getDirectory).toHaveBeenCalledTimes(2)
+      expect(mockDirectoryHandle.getDirectoryHandle).toHaveBeenCalledTimes(2)
     })
   })
 })

--- a/packages/openneuro-app/src/scripts/datalad/download/download-link.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/download/download-link.jsx
@@ -63,7 +63,7 @@ DownloadLinkServiceWorker.propTypes = {
  * Generate a magic bundle link for this dataset
  */
 const DownloadLink = ({ datasetId, snapshotTag }) =>
-  'chooseFileSystemEntries' in window ? (
+  'showDirectoryPicker' in window ? (
     <DownloadLinkNative datasetId={datasetId} snapshotTag={snapshotTag} />
   ) : (
     <DownloadLinkServiceWorker

--- a/packages/openneuro-app/src/scripts/datalad/download/native-file-toast.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/download/native-file-toast.jsx
@@ -21,8 +21,16 @@ export const nativeErrorToast = () => {
     <ToastContent title="Download Error" body="An error occurred writing files">
       <p>
         Make sure you have enough free disk space and permission to write to the
-        dataset.
+        local directory.
       </p>
+    </ToastContent>,
+  )
+}
+
+export const requestFailureToast = () => {
+  toast.error(
+    <ToastContent title="Download Error" body="A file failed to download">
+      <p>You may not have access to download this dataset.</p>
     </ToastContent>,
   )
 }


### PR DESCRIPTION
This makes the updates required to enable native file downloads for Chrome 86 or later now that the origin trial has concluded.