### PR TITLE
Namespace uploadId hashes to the dataset to prevent duplicate uploadIds.

### DIFF
--- a/packages/openneuro-app/src/scripts/uploader/uploader.jsx
+++ b/packages/openneuro-app/src/scripts/uploader/uploader.jsx
@@ -255,7 +255,7 @@ export class UploadClient extends React.Component {
       },
     } = await mutation.prepareUpload(this.props.client)({
       datasetId: this.state.datasetId,
-      uploadId: uploads.hashFileList(filesToUpload),
+      uploadId: uploads.hashFileList(this.state.datasetId, filesToUpload),
     })
 
     try {

--- a/packages/openneuro-cli/src/upload.js
+++ b/packages/openneuro-cli/src/upload.js
@@ -105,7 +105,10 @@ export const prepareUpload = async (
   const mutationFiles = files.map(f => ({ filename: f.filename, size: f.size }))
   const { data } = await client.mutate({
     mutation: uploads.prepareUpload,
-    variables: { datasetId, uploadId: uploads.hashFileList(mutationFiles) },
+    variables: {
+      datasetId,
+      uploadId: uploads.hashFileList(datasetId, mutationFiles),
+    },
   })
   const id = data.prepareUpload.id
   // eslint-disable-next-line no-console

--- a/packages/openneuro-client/src/__tests__/uploads.spec.js
+++ b/packages/openneuro-client/src/__tests__/uploads.spec.js
@@ -56,14 +56,14 @@ describe('upload implementation', () => {
   describe('hashFileList()', () => {
     it('works for node.js file arrays', () => {
       const fileList = [{ filename: 'dataset_description.json', size: 256 }]
-      expect(hashFileList(fileList)).toBe('191c26')
+      expect(hashFileList('ds000001', fileList)).toBe('27bb832a')
     })
     it('works for browser arrays of File objects', () => {
       const fileList = [
         new File('{"name": "Dataset"}', 'dataset_description.json'),
         new File('mock dataset', 'README'),
       ]
-      expect(hashFileList(fileList)).toBe('797ffbf2')
+      expect(hashFileList('ds000001', fileList)).toBe('509a4d42')
     })
   })
 })

--- a/packages/openneuro-client/src/uploads.js
+++ b/packages/openneuro-client/src/uploads.js
@@ -55,21 +55,23 @@ function hashCode(str) {
 
 /**
  * Calculate a hash from a list of files to upload
+ * @param {string} datasetId Dataset namespace for this hash
  * @param {Array<object>} files Files being uploaded
  * @returns {string} Hex string identity hash
  */
-export function hashFileList(files) {
+export function hashFileList(datasetId, files) {
   return Math.abs(
     hashCode(
-      files
-        .map(
-          f =>
-            `${'webkitRelativePath' in f ? f.webkitRelativePath : f.filename}:${
-              f.size
-            }`,
-        )
-        .sort()
-        .join(':'),
+      datasetId +
+        files
+          .map(
+            f =>
+              `${
+                'webkitRelativePath' in f ? f.webkitRelativePath : f.filename
+              }:${f.size}`,
+          )
+          .sort()
+          .join(':'),
     ),
   ).toString(16)
 }


### PR DESCRIPTION
Bug fix for missing content on the second upload of the same set of files. Regression introduced in #1824