### PR TITLE
openneuro-cli: Raise minimum Node.js version to 12.9.0 account for current API usage

### DIFF
--- a/packages/openneuro-cli/package.json
+++ b/packages/openneuro-cli/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "repository": "git@github.com:OpenNeuroOrg/openneuro.git",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.9.0"
   },
   "os": [
     "!win32"


### PR DESCRIPTION
When we updated our Node.js target to the current LTS release the engine field in openneuro-cli was missed. 12.9.0 is the minimum version with all of the required APIs.