### PR TITLE
Fix various typescript compile issues in openneuro-client

### DIFF
--- a/packages/openneuro-client/src/uploads.js
+++ b/packages/openneuro-client/src/uploads.js
@@ -105,7 +105,7 @@ export function parseFilename(url) {
 
 /**
  * Repeatable function for single file upload fetch request
- * @param {UploadProgress} uploadProgress Progress controller instance
+ * @param {object} uploadProgress Progress controller instance
  * @param {fetch} fetch Fetch implementation to use - useful for environments without a native fetch
  * @returns {function (Request, number): Promise<Response>}
  */
@@ -133,7 +133,7 @@ export const uploadFile = (uploadProgress, fetch) => (request, attempt = 1) => {
         )
       } else {
         // Retry if up to attempts times
-        await uploadFile(uploadProgress, fetch)(request, attempt + 1)
+        return await uploadFile(uploadProgress, fetch)(request, attempt + 1)
       }
     }
   })
@@ -143,7 +143,7 @@ export async function uploadParallel(
   requests,
   totalSize,
   uploadProgress,
-  fetch = global.fetch,
+  fetch = window.fetch,
 ) {
   // Array stride of parallel requests
   const parallelism = uploadParallelism(requests, totalSize)

--- a/packages/openneuro-indexer/package.json
+++ b/packages/openneuro-indexer/package.json
@@ -17,8 +17,8 @@
     "@elastic/elasticsearch": "^7.5.0",
     "apollo-link-retry": "^2.2.15",
     "graphql-tag": "^2.10.3",
-    "ts-node": "^8.6.2",
-    "typescript": "^3.7.5"
+    "ts-node": "^9.0.0",
+    "typescript": "^4.0.3"
   },
   "scripts": {
     "build": "tsc",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,8 @@
     "target": "es6",
     "jsx": "preserve",
     "moduleResolution": "node",
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "lib": ["es2020", "dom"]
   },
   "include": ["./packages/**/*"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -23381,15 +23381,15 @@ ts-node@^8.10.2:
     source-map-support "^0.5.17"
     yn "3.1.1"
 
-ts-node@^8.6.2:
-  version "8.6.2"
-  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-8.6.2.tgz#7419a01391a818fbafa6f826a33c1a13e9464e35"
-  integrity sha512-4mZEbofxGqLL2RImpe3zMJukvEvcO1XP8bj8ozBPySdCUXEcU5cIRwR0aM3R+VoZq7iXc8N86NC0FspGRqP4gg==
+ts-node@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-9.0.0.tgz#e7699d2a110cc8c0d3b831715e417688683460b3"
+  integrity sha512-/TqB4SnererCDR/vb4S/QvSZvzQMJN8daAslg7MeaiHvD8rDZsSfXmNeNumyZZzMned72Xoq/isQljYSt8Ynfg==
   dependencies:
     arg "^4.1.0"
     diff "^4.0.1"
     make-error "^1.1.1"
-    source-map-support "^0.5.6"
+    source-map-support "^0.5.17"
     yn "3.1.1"
 
 ts-pnp@^1.1.6:
@@ -23507,6 +23507,11 @@ typescript@^3.9.6:
   version "3.9.6"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.6.tgz#8f3e0198a34c3ae17091b35571d3afd31999365a"
   integrity sha512-Pspx3oKAPJtjNwE92YS05HQoY7z2SFyOpHo9MqJor3BXAGNaPUs83CuVp9VISFkSjyRfiTpmKuAYGJB7S7hOxw==
+
+typescript@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.3.tgz#153bbd468ef07725c1df9c77e8b453f8d36abba5"
+  integrity sha512-tEu6DGxGgRJPb/mVPIZ48e69xCn2yRmCgYmDugAVwmJ6o+0u1RI18eO7E7WBTLYLaEVVOhwQmcdhQHweux/WPg==
 
 typography-breakpoint-constants@^0.16.19:
   version "0.16.19"


### PR DESCRIPTION
This is the underlying cause of #1834 - since we don't build this until runtime for openneuro-indexer it doesn't throw an error until it executes. We should do the build ahead of time to catch this.