### PR TITLE
Update bids-validator to 1.5.6

### DIFF
--- a/packages/openneuro-app/package.json
+++ b/packages/openneuro-app/package.json
@@ -25,7 +25,7 @@
     "apollo-client": "2.6.4",
     "apollo-link-ws": "^1.0.18",
     "babel-runtime": "^6.26.0",
-    "bids-validator": "1.5.4",
+    "bids-validator": "1.5.6",
     "bowser": "^1.7.3",
     "bytes": "^3.0.0",
     "comlink": "^4.0.5",

--- a/packages/openneuro-cli/package.json
+++ b/packages/openneuro-cli/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "abort-controller": "^3.0.0",
-    "bids-validator": "1.5.4",
+    "bids-validator": "1.5.6",
     "cli-progress": "^3.8.2",
     "commander": "^2.15.1",
     "cross-fetch": "^3.0.5",

--- a/services/datalad/package.json
+++ b/services/datalad/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "bids-validator": "1.5.4"
+    "bids-validator": "1.5.6"
   }
 }

--- a/services/datalad/yarn.lock
+++ b/services/datalad/yarn.lock
@@ -1226,10 +1226,10 @@ before-after-hook@^2.0.0:
   resolved "https://registry.yarnpkg.com/before-after-hook/-/before-after-hook-2.1.0.tgz#b6c03487f44e24200dd30ca5e6a1979c5d2fb635"
   integrity sha512-IWIbu7pMqyw3EAJHzzHbWa85b6oud/yfKYg5rqB5hNE8CeMi3nX+2C2sj0HswfblST86hpVEOAb9x34NZd6P7A==
 
-bids-validator@1.5.4:
-  version "1.5.4"
-  resolved "https://registry.yarnpkg.com/bids-validator/-/bids-validator-1.5.4.tgz#2f59a65a712dc1d0af685d774e7796ce0d7cabfc"
-  integrity sha512-ZjS+IIPunLyQv/c6G2gRNraYnD0HTuRvWQFPmrvMTQUyP4+l49vMaTwm4IzN9V6FlO9M2FL7bXvkyyN7KHvVIg==
+bids-validator@1.5.6:
+  version "1.5.6"
+  resolved "https://registry.yarnpkg.com/bids-validator/-/bids-validator-1.5.6.tgz#c0eb0f0b8ba0f1561f45c58465fac05ae434d93a"
+  integrity sha512-pnKGFTlinaEuY5QxVECpynNQcKzIiy8Y3Ov5xF4Sdz/h5UA7RpIlzUBLKgWBjA8+4BylcMLzvF7BGVMeBy7z9g==
   dependencies:
     ajv "^6.5.2"
     aws-sdk "^2.327.0"
@@ -1238,7 +1238,7 @@ bids-validator@1.5.4:
     cross-fetch "^2.2.2"
     date-fns "^2.7.0"
     esm "^3.2.25"
-    hed-validator "^1.1.2"
+    hed-validator "^1.3.2"
     ignore "^4.0.2"
     is-utf8 "^0.2.1"
     jshint "^2.9.6"
@@ -1249,6 +1249,7 @@ bids-validator@1.5.4:
     pako "^1.0.6"
     path "^0.12.7"
     pluralize "^7.0.0"
+    semver "^7.3.2"
     table "^5.2.3"
     yargs "^12.0.1"
 
@@ -1790,10 +1791,15 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
-date-and-time@^0.9.0:
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/date-and-time/-/date-and-time-0.9.0.tgz#1524579e56dc07675c640b41735a7665c0659240"
-  integrity sha512-4JybB6PbR+EebpFx/KyR5Ybl+TcdXMLIJkyYsCx3P4M4CWGMuDyFF19yh6TyasMAIF5lrsgIxiSHBXh2FFc7Fg==
+date-and-time@^0.14.0:
+  version "0.14.1"
+  resolved "https://registry.yarnpkg.com/date-and-time/-/date-and-time-0.14.1.tgz#969634697b78956fb66b8be6fb0f39fbd631f2f6"
+  integrity sha512-M4RggEH5OF2ZuCOxgOU67R6Z9ohjKbxGvAQz48vj53wLmL0bAgumkBvycR32f30pK+Og9pIR+RFDyChbaE4oLA==
+
+date-fns@^2.15.0:
+  version "2.16.1"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.16.1.tgz#05775792c3f3331da812af253e1a935851d3834b"
+  integrity sha512-sAJVKx/FqrLYHAQeN7VpJrPhagZc9R4ImZIWYRFZaaohR3KzmuK88touwsSwSVT8Qcbd4zoDsnGfX4GFB4imyQ==
 
 date-fns@^2.7.0:
   version "2.8.0"
@@ -2659,12 +2665,14 @@ hasha@^2.2.0:
     is-stream "^1.0.1"
     pinkie-promise "^2.0.0"
 
-hed-validator@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/hed-validator/-/hed-validator-1.1.2.tgz#22dcd87e1c85aa31b2b5e385ba106fec242248ef"
-  integrity sha512-RoLqtSlCtaYnDxpSRA5sqwcOO7dg5nhtGIUrc5OTZDD4JIJ77gDlKIbRhiNtEYCpBvfjq6T/5hdGYvZwykcSVg==
+hed-validator@^1.3.2:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/hed-validator/-/hed-validator-1.4.0.tgz#613c87c186d8845bfd1c51f97a352bffc4914e9c"
+  integrity sha512-GsPnPz7OLMbrVaLlaP4iVg6oy/B7H47gGJvMWLceFKuBd5ZbjOKdJ01iW0jFhYMOrPYA549rz4wSYFANeqR0rw==
   dependencies:
-    date-and-time "^0.9.0"
+    date-and-time "^0.14.0"
+    date-fns "^2.15.0"
+    pluralize "^8.0.0"
     then-request "^6.0.2"
     xml2js "^0.4.23"
 
@@ -4219,6 +4227,11 @@ pluralize@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-7.0.0.tgz#298b89df8b93b0221dbf421ad2b1b1ea23fc6777"
 
+pluralize@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-8.0.0.tgz#1a6fa16a38d12a1901e0320fa017051c539ce3b1"
+  integrity sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==
+
 posix-character-classes@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
@@ -4702,6 +4715,11 @@ semver@^6.0.0, semver@^6.2.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
+
+semver@^7.3.2:
+  version "7.3.2"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.2.tgz#604962b052b81ed0786aae84389ffba70ffd3938"
+  integrity sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==
 
 set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6326,10 +6326,10 @@ better-queue@^3.8.10:
     node-eta "^0.9.0"
     uuid "^3.0.0"
 
-bids-validator@1.5.4:
-  version "1.5.4"
-  resolved "https://registry.yarnpkg.com/bids-validator/-/bids-validator-1.5.4.tgz#2f59a65a712dc1d0af685d774e7796ce0d7cabfc"
-  integrity sha512-ZjS+IIPunLyQv/c6G2gRNraYnD0HTuRvWQFPmrvMTQUyP4+l49vMaTwm4IzN9V6FlO9M2FL7bXvkyyN7KHvVIg==
+bids-validator@1.5.6:
+  version "1.5.6"
+  resolved "https://registry.yarnpkg.com/bids-validator/-/bids-validator-1.5.6.tgz#c0eb0f0b8ba0f1561f45c58465fac05ae434d93a"
+  integrity sha512-pnKGFTlinaEuY5QxVECpynNQcKzIiy8Y3Ov5xF4Sdz/h5UA7RpIlzUBLKgWBjA8+4BylcMLzvF7BGVMeBy7z9g==
   dependencies:
     ajv "^6.5.2"
     aws-sdk "^2.327.0"
@@ -6338,7 +6338,7 @@ bids-validator@1.5.4:
     cross-fetch "^2.2.2"
     date-fns "^2.7.0"
     esm "^3.2.25"
-    hed-validator "^1.1.2"
+    hed-validator "^1.3.2"
     ignore "^4.0.2"
     is-utf8 "^0.2.1"
     jshint "^2.9.6"
@@ -6349,6 +6349,7 @@ bids-validator@1.5.4:
     pako "^1.0.6"
     path "^0.12.7"
     pluralize "^7.0.0"
+    semver "^7.3.2"
     table "^5.2.3"
     yargs "^12.0.1"
 
@@ -8682,10 +8683,10 @@ datauri@~0.2.0:
     mimer "*"
     templayed "*"
 
-date-and-time@^0.9.0:
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/date-and-time/-/date-and-time-0.9.0.tgz#1524579e56dc07675c640b41735a7665c0659240"
-  integrity sha512-4JybB6PbR+EebpFx/KyR5Ybl+TcdXMLIJkyYsCx3P4M4CWGMuDyFF19yh6TyasMAIF5lrsgIxiSHBXh2FFc7Fg==
+date-and-time@^0.14.0:
+  version "0.14.1"
+  resolved "https://registry.yarnpkg.com/date-and-time/-/date-and-time-0.14.1.tgz#969634697b78956fb66b8be6fb0f39fbd631f2f6"
+  integrity sha512-M4RggEH5OF2ZuCOxgOU67R6Z9ohjKbxGvAQz48vj53wLmL0bAgumkBvycR32f30pK+Og9pIR+RFDyChbaE4oLA==
 
 date-fns@^1.27.2, date-fns@^1.29.0:
   version "1.30.1"
@@ -8696,6 +8697,11 @@ date-fns@^2.12.0:
   version "2.13.0"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.13.0.tgz#d7b8a0a2d392e8d88a8024d0a46b980bbfdbd708"
   integrity sha512-xm0c61mevGF7f0XpCGtDTGpzEFC/1fpLXHbmFpxZZQJuvByIK2ozm6cSYuU+nxFYOPh2EuCfzUwlTEFwKG+h5w==
+
+date-fns@^2.15.0:
+  version "2.16.1"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.16.1.tgz#05775792c3f3331da812af253e1a935851d3834b"
+  integrity sha512-sAJVKx/FqrLYHAQeN7VpJrPhagZc9R4ImZIWYRFZaaohR3KzmuK88touwsSwSVT8Qcbd4zoDsnGfX4GFB4imyQ==
 
 date-fns@^2.7.0:
   version "2.8.0"
@@ -12847,12 +12853,14 @@ header-case@^1.0.0:
     no-case "^2.2.0"
     upper-case "^1.1.3"
 
-hed-validator@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/hed-validator/-/hed-validator-1.1.2.tgz#22dcd87e1c85aa31b2b5e385ba106fec242248ef"
-  integrity sha512-RoLqtSlCtaYnDxpSRA5sqwcOO7dg5nhtGIUrc5OTZDD4JIJ77gDlKIbRhiNtEYCpBvfjq6T/5hdGYvZwykcSVg==
+hed-validator@^1.3.2:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/hed-validator/-/hed-validator-1.4.0.tgz#613c87c186d8845bfd1c51f97a352bffc4914e9c"
+  integrity sha512-GsPnPz7OLMbrVaLlaP4iVg6oy/B7H47gGJvMWLceFKuBd5ZbjOKdJ01iW0jFhYMOrPYA549rz4wSYFANeqR0rw==
   dependencies:
-    date-and-time "^0.9.0"
+    date-and-time "^0.14.0"
+    date-fns "^2.15.0"
+    pluralize "^8.0.0"
     then-request "^6.0.2"
     xml2js "^0.4.23"
 
@@ -18652,6 +18660,11 @@ pluralize@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-7.0.0.tgz#298b89df8b93b0221dbf421ad2b1b1ea23fc6777"
   integrity sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==
+
+pluralize@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-8.0.0.tgz#1a6fa16a38d12a1901e0320fa017051c539ce3b1"
+  integrity sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==
 
 pn@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
Update to the [latest bids-validator release](https://github.com/bids-standard/bids-validator/releases/tag/v1.5.6).