### PR TITLE
openneuro-cli: Avoid untracked flag while preparing uploads.

### DIFF
--- a/packages/openneuro-cli/src/datasets.js
+++ b/packages/openneuro-cli/src/datasets.js
@@ -23,7 +23,7 @@ export const getDataset = (client, dir, datasetId) => {
  */
 export const getDatasetFiles = (client, datasetId) => {
   return client.query({
-    query: datasets.getUntrackedFiles,
+    query: datasets.getDraftFiles,
     variables: { id: datasetId },
   })
 }

--- a/packages/openneuro-client/src/datasets.js
+++ b/packages/openneuro-client/src/datasets.js
@@ -71,13 +71,13 @@ export const getDataset = gql`
 `
 
 // Get only working tree files
-export const getUntrackedFiles = gql`
+export const getDraftFiles = gql`
   query dataset($id: ID!) {
     dataset(id: $id) {
       id
       draft {
         id
-        files(untracked: true, prefix: null) {
+        files(prefix: null) {
           filename
           size
         }


### PR DESCRIPTION
This drops untracked: true from the request used to diff the remote content with the local content. This prevents an issue with the size of this request getting dropped for very large datasets. This is no longer necessary with the current uploader, it was a requirement previously to resume in-progress uploads.