### PR TITLE
Fix invalid type error thrown during downloads

### DIFF
--- a/packages/openneuro-server/src/graphql/resolvers/dataset.js
+++ b/packages/openneuro-server/src/graphql/resolvers/dataset.js
@@ -198,7 +198,12 @@ export const analytics = async obj => {
  * Track analytic of type 'view' or 'download' for a dataset / snapshot
  */
 export const trackAnalytics = (obj, { datasetId, tag, type }) => {
-  return dataladAnalytics.trackAnalytics(datasetId, tag, type)
+  try {
+    dataladAnalytics.trackAnalytics(datasetId, tag, type)
+    return true
+  } catch (err) {
+    return false
+  }
 }
 
 /**


### PR DESCRIPTION
trackAnalytics was not returning a valid boolean when succesful.

[Sentry issue](https://sentry.io/organizations/openneuro/issues/1942633431)