### PR TITLE
Add a root level script to rebuild dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ You can run tests with `yarn test` at the top level of the project. For each pac
 [docker-compose](https://docs.docker.com/compose/overview/) is used to run a local copy of all required services together. Copy the example `.env.example` file to `.env` and `config.env.example` to `config.env` and use docker-compose to start the containers.
 
 ```shell
-docker-compose up -d
+# This will run docker-compose in the background (-d flag is --detach)
+yarn start -d
 ```
 
 For example, you can restart the server container with `docker-compose restart server` or view logs with `docker-compose logs -f --tail=10 server`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "private": true,
   "scripts": {
+    "start": "docker-compose up --build -V",
     "bootstrap": "lerna bootstrap",
     "test": "jest",
     "coverage": "jest --coverage",


### PR DESCRIPTION
Looking for ways to really solve #1619 doesn't seem possible given the docker-compose tooling available. Instead I think we should update the recommended way to the start docker-compose to add the `--build -V` flags which will always result in consistent dependencies on start. This makes the `docker-compose up` method of starting more of an advanced use case.

This PR adds `yarn start` and documents it in the README.