### PR TITLE
Fix TypeScript build issues with promise.allSettled

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "lerna": "3.20.2",
     "lint-staged": "^6.0.1",
     "prettier": "^1.7.0",
-    "typescript": "^3.7.5"
+    "typescript": "^4.0.3"
   },
   "workspaces": [
     "packages/*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,9 +2,6 @@
 # yarn lockfile v1
 
 
-
-
-
 "@apollo/react-common@^3.1.3":
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/@apollo/react-common/-/react-common-3.1.3.tgz#ddc34f6403f55d47c0da147fd4756dfd7c73dac5"
@@ -23516,11 +23513,6 @@ typescript@3.5.3:
   version "3.5.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.3.tgz#c830f657f93f1ea846819e929092f5fe5983e977"
   integrity sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==
-
-typescript@^3.7.5:
-  version "3.7.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.5.tgz#0692e21f65fd4108b9330238aac11dd2e177a1ae"
-  integrity sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==
 
 typescript@^3.9.6:
   version "3.9.6"


### PR DESCRIPTION
This fixes a build regression reported in #1846 - I think this is just due to the Docker changes in #1845 using a different entrypoint for TypeScript where an older version was still in use.