### PR TITLE
Fix bad z-index on modal styles for dataset toolbar

### DIFF
--- a/packages/openneuro-app/src/sass/bootstrap/_navbar.scss
+++ b/packages/openneuro-app/src/sass/bootstrap/_navbar.scss
@@ -2,7 +2,6 @@
 // Navbars
 // --------------------------------------------------
 
-
 // Wrapper and base class
 //
 // Provide a static navbar from which we expand to create full-width, fixed, and
@@ -22,7 +21,6 @@
   }
 }
 
-
 // Navbar heading
 //
 // Groups `.navbar-brand` and `.navbar-toggle` into a single component for easy
@@ -35,7 +33,6 @@
     float: left;
   }
 }
-
 
 // Navbar collapse (body)
 //
@@ -50,9 +47,9 @@
 .navbar-collapse {
   overflow-x: visible;
   padding-right: $navbar-padding-horizontal;
-  padding-left:  $navbar-padding-horizontal;
+  padding-left: $navbar-padding-horizontal;
   border-top: 1px solid transparent;
-  box-shadow: inset 0 1px 0 rgba(255,255,255,.1);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.1);
   @include clearfix;
   -webkit-overflow-scrolling: touch;
 
@@ -98,7 +95,6 @@
   }
 }
 
-
 // Both navbar header and collapse
 //
 // When a container is present, change the behavior of the header and collapse.
@@ -108,15 +104,14 @@
   > .navbar-header,
   > .navbar-collapse {
     margin-right: -$navbar-padding-horizontal;
-    margin-left:  -$navbar-padding-horizontal;
+    margin-left: -$navbar-padding-horizontal;
 
     @media (min-width: $grid-float-breakpoint) {
       margin-right: 0;
-      margin-left:  0;
+      margin-left: 0;
     }
   }
 }
-
 
 //
 // Navbar alignment options
@@ -157,7 +152,6 @@
   border-width: 1px 0 0;
 }
 
-
 // Brand/project name
 
 .navbar-brand {
@@ -183,7 +177,6 @@
     }
   }
 }
-
 
 // Navbar toggle
 //
@@ -223,7 +216,6 @@
   }
 }
 
-
 // Navbar nav links
 //
 // Builds on top of the `.nav` components with its own modifier class to make
@@ -233,7 +225,7 @@
   margin: ($navbar-padding-vertical / 2) (-$navbar-padding-horizontal);
 
   > li > a {
-    padding-top:    10px;
+    padding-top: 10px;
     padding-bottom: 10px;
     line-height: $line-height-computed;
   }
@@ -270,13 +262,12 @@
     > li {
       float: left;
       > a {
-        padding-top:    $navbar-padding-vertical;
+        padding-top: $navbar-padding-vertical;
         padding-bottom: $navbar-padding-vertical;
       }
     }
   }
 }
-
 
 // Navbar form
 //
@@ -289,7 +280,8 @@
   padding: 10px $navbar-padding-horizontal;
   border-top: 1px solid transparent;
   border-bottom: 1px solid transparent;
-  $shadow: inset 0 1px 0 rgba(255,255,255,.1), 0 1px 0 rgba(255,255,255,.1);
+  $shadow: inset 0 1px 0 rgba(255, 255, 255, 0.1),
+    0 1px 0 rgba(255, 255, 255, 0.1);
   @include box-shadow($shadow);
 
   // Mixin behavior for optimum display
@@ -320,7 +312,6 @@
   }
 }
 
-
 // Dropdown menus
 
 // Menu position and menu carets
@@ -334,7 +325,6 @@
   @include border-top-radius($navbar-border-radius);
   @include border-bottom-radius(0);
 }
-
 
 // Buttons in navbars
 //
@@ -351,7 +341,6 @@
   }
 }
 
-
 // Text in navbars
 //
 // Add a class to make any element properly align itself vertically within the navbars.
@@ -365,7 +354,6 @@
     margin-right: $navbar-padding-horizontal;
   }
 }
-
 
 // Component alignment
 //
@@ -381,14 +369,13 @@
   }
   .navbar-right {
     float: right !important;
-  margin-right: -$navbar-padding-horizontal;
+    margin-right: -$navbar-padding-horizontal;
 
     ~ .navbar-right {
       margin-right: 0;
     }
   }
 }
-
 
 // Alternate navbars
 // --------------------------------------------------
@@ -497,7 +484,6 @@
       }
     }
   }
-
 
   // Links in navbars
   //

--- a/packages/openneuro-app/src/sass/bootstrap/_navbar.scss
+++ b/packages/openneuro-app/src/sass/bootstrap/_navbar.scss
@@ -11,7 +11,6 @@
   position: relative;
   min-height: $navbar-height; // Ensure a navbar always shows (e.g., without a .navbar-brand in collapsed mode)
   margin-bottom: $navbar-margin-bottom;
-  border: 1px solid transparent;
 
   // Prevent floats from breaking the navbar
   @include clearfix;

--- a/packages/openneuro-app/src/scripts/datalad/fragments/dataset-tools.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/fragments/dataset-tools.jsx
@@ -40,75 +40,7 @@ const DatasetTools = ({ dataset, location, history }) => {
   const isMobile = useMedia('(max-width: 765px) ')
   const [showDeleteModal, setShowDeleteModal] = React.useState(false)
   return (
-    <div className="col-xs-12 dataset-tools-wrap">
-      <div className="tools clearfix">
-        <LoggedIn>
-          <div role="presentation" className="tool">
-            {!dataset.public && edit && (
-              <WarnButton
-                tooltip="Publish Dataset"
-                icon="fa-globe icon-plus"
-                warn={false}
-                action={cb => {
-                  toolRedirect(history, rootPath, 'publish')
-                  cb()
-                }}
-              />
-            )}
-          </div>
-          <div role="presentation" className="tool">
-            <span>
-              <button
-                className="btn-warn-component warning"
-                onClick={() => setShowDeleteModal(true)}>
-                <i className="fa fa-trash" />
-              </button>
-            </span>
-          </div>
-          <div role="presentation" className="tool">
-            {edit && (
-              <WarnButton
-                tooltip="Manage Dataset Permissions"
-                icon="fa-user icon-plus"
-                warn={false}
-                action={cb => {
-                  toolRedirect(history, rootPath, 'share')
-                  cb()
-                }}
-              />
-            )}
-          </div>
-          <div role="presentation" className="tool">
-            {edit && !isMobile && (
-              <WarnButton
-                tooltip="Create Snapshot"
-                icon="fa-camera-retro icon-plus"
-                warn={false}
-                action={cb => {
-                  toolRedirect(history, rootPath, 'snapshot')
-                }}
-              />
-            )}
-          </div>
-          <div role="presentation" className="tool">
-            <FollowDataset
-              datasetId={dataset.id}
-              following={dataset.following}
-            />
-          </div>
-          <div role="presentation" className="tool">
-            <StarDataset datasetId={dataset.id} starred={dataset.starred} />
-          </div>
-          {isMobile && (
-            <div role="presentation" className="tool">
-              <ShareDatasetLink url={`https://openneuro.org${rootPath}`} />
-            </div>
-          )}
-        </LoggedIn>
-        <div role="presentation" className="tool">
-          <DatasetMetadata datasetId={dataset.id} metadata={dataset.metadata} />
-        </div>
-      </div>
+    <>
       {showDeleteModal && (
         <Overlay>
           <ModalContainer>
@@ -122,7 +54,80 @@ const DatasetTools = ({ dataset, location, history }) => {
           </ModalContainer>
         </Overlay>
       )}
-    </div>
+      <div className="col-xs-12 dataset-tools-wrap">
+        <div className="tools clearfix">
+          <LoggedIn>
+            <div role="presentation" className="tool">
+              {!dataset.public && edit && (
+                <WarnButton
+                  tooltip="Publish Dataset"
+                  icon="fa-globe icon-plus"
+                  warn={false}
+                  action={cb => {
+                    toolRedirect(history, rootPath, 'publish')
+                    cb()
+                  }}
+                />
+              )}
+            </div>
+            <div role="presentation" className="tool">
+              <span>
+                <button
+                  className="btn-warn-component warning"
+                  onClick={() => setShowDeleteModal(true)}>
+                  <i className="fa fa-trash" />
+                </button>
+              </span>
+            </div>
+            <div role="presentation" className="tool">
+              {edit && (
+                <WarnButton
+                  tooltip="Manage Dataset Permissions"
+                  icon="fa-user icon-plus"
+                  warn={false}
+                  action={cb => {
+                    toolRedirect(history, rootPath, 'share')
+                    cb()
+                  }}
+                />
+              )}
+            </div>
+            <div role="presentation" className="tool">
+              {edit && !isMobile && (
+                <WarnButton
+                  tooltip="Create Snapshot"
+                  icon="fa-camera-retro icon-plus"
+                  warn={false}
+                  action={cb => {
+                    toolRedirect(history, rootPath, 'snapshot')
+                  }}
+                />
+              )}
+            </div>
+            <div role="presentation" className="tool">
+              <FollowDataset
+                datasetId={dataset.id}
+                following={dataset.following}
+              />
+            </div>
+            <div role="presentation" className="tool">
+              <StarDataset datasetId={dataset.id} starred={dataset.starred} />
+            </div>
+            {isMobile && (
+              <div role="presentation" className="tool">
+                <ShareDatasetLink url={`https://openneuro.org${rootPath}`} />
+              </div>
+            )}
+          </LoggedIn>
+          <div role="presentation" className="tool">
+            <DatasetMetadata
+              datasetId={dataset.id}
+              metadata={dataset.metadata}
+            />
+          </div>
+        </div>
+      </div>
+    </>
   )
 }
 DatasetTools.propTypes = {

--- a/packages/openneuro-app/src/scripts/styles/support-modal.jsx
+++ b/packages/openneuro-app/src/scripts/styles/support-modal.jsx
@@ -14,7 +14,7 @@ const Overlay = styled.div`
   transition: opacity 400ms ease-in;
   display: inline-block;
   opacity: 100;
-  z-index: 999;
+  z-index: 2000;
 `
 
 const ModalContainer = styled.div`


### PR DESCRIPTION
Looks like this is caused by the toolbar open/close button being in a different z-index context than the modal and the modal being a later component it would always render underneath the button. I moved it up the tree and also took out a 1px transparent border which was negating the background.

![Screenshot from 2020-10-19 16-36-41](https://user-images.githubusercontent.com/11369795/96523107-bab03000-1229-11eb-8407-176c829f8697.png)
