### PR TITLE
Document configuration for disabling Elastic APM locally

### DIFF
--- a/config.env.example
+++ b/config.env.example
@@ -83,6 +83,9 @@ DATALAD_S3_PUBLIC_ON_EXPORT=yes
 # Elastic Search connection string
 ELASTICSEARCH_CONNECTION=http://elasticsearch:9200
 
+# Disable Elastic APM by default
+ELASTIC_APM_ACTIVE=false
+
 # GraphQL path
 # For docker-compose, use a network relative URI
 GRAPHQL_URI=http://web/crn/graphql


### PR DESCRIPTION
This can be added to config.env to disable the Elastic APM reporting from the server.