### PR TITLE
cli: Add Elastic APM reporting with user prompt to enable

### DIFF
--- a/packages/openneuro-cli/package.json
+++ b/packages/openneuro-cli/package.json
@@ -21,6 +21,7 @@
     "cli-progress": "^3.8.2",
     "commander": "^2.15.1",
     "cross-fetch": "^3.0.5",
+    "elastic-apm-node": "^3.7.0",
     "esm": "^3.0.16",
     "fetch-h2": "^2.5.1",
     "find-config": "^1.0.0",

--- a/packages/openneuro-cli/src/apm.js
+++ b/packages/openneuro-cli/src/apm.js
@@ -1,0 +1,15 @@
+import elasticApm from 'elastic-apm-node'
+import { getErrorReporting } from './config.js'
+import packageJson from '../package.json'
+
+export let apm
+const url = getErrorReporting()
+if (url) {
+  apm = elasticApm.start({
+    serverUrl: url,
+    serviceName: 'openneuro-cli',
+    serviceVersion: packageJson.version,
+    environment: 'production',
+    logLevel: 'fatal',
+  })
+}

--- a/packages/openneuro-cli/src/config.js
+++ b/packages/openneuro-cli/src/config.js
@@ -56,3 +56,16 @@ export const getUrl = () => {
     )
   }
 }
+
+export const getErrorReporting = () => {
+  const config = JSON.parse(readConfig())
+  if (
+    config.hasOwnProperty('errorReporting') &&
+    config.hasOwnProperty('url') &&
+    config.errorReporting
+  ) {
+    return config.url
+  } else {
+    return false
+  }
+}

--- a/packages/openneuro-cli/src/download.js
+++ b/packages/openneuro-cli/src/download.js
@@ -105,8 +105,10 @@ export const downloadFile = async (destination, filename, fileUrl) => {
   }
 }
 
-export const getDownload = (destination, datasetId, tag) =>
+export const getDownload = (destination, datasetId, tag, apmTransaction) =>
   getDownloadMetadata(datasetId, tag).then(async body => {
+    apmTransaction.addLabels({ datasetId, tag })
+    const apmDownload = apmTransaction.startSpan('download')
     checkDestination(destination)
     for (const file of body.files) {
       if (testFile(destination, file.filename, file.size)) {
@@ -119,4 +121,5 @@ export const getDownload = (destination, datasetId, tag) =>
         console.log(`Skipping present file "${file.filename}"`)
       }
     }
+    apmDownload.end()
   })


### PR DESCRIPTION
This adds a transaction and spans for downloads and uploads via the CLI to improve our ability to debug issues with these.

To enable this feature a user has to add `"errorReporting":true` to their configuration or answer yes to the prompt during `openneuro login`.