### PR TITLE
Update to bids-validator@1.5.7 and add ignoreSubjectConsistency support

### DIFF
--- a/packages/openneuro-app/package.json
+++ b/packages/openneuro-app/package.json
@@ -25,7 +25,7 @@
     "apollo-client": "2.6.4",
     "apollo-link-ws": "^1.0.18",
     "babel-runtime": "^6.26.0",
-    "bids-validator": "1.5.6",
+    "bids-validator": "1.5.7",
     "bowser": "^1.7.3",
     "bytes": "^3.0.0",
     "comlink": "^4.0.5",

--- a/packages/openneuro-app/src/scripts/uploader/upload-issues.jsx
+++ b/packages/openneuro-app/src/scripts/uploader/upload-issues.jsx
@@ -69,6 +69,7 @@ class UploadValidator extends React.Component {
     const options = {
       config: {
         error: ['NO_AUTHORS'],
+        ignoreSubjectConsistency: true,
       },
     }
     validate(this.props.files, options).then(this.done)

--- a/packages/openneuro-cli/package.json
+++ b/packages/openneuro-cli/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "abort-controller": "^3.0.0",
-    "bids-validator": "1.5.6",
+    "bids-validator": "1.5.7",
     "cli-progress": "^3.8.2",
     "commander": "^2.15.1",
     "cross-fetch": "^3.0.5",

--- a/packages/openneuro-cli/src/actions.js
+++ b/packages/openneuro-cli/src/actions.js
@@ -138,6 +138,7 @@ export const upload = (dir, cmd) => {
     const validatorOptions = {
       ignoreWarnings: cmd.ignoreWarnings,
       ignoreNiftiHeaders: cmd.ignoreNiftiHeaders,
+      ignoreSubjectConsistency: cmd.ignoreSubjectConsistency,
       verbose: cmd.verbose,
     }
     if (cmd.dataset) {

--- a/packages/openneuro-cli/src/cli.js
+++ b/packages/openneuro-cli/src/cli.js
@@ -40,6 +40,10 @@ commander
     '-n, --ignoreNiftiHeaders',
     'Disregard NIfTI header content during validation',
   )
+  .option(
+    '--ignoreSubjectConsistency',
+    'Skip checking that any given file for one subject is present for all other subjects',
+  )
   .option('-v, --verbose', 'Verbose output')
   .action(upload)
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6326,10 +6326,10 @@ better-queue@^3.8.10:
     node-eta "^0.9.0"
     uuid "^3.0.0"
 
-bids-validator@1.5.6:
-  version "1.5.6"
-  resolved "https://registry.yarnpkg.com/bids-validator/-/bids-validator-1.5.6.tgz#c0eb0f0b8ba0f1561f45c58465fac05ae434d93a"
-  integrity sha512-pnKGFTlinaEuY5QxVECpynNQcKzIiy8Y3Ov5xF4Sdz/h5UA7RpIlzUBLKgWBjA8+4BylcMLzvF7BGVMeBy7z9g==
+bids-validator@1.5.7:
+  version "1.5.7"
+  resolved "https://registry.yarnpkg.com/bids-validator/-/bids-validator-1.5.7.tgz#14f993a0e1d194d0108567d1c21d8e4f1336f80c"
+  integrity sha512-GOlqvzZ5d6rlJn/Y8KVEfmugOzGoftNMlw3oK4JgosU+ejAv+JBhrZqTfH5Kk11PpZmi57DWa4XIKmsC4RB01g==
   dependencies:
     ajv "^6.5.2"
     aws-sdk "^2.327.0"


### PR DESCRIPTION
See https://github.com/bids-standard/bids-validator/pull/1099 for why this option exists. We've decided to enable it by default in for the web uploader but it has an optional flag to enable it for openneuro-cli.