### PR TITLE
Add datalad-service API for dataset history

### DIFF
--- a/services/datalad/datalad_service/app.py
+++ b/services/datalad/datalad_service/app.py
@@ -12,6 +12,7 @@ from datalad_service.handlers.dataset import DatasetResource
 from datalad_service.handlers.draft import DraftResource
 from datalad_service.handlers.description import DescriptionResource
 from datalad_service.handlers.files import FilesResource
+from datalad_service.handlers.history import HistoryResource
 from datalad_service.handlers.snapshots import SnapshotResource
 from datalad_service.handlers.heartbeat import HeartbeatResource
 from datalad_service.handlers.publish import PublishResource
@@ -52,6 +53,7 @@ def create_app(annex_path):
     heartbeat = HeartbeatResource()
     datasets = DatasetResource(store)
     dataset_draft = DraftResource(store)
+    dataset_history = HistoryResource(store)
     dataset_description = DescriptionResource(store)
     dataset_files = FilesResource(store)
     dataset_publish = PublishResource(store)
@@ -65,6 +67,7 @@ def create_app(annex_path):
     api.add_route('/datasets/{dataset}', datasets)
 
     api.add_route('/datasets/{dataset}/draft', dataset_draft)
+    api.add_route('/datasets/{dataset}/history', dataset_history)
     api.add_route('/datasets/{dataset}/description', dataset_description)
 
     api.add_route('/datasets/{dataset}/files', dataset_files)

--- a/services/datalad/datalad_service/handlers/history.py
+++ b/services/datalad/datalad_service/handlers/history.py
@@ -1,0 +1,16 @@
+import falcon
+
+class HistoryResource(object):
+    def __init__(self, store):
+        self.store = store
+
+    def on_get(self, req, resp, dataset):
+        """
+        Return dataset history (text format)
+        """
+        if dataset:
+            ds = self.store.get_dataset(dataset)
+            resp.media = {'log': ds.repo.get_revisions(fmt='%H %ai %cn <%ce> %d %s')}
+            resp.status = falcon.HTTP_OK
+        else:
+            resp.status = falcon.HTTP_NOT_FOUND

--- a/services/datalad/tests/test_history.py
+++ b/services/datalad/tests/test_history.py
@@ -1,0 +1,15 @@
+import falcon
+import json
+
+from .dataset_fixtures import *
+from datalad_service.handlers.history import HistoryResource
+
+
+def test_history(client):
+    response = client.simulate_get(
+        '/datasets/{}/history'.format('ds000001'))
+    assert response.status == falcon.HTTP_OK
+    history = json.loads(
+        response.content) if response.content else None
+    assert history is not None
+    assert len(history["log"]) == 4


### PR DESCRIPTION
Adds an internal API that returns a JSON log with one line per commit for the dataset draft HEAD.

This is a dependency for #1646 