### PR TITLE
Document how to unpublish a dataset with the search index step

### DIFF
--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -1,0 +1,17 @@
+---
+name: Site Maintenance
+route: maintenance
+---
+
+## Unpublishing a dataset
+
+To unpublish a dataset the database flag datasets.public can be set to false. Example query: `db.datasets.updateOne({id: "accession-number"}, {$set: {public: false}}`. This will hide the dataset on OpenNeuro but not remove it from any configured git-annex remotes.
+
+After unpublishing a dataset like this the search index must either have the hidden dataset removed or the index needs to be rebuilt.
+
+```shell
+# One dataset can be removed like so
+curl -X DELETE "http://elastic-server/datasets/_doc/${ACCESSION_NUMBER}"
+```
+
+To make the dataset public again it can simply be republished by a dataset administrator. Any remotes which were altered will need to be updated manually.


### PR DESCRIPTION
Adds documentation with instructions for a site administrator to unpublish a dataset given the current limitations around that.