### PR TITLE
Add download progress toast to the native file web downloader

### DIFF
--- a/packages/openneuro-app/package.json
+++ b/packages/openneuro-app/package.json
@@ -55,7 +55,7 @@
     "react-router": "^5.1.2",
     "react-router-dom": "^5.1.2",
     "react-spring": "^8.0.27",
-    "react-toastify": "^4.4.0",
+    "react-toastify": "6.0.9",
     "react-virtualized": "^9.21.0",
     "resize-observer-polyfill": "^1.5.1",
     "semver": "^5.5.0",

--- a/packages/openneuro-app/src/sass/crn_app/_elements-wrappers.scss
+++ b/packages/openneuro-app/src/sass/crn_app/_elements-wrappers.scss
@@ -707,6 +707,13 @@ h6 {
   }
 }
 
+.Toastify__toast--default {
+  border-top: 4px solid $c-33;
+  .Toastify__progress-bar {
+    background: $secondary;
+  }
+}
+
 .Toastify__toast--success {
   border-top: 4px solid $success;
 }

--- a/packages/openneuro-app/src/scripts/datalad/download/download-native.js
+++ b/packages/openneuro-app/src/scripts/datalad/download/download-native.js
@@ -1,6 +1,10 @@
 import * as Sentry from '@sentry/browser'
 import { trackDownload } from './track-download.js'
 import {
+  downloadToast,
+  downloadToastUpdate,
+  downloadToastDone,
+  downloadAbortToast,
   nativeErrorToast,
   permissionsToast,
   downloadCompleteToast,
@@ -29,6 +33,13 @@ export const openFileTree = async (initialDirectoryHandle, path) => {
   return directoryHandle.getFileHandle(filename, { create: true })
 }
 
+class DownloadAbortError extends Error {
+  constructor(message) {
+    super(message)
+    this.name = 'DownloadAbortError'
+  }
+}
+
 /**
  * Downloads a dataset via the native file API, skipping expensive compression if the browser supports it
  * @param {string} datasetId Accession number string for a dataset
@@ -36,17 +47,31 @@ export const openFileTree = async (initialDirectoryHandle, path) => {
  */
 export const downloadNative = (datasetId, snapshotTag) => async () => {
   const uri = downloadUri(datasetId, snapshotTag)
-  const filesToDownload = await (await fetch(uri + '?skip-bundle')).json()
+  const { files: filesToDownload } = await (
+    await fetch(uri + '?skip-bundle')
+  ).json()
+
   // Try trackDownload but don't worry if it fails
   try {
     trackDownload(datasetId, snapshotTag)
   } catch (err) {
     Sentry.captureException(err)
   }
+  let downloadCanceled = false
+  let toastId
   try {
     // Open user selected directory
     const dirHandle = await window.showDirectoryPicker()
-    for (const file of filesToDownload.files) {
+    toastId = downloadToast(
+      dirHandle.name,
+      datasetId,
+      snapshotTag,
+      () => (downloadCanceled = true),
+    )
+    for (const [index, file] of filesToDownload.entries()) {
+      if (downloadCanceled) {
+        throw new DownloadAbortError('Download canceled by user request')
+      }
       const fileHandle = await openFileTree(dirHandle, file.filename)
       // Skip files which are already complete
       if (fileHandle.size == file.size) continue
@@ -57,15 +82,20 @@ export const downloadNative = (datasetId, snapshotTag) => async () => {
       } else {
         return requestFailureToast()
       }
+      downloadToastUpdate(toastId, index / filesToDownload.length)
     }
     downloadCompleteToast(dirHandle.name)
   } catch (err) {
-    if (err.name === 'NoModificationAllowedError') {
+    if (err.name === 'DownloadAbortError') {
+      downloadAbortToast()
+    } else if (err.name === 'NoModificationAllowedError') {
       permissionsToast()
     } else {
       // Some unknown issue occurred (out of disk space, disk caught fire, etc...)
       nativeErrorToast()
     }
     Sentry.captureException(err)
+  } finally {
+    downloadToastDone(toastId)
   }
 }

--- a/packages/openneuro-app/src/scripts/datalad/download/download-native.js
+++ b/packages/openneuro-app/src/scripts/datalad/download/download-native.js
@@ -86,7 +86,9 @@ export const downloadNative = (datasetId, snapshotTag) => async () => {
     }
     downloadCompleteToast(dirHandle.name)
   } catch (err) {
-    if (err.name === 'DownloadAbortError') {
+    if (err.name === 'AbortError') {
+      return
+    } else if (err.name === 'DownloadAbortError') {
       downloadAbortToast()
     } else if (err.name === 'NotAllowedError') {
       permissionsToast()

--- a/packages/openneuro-app/src/scripts/datalad/download/download-native.js
+++ b/packages/openneuro-app/src/scripts/datalad/download/download-native.js
@@ -88,7 +88,7 @@ export const downloadNative = (datasetId, snapshotTag) => async () => {
   } catch (err) {
     if (err.name === 'DownloadAbortError') {
       downloadAbortToast()
-    } else if (err.name === 'NoModificationAllowedError') {
+    } else if (err.name === 'NotAllowedError') {
       permissionsToast()
     } else {
       // Some unknown issue occurred (out of disk space, disk caught fire, etc...)

--- a/packages/openneuro-app/src/scripts/datalad/download/native-file-toast.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/download/native-file-toast.jsx
@@ -14,6 +14,20 @@ export const permissionsToast = () => {
 }
 
 /**
+ * Write failures due to a user event
+ */
+export const downloadAbortToast = () => {
+  toast.error(
+    <ToastContent title="Download Canceled">
+      <p>
+        To retry your download click the download button and reselect the target
+        directory.
+      </p>
+    </ToastContent>,
+  )
+}
+
+/**
  * Generic download issues
  */
 export const nativeErrorToast = () => {
@@ -44,5 +58,33 @@ export const downloadCompleteToast = dirName => {
     <ToastContent
       title="Download Complete"
       body={`See "${dirName}" directory for downloaded files`}></ToastContent>,
+    { autoClose: false },
   )
 }
+
+/**
+ * Show download progress
+ * @param {string} dirName Local directory chosen
+ * @param {string} datasetId Dataset identifier
+ * @param {string} snapshotId Snapshot identifier
+ */
+export const downloadToast = (dirName, datasetId, snapshotId, onClose) => {
+  const downloadMessage = snapshotId
+    ? `Copying ${datasetId} snapshot ${snapshotId} to local folder ${dirName}`
+    : `Copying ${datasetId} to local folder ${dirName}`
+  return toast(
+    <ToastContent title={'Downloading'} body={downloadMessage}></ToastContent>,
+    {
+      progress: 0,
+      hideProgressBar: false,
+      autoClose: false,
+      closeOnClick: false,
+      onClose,
+    },
+  )
+}
+
+export const downloadToastUpdate = (toastId, progress) =>
+  toast.update(toastId, { progress })
+
+export const downloadToastDone = toastId => toast.done(toastId)

--- a/yarn.lock
+++ b/yarn.lock
@@ -1875,7 +1875,7 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
-"@babel/runtime@^7.10.2", "@babel/runtime@^7.10.3", "@babel/runtime@^7.11.2":
+"@babel/runtime@^7.10.2", "@babel/runtime@^7.10.3", "@babel/runtime@^7.11.2", "@babel/runtime@^7.8.7":
   version "7.12.1"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.12.1.tgz#b4116a6b6711d010b2dad3b7b6e43bf1b9954740"
   integrity sha512-J5AIf3vPj3UwXaAzb5j1xM4WAQDX3EMgemF8rjCP3SoW09LfRKAXQKt6CoVYl230P6iWdRcBbnLDDdnqWxZSCA==
@@ -8740,6 +8740,11 @@ csstype@^2.5.7:
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.6.tgz#c34f8226a94bbb10c32cc0d714afdf942291fc41"
   integrity sha512-RpFbQGUE74iyPgvr46U9t1xoQBM8T4BL8SxrN66Le2xYAPSaDJJKeztV3awugusb3g3G9iL8StmkBBXhcbbXhg==
 
+csstype@^3.0.2:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.4.tgz#b156d7be03b84ff425c9a0a4b1e5f4da9c5ca888"
+  integrity sha512-xc8DUsCLmjvCfoD7LTGE0ou2MIWLx0K9RCZwSHMOdynqRsP4MtUcLeqh1HcQ2dInwDTqn+3CE0/FZh1et+p4jA==
+
 currently-unhandled@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/currently-unhandled/-/currently-unhandled-0.4.1.tgz#988df33feab191ef799a61369dd76c17adf957ea"
@@ -9447,6 +9452,14 @@ dom-converter@^0.2:
   integrity sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==
   dependencies:
     "@babel/runtime" "^7.1.2"
+
+dom-helpers@^5.0.1:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-5.2.0.tgz#57fd054c5f8f34c52a3eeffdb7e7e93cd357d95b"
+  integrity sha512-Ru5o9+V8CpunKnz5LGgWXkmrH/20cGKwcHwS4m73zIvs54CN9epEmT/HLqFJW3kXpakAFkEdzgy1hzlJe3E4OQ==
+  dependencies:
+    "@babel/runtime" "^7.8.7"
+    csstype "^3.0.2"
 
 dom-iterator@^1.0.0:
   version "1.0.0"
@@ -20132,24 +20145,24 @@ react-test-renderer@^16.0.0-0, react-test-renderer@^16.8.6:
     react-is "^16.9.0"
     scheduler "^0.15.0"
 
-react-toastify@^4.4.0:
-  version "4.5.2"
-  resolved "https://registry.yarnpkg.com/react-toastify/-/react-toastify-4.5.2.tgz#a75b5f8b6219f62d4aacd0455d578a53341e37ca"
-  integrity sha512-KymDDhkcX5EvFht17nO0MCsegM/Kdhyfxhi+WQl2tE3IxJrueOhY6TUnALTfvz7eDRUjPYBGb+ywWqWrGyvBnw==
+react-toastify@6.0.9:
+  version "6.0.9"
+  resolved "https://registry.yarnpkg.com/react-toastify/-/react-toastify-6.0.9.tgz#2a65e5ad9e05f3ee47664cbc69441498b9d694ce"
+  integrity sha512-StHXv+4kezHUnPyoILlvygSptQ79bxVuvKcC05yXP0FlqQgPA1ue+80BqxZZiCw2jWDGiY2MHyqBfFKf5YzZbA==
   dependencies:
     classnames "^2.2.6"
-    prop-types "^15.6.0"
-    react-transition-group "^2.4.0"
+    prop-types "^15.7.2"
+    react-transition-group "^4.4.1"
 
-react-transition-group@^2.4.0:
-  version "2.9.0"
-  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-2.9.0.tgz#df9cdb025796211151a436c69a8f3b97b5b07c8d"
-  integrity sha512-+HzNTCHpeQyl4MJ/bdE0u6XRMe9+XG/+aL4mCxVN4DnPBQ0/5bfHWPDuOZUzYdMj94daZaZdCCc1Dzt9R/xSSg==
+react-transition-group@^4.4.1:
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.4.1.tgz#63868f9325a38ea5ee9535d828327f85773345c9"
+  integrity sha512-Djqr7OQ2aPUiYurhPalTrVy9ddmFCCzwhqQmtN+J3+3DzLO209Fdr70QrN8Z3DsglWql6iY1lDWAfpFiBtuKGw==
   dependencies:
-    dom-helpers "^3.4.0"
+    "@babel/runtime" "^7.5.5"
+    dom-helpers "^5.0.1"
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
-    react-lifecycles-compat "^3.0.4"
 
 react-virtualized@^9.21.0:
   version "9.21.1"


### PR DESCRIPTION
This is an alternative solution to the issue in #1356 due to the disk space limitations with actually using background fetch for these operations. Instead this implements a download toast that shows progress per file and allows you to cancel downloads in progress, giving most of the same benefits (no downloading without the main thread though, so the page must stay open).