### PR TITLE
Add dataset admin tools

### DIFF
--- a/packages/openneuro-app/src/scripts/datalad/dataset/dataset-query-fragments.js
+++ b/packages/openneuro-app/src/scripts/datalad/dataset/dataset-query-fragments.js
@@ -7,6 +7,7 @@ export const DRAFT_FRAGMENT = gql`
       id
       modified
       readme
+      head
       description {
         Name
         Authors

--- a/packages/openneuro-app/src/scripts/datalad/fragments/dataset-history.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/fragments/dataset-history.jsx
@@ -1,0 +1,25 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import styled from '@emotion/styled'
+import gql from 'graphql-tag'
+
+const GET_HISTORY = gql`
+  query DatasetHistory($datasetId: ID!) {
+    dataset(id: $datasetId) {
+      id
+      history
+    }
+  }
+`
+
+const DatasetHistory = ({ datasetId }) => (
+  <div className="dataset-history">
+    <div className="col-xs-12"></div>
+  </div>
+)
+
+DatasetHistory.propTypes = {
+  datasetId: PropTypes.string,
+}
+
+export default DatasetHistory

--- a/packages/openneuro-app/src/scripts/datalad/fragments/dataset-history.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/fragments/dataset-history.jsx
@@ -2,21 +2,40 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import styled from '@emotion/styled'
 import gql from 'graphql-tag'
+import { useQuery } from 'react-apollo'
 
 const GET_HISTORY = gql`
-  query DatasetHistory($datasetId: ID!) {
+  query getHistory($datasetId: ID!) {
     dataset(id: $datasetId) {
       id
       history
+      worker
     }
   }
 `
 
-const DatasetHistory = ({ datasetId }) => (
-  <div className="dataset-history">
-    <div className="col-xs-12"></div>
-  </div>
-)
+const DatasetHistory = ({ datasetId }) => {
+  const { loading, data } = useQuery(GET_HISTORY, {
+    variables: { datasetId },
+  })
+  if (loading) {
+    return <div className="dataset-history">Loading...</div>
+  } else {
+    return (
+      <div className="dataset-history">
+        <div className="col-xs-6">
+          <h4>Worker Assignment</h4> {data.dataset.worker}
+        </div>
+        <div className="col-xs-12">
+          <h4>Git History</h4>
+          {data.dataset.history.map(row => (
+            <div key={row}>{row}</div>
+          ))}
+        </div>
+      </div>
+    )
+  }
+}
 
 DatasetHistory.propTypes = {
   datasetId: PropTypes.string,

--- a/packages/openneuro-app/src/scripts/datalad/fragments/dataset-history.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/fragments/dataset-history.jsx
@@ -8,9 +8,32 @@ const GET_HISTORY = gql`
   query getHistory($datasetId: ID!) {
     dataset(id: $datasetId) {
       id
-      history
+      history {
+        id
+        authorName
+        authorEmail
+        date
+        references
+        message
+      }
       worker
     }
+  }
+`
+
+const DatasetHistoryTable = styled.div`
+  .row {
+    line-height: 1.2em;
+  }
+  .row:nth-of-type(2n) {
+    padding-top: 1em;
+  }
+  .row:nth-of-type(2n + 1) {
+    padding-bottom: 1em;
+  }
+  .row:nth-of-type(4n),
+  .row:nth-of-type(4n + 1) {
+    background: #f4f4f4;
   }
 `
 
@@ -23,14 +46,34 @@ const DatasetHistory = ({ datasetId }) => {
   } else {
     return (
       <div className="dataset-history">
-        <div className="col-xs-6">
-          <h4>Worker Assignment</h4> {data.dataset.worker}
+        <div className="col-lg-6">
+          <h3>Worker Assignment</h3> {data.dataset.worker}
         </div>
-        <div className="col-xs-12">
-          <h4>Git History</h4>
-          {data.dataset.history.map(row => (
-            <div key={row}>{row}</div>
-          ))}
+        <div className="col-lg-12">
+          <h3>Git History</h3>
+          <DatasetHistoryTable>
+            <div className="row">
+              <h4 className="col-lg-4">Commit</h4>
+              <h4 className="col-lg-2">Date</h4>
+              <h4 className="col-lg-3">Author</h4>
+              <h4 className="col-lg-3">References</h4>
+            </div>
+            {data.dataset.history.map(commit => (
+              <>
+                <div className="row">
+                  <div className="col-lg-4">{commit.id}</div>
+                  <div className="col-lg-2">{commit.date}</div>
+                  <div className="col-lg-3">
+                    {commit.authorName} &lt;{commit.authorEmail}&gt;
+                  </div>
+                  <div className="col-lg-3">{commit.references}</div>
+                </div>
+                <div className="row">
+                  <div className="col-lg-12">{commit.message}</div>
+                </div>
+              </>
+            ))}
+          </DatasetHistoryTable>
         </div>
       </div>
     )

--- a/packages/openneuro-app/src/scripts/datalad/fragments/dataset-tools.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/fragments/dataset-tools.jsx
@@ -10,6 +10,7 @@ import DatasetMetadata from './metadata-tool.jsx'
 import LoggedIn from '../../authentication/logged-in.jsx'
 import useMedia from '../../mobile/media-hook.jsx'
 import DeletePage from '../dataset/delete-page.jsx'
+import AdminUser from '../../authentication/admin-user.jsx'
 import {
   Overlay,
   ModalContainer,
@@ -112,6 +113,19 @@ const DatasetTools = ({ dataset, location, history }) => {
             </div>
             <div role="presentation" className="tool">
               <StarDataset datasetId={dataset.id} starred={dataset.starred} />
+            </div>
+            <div role="presentation" className="tool">
+              <AdminUser>
+                <WarnButton
+                  tooltip="Admin Tools"
+                  icon="fa-magic"
+                  warn={false}
+                  action={cb => {
+                    toolRedirect(history, rootPath, 'admin')
+                    cb()
+                  }}
+                />
+              </AdminUser>
             </div>
             {isMobile && (
               <div role="presentation" className="tool">

--- a/packages/openneuro-app/src/scripts/datalad/mutations/cache-clear.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/mutations/cache-clear.jsx
@@ -1,0 +1,37 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import gql from 'graphql-tag'
+import { Mutation } from 'react-apollo'
+
+const CACHE_CLEAR = gql`
+  mutation cacheClear($datasetId: ID!) {
+    cacheClear(datasetId: $datasetId)
+  }
+`
+
+const CacheClear = ({ datasetId }) => (
+  <Mutation mutation={CACHE_CLEAR}>
+    {cacheClear => (
+      <span>
+        <button
+          className="btn-admin-blue"
+          onClick={async () => {
+            await cacheClear({
+              variables: {
+                id: datasetId,
+              },
+            })
+          }}>
+          <i className="fa fa-trash" />
+          Delete Dataset Cache
+        </button>
+      </span>
+    )}
+  </Mutation>
+)
+
+CacheClear.propTypes = {
+  datasetId: PropTypes.string,
+}
+
+export default CacheClear

--- a/packages/openneuro-app/src/scripts/datalad/mutations/cache-clear.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/mutations/cache-clear.jsx
@@ -22,8 +22,7 @@ const CacheClear = ({ datasetId }) => (
               },
             })
           }}>
-          <i className="fa fa-trash" />
-          Delete Dataset Cache
+          <i className="fa fa-eraser" /> Delete Dataset Cache
         </button>
       </span>
     )}

--- a/packages/openneuro-app/src/scripts/datalad/mutations/cache-clear.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/mutations/cache-clear.jsx
@@ -18,7 +18,7 @@ const CacheClear = ({ datasetId }) => (
           onClick={async () => {
             await cacheClear({
               variables: {
-                id: datasetId,
+                datasetId,
               },
             })
           }}>

--- a/packages/openneuro-app/src/scripts/datalad/mutations/update-ref.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/mutations/update-ref.jsx
@@ -1,0 +1,38 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import gql from 'graphql-tag'
+import { Mutation } from 'react-apollo'
+
+const UPDATE_REF = gql`
+  mutation updateRef($datasetId: ID!, $ref: String!) {
+    updateRef(datasetId: $datasetId, ref: $ref)
+  }
+`
+
+const UpdateRef = ({ datasetId, revision }) => (
+  <Mutation mutation={UPDATE_REF}>
+    {updateRef => (
+      <span>
+        <button
+          className="btn-admin-blue"
+          onClick={async () => {
+            await updateRef({
+              variables: {
+                datasetId,
+                ref: revision,
+              },
+            })
+          }}>
+          <i className="fa fa-random" /> Reset Draft Head
+        </button>
+      </span>
+    )}
+  </Mutation>
+)
+
+UpdateRef.propTypes = {
+  datasetId: PropTypes.string,
+  ref: PropTypes.string,
+}
+
+export default UpdateRef

--- a/packages/openneuro-app/src/scripts/datalad/routes/admin.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/routes/admin.jsx
@@ -1,0 +1,31 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { Link } from 'react-router-dom'
+import DatasetHistory from '../fragments/dataset-history.jsx'
+import CacheClear from '../mutations/cache-clear.jsx'
+
+const AdminDataset = ({ datasetId }) => (
+  <div className="dataset-form">
+    <div className="col-xs-12 dataset-form-header">
+      <div className="form-group">
+        <label>Admin</label>
+      </div>
+      <DatasetHistory datasetId={datasetId} />
+      <CacheClear datasetId={datasetId} />
+      <hr />
+      <div className="col-xs-12 dataset-form-controls">
+        <div className="col-xs-12 modal-actions">
+          <Link to={`/datasets/${datasetId}`}>
+            <button className="btn-admin-blue">Return to Dataset</button>
+          </Link>
+        </div>
+      </div>
+    </div>
+  </div>
+)
+
+AdminDataset.propTypes = {
+  datasetId: PropTypes.string,
+}
+
+export default AdminDataset

--- a/packages/openneuro-app/src/scripts/datalad/routes/admin.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/routes/admin.jsx
@@ -3,21 +3,37 @@ import PropTypes from 'prop-types'
 import { Link } from 'react-router-dom'
 import DatasetHistory from '../fragments/dataset-history.jsx'
 import CacheClear from '../mutations/cache-clear.jsx'
+import UpdateRef from '../mutations/update-ref.jsx'
 
-const AdminDataset = ({ datasetId }) => (
+/**
+ * Map dataset IDs to a normal distribution of backend workers
+ * @param {string} dataset Accession number string - e.g. ds000001
+ * @param {number} range Integer bound for offset from hash
+ */
+export function hashDatasetToRange(dataset, range) {
+  const hash = crypto.createHash('sha1').update(dataset, 'utf8')
+  const hexstring = hash.digest().toString('hex')
+  return parseInt(hexstring.substring(32, 40), 16) % range
+}
+
+const AdminDataset = ({ dataset }) => (
   <div className="dataset-form">
     <div className="col-xs-12 dataset-form-header">
       <div className="form-group">
         <label>Admin</label>
       </div>
-      <DatasetHistory datasetId={datasetId} />
-      <CacheClear datasetId={datasetId} />
+      <div className="col-xs-6">
+        <h4>Draft Head</h4> {dataset.draft.head}
+      </div>
+      <DatasetHistory datasetId={dataset.id} />
       <hr />
       <div className="col-xs-12 dataset-form-controls">
         <div className="col-xs-12 modal-actions">
-          <Link to={`/datasets/${datasetId}`}>
+          <Link to={`/datasets/${dataset.id}`}>
             <button className="btn-admin-blue">Return to Dataset</button>
           </Link>
+          <CacheClear datasetId={dataset.id} />
+          <UpdateRef datasetId={dataset.id} revision={dataset.draft.head} />
         </div>
       </div>
     </div>
@@ -25,7 +41,7 @@ const AdminDataset = ({ datasetId }) => (
 )
 
 AdminDataset.propTypes = {
-  datasetId: PropTypes.string,
+  dataset: PropTypes.object,
 }
 
 export default AdminDataset

--- a/packages/openneuro-app/src/scripts/datalad/routes/admin.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/routes/admin.jsx
@@ -18,17 +18,17 @@ export function hashDatasetToRange(dataset, range) {
 
 const AdminDataset = ({ dataset }) => (
   <div className="dataset-form">
-    <div className="col-xs-12 dataset-form-header">
+    <div className="col-lg-12 dataset-form-header">
       <div className="form-group">
         <label>Admin</label>
       </div>
-      <div className="col-xs-6">
+      <div className="col-lg-6">
         <h3>Draft Head</h3> {dataset.draft.head}
       </div>
       <DatasetHistory datasetId={dataset.id} />
       <hr />
-      <div className="col-xs-12 dataset-form-controls">
-        <div className="col-xs-12 modal-actions">
+      <div className="col-lg-12 dataset-form-controls">
+        <div className="col-lg-12 modal-actions">
           <Link to={`/datasets/${dataset.id}`}>
             <button className="btn-admin-blue">Return to Dataset</button>
           </Link>

--- a/packages/openneuro-app/src/scripts/datalad/routes/admin.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/routes/admin.jsx
@@ -23,7 +23,7 @@ const AdminDataset = ({ dataset }) => (
         <label>Admin</label>
       </div>
       <div className="col-xs-6">
-        <h4>Draft Head</h4> {dataset.draft.head}
+        <h3>Draft Head</h3> {dataset.draft.head}
       </div>
       <DatasetHistory datasetId={dataset.id} />
       <hr />

--- a/packages/openneuro-app/src/scripts/datalad/routes/dataset-content.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/routes/dataset-content.jsx
@@ -138,7 +138,7 @@ const DatasetContent = ({ dataset }) => {
             files={dataset.draft.files}
             editMode={hasEdit}
           />
-          <DatasetGitHash gitHash={dataset.draft.id} />
+          <DatasetGitHash gitHash={dataset.draft.head} />
         </div>
       </LoggedIn>
       {dataset.snapshots && !hasEdit && (

--- a/packages/openneuro-app/src/scripts/datalad/routes/dataset-routes.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/routes/dataset-routes.jsx
@@ -39,7 +39,7 @@ const DatasetRoutes = ({ dataset, error }) => {
         name="admin"
         exact
         path="/datasets/:datasetId/admin"
-        component={AdminDataset}
+        component={() => <AdminDataset dataset={dataset} />}
       />
       <Route
         name="publish"

--- a/packages/openneuro-app/src/scripts/datalad/routes/dataset-routes.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/routes/dataset-routes.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react'
 import PropTypes from 'prop-types'
 import { Route, Switch } from 'react-router-dom'
+import AdminDataset from './admin.jsx'
 import DatasetContent from './dataset-content.jsx'
 import SnapshotContent from './snapshot-content.jsx'
 import DownloadDataset from '../download/download-dataset.jsx'
@@ -33,6 +34,12 @@ const DatasetRoutes = ({ dataset, error }) => {
         exact
         path="/datasets/:datasetId/download"
         component={DownloadDataset}
+      />
+      <Route
+        name="admin"
+        exact
+        path="/datasets/:datasetId/admin"
+        component={AdminDataset}
       />
       <Route
         name="publish"

--- a/packages/openneuro-server/src/graphql/resolvers/dataset.js
+++ b/packages/openneuro-server/src/graphql/resolvers/dataset.js
@@ -8,6 +8,7 @@ import { user } from './user.js'
 import { permissions } from './permissions.js'
 import { datasetComments } from './comment.js'
 import { metadata } from './metadata.js'
+import { history } from './history.js'
 import * as dataladAnalytics from '../../datalad/analytics.js'
 import DatasetModel from '../../models/dataset.js'
 import Deletion from '../../models/deletion.js'
@@ -280,6 +281,7 @@ const Dataset = {
   starred,
   onBrainlife,
   metadata,
+  history,
 }
 
 export default Dataset

--- a/packages/openneuro-server/src/graphql/resolvers/dataset.js
+++ b/packages/openneuro-server/src/graphql/resolvers/dataset.js
@@ -15,6 +15,7 @@ import Deletion from '../../models/deletion.js'
 import fetch from 'node-fetch'
 import * as Sentry from '@sentry/node'
 import { UpdatedFile } from '../utils/file.js'
+import { getDatasetWorker } from '../../libs/datalad-service.js'
 
 export const dataset = (obj, { id }, { user, userInfo }) => {
   return checkDatasetRead(id, user, userInfo).then(() => {
@@ -259,6 +260,8 @@ export const onBrainlife = async dataset => {
   }
 }
 
+const worker = obj => getDatasetWorker(obj.id)
+
 /**
  * Dataset object
  */
@@ -282,6 +285,7 @@ const Dataset = {
   onBrainlife,
   metadata,
   history,
+  worker,
 }
 
 export default Dataset

--- a/packages/openneuro-server/src/graphql/resolvers/draft.js
+++ b/packages/openneuro-server/src/graphql/resolvers/draft.js
@@ -6,6 +6,7 @@ import { getDraftFiles, updateDatasetRevision } from '../../datalad/draft.js'
 import { checkDatasetWrite } from '../permissions.js'
 import { filterFiles } from '../../datalad/files.js'
 import { createSnapshot } from '../../datalad/snapshots.js'
+import Dataset from '../../models/dataset.js'
 import Snapshot from '../../models/snapshot.js'
 
 // A draft must have a dataset parent
@@ -40,6 +41,7 @@ const draft = {
   modified: obj => obj.modified,
   description,
   readme,
+  head: async obj => (await Dataset.findOne({ id: obj.id }).exec()).revision,
 }
 
 export default draft

--- a/packages/openneuro-server/src/graphql/resolvers/history.js
+++ b/packages/openneuro-server/src/graphql/resolvers/history.js
@@ -1,0 +1,10 @@
+import { getDatasetWorker } from '../../libs/datalad-service.js'
+
+export const history = async obj => {
+  const historyUrl = `${getDatasetWorker(
+    datasetId,
+  )}/datasets/${datasetId}/history`
+  const resp = await fetch(historyUrl)
+  const { log } = await resp.json()
+  return log
+}

--- a/packages/openneuro-server/src/graphql/resolvers/history.js
+++ b/packages/openneuro-server/src/graphql/resolvers/history.js
@@ -1,7 +1,9 @@
+import fetch from 'node-fetch'
 import { getDatasetWorker } from '../../libs/datalad-service.js'
 
 export const history = async obj => {
-  const historyUrl = `${getDatasetWorker(
+  const datasetId = obj.id
+  const historyUrl = `http://${getDatasetWorker(
     datasetId,
   )}/datasets/${datasetId}/history`
   const resp = await fetch(historyUrl)

--- a/packages/openneuro-server/src/graphql/schema.js
+++ b/packages/openneuro-server/src/graphql/schema.js
@@ -314,9 +314,24 @@ export const typeDefs = `
     # Dataset Metadata
     metadata: Metadata
     # Return the version history for a dataset (git log)
-    history: [String]
+    history: [DatasetCommit]
     # Worker assignment
     worker: String
+  }
+
+  type DatasetCommit {
+    # Git commit hash
+    id: ID!
+    # Commit time
+    date: DateTime
+    # Author string
+    authorName: String
+    # Author email
+    authorEmail: String
+    # Commit message
+    message: String
+    # Associated commit references (tags or branches)
+    references: String
   }
 
   # Ephemeral draft or working tree for a dataset

--- a/packages/openneuro-server/src/graphql/schema.js
+++ b/packages/openneuro-server/src/graphql/schema.js
@@ -313,6 +313,8 @@ export const typeDefs = `
     onBrainlife: Boolean @cacheControl(maxAge: 10080, scope: PUBLIC)
     # Dataset Metadata
     metadata: Metadata
+    # Return the version history for a dataset (git log)
+    history: [String]
   }
 
   # Ephemeral draft or working tree for a dataset

--- a/packages/openneuro-server/src/graphql/schema.js
+++ b/packages/openneuro-server/src/graphql/schema.js
@@ -315,11 +315,12 @@ export const typeDefs = `
     metadata: Metadata
     # Return the version history for a dataset (git log)
     history: [String]
+    # Worker assignment
+    worker: String
   }
 
   # Ephemeral draft or working tree for a dataset
   type Draft {
-    # The draft id is the git hexsha of the most recent committed draft
     id: ID
     # Which dataset this draft is related to
     dataset: Dataset
@@ -337,6 +338,8 @@ export const typeDefs = `
     readme: String
     # Uploads in progress or recently completed
     uploads: [UploadMetadata]
+    # Git commit hash
+    head: String
   }
 
   # Tagged snapshot of a draft

--- a/services/datalad/datalad_service/handlers/history.py
+++ b/services/datalad/datalad_service/handlers/history.py
@@ -1,5 +1,6 @@
 import falcon
 
+
 class HistoryResource(object):
     def __init__(self, store):
         self.store = store
@@ -10,7 +11,19 @@ class HistoryResource(object):
         """
         if dataset:
             ds = self.store.get_dataset(dataset)
-            resp.media = {'log': ds.repo.get_revisions(fmt='%H %ai %cn <%ce> %d %s')}
+            # Rare sequence used for delimiter
+            utf_delimiter = '!5$H%E^P&'
+            git_format = '%H{}%aI{}%cn{}%ce{}%d{}%s'.format(
+                *[utf_delimiter for x in range(5)])
+            log = ds.repo.get_revisions(fmt=git_format)
+            parsed_lines = []
+            for line in log:
+                values = line.split(utf_delimiter)
+                commit = {"id": values[0], "date": values[1],
+                          "authorName": values[2], "authorEmail": values[3],
+                          "references": values[4], "message": values[5]}
+                parsed_lines.append(commit)
+            resp.media = {'log': parsed_lines}
             resp.status = falcon.HTTP_OK
         else:
             resp.status = falcon.HTTP_NOT_FOUND


### PR DESCRIPTION
This adds tools to help with quickly fixing or debugging issues with datasets. Site administrators can view the worker/storage pool assigned to the dataset, the current git revision (also fixes a bug with this in general), and clear the dataset caches or reset the draft head which will retrigger validation and sync the website with the repository state if they have diverged somehow.