### PR TITLE
Fix a regression in resumeDataset with an incorrect query name

### DIFF
--- a/packages/openneuro-app/src/scripts/uploader/uploader.jsx
+++ b/packages/openneuro-app/src/scripts/uploader/uploader.jsx
@@ -90,7 +90,7 @@ export class UploadClient extends React.Component {
     return ({ files }) => {
       this.props.client
         .query({
-          query: datasets.getUntrackedFiles,
+          query: datasets.getDraftFiles,
           variables: { id: datasetId },
         })
         .then(({ data }) => {


### PR DESCRIPTION
Fixes a regression with "add files" or "add directory" in the dataset file tree throwing invariant violation.