### PR TITLE
Add admin dashboard information and more versatile reset draft head

### DIFF
--- a/packages/openneuro-app/src/scripts/datalad/fragments/dataset-history.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/fragments/dataset-history.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import styled from '@emotion/styled'
 import gql from 'graphql-tag'
 import { useQuery } from 'react-apollo'
+import UpdateRef from '../mutations/update-ref.jsx'
 
 const GET_HISTORY = gql`
   query getHistory($datasetId: ID!) {
@@ -55,23 +56,27 @@ const DatasetHistory = ({ datasetId }) => {
             <div className="row">
               <h4 className="col-lg-4">Commit</h4>
               <h4 className="col-lg-2">Date</h4>
-              <h4 className="col-lg-3">Author</h4>
-              <h4 className="col-lg-3">References</h4>
+              <h4 className="col-lg-2">Author</h4>
+              <h4 className="col-lg-2">References</h4>
+              <h4 className="col-lg-2">Action</h4>
             </div>
             {data.dataset.history.map(commit => (
-              <>
+              <React.Fragment key={commit.id}>
                 <div className="row">
                   <div className="col-lg-4">{commit.id}</div>
                   <div className="col-lg-2">{commit.date}</div>
-                  <div className="col-lg-3">
+                  <div className="col-lg-2">
                     {commit.authorName} &lt;{commit.authorEmail}&gt;
                   </div>
-                  <div className="col-lg-3">{commit.references}</div>
+                  <div className="col-lg-2">{commit.references}</div>
+                  <div className="col-lg-2">
+                    <UpdateRef datasetId={datasetId} revision={commit.id} />
+                  </div>
                 </div>
                 <div className="row">
                   <div className="col-lg-12">{commit.message}</div>
                 </div>
-              </>
+              </React.Fragment>
             ))}
           </DatasetHistoryTable>
         </div>

--- a/packages/openneuro-app/src/scripts/datalad/routes/admin.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/routes/admin.jsx
@@ -22,6 +22,17 @@ const AdminDataset = ({ dataset }) => (
       <div className="form-group">
         <label>Admin</label>
       </div>
+      <div className="col-lg-12">
+        <p>
+          Delete dataset cache drops all dataset caches (snapshot index,
+          draft/snapshot file listings, current dataset description) and the
+          cache is repopulated on the next API call.
+        </p>
+        <p>
+          Reset draft head will move the draft to a given commit and rerun
+          validation.
+        </p>
+      </div>
       <div className="col-lg-6">
         <h3>Draft Head</h3> {dataset.draft.head}
       </div>
@@ -33,7 +44,6 @@ const AdminDataset = ({ dataset }) => (
             <button className="btn-admin-blue">Return to Dataset</button>
           </Link>
           <CacheClear datasetId={dataset.id} />
-          <UpdateRef datasetId={dataset.id} revision={dataset.draft.head} />
         </div>
       </div>
     </div>


### PR DESCRIPTION
This fixes some minor issues with the admin tab to allow you to move the draft to any existing commit, adds a description of what the actions available do, and fixes an issue with rendering due to missing key prop on the commit rows.