### PR TITLE
Prevent erroneous nesting when adding files to existing directories

### DIFF
--- a/packages/openneuro-app/src/scripts/uploader/__tests__/file-upload.spec.js
+++ b/packages/openneuro-app/src/scripts/uploader/__tests__/file-upload.spec.js
@@ -1,4 +1,4 @@
-import { getRelativePath } from '../file-upload.js'
+import { getRelativePath, encodeFilePath } from '../file-upload.js'
 
 describe('file upload helpers', () => {
   describe('getRelativePath', () => {
@@ -11,6 +11,64 @@ describe('file upload helpers', () => {
       expect(
         getRelativePath({ webkitRelativePath: 'dataset_description.json' }),
       ).toBe('dataset_description.json')
+    })
+  })
+  describe('encodeFilePath', () => {
+    it('supports directory upload from a webkit-derived browser (stripRelativePath: true)', () => {
+      expect(
+        encodeFilePath(
+          {
+            name: 'sub-02_T1w.nii.gz',
+            lastModified: 1604713385516,
+            webkitRelativePath: 'dataset/sub-02/anat/sub-02_T1w.nii.gz',
+            size: 311112,
+            type: 'application/gzip',
+          },
+          { stripRelativePath: true },
+        ),
+      ).toEqual('sub-02:anat:sub-02_T1w.nii.gz')
+    })
+    it('supports directory upload from a webkit-derived browser (stripRelativePath: false)', () => {
+      expect(
+        encodeFilePath(
+          {
+            name: 'sub-02_T1w.nii.gz',
+            lastModified: 1604713385516,
+            webkitRelativePath: 'sub-02/anat/sub-02_T1w.nii.gz',
+            size: 311112,
+            type: 'application/gzip',
+          },
+          { stripRelativePath: false },
+        ),
+      ).toEqual('sub-02:anat:sub-02_T1w.nii.gz')
+    })
+    it('supports file upload from a webkit-derived browser (stripRelativePath: true)', () => {
+      expect(
+        encodeFilePath(
+          {
+            name: 'README',
+            lastModified: 1604713385516,
+            webkitRelativePath: '',
+            size: 809,
+            type: 'text/plain',
+          },
+          { stripRelativePath: true },
+        ),
+      ).toEqual('README')
+    })
+    it('supports file upload from a webkit-derived browser (stripRelativePath: true)', () => {
+      expect(
+        encodeFilePath(
+          {
+            name: 'README',
+            lastModified: 1604713385516,
+            webkitRelativePath: '',
+            size: 809,
+            type: 'text/plain',
+          },
+          { stripRelativePath: false },
+        ),
+      ).toEqual('README')
     })
   })
 })

--- a/packages/openneuro-app/src/scripts/uploader/__tests__/file-upload.spec.js
+++ b/packages/openneuro-app/src/scripts/uploader/__tests__/file-upload.spec.js
@@ -56,7 +56,7 @@ describe('file upload helpers', () => {
         ),
       ).toEqual('README')
     })
-    it('supports file upload from a webkit-derived browser (stripRelativePath: true)', () => {
+    it('supports file upload from a webkit-derived browser (stripRelativePath: false)', () => {
       expect(
         encodeFilePath(
           {
@@ -69,6 +69,48 @@ describe('file upload helpers', () => {
           { stripRelativePath: false },
         ),
       ).toEqual('README')
+    })
+    it('supports nested file upload from a webkit-derived browser (stripRelativePath: true)', () => {
+      expect(
+        encodeFilePath(
+          {
+            name: 'sub-02_T1w.nii.gz',
+            lastModified: 1604713385516,
+            webkitRelativePath: '/dataset/sub-02/anat/',
+            size: 2000,
+            type: 'text/plain',
+          },
+          { stripRelativePath: true },
+        ),
+      ).toEqual('sub-02:anat:sub-02_T1w.nii.gz')
+    })
+    it('supports nested file upload from a webkit-derived browser (stripRelativePath: false)', () => {
+      expect(
+        encodeFilePath(
+          {
+            name: 'sub-02_T1w.nii.gz',
+            lastModified: 1604713385516,
+            webkitRelativePath: '/sub-02/anat/',
+            size: 2000,
+            type: 'text/plain',
+          },
+          { stripRelativePath: false },
+        ),
+      ).toEqual('sub-02:anat:sub-02_T1w.nii.gz')
+    })
+    it('supports nested directory upload from a webkit-derived browser (stripRelativePath: false)', () => {
+      expect(
+        encodeFilePath(
+          {
+            name: 'sub-02_T1w.nii.gz',
+            lastModified: 1604713385516,
+            webkitRelativePath: '/sub-02/anat/sub-02_T1w.nii.gz',
+            size: 2000,
+            type: 'text/plain',
+          },
+          { stripRelativePath: false },
+        ),
+      ).toEqual('sub-02:anat:sub-02_T1w.nii.gz')
     })
   })
 })

--- a/packages/openneuro-app/src/scripts/uploader/file-upload.js
+++ b/packages/openneuro-app/src/scripts/uploader/file-upload.js
@@ -5,13 +5,25 @@ import { uploads } from 'openneuro-client'
  * Trim the webkitRelativePath value to only include the dataset relative path
  * @param {File} file FileAPI object from a browser multiple file selector
  */
-export const getRelativePath = file => {
+export const getRelativePath = (
+  file,
+  options = { stripRelativePath: true },
+) => {
   const path = file.webkitRelativePath
-  const dirIndex = path.indexOf('/')
-  if (dirIndex === -1) {
+  const pathTokens = path.split('/')
+  if (pathTokens.length === 1) {
     return path
+  }
+  if (pathTokens[0] === '') {
+    pathTokens.shift()
+  }
+  if (pathTokens[pathTokens.length - 1] === '') {
+    pathTokens[pathTokens.length - 1] = file.name
+  }
+  if (options.stripRelativePath) {
+    return pathTokens.slice(1).join('/')
   } else {
-    return path.substring(dirIndex + 1, path.length)
+    return pathTokens.join('/')
   }
 }
 
@@ -26,11 +38,7 @@ export const getRelativePath = file => {
  **/
 export const encodeFilePath = (file, options = { stripRelativePath: false }) =>
   file.webkitRelativePath
-    ? uploads.encodeFilePath(
-        options.stripRelativePath
-          ? getRelativePath(file)
-          : file.webkitRelativePath,
-      )
+    ? uploads.encodeFilePath(getRelativePath(file, options))
     : file.name
 
 /**

--- a/services/datalad/datalad_service/handlers/upload.py
+++ b/services/datalad/datalad_service/handlers/upload.py
@@ -13,7 +13,6 @@ from datalad_service.common.annex import CommitInfo
 
 
 def move_files(upload_path, dataset_path):
-    print(dataset_path)
     for filename in pathlib.Path(upload_path).glob('**/*'):
         if os.path.isfile(filename):
             target = os.path.join(dataset_path, os.path.relpath(

--- a/services/datalad/datalad_service/handlers/upload.py
+++ b/services/datalad/datalad_service/handlers/upload.py
@@ -12,6 +12,13 @@ from datalad_service.common.draft import update_head
 from datalad_service.common.annex import CommitInfo
 
 
+def move_files(upload_path, dataset_path):
+    for filename in pathlib.Path(upload_path).glob('**/*'):
+        target = os.path.join(dataset_path, os.path.relpath(
+            filename, start=upload_path))
+        shutil.move(str(filename), target)
+
+
 class UploadResource(object):
     def __init__(self, store):
         self.store = store
@@ -25,10 +32,7 @@ class UploadResource(object):
                 unlock_files = [os.path.relpath(filename, start=upload_path) for filename in
                                 pathlib.Path(upload_path).glob('**/*') if os.path.islink(
                     os.path.join(ds.path, os.path.relpath(filename, start=upload_path)))]
-                for filename in pathlib.Path(upload_path).glob('**/*'):
-                    target = os.path.join(ds.path, os.path.relpath(
-                        filename, start=upload_path))
-                    shutil.move(str(filename), target)
+                move_files(upload_path, ds.path)
                 shutil.rmtree(upload_path)
                 ds.save(unlock_files)
                 update_head(ds, dataset_id, cookies)

--- a/services/datalad/datalad_service/handlers/upload.py
+++ b/services/datalad/datalad_service/handlers/upload.py
@@ -18,7 +18,7 @@ def move_files(upload_path, dataset_path):
         if os.path.isfile(filename):
             target = os.path.join(dataset_path, os.path.relpath(
                 filename, start=upload_path))
-            os.makedirs(target, exist_ok=True)
+            pathlib.Path(target).parent.mkdir(parents=True, exist_ok=True)
             shutil.move(str(filename), target)
 
 

--- a/services/datalad/datalad_service/handlers/upload.py
+++ b/services/datalad/datalad_service/handlers/upload.py
@@ -13,10 +13,13 @@ from datalad_service.common.annex import CommitInfo
 
 
 def move_files(upload_path, dataset_path):
+    print(dataset_path)
     for filename in pathlib.Path(upload_path).glob('**/*'):
-        target = os.path.join(dataset_path, os.path.relpath(
-            filename, start=upload_path))
-        shutil.move(str(filename), target)
+        if os.path.isfile(filename):
+            target = os.path.join(dataset_path, os.path.relpath(
+                filename, start=upload_path))
+            os.makedirs(target, exist_ok=True)
+            shutil.move(str(filename), target)
 
 
 class UploadResource(object):

--- a/services/datalad/tests/test_upload.py
+++ b/services/datalad/tests/test_upload.py
@@ -45,9 +45,31 @@ def test_skip_invalid_files():
     assert not skip_invalid_files('.bidsignore')
 
 
+def test_move_files(tmpdir_factory, new_dataset):
+    # Create an upload source path
+    tmp_dir = tmpdir_factory.mktemp('upload')
+    tmp_anat = tmp_dir.join('sub-01', 'anat')
+    os.makedirs(tmp_anat)
+    with open(os.path.join(tmp_anat, 'sub-01_T1w.json'), 'w') as f:
+        f.write('{"dummy": "json"}')
+    nifti_path = os.path.join(tmp_anat, 'sub-01_T1w.nii.gz')
+    with open(nifti_path, 'w') as f:
+        f.write('dummy file.gz')
+    # Test moving the files
+    move_files(tmp_dir, new_dataset.path)
+    new_dataset.save('sub-01')
+    # Verify paths exist
+    assert os.path.exists(os.path.join(
+        new_dataset.path, 'sub-01', 'anat', 'sub-01_T1w.nii.gz'))
+    assert os.path.exists(os.path.join(
+        new_dataset.path, 'sub-01', 'anat', 'sub-01_T1w.json'))
+
+
 def test_move_files_nesting(tmpdir_factory, new_dataset):
     # Create an upload source path
     tmp_dir = tmpdir_factory.mktemp('upload')
+    with open(tmp_dir.join('.bidsignore'), 'w') as f:
+        f.write('derivatives')
     tmp_anat = tmp_dir.join('sub-01', 'anat')
     os.makedirs(tmp_anat)
     with open(os.path.join(tmp_anat, 'sub-01_T1w.json'), 'w') as f:

--- a/services/datalad/tests/test_upload.py
+++ b/services/datalad/tests/test_upload.py
@@ -1,9 +1,12 @@
+import os
+
 import falcon
 from falcon import testing
 
 from .dataset_fixtures import *
 
 from datalad_service.handlers.upload_file import skip_invalid_files
+from datalad_service.handlers.upload import move_files
 
 
 def test_upload_file_no_auth(client):
@@ -40,3 +43,24 @@ def test_skip_invalid_files():
     assert not skip_invalid_files('dataset_description.json')
     assert not skip_invalid_files('sub-01/anat/sub-01_T1w.nii.gz')
     assert not skip_invalid_files('.bidsignore')
+
+
+def test_move_files_nesting(tmpdir_factory, new_dataset):
+    # Create an upload source path
+    tmp_dir = tmpdir_factory.mktemp('upload')
+    tmp_anat = tmp_dir.join('sub-01', 'anat')
+    os.makedirs(tmp_anat)
+    with open(os.path.join(tmp_anat, 'sub-01_T1w.json'), 'w') as f:
+        f.write('{"dummy": "json"}')
+    # add conflicting file to dataset
+    anat_path = os.path.join(new_dataset.path, 'sub-01', 'anat')
+    nifti_path = os.path.join(anat_path, 'sub-01_T1w.nii.gz')
+    os.makedirs(anat_path)
+    with open(nifti_path, 'w') as f:
+        f.write('dummy file.gz')
+    new_dataset.save(nifti_path)
+    move_files(tmp_dir, new_dataset.path)
+    assert os.path.exists(os.path.join(
+        new_dataset.path, 'sub-01', 'anat', 'sub-01_T1w.nii.gz'))
+    assert os.path.exists(os.path.join(
+        new_dataset.path, 'sub-01', 'anat', 'sub-01_T1w.json'))

--- a/services/datalad/tests/test_upload.py
+++ b/services/datalad/tests/test_upload.py
@@ -59,9 +59,9 @@ def test_move_files(tmpdir_factory, new_dataset):
     move_files(tmp_dir, new_dataset.path)
     new_dataset.save('sub-01')
     # Verify paths exist
-    assert os.path.exists(os.path.join(
+    assert os.path.isfile(os.path.join(
         new_dataset.path, 'sub-01', 'anat', 'sub-01_T1w.nii.gz'))
-    assert os.path.exists(os.path.join(
+    assert os.path.isfile(os.path.join(
         new_dataset.path, 'sub-01', 'anat', 'sub-01_T1w.json'))
 
 
@@ -82,7 +82,7 @@ def test_move_files_nesting(tmpdir_factory, new_dataset):
         f.write('dummy file.gz')
     new_dataset.save(nifti_path)
     move_files(tmp_dir, new_dataset.path)
-    assert os.path.exists(os.path.join(
+    assert os.path.isfile(os.path.join(
         new_dataset.path, 'sub-01', 'anat', 'sub-01_T1w.nii.gz'))
-    assert os.path.exists(os.path.join(
+    assert os.path.isfile(os.path.join(
         new_dataset.path, 'sub-01', 'anat', 'sub-01_T1w.json'))


### PR DESCRIPTION
This fixes an issue with the finishUpload logic when adding data to an existing directory that would cause the directory to be incorrectly nested.

Adds two test cases for this:
1. The working behavior where the directory does not exist
2. The failing behavior where the directory does exist