### PR TITLE
CLI: Add early exit for zero length files

### DIFF
--- a/packages/openneuro-cli/src/upload.js
+++ b/packages/openneuro-cli/src/upload.js
@@ -154,6 +154,15 @@ export const uploadFiles = async ({
       console.error(err)
       controller.abort()
     })
+    fileStream.on('close', () => {
+      if (fileStream.bytesRead === 0) {
+        uploadProgress.stop()
+        console.error(
+          `Warning: "${file.filename}" read zero bytes - check that this file is readable and try again`,
+        )
+        controller.abort()
+      }
+    })
     return new Request(
       `${rootUrl}uploads/${endpoint}/${datasetId}/${id}/${encodedFilePath}`,
       {


### PR DESCRIPTION
This will halt the upload if a file is zero bytes long. The one legitimate way you can end up triggering this check is a .bidsignore file that is supposed to be empty, otherwise the validator check for zero length files is considered an error. This should prevent overwriting files with zero length files in the case where the issue is the file became unreadable after validation but before the upload is complete.