### PR TITLE
Add EthicsApproval's field from BIDS 1.3.0

### DIFF
--- a/packages/openneuro-app/src/scripts/datalad/dataset/dataset-description.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/dataset/dataset-description.jsx
@@ -93,6 +93,19 @@ const DatasetDescription = ({
         </div>
       </EditDescriptionList>
     </div>
+    <div className="description-item">
+      <h2>Ethics Approvals</h2>
+      <EditDescriptionList
+        datasetId={datasetId}
+        description={description}
+        field="EthicsApprovals"
+        editMode={editMode}
+        isMobile={isMobile}>
+        <div className="cte-display fade-in">
+          <Markdown>{arrayToMarkdown(description.EthicsApprovals)}</Markdown>
+        </div>
+      </EditDescriptionList>
+    </div>
   </>
 )
 

--- a/packages/openneuro-app/src/scripts/datalad/dataset/dataset-query-fragments.js
+++ b/packages/openneuro-app/src/scripts/datalad/dataset/dataset-query-fragments.js
@@ -17,6 +17,7 @@ export const DRAFT_FRAGMENT = gql`
         HowToAcknowledge
         Funding
         ReferencesAndLinks
+        EthicsApprovals
       }
       summary {
         modalities
@@ -133,6 +134,7 @@ export const SNAPSHOT_FIELDS = gql`
       HowToAcknowledge
       Funding
       ReferencesAndLinks
+      EthicsApprovals
     }
     files {
       id

--- a/packages/openneuro-app/src/scripts/datalad/mutations/__tests__/__snapshots__/description.spec.jsx.snap
+++ b/packages/openneuro-app/src/scripts/datalad/mutations/__tests__/__snapshots__/description.spec.jsx.snap
@@ -181,6 +181,17 @@ exports[`UpdateDescription mutation renders with common props 1`] = `
                       },
                       "selectionSet": undefined,
                     },
+                    Object {
+                      "alias": undefined,
+                      "arguments": Array [],
+                      "directives": Array [],
+                      "kind": "Field",
+                      "name": Object {
+                        "kind": "Name",
+                        "value": "EthicsApprovals",
+                      },
+                      "selectionSet": undefined,
+                    },
                   ],
                 },
               },
@@ -258,7 +269,7 @@ exports[`UpdateDescription mutation renders with common props 1`] = `
       ],
       "kind": "Document",
       "loc": Object {
-        "end": 352,
+        "end": 374,
         "start": 0,
       },
     }

--- a/packages/openneuro-app/src/scripts/datalad/mutations/description.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/mutations/description.jsx
@@ -23,6 +23,7 @@ export const UPDATE_DESCRIPTION = gql`
       Funding
       ReferencesAndLinks
       DatasetDOI
+      EthicsApprovals
     }
   }
 `
@@ -44,6 +45,7 @@ export const UPDATE_DESCRIPTION_LIST = gql`
       Funding
       ReferencesAndLinks
       DatasetDOI
+      EthicsApprovals
     }
   }
 `
@@ -118,6 +120,7 @@ UpdateDescription.propTypes = {
     'Funding',
     'ReferencesAndLinks',
     'DatasetDOI',
+    'EthicsApprovals',
   ]),
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.array]),
   done: PropTypes.func,

--- a/packages/openneuro-server/src/graphql/schema.js
+++ b/packages/openneuro-server/src/graphql/schema.js
@@ -404,6 +404,8 @@ export const typeDefs = `
     ReferencesAndLinks: [String]
     # The Document Object Identifier of the dataset (not the corresponding paper).
     DatasetDOI: String
+    # List of ethics committee approvals of the research protocols and/or protocol identifiers.
+    EthicsApprovals: [String]
   }
 
   # User permissions on a dataset


### PR DESCRIPTION
Adds the EthicsApprovals field where required to the API and dataset page.