### PR TITLE
Add --ignoreSubjectConsistency to datalad-service

### DIFF
--- a/services/datalad/datalad_service/tasks/validator.py
+++ b/services/datalad/datalad_service/tasks/validator.py
@@ -24,7 +24,7 @@ def validate_dataset_sync(dataset_path, ref):
     setup_validator()
     try:
         process = subprocess.run(
-            ['./node_modules/.bin/bids-validator', '--json', dataset_path], stdout=subprocess.PIPE, timeout=300)
+            ['./node_modules/.bin/bids-validator', '--json', '--ignoreSubjectConsistency', dataset_path], stdout=subprocess.PIPE, timeout=300)
         return json.loads(process.stdout)
     except subprocess.TimeoutExpired:
         sentry_sdk.capture_exception()

--- a/services/datalad/package.json
+++ b/services/datalad/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "bids-validator": "1.5.6"
+    "bids-validator": "1.5.7"
   }
 }

--- a/services/datalad/yarn.lock
+++ b/services/datalad/yarn.lock
@@ -1226,10 +1226,10 @@ before-after-hook@^2.0.0:
   resolved "https://registry.yarnpkg.com/before-after-hook/-/before-after-hook-2.1.0.tgz#b6c03487f44e24200dd30ca5e6a1979c5d2fb635"
   integrity sha512-IWIbu7pMqyw3EAJHzzHbWa85b6oud/yfKYg5rqB5hNE8CeMi3nX+2C2sj0HswfblST86hpVEOAb9x34NZd6P7A==
 
-bids-validator@1.5.6:
-  version "1.5.6"
-  resolved "https://registry.yarnpkg.com/bids-validator/-/bids-validator-1.5.6.tgz#c0eb0f0b8ba0f1561f45c58465fac05ae434d93a"
-  integrity sha512-pnKGFTlinaEuY5QxVECpynNQcKzIiy8Y3Ov5xF4Sdz/h5UA7RpIlzUBLKgWBjA8+4BylcMLzvF7BGVMeBy7z9g==
+bids-validator@1.5.7:
+  version "1.5.7"
+  resolved "https://registry.yarnpkg.com/bids-validator/-/bids-validator-1.5.7.tgz#14f993a0e1d194d0108567d1c21d8e4f1336f80c"
+  integrity sha512-GOlqvzZ5d6rlJn/Y8KVEfmugOzGoftNMlw3oK4JgosU+ejAv+JBhrZqTfH5Kk11PpZmi57DWa4XIKmsC4RB01g==
   dependencies:
     ajv "^6.5.2"
     aws-sdk "^2.327.0"


### PR DESCRIPTION
This brings the datalad-service validation step into alignment with the uploader checks by disabling the subject consistency checks that run into stack limits.