### PR TITLE
Coealesce invalid EthicsApprovals values to a single element array

### DIFF
--- a/packages/openneuro-server/src/datalad/__tests__/description.spec.js
+++ b/packages/openneuro-server/src/datalad/__tests__/description.spec.js
@@ -17,6 +17,7 @@ describe('datalad dataset descriptions', () => {
         BIDSVersion: '1.2.0',
         ReferencesAndLinks: 'https://openneuro.org',
         Funding: ['This one', 'is correct'],
+        EthicsApprovals: 'Also, Not, Array',
       }
       const repaired = repairDescriptionTypes(description)
       // Check for discarded fields
@@ -27,6 +28,7 @@ describe('datalad dataset descriptions', () => {
       expect(Array.isArray(repaired.Authors)).toBe(true)
       expect(Array.isArray(repaired.ReferencesAndLinks)).toBe(true)
       expect(Array.isArray(repaired.Funding)).toBe(true)
+      expect(Array.isArray(repaired.EthicsApprovals)).toBe(true)
     })
     it('converts any invalid value to string values for string fields', () => {
       const description = {

--- a/packages/openneuro-server/src/datalad/description.js
+++ b/packages/openneuro-server/src/datalad/description.js
@@ -65,6 +65,12 @@ export const repairDescriptionTypes = description => {
   ) {
     newDescription.Funding = [description.Funding]
   }
+  if (
+    description.hasOwnProperty('EthicsApprovals') &&
+    !Array.isArray(description.EthicsApprovals)
+  ) {
+    newDescription.EthicsApprovals = [description.EthicsApprovals]
+  }
   // String types
   if (
     description.hasOwnProperty('Name') &&


### PR DESCRIPTION
This adds support for automatically fixing non-array EthicsApprovals values, like the other DatasetDescription array fields.