### PR TITLE
Display the affirmed defaced and affirmed consent fields on dataset page

### DIFF
--- a/packages/openneuro-app/src/scripts/datalad/dataset/dataset-query-fragments.js
+++ b/packages/openneuro-app/src/scripts/datalad/dataset/dataset-query-fragments.js
@@ -192,6 +192,8 @@ export const DATASET_METADATA = gql`
       adminUsers
       ages
       modalities
+      affirmedDefaced
+      affirmedConsent
     }
   }
 `

--- a/packages/openneuro-app/src/scripts/datalad/mutations/add-metadata.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/mutations/add-metadata.jsx
@@ -33,6 +33,8 @@ export const compileMetadata = dataset => {
     dxStatus: getFromMetadata('dxStatus') || '',
     grantFunderName: getFromMetadata('grantFunderName') || '',
     grantIdentifier: getFromMetadata('grantIdentifier') || '',
+    affirmedDefaced: getFromMetadata('affirmedDefaced') || false,
+    affirmedConsent: getFromMetadata('affirmedConsent') || false,
 
     // get from openneuro
     datasetId: dataset.id || '',

--- a/packages/openneuro-app/src/scripts/datalad/mutations/metadata-form.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/mutations/metadata-form.jsx
@@ -243,6 +243,26 @@ const metadataFields = hasEdit => {
         required: false,
       },
     },
+    {
+      key: 'affirmedDefaced',
+      label: 'Uploader Affirmed Structural Scans Are Defaced',
+      Component: TextInput,
+      additionalProps: {
+        disabled: true,
+        annotated: true,
+        required: false,
+      },
+    },
+    {
+      key: 'affirmedConsent',
+      label: 'Uploader Affirmed Consent To Publish Scans Without Defacing',
+      Component: TextInput,
+      additionalProps: {
+        disabled: true,
+        annotated: true,
+        required: false,
+      },
+    },
   ]
   return hasEdit
     ? fields


### PR DESCRIPTION
This adds these as read only values on the metadata page, making them visible somewhere that doesn't require writing a query to see the values chosen during upload.