### PR TITLE
Fix extra files being returned when multiple directories match prefix

### DIFF
--- a/packages/openneuro-app/src/scripts/file-tree/file-tree-unloaded-directory.jsx
+++ b/packages/openneuro-app/src/scripts/file-tree/file-tree-unloaded-directory.jsx
@@ -64,7 +64,7 @@ export const fetchMoreDirectory = (
 ) =>
   fetchMore({
     query: snapshotTag ? SNAPSHOT_FILES_QUERY : DRAFT_FILES_QUERY,
-    variables: { datasetId, snapshotTag, filePrefix: directory.filename },
+    variables: { datasetId, snapshotTag, filePrefix: directory.filename + '/' },
     updateQuery: mergeNewFiles(directory, snapshotTag),
   })
 


### PR DESCRIPTION
Resolves an issue with loading directory trees where a prefix might match multiple subdirs (sub-30 and sub-3 for example).