### PR TITLE
Drop dataset.revision field from MongoDB model

### DIFF
--- a/packages/openneuro-app/src/scripts/datalad/fragments/dataset-history.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/fragments/dataset-history.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import styled from '@emotion/styled'
 import gql from 'graphql-tag'
 import { useQuery } from '@apollo/client'
-import UpdateRef from '../mutations/update-ref.jsx'
+import Revalidate from '../mutations/revalidate.jsx'
 
 const GET_HISTORY = gql`
   query getHistory($datasetId: ID!) {
@@ -70,7 +70,7 @@ const DatasetHistory = ({ datasetId }) => {
                   </div>
                   <div className="col-lg-2">{commit.references}</div>
                   <div className="col-lg-2">
-                    <UpdateRef datasetId={datasetId} revision={commit.id} />
+                    <Revalidate datasetId={datasetId} revision={commit.id} />
                   </div>
                 </div>
                 <div className="row">

--- a/packages/openneuro-app/src/scripts/datalad/mutations/revalidate.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/mutations/revalidate.jsx
@@ -3,36 +3,36 @@ import PropTypes from 'prop-types'
 import gql from 'graphql-tag'
 import { Mutation } from '@apollo/client/react/components'
 
-const UPDATE_REF = gql`
-  mutation updateRef($datasetId: ID!, $ref: String!) {
-    updateRef(datasetId: $datasetId, ref: $ref)
+const REVALIDATE = gql`
+  mutation revalidate($datasetId: ID!, $ref: String!) {
+    revalidate(datasetId: $datasetId, ref: $ref)
   }
 `
 
-const UpdateRef = ({ datasetId, revision }) => (
-  <Mutation mutation={UPDATE_REF}>
-    {updateRef => (
+const Revalidate = ({ datasetId, revision }) => (
+  <Mutation mutation={REVALIDATE}>
+    {revalidate => (
       <span>
         <button
           className="btn-admin-blue"
           onClick={async () => {
-            await updateRef({
+            await revalidate({
               variables: {
                 datasetId,
                 ref: revision,
               },
             })
           }}>
-          <i className="fa fa-random" /> Reset Draft Head
+          <i className="fa fa-random" /> Revalidate Commit
         </button>
       </span>
     )}
   </Mutation>
 )
 
-UpdateRef.propTypes = {
+Revalidate.propTypes = {
   datasetId: PropTypes.string,
-  ref: PropTypes.string,
+  revision: PropTypes.string,
 }
 
-export default UpdateRef
+export default Revalidate

--- a/packages/openneuro-app/src/scripts/datalad/routes/admin.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/routes/admin.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types'
 import { Link } from 'react-router-dom'
 import DatasetHistory from '../fragments/dataset-history.jsx'
 import CacheClear from '../mutations/cache-clear.jsx'
-import UpdateRef from '../mutations/update-ref.jsx'
 
 /**
  * Map dataset IDs to a normal distribution of backend workers

--- a/packages/openneuro-server/src/datalad/draft.js
+++ b/packages/openneuro-server/src/datalad/draft.js
@@ -59,30 +59,13 @@ export const getDraftFiles = (datasetId, options = {}) => {
 
 export const updateDatasetRevision = (datasetId, gitRef) => {
   /**
-   * Update the revision pointer in a draft on changes
+   * Update the revision modified time in a draft on changes
    */
-  return Dataset.updateOne(
-    { id: datasetId },
-    { revision: gitRef, modified: new Date() },
-  )
+  return Dataset.updateOne({ id: datasetId }, { modified: new Date() })
     .exec()
     .then(() => {
       // Remove the now invalid draft files cache
       return expireDraftFiles(datasetId)
     })
     .then(() => publishDraftUpdate(datasetId, gitRef))
-}
-
-export const getDatasetRevision = async datasetId => {
-  return new Promise((resolve, reject) => {
-    Dataset.findOne({ id: datasetId })
-      .exec()
-      .then(obj => {
-        if (obj) {
-          resolve(obj.revision)
-        } else {
-          reject(null)
-        }
-      })
-  })
 }

--- a/packages/openneuro-server/src/graphql/resolvers/draft.js
+++ b/packages/openneuro-server/src/graphql/resolvers/draft.js
@@ -33,6 +33,17 @@ export const updateRef = async (
   if (!snapshot) await createSnapshot(datasetId, '1.0.0', userInfo)
 }
 
+/**
+ * Mutation to move the draft HEAD reference forward or backward
+ */
+export const revalidate = async (
+  obj,
+  { datasetId, ref },
+  { user, userInfo },
+) => {
+  await checkDatasetWrite(datasetId, user, userInfo)
+}
+
 const draft = {
   id: obj => obj.id,
   files: draftFiles,
@@ -41,7 +52,7 @@ const draft = {
   modified: obj => obj.modified,
   description,
   readme,
-  head: async obj => (await Dataset.findOne({ id: obj.id }).exec()).revision,
+  head: obj => obj.revision,
 }
 
 export default draft

--- a/packages/openneuro-server/src/graphql/resolvers/mutation.js
+++ b/packages/openneuro-server/src/graphql/resolvers/mutation.js
@@ -13,7 +13,7 @@ import { updateRef } from './draft.js'
 import { createSnapshot, deleteSnapshot } from './snapshots.js'
 import { removeUser, setAdmin, setBlocked } from './user.js'
 import { updateSummary } from './summary.js'
-import { updateValidation } from './validation.js'
+import { revalidate, updateValidation } from './validation.js'
 import { updatePermissions, removePermissions } from './permissions.js'
 import { followDataset } from './follow.js'
 import { starDataset } from './stars.js'
@@ -57,6 +57,7 @@ const Mutation = {
   prepareUpload,
   finishUpload,
   cacheClear,
+  revalidate,
 }
 
 export default Mutation

--- a/packages/openneuro-server/src/graphql/resolvers/validation.js
+++ b/packages/openneuro-server/src/graphql/resolvers/validation.js
@@ -1,3 +1,7 @@
+import fetch from 'node-fetch'
+import config from '../../config'
+import { generateDataladCookie } from '../../libs/authentication/jwt'
+import { getDatasetWorker } from '../../libs/datalad-service'
 import Issue from '../../models/issue'
 import publishDraftUpdate from '../utils/publish-draft-update.js'
 
@@ -19,4 +23,32 @@ export const updateValidation = (obj, args) => {
       publishDraftUpdate(args.validation.datasetId, args.validation.id)
       return true
     })
+}
+
+export const validationUrl = (datasetId, ref) => {
+  return `http://${getDatasetWorker(
+    datasetId,
+  )}/datasets/${datasetId}/validate/${ref}`
+}
+
+/**
+ * Request revalidation for a given commit
+ * @param {object} obj Parent resolver
+ * @param {object} args
+ * @param {string} args.datasetId Dataset accession number
+ * @param {string} args.ref Git hexsha
+ */
+export const revalidate = async (obj, { datasetId, ref }, { userInfo }) => {
+  const response = await fetch(validationUrl(datasetId, ref), {
+    method: 'POST',
+    body: JSON.stringify({}),
+    headers: {
+      cookie: generateDataladCookie(config)(userInfo),
+    },
+  })
+  if (response.status === 200) {
+    return true
+  } else {
+    return false
+  }
 }

--- a/packages/openneuro-server/src/graphql/schema.js
+++ b/packages/openneuro-server/src/graphql/schema.js
@@ -147,6 +147,8 @@ export const typeDefs = `
     finishUpload(uploadId: ID!): Boolean
     # Drop caches for a given dataset - requires site admin access
     cacheClear(datasetId: ID!): Boolean
+    # Rerun the latest validator on a given commit
+    revalidate(datasetId: ID!, ref: String!): Boolean
   }
 
   input UploadFile {

--- a/packages/openneuro-server/src/models/dataset.js
+++ b/packages/openneuro-server/src/models/dataset.js
@@ -8,7 +8,6 @@ const datasetSchema = new mongoose.Schema(
     public: Boolean,
     publishDate: { type: Date, default: null },
     uploader: String,
-    revision: String,
     name: String,
   },
   { toJSON: { virtuals: true }, toObject: { virtuals: true } },

--- a/services/datalad/datalad_service/app.py
+++ b/services/datalad/datalad_service/app.py
@@ -18,6 +18,7 @@ from datalad_service.handlers.heartbeat import HeartbeatResource
 from datalad_service.handlers.publish import PublishResource
 from datalad_service.handlers.upload import UploadResource
 from datalad_service.handlers.upload_file import UploadFileResource
+from datalad_service.handlers.validation import ValidationResource
 from datalad_service.middleware.auth import AuthenticateMiddleware
 
 
@@ -53,6 +54,7 @@ def create_app(annex_path):
     heartbeat = HeartbeatResource()
     datasets = DatasetResource(store)
     dataset_draft = DraftResource(store)
+    dataset_validation = ValidationResource(store)
     dataset_history = HistoryResource(store)
     dataset_description = DescriptionResource(store)
     dataset_files = FilesResource(store)
@@ -69,6 +71,7 @@ def create_app(annex_path):
     api.add_route('/datasets/{dataset}/draft', dataset_draft)
     api.add_route('/datasets/{dataset}/history', dataset_history)
     api.add_route('/datasets/{dataset}/description', dataset_description)
+    api.add_route('/datasets/{dataset}/validate/{hexsha}', dataset_validation)
 
     api.add_route('/datasets/{dataset}/files', dataset_files)
     api.add_route('/datasets/{dataset}/files/{filename:path}', dataset_files)

--- a/services/datalad/datalad_service/handlers/draft.py
+++ b/services/datalad/datalad_service/handlers/draft.py
@@ -15,7 +15,7 @@ class DraftResource(object):
         if dataset:
             # Maybe turn this into status?
             ds = self.store.get_dataset(dataset)
-            resp.media = {'partial': ds.repo.dirty}
+            resp.media = {'hexsha': ds.repo.get_hexsha()}
             resp.status = falcon.HTTP_OK
         else:
             resp.status = falcon.HTTP_NOT_FOUND

--- a/services/datalad/datalad_service/handlers/validation.py
+++ b/services/datalad/datalad_service/handlers/validation.py
@@ -1,0 +1,30 @@
+import falcon
+
+from datalad_service.common.user import get_user_info
+from datalad_service.tasks.validator import validate_dataset
+
+
+class ValidationResource(object):
+    def __init__(self, store):
+        self.store = store
+
+    def on_post(self, req, resp, dataset, hexsha):
+        """Run validation for a given commit"""
+        if dataset and hexsha:
+            # Record if this was done on behalf of a user
+            name, email = get_user_info(req)
+            media_dict = {}
+            if name and email:
+                media_dict['name'] = name
+                media_dict['email'] = email
+            try:
+                ds = self.store.get_dataset(dataset)
+                # Run the validator but don't block on the request
+                validate_dataset(dataset, ds.path, hexsha, req.cookies)
+                resp.status = falcon.HTTP_OK
+            except:
+                resp.status = falcon.HTTP_INTERNAL_SERVER_ERROR
+        else:
+            resp.media = {
+                'error': 'Missing or malformed dataset parameter in request.'}
+            resp.status = falcon.HTTP_UNPROCESSABLE_ENTITY

--- a/services/datalad/tests/test_draft.py
+++ b/services/datalad/tests/test_draft.py
@@ -34,19 +34,10 @@ def test_add_commit_info(client):
     assert response_content['email'] == email
 
 
-def test_is_dirty(client, new_dataset):
+def test_get_draft(client, new_dataset):
     ds_id = os.path.basename(new_dataset.path)
     # Check if new_dataset is not dirty
     response = client.simulate_get(
         '/datasets/{}/draft'.format(ds_id))
     assert response.status == falcon.HTTP_OK
-    assert json.loads(response.content)['partial'] == False
-    # Make the dataset dirty
-    response = client.simulate_post(
-        '/datasets/{}/files/NEW_FILE'.format(ds_id), body='some file data')
-    assert response.status == falcon.HTTP_OK
-    # Check if partial state is now true
-    response = client.simulate_get(
-        '/datasets/{}/draft'.format(ds_id))
-    assert response.status == falcon.HTTP_OK
-    assert json.loads(response.content)['partial'] == True
+    assert len(json.loads(response.content)['hexsha']) == 40


### PR DESCRIPTION
This replaces the draft revision pointer with a dynamic resolver which always points at the HEAD from the dataset. This adds an extra request to many draft operations but simplifies complex updates like git pushes required for git-annex push support.

Secondary change here is that since the draft pointer no longer exists, I've implemented a revalidation component to replace the reset draft pointer component used on the admin page.