### PR TITLE
Prevent non-cooperative gevent tasks from blocking gunicorn

### DIFF
--- a/services/datalad/datalad_service/handlers/dataset.py
+++ b/services/datalad/datalad_service/handlers/dataset.py
@@ -8,6 +8,7 @@ from datalad_service.tasks.dataset import create_dataset
 from datalad_service.tasks.dataset import delete_dataset
 from datalad_service.tasks.publish import delete_siblings
 
+
 class DatasetResource(object):
 
     """A Falcon API wrapper around underlying datalad/git-annex datasets."""
@@ -47,6 +48,7 @@ class DatasetResource(object):
     def on_delete(self, req, resp, dataset):
         def run_delete_tasks(store, dataset):
             delete_siblings(store, dataset)
+            gevent.sleep()
             delete_dataset(store, dataset)
 
         try:

--- a/services/datalad/datalad_service/handlers/upload.py
+++ b/services/datalad/datalad_service/handlers/upload.py
@@ -19,6 +19,7 @@ def move_files(upload_path, dataset_path):
                 filename, start=upload_path))
             pathlib.Path(target).parent.mkdir(parents=True, exist_ok=True)
             shutil.move(str(filename), target)
+            gevent.sleep()
 
 
 class UploadResource(object):
@@ -34,10 +35,12 @@ class UploadResource(object):
                 unlock_files = [os.path.relpath(filename, start=upload_path) for filename in
                                 pathlib.Path(upload_path).glob('**/*') if os.path.islink(
                     os.path.join(ds.path, os.path.relpath(filename, start=upload_path)))]
+                gevent.sleep()
                 move_files(upload_path, ds.path)
-                shutil.rmtree(upload_path)
                 ds.save(unlock_files)
                 update_head(ds, dataset_id, cookies)
+                gevent.sleep()
+                shutil.rmtree(upload_path)
         except:
             self.logger.exception('Dataset upload could not be finalized')
             sentry_sdk.capture_exception()

--- a/services/datalad/datalad_service/tasks/publish.py
+++ b/services/datalad/datalad_service/tasks/publish.py
@@ -16,6 +16,7 @@ from datalad_service.common.s3 import validate_s3_config, update_s3_sibling
 
 import boto3
 from github import Github
+import gevent
 
 
 def create_github_repo(dataset, repo_name):
@@ -113,10 +114,12 @@ def migrate_to_bucket(store, dataset, cookies=None, realm='PUBLIC'):
     s3_remote = s3_sibling(ds, siblings, realm=realm)
     for tag in tags:
         publish_target(ds, realm.s3_remote, tag)
+        gevent.sleep()
         # Public publishes to GitHub
         if realm == DatasetRealm.PUBLIC and DATALAD_GITHUB_EXPORTS_ENABLED:
             github_remote = github_sibling(ds, dataset_id, siblings)
             publish_target(ds, realm.github_remote, tag)
+            gevent.sleep()
     clear_dataset_cache(dataset, cookies)
 
 

--- a/services/datalad/datalad_service/tasks/validator.py
+++ b/services/datalad/datalad_service/tasks/validator.py
@@ -1,9 +1,9 @@
 import json
 import os
-import subprocess
 import requests
 
 import gevent
+from gevent import subprocess
 import sentry_sdk
 
 from datalad_service.config import GRAPHQL_ENDPOINT
@@ -23,7 +23,7 @@ def validate_dataset_sync(dataset_path, ref):
     """
     setup_validator()
     try:
-        process = subprocess.run(
+        process = gevent.subprocess.run(
             ['./node_modules/.bin/bids-validator', '--json', '--ignoreSubjectConsistency', dataset_path], stdout=subprocess.PIPE, timeout=300)
         return json.loads(process.stdout)
     except subprocess.TimeoutExpired:


### PR DESCRIPTION
This fixes timeouts by yielding during long file copies to allow gunicorn to process higher priority greenlets and uses the gevent patched version of multiprocess to yield while validation is running. This avoids a rare timeout on larger uploads that would crash the final copy when gunicorn declared the worker dead (due to blocking).

This issue is also worse than expected because of the order of operations for the finish upload call. This avoids data loss in the case the commit fails by moving rmtree to the end of the calls.