### PR TITLE
Add pre-receive hook to run validation on git push

### DIFF
--- a/services/datalad/Dockerfile
+++ b/services/datalad/Dockerfile
@@ -1,5 +1,6 @@
 FROM python:3.8-slim as base
 
+COPY hooks /hooks
 COPY package.json /package.json
 COPY Pipfile /Pipfile
 COPY Pipfile.lock /Pipfile.lock

--- a/services/datalad/datalad_service/handlers/git.py
+++ b/services/datalad/datalad_service/handlers/git.py
@@ -1,3 +1,4 @@
+import os.path
 import logging
 import subprocess
 
@@ -85,6 +86,9 @@ class GitReceiveResource(object):
             return _handle_failed_access(req, resp)
         if dataset:
             ds = self.store.get_dataset(dataset)
+            pre_receive_path = os.path.join(ds.path, '.git', 'hooks', 'pre-receive')
+            if not os.path.islink(pre_receive_path):
+                os.symlink('/hooks/pre-receive', pre_receive_path)
             process = subprocess.Popen(
                 ['git-receive-pack', '--stateless-rpc', ds.path], stdin=subprocess.PIPE, stdout=subprocess.PIPE)
             pipe_chunks(reader=req.bounded_stream, writer=process.stdin)

--- a/services/datalad/hooks/pre-receive
+++ b/services/datalad/hooks/pre-receive
@@ -1,0 +1,82 @@
+#!/bin/bash -u
+#
+# Pre-receive hook to limit pushed file size and run filename only validation
+#
+# Derived from https://github.com/mgit-at/git-max-filesize
+# Author: Christoph Hack <chack@mgit.at>
+# Copyright (c) 2017 mgIT GmbH. All rights reserved.
+# Distributed under the Apache License. See http://www.apache.org/licenses/LICENSE-2.0 for details.
+#
+set -o pipefail
+
+readonly MAXSIZE="104857600" # 100MB
+readonly NULLSHA="0000000000000000000000000000000000000000"
+readonly EXIT_SUCCESS="0"
+readonly EXIT_FAILURE="1"
+
+# main entry point
+function main() {
+  local status="$EXIT_SUCCESS"
+
+  # read lines from stdin (format: "<oldref> <newref> <refname>\n")
+  local oldref
+  local newref
+  local refname
+  while read oldref newref refname; do
+    # skip branch deletions
+    if [[ "$newref" == "$NULLSHA" ]]; then
+      continue
+    fi
+
+    # find large objects
+    # check all objects from $oldref (possible $NULLSHA) to $newref, but
+    # skip all objects that have already been accepted (i.e. are referenced by
+    # another branch or tag).
+    local target
+    if [[ "$oldref" == "$NULLSHA" ]]; then
+      target="$newref"
+    else
+      target="${oldref}..${newref}"
+    fi
+    local large_files
+    large_files="$(git rev-list --objects "$target" --not --branches=\* --tags=\* | \
+      git cat-file $'--batch-check=%(objectname)\t%(objecttype)\t%(objectsize)\t%(rest)' | \
+      awk -F '\t' -v maxbytes="$MAXSIZE" '$3 > maxbytes' | cut -f 4-)"
+    if [[ "$?" != 0 ]]; then
+      echo "failed to check for large files in ref ${refname}"
+      continue
+    fi
+
+
+    git diff --stat --name-only --diff-filter=ACMRT ${target} | \
+      /node_modules/.bin/bids-validator --filenames -
+    if [[ "$?" != 0 ]]; then
+      echo ""
+      echo "-------------------------------------------------------------------------"
+      echo "Your push was rejected because it failed validation."
+      echo "Please test with bids-validator locally to resolve any errors before pushing."
+      echo "-------------------------------------------------------------------------"
+      exit $?
+    fi
+
+    IFS=$'\n'
+    for file in $large_files; do
+      if [[ "$status" == 0 ]]; then
+        echo ""
+        echo "-------------------------------------------------------------------------"
+        echo "Your push was rejected because it contains files larger than 100MB."
+        echo "Please use git-annex to store larger files."
+        echo "-------------------------------------------------------------------------"
+        echo ""
+        echo "Offending files:"
+        status="$EXIT_FAILURE"
+      fi
+      echo " - ${file} (ref: ${refname})"
+    done
+    unset IFS
+  done
+
+  exit "$status"
+}
+
+main


### PR DESCRIPTION
Depends on https://github.com/bids-standard/bids-validator/pull/1143

This will run validation on the file tree during a git push. This is limited to checks that do not examine file contents or sizes as only newly pushed objects have their size examined. Newly pushed git objects are examined and limited to 100MB.

The hook is installed for each repo when a push containing new refs is received.