### PR TITLE
Defacing form improvements

### DIFF
--- a/packages/openneuro-app/src/scripts/datalad/fragments/select-input.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/fragments/select-input.jsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import TextInput from './text-input.jsx'
 import { PropTypes } from 'prop-types'
 import styled from '@emotion/styled'
@@ -132,10 +132,10 @@ const SelectInput = ({
   disabled,
   annotated,
   required,
+  warningOnChange = '',
   onChange,
   hasBooleanValues,
 }) => {
-  const defaultOptions = options.map(option => option.value)
   if (hasBooleanValues && typeof value === 'boolean') {
     value = value.toString()
   }
@@ -147,13 +147,17 @@ const SelectInput = ({
   else if (otherOptionSelected) selectValue = 'Other'
   else selectValue = value
 
+  const [changed, setChanged] = useState(false)
+
   const handleChange = e => {
-    let value = e.target.value
+    const prevValue = value
+    let newValue = e.target.value
     if (hasBooleanValues) {
-      if (value === 'true') value = true
-      else if (value === 'false') value = false
+      if (newValue === 'true') newValue = true
+      else if (newValue === 'false') newValue = false
     }
-    onChange(e.target.name, value)
+    if (prevValue != newValue) setChanged(true)
+    onChange(e.target.name, newValue)
   }
 
   return (
@@ -195,6 +199,7 @@ const SelectInput = ({
           onChange={onChange}
         />
       </OtherInputContainer>
+      {changed && <p>{warningOnChange}</p>}
     </>
   )
 }
@@ -208,6 +213,7 @@ SelectInput.propTypes = {
   disabled: PropTypes.bool,
   annotated: PropTypes.bool,
   required: PropTypes.bool,
+  warningOnChange: PropTypes.string,
   onChange: PropTypes.func,
   handleChange: PropTypes.func,
   hasBooleanValues: PropTypes.bool,

--- a/packages/openneuro-app/src/scripts/datalad/mutations/add-metadata.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/mutations/add-metadata.jsx
@@ -65,6 +65,7 @@ export const compileMetadata = dataset => {
     tasksCompleted: getFromSummary('tasks') || [],
   }
 }
+
 const AddMetadata = ({ dataset, history, location }) => {
   const [values, setValues] = useState(compileMetadata(dataset))
   const handleInputChange = (name, value) => {

--- a/packages/openneuro-app/src/scripts/datalad/mutations/metadata-form.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/mutations/metadata-form.jsx
@@ -263,6 +263,8 @@ const metadataFields = hasEdit => {
         disabled: false,
         annotated: false,
         required: false,
+        warningOnChange:
+          'Details: Affirms or refutes that all structural scans have been defaced, obscuring any tissue on or near the face that could potentially be used to reconstruct the facial structure.',
       },
     },
     {
@@ -285,6 +287,8 @@ const metadataFields = hasEdit => {
         disabled: false,
         annotated: false,
         required: false,
+        warningOnChange:
+          'Details: Affirms or refutes that I have explicit participant consent and ethical authorization to publish structural scans without defacing',
       },
     },
   ]
@@ -296,7 +300,13 @@ const metadataFields = hasEdit => {
       })
 }
 
-const MetadataForm = ({ values, onChange, hideDisabled, hasEdit }) => (
+const MetadataForm = ({
+  values,
+  onChange,
+  hideDisabled,
+  hiddenFields = [],
+  hasEdit,
+}) => (
   <Form id="metadata-form" className="col-xs-6">
     <InfoText>
       Incomplete fields in this form will make it more difficult for users to
@@ -317,7 +327,9 @@ const MetadataForm = ({ values, onChange, hideDisabled, hasEdit }) => (
     {metadataFields(hasEdit)
       .filter(
         // remove disabled fields when hideDisabled is true
-        field => !(hideDisabled && field.additionalProps.disabled),
+        field =>
+          !(hideDisabled && field.additionalProps.disabled) &&
+          !hiddenFields.includes(field.key),
       )
       .map(
         (
@@ -343,6 +355,7 @@ MetadataForm.propTypes = {
   values: PropTypes.object,
   onChange: PropTypes.func,
   hideDisabled: PropTypes.bool,
+  hiddenFields: PropTypes.array,
   hasEdit: PropTypes.bool,
 }
 

--- a/packages/openneuro-app/src/scripts/datalad/mutations/metadata-form.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/mutations/metadata-form.jsx
@@ -23,6 +23,15 @@ const DisabledNote = styled.div({
   },
 })
 
+const ValidationError = styled.div({
+  display: 'flex',
+  color: 'red',
+
+  i: {
+    marginRight: '0.5rem',
+  },
+})
+
 const metadataFields = hasEdit => {
   const fields = [
     {
@@ -306,6 +315,7 @@ const MetadataForm = ({
   hideDisabled,
   hiddenFields = [],
   hasEdit,
+  validationErrors = [],
 }) => (
   <Form id="metadata-form" className="col-xs-6">
     <InfoText>
@@ -347,6 +357,13 @@ const MetadataForm = ({
           />
         ),
       )}
+    {Boolean(validationErrors.length) &&
+      validationErrors.map((errorMessage, i) => (
+        <ValidationError key={i}>
+          <i className="fa fa-asterisk" />
+          <p>{errorMessage}</p>
+        </ValidationError>
+      ))}
   </Form>
 )
 
@@ -357,6 +374,7 @@ MetadataForm.propTypes = {
   hideDisabled: PropTypes.bool,
   hiddenFields: PropTypes.array,
   hasEdit: PropTypes.bool,
+  validationErrors: PropTypes.array,
 }
 
 export default MetadataForm

--- a/packages/openneuro-app/src/scripts/datalad/mutations/submit-metadata.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/mutations/submit-metadata.jsx
@@ -35,7 +35,7 @@ export const SUBMIT_METADATA = gql`
   }
 `
 
-const SubmitMetadata = ({ datasetId, metadata, done }) => (
+const SubmitMetadata = ({ datasetId, metadata, done, disabled }) => (
   <Mutation
     mutation={SUBMIT_METADATA}
     update={(cache, { data: { addMetadata } }) => {
@@ -53,7 +53,8 @@ const SubmitMetadata = ({ datasetId, metadata, done }) => (
       <button
         type="submit"
         form="metadata-form"
-        className="btn-modal-action"
+        className={`btn-modal-action${disabled ? ' btn-modal-danger' : ''}`}
+        disabled={disabled}
         onClick={async e => {
           e.preventDefault()
           await submitMetadata({
@@ -71,6 +72,7 @@ SubmitMetadata.propTypes = {
   datasetId: PropTypes.string,
   metadata: PropTypes.object,
   done: PropTypes.func,
+  disabled: PropTypes.bool,
 }
 
 export default SubmitMetadata

--- a/packages/openneuro-app/src/scripts/uploader/upload-metadata.jsx
+++ b/packages/openneuro-app/src/scripts/uploader/upload-metadata.jsx
@@ -38,6 +38,7 @@ const UploadMetadata = () => {
             values={values}
             onChange={handleInputChange}
             hideDisabled={true}
+            hiddenFields={['affirmedConsent', 'affirmedDefaced']}
             hasEdit={true}
           />
           <br />


### PR DESCRIPTION
resolves #1860

Adds specific terms to affirmDefaced and affirmConsent fields on change.
<img width="382" alt="Screen Shot 2021-01-12 at 12 22 21" src="https://user-images.githubusercontent.com/28666458/104368849-7f906680-54d1-11eb-9dc7-5b1c61519414.png">

Adds validation to the metadata form preventing users from submitting metadata if neither defacing fields are true.
<img width="390" alt="Screen Shot 2021-01-12 at 12 22 08" src="https://user-images.githubusercontent.com/28666458/104368991-b0709b80-54d1-11eb-80e6-c27c9f0afe47.png">
