### PR TITLE
docker-compose: Install arm64 builds of git-annex

### DIFF
--- a/services/datalad/Dockerfile
+++ b/services/datalad/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update \
   && mkdir /yarn \
   && curl -L https://github.com/yarnpkg/yarn/releases/download/v1.22.5/yarn-v1.22.5.tar.gz | tar -C /yarn --strip-components 1 -xvz \
   && ln -sf /yarn/bin/yarn /usr/local/bin/yarn \
-  && curl -L http://archive.org/download/git-annex-builds/SHA256E-s54746876--31525511e3aecfd77a0425f0c3ae3f52194e841288300ab04f2e60406619d225.tar.gz | tar -C /usr/local/bin --strip-components 1 -xvz \
+  && [[ $(uname -m ) = "aarch64" ]] && curl -L http://archive.org/download/git-annex-builds/SHA256E-s56843093--0be241196d58d848f169c7cfc7094b7dc89d8ca373f86a17e85d5d52848281e7.tar.gz | tar -C /usr/local/bin --strip-components 1 -xvz || curl -L http://archive.org/download/git-annex-builds/SHA256E-s54746876--31525511e3aecfd77a0425f0c3ae3f52194e841288300ab04f2e60406619d225.tar.gz | tar -C /usr/local/bin --strip-components 1 -xvz \
   && pip3 install 'pipenv==2020.6.2' \
   && pipenv install --deploy --system \
   && chmod 600 /root/.ssh/config \


### PR DESCRIPTION
This detects the arm64 container architecture and installs the correct git-annex build.