### PR TITLE
Validate branch and tag names on pre-receive

### DIFF
--- a/services/datalad/hooks/pre-receive
+++ b/services/datalad/hooks/pre-receive
@@ -28,6 +28,29 @@ function main() {
       continue
     fi
 
+    case $refname in
+      refs/heads/*)
+        branch=$(expr "$refname" : "refs/heads/\(.*\)")
+        if ! [[ "$branch" == "master" || "$branch" == "git-annex" || "$branch" == "main" || "$branch" =~ "^synced\/.*$" ]]; then
+          echo ""
+          echo "-------------------------------------------------------------------------"
+          echo "Only 'master', 'main', or 'git-annex' branches are accepted."
+          echo "-------------------------------------------------------------------------"
+          exit 1
+        fi
+        ;;
+      refs/tags/*)
+        tag=$(expr "$refname" : "refs/tags/\(.*\)")
+        if ! [[ "$tag" =~ "^[0-9]+\.[0-9]+\.[0-9]+$" ]]; then
+          echo ""
+          echo "-------------------------------------------------------------------------"
+          echo "Only version numbered tags are accepted, e.g. '1.2.3'"
+          echo "-------------------------------------------------------------------------"
+          exit 1
+        fi
+        ;;
+    esac
+    
     # find large objects
     # check all objects from $oldref (possible $NULLSHA) to $newref, but
     # skip all objects that have already been accepted (i.e. are referenced by


### PR DESCRIPTION
Disallows tags not matching basic semver (only numeric versions) or branches except for the standard branch names and the [prefix synced/...](https://git-annex.branchable.com/sync/).