### PR TITLE
Fix syntax for tracking-datasets template for docz

### DIFF
--- a/.github/ISSUE_TEMPLATE/tracking-datasets.md
+++ b/.github/ISSUE_TEMPLATE/tracking-datasets.md
@@ -13,5 +13,5 @@ assignees: ckrountree, franklin-feingold
 **The following datasets are affected:**
 *Please list below all affected datasets and add any additional information unique to that dataset. Check each off as it is resolved.*
 
-- [ ] ds0 , reported on <date> (also affected by: ) 
-- [ ] ds0 , reported on <date> (also affected by: )
+- [ ] ds0 , reported on `<date>` (also affected by: ) 
+- [ ] ds0 , reported on `<date>` (also affected by: )


### PR DESCRIPTION
These unescaped brackets prevent docz build from finishing even though this file isn't included in the output (it is still parsed).