### PR TITLE
Implement git-annex external remote for pushing annexed objects.

### DIFF
--- a/docs/git.md
+++ b/docs/git.md
@@ -71,9 +71,31 @@ path=/git/0/ds000001
 EOF
 ```
 
-
 ## Snapshots
 
-Snapshots are represented as git tags. To use all OpenNeuro features, you must have at least one tag with a valid semantic versioning name. This is typically `1.0.0` but can be any valid semantic version.
+Snapshots are represented as git tags. To use all OpenNeuro features, you must have at least one tag with a valid semantic versioning name. This is typically `1.0.0` but can be any valid numeric semantic version.
 
-Other tags are allowed but will not be published to S3. This can be useful but the only way to retrieve the full copy of these snapshots at the moment is via direct git access. They will appear on the web.
+## git-annex special remote
+
+Direct access can clone, push, and pull dataset contents but it does not transfer annexed objects on its own. For public datasets, the annexed objects are available with a preconfigured remote on S3 shortly after the dataset is made public or a new snapshot is created if the dataset is already public.
+
+For private datasets or to add new data with DataLad or git-annex, a special remote is available to push data directly to OpenNeuro.
+
+### Configuring OpenNeuro special remote
+
+Obtain the URL from the dataset page and run initremote (or enableremote if you need to update it).
+
+```shell
+# Make sure openneuro-cli is installed and available in your path
+# You should see 'VERSION 1' 'EXTENSIONS' if this is working
+echo "EXTENSIONS" | git-annex-remote-openneuro
+# Configure the remote with the URL for your dataset
+git annex initremote openneuro type=external externaltype=openneuro encryption=none url=https://openneuro.org/git/0/ds0000001
+```
+
+After this you can use regular git-annex or datalad commands to upload or download any annexed files by using the openneuro remote.
+
+```shell
+# To upload any annexed objects to the remote
+git annex copy --to openneuro
+```

--- a/packages/openneuro-cli/package.json
+++ b/packages/openneuro-cli/package.json
@@ -14,7 +14,8 @@
   "license": "MIT",
   "bin": {
     "openneuro": "./src/index.js",
-    "git-credential-openneuro": "./src/index.js"
+    "git-credential-openneuro": "./src/index.js",
+    "git-annex-remote-openneuro": "./src/index.js"
   },
   "dependencies": {
     "abort-controller": "^3.0.0",
@@ -33,7 +34,8 @@
   },
   "scripts": {
     "openneuro": "node src/index.js",
-    "git-credential-openneuro": "node src/index.js"
+    "git-credential-openneuro": "node src/index.js",
+    "git-annex-remote-openneuro": "node src/index.js"
   },
   "jest": {
     "setupFiles": [

--- a/packages/openneuro-cli/src/__tests__/gitAnnexRemote.spec.js
+++ b/packages/openneuro-cli/src/__tests__/gitAnnexRemote.spec.js
@@ -1,0 +1,69 @@
+import { handleGitAnnexMessage } from '../gitAnnexRemote.js'
+import { storeKey, retrieveKey, checkKey } from '../transferKey.js'
+
+jest.mock('../transferKey.js', () => {
+  return {
+    __esModule: true,
+    storeKey: jest.fn(() => true),
+    retrieveKey: jest.fn(() => true),
+    checkKey: jest.fn(() => true),
+    removeKey: jest.fn(() => true),
+  }
+})
+
+const mockState = {
+  url: 'https://example.com',
+}
+
+describe('gitAnnexRemote protocol implementation', () => {
+  describe('gitAnnexRemote handler', () => {
+    it('accepts EXTENSIONS message', async () => {
+      expect(await handleGitAnnexMessage('EXTENSIONS INFO ASYNC')).toEqual(
+        'EXTENSIONS',
+      )
+    })
+    it('accepts PREPARE message', async () => {
+      expect(await handleGitAnnexMessage('PREPARE')).toEqual('GETCONFIG url')
+    })
+    it('accepts VALUE message', async () => {
+      expect(
+        await handleGitAnnexMessage('VALUE https://openneuro.org', {
+          url: 'https://openneuro.org',
+        }),
+      ).toEqual('PREPARE-SUCCESS')
+    })
+    it('accepts TRANSFER STORE message', async () => {
+      expect(
+        await handleGitAnnexMessage('TRANSFER STORE key path', mockState),
+      ).toEqual('TRANSFER-SUCCESS STORE key')
+      expect(storeKey).toHaveBeenCalled()
+    })
+    it('accepts TRANSFER RETRIEVE message', async () => {
+      expect(
+        await handleGitAnnexMessage('TRANSFER RETRIEVE key path', mockState),
+      ).toEqual('TRANSFER-SUCCESS RETRIEVE key')
+      expect(retrieveKey).toHaveBeenCalled()
+    })
+    it('accepts CHECKPRESENT key message', async () => {
+      expect(
+        await handleGitAnnexMessage('CHECKPRESENT key', mockState),
+      ).toEqual('CHECKPRESENT-SUCCESS key')
+      expect(checkKey).toHaveBeenCalled()
+    })
+    it('accepts INITREMOTE message', async () => {
+      expect(await handleGitAnnexMessage('INITREMOTE')).toEqual(
+        'INITREMOTE-SUCCESS',
+      )
+    })
+    it('accepts a REMOVE message', async () => {
+      expect(await handleGitAnnexMessage('REMOVE key', mockState)).toEqual(
+        'REMOVE-SUCCESS key',
+      )
+    })
+    it('any other request should return UNSUPPORTED-REQUEST', async () => {
+      expect(await handleGitAnnexMessage('GETCOST')).toEqual(
+        'UNSUPPORTED-REQUEST',
+      )
+    })
+  })
+})

--- a/packages/openneuro-cli/src/cli.js
+++ b/packages/openneuro-cli/src/cli.js
@@ -4,6 +4,7 @@ import colors from 'colors'
 import packageJson from '../package.json'
 import { login, upload, download } from './actions.js'
 import { gitCredential } from './gitCredential.js'
+import { gitAnnexRemote } from './gitAnnexRemote.js'
 
 /**
  * display the help text in red on the console
@@ -75,6 +76,8 @@ commander.parse(process.argv)
 
 if (process.argv[1].endsWith('git-credential-openneuro')) {
   gitCredential()
+} else if (process.argv[1].endsWith('git-annex-remote-openneuro')) {
+  gitAnnexRemote()
 } else if (!process.argv.slice(2).length) {
   commander.outputHelp(makeRed)
 }

--- a/packages/openneuro-cli/src/gitAnnexRemote.js
+++ b/packages/openneuro-cli/src/gitAnnexRemote.js
@@ -88,6 +88,7 @@ export async function gitAnnexRemote() {
     console.log(GIT_ANNEX_VERSION)
     rl.on('line', response(rl))
     await once(rl, 'close')
+    process.exit(0)
   } catch (err) {
     console.error(err)
   }

--- a/packages/openneuro-cli/src/gitAnnexRemote.js
+++ b/packages/openneuro-cli/src/gitAnnexRemote.js
@@ -1,0 +1,94 @@
+import readline from 'readline'
+import { once } from 'events'
+import { getRepoToken } from './gitCredential.js'
+import gql from 'graphql-tag'
+import { storeKey, retrieveKey, checkKey, removeKey } from './transferKey.js'
+
+const GIT_ANNEX_VERSION = 'VERSION 1'
+
+export async function handleGitAnnexMessage(line, state) {
+  if (line.startsWith('EXTENSIONS')) {
+    return 'EXTENSIONS'
+  } else if (line.startsWith('PREPARE')) {
+    // Ask for configuration to validate
+    return 'GETCONFIG url'
+  } else if (line.startsWith('VALUE ')) {
+    // Check if VALUE is configured already
+    if (state.url) {
+      return 'PREPARE-SUCCESS'
+    } else {
+      return 'PREPARE-FAILURE url must be configured when running initremote or enableremote'
+    }
+  } else if (line.startsWith('TRANSFER STORE')) {
+    const [transfer, store, key, file] = line.split(' ', 4)
+    if (await storeKey(state, key, file)) {
+      return `TRANSFER-SUCCESS STORE ${key}`
+    } else {
+      return `TRANSFER-FAILURE STORE ${key}`
+    }
+  } else if (line.startsWith('TRANSFER RETRIEVE')) {
+    const [transfer, retrieve, key, file] = line.split(' ', 4)
+    if (await retrieveKey(state, key, file)) {
+      return `TRANSFER-SUCCESS RETRIEVE ${key}`
+    } else {
+      return `TRANSFER-FAILURE RETRIEVE ${key}`
+    }
+  } else if (line.startsWith('CHECKPRESENT')) {
+    const key = line.split('CHECKPRESENT ', 2)[1]
+    if (await checkKey(state, key)) {
+      return `CHECKPRESENT-SUCCESS ${key}`
+    } else {
+      return `CHECKPRESENT-FAILURE ${key}`
+    }
+  } else if (line.startsWith('INITREMOTE')) {
+    // No init steps are required - always succeed
+    return 'INITREMOTE-SUCCESS'
+  } else if (line.startsWith('GETAVAILABILITY')) {
+    return 'AVAILABILITY GLOBAL'
+  } else if (line.startsWith('REMOVE')) {
+    const key = line.split('REMOVE ', 2)[1]
+    if (await removeKey(state, key)) {
+      return `REMOVE-SUCCESS ${key}`
+    } else {
+      return `REMOVE-FAILURE ${key}`
+    }
+  } else {
+    return 'UNSUPPORTED-REQUEST'
+  }
+}
+
+/**
+ * Stateful response handling for git annex protocol
+ * @param {readline.Interface} rl Instance of Node.js readline
+ */
+export const response = rl => {
+  const state = {}
+  return async line => {
+    if (line.startsWith('VALUE ')) {
+      try {
+        const url = line.split('VALUE ')[1]
+        // Obtain the filename (no extensions) in url value
+        const datasetId = url.substring(url.lastIndexOf('/') + 1, url.length)
+        state.url = url
+        state.token = await getRepoToken(datasetId)
+      } catch (err) {
+        state.url = undefined
+        state.token = undefined
+      }
+    }
+    console.log(await handleGitAnnexMessage(line, state))
+  }
+}
+
+export async function gitAnnexRemote() {
+  try {
+    const rl = readline.createInterface({
+      input: process.stdin,
+    })
+    console.log(GIT_ANNEX_VERSION)
+    rl.on('line', response(rl))
+    await once(rl, 'close')
+  } catch (err) {
+    console.error(err)
+  }
+}

--- a/packages/openneuro-cli/src/transferKey.js
+++ b/packages/openneuro-cli/src/transferKey.js
@@ -1,0 +1,104 @@
+import fs from 'fs'
+import { fetch, Request, Headers } from 'fetch-h2'
+import { once } from 'events'
+
+/**
+ * Create a Request object for this url and key
+ * @param {object} state
+ * @param {string} state.url Base URL
+ * @param {string} state.token Basic auth token for repos
+ * @param {string} key git-annex key
+ * @param {object} options fetch options
+ * @returns {Request} Configured fetch Request object
+ */
+export function keyRequest(state, key, options) {
+  const headers = new Headers()
+  headers.set(
+    'Authorization',
+    'Basic ' + Buffer.from(`openneuro-cli:${state.token}`).toString('base64'),
+  )
+  const requestUrl = `${state.url}/annex/${key}`
+  return new Request(requestUrl, { headers, ...options })
+}
+
+/**
+ * Call POST to upload a key to a remote
+ * @param {object} state
+ * @param {string} state.url Base URL
+ * @param {string} state.token Basic auth token for repos
+ * @param {string} key Git-annex key
+ * @param {string} file File path
+ */
+export async function storeKey(state, key, file) {
+  const body = fs.createReadStream(file)
+  const request = keyRequest(state, key, { body, method: 'POST' })
+  const response = await fetch(request)
+  if (response.status === 200) {
+    return true
+  } else {
+    return false
+  }
+}
+
+/**
+ * Call GET to download a key from a remote
+ * @param {object} state
+ * @param {string} state.url Base URL
+ * @param {string} state.token Basic auth token for repos
+ * @param {string} key Git-annex key
+ * @param {string} file File path
+ */
+export async function retrieveKey(state, key, file) {
+  try {
+    const request = keyRequest(state, key, { method: 'GET' })
+    const response = await fetch(request)
+    if (response.status === 200) {
+      const writable = fs.createWriteStream(file)
+      const readable = await response.readable()
+      readable.pipe(writable)
+      await once(readable, 'close')
+      return true
+    } else {
+      return false
+    }
+  } catch (err) {
+    console.error(err)
+    return false
+  }
+}
+
+/**
+ * Call HEAD to check if key exists on remote
+ * @param {object} state
+ * @param {string} state.url Base URL
+ * @param {string} state.token Basic auth token for repos
+ * @param {string} key
+ * @returns {Promise<boolean>} True or false if key exists
+ */
+export async function checkKey(state, key) {
+  const request = keyRequest(state, key, { method: 'HEAD' })
+  const response = await fetch(request)
+  if (response.status === 200) {
+    return true
+  } else {
+    return false
+  }
+}
+
+/**
+ * Call DELETE to remove a key from the remote
+ * @param {object} state
+ * @param {string} state.url Base URL
+ * @param {string} state.token Basic auth token for repos
+ * @param {string} key
+ * @returns {Promise<boolean>} True or false if key exists
+ */
+export async function removeKey(state, key) {
+  const request = keyRequest(state, key, { method: 'DELETE' })
+  const response = await fetch(request)
+  if (response.status === 204) {
+    return true
+  } else {
+    return false
+  }
+}

--- a/services/datalad/datalad_service/app.py
+++ b/services/datalad/datalad_service/app.py
@@ -20,6 +20,7 @@ from datalad_service.handlers.upload import UploadResource
 from datalad_service.handlers.upload_file import UploadFileResource
 from datalad_service.handlers.validation import ValidationResource
 from datalad_service.handlers.git import GitRefsResource, GitReceiveResource, GitUploadResource
+from datalad_service.handlers.annex import GitAnnexResource
 from datalad_service.middleware.auth import AuthenticateMiddleware
 
 
@@ -66,6 +67,7 @@ def create_app(annex_path):
     dataset_git_refs_resource = GitRefsResource(store)
     dataset_git_receive_resource = GitReceiveResource(store)
     dataset_git_upload_resource = GitUploadResource(store)
+    dataset_git_annex_resource = GitAnnexResource(store)
 
     api.add_route('/heartbeat', heartbeat)
 
@@ -105,5 +107,7 @@ def create_app(annex_path):
                   dataset_git_receive_resource)
     api.add_route('/git/{worker}/{dataset}/git-upload-pack',
                   dataset_git_upload_resource)
+    api.add_route('/git/{worker}/{dataset}/annex/{key}',
+                  dataset_git_annex_resource)
 
     return api

--- a/services/datalad/datalad_service/common/stream.py
+++ b/services/datalad/datalad_service/common/stream.py
@@ -1,15 +1,26 @@
+import os
+import tempfile
+
 CHUNK_SIZE_BYTES = 2048
 
 
 def update_file(path, stream):
-    """Update a file on disk with a path and source stream."""
-    with open(path, 'wb') as new_file:
-        # Stream file to disk
-        while True:
-            chunk = stream.read(CHUNK_SIZE_BYTES)
-            if not chunk:
-                break
-            new_file.write(chunk)
+    """Atomically update a file on disk with a path and source stream."""
+    # Delete is disabled here because we want to keep the file without double linking it
+    with tempfile.NamedTemporaryFile(dir=os.path.dirname(path), delete=False) as tmp:
+        try:
+            # Stream file to disk
+            while True:
+                chunk = stream.read(CHUNK_SIZE_BYTES)
+                if not chunk:
+                    break
+                tmp.write(chunk)
+            # Done streaming, replace the file
+            os.replace(tmp.name, path)
+        except:
+            # Only remove in the failure case, we want the file if the rest succeeds
+            os.remove(tmp.name)
+            raise
 
 
 def pipe_chunks(reader, writer):

--- a/services/datalad/datalad_service/handlers/annex.py
+++ b/services/datalad/datalad_service/handlers/annex.py
@@ -1,0 +1,89 @@
+import hashlib
+import logging
+import os
+import shutil
+import struct
+import tempfile
+
+import falcon
+
+from datalad_service.common.stream import update_file
+from datalad_service.handlers.git import _check_git_access, _handle_failed_access
+
+
+def hashdirmixed(key):
+    """Python implementation of git-annex hashing for non-bare git repos
+
+    https://git-annex.branchable.com/internals/hashing/"""
+    digest = hashlib.md5(key.encode()).digest()
+    first_word = struct.unpack('<I', digest[:4])[0]
+    nums = [first_word >> (6 * x) & 31 for x in range(4)]
+    letters = ["0123456789zqjxkmvwgpfZQJXKMVWGPF"[i] for i in nums]
+    return ("{0:s}{1:s}".format(letters[1], letters[0]), "{0:s}{1:s}".format(letters[3], letters[2]))
+
+
+def key_to_path(key):
+    return os.path.join('.git', 'annex', 'objects', *hashdirmixed(key), key, key)
+
+
+class GitAnnexResource(object):
+    """{worker}/{dataset}/annex/{key} serves git-annex object requests
+
+    This allows OpenNeuro to act as a special remote, adding or removing objects from .git/annex/objects/
+    """
+
+    def __init__(self, store):
+        self.store = store
+        self.logger = logging.getLogger('datalad_service.' + __name__)
+
+    def on_head(self, req, resp, worker, dataset, key):
+        """HEAD requests check if objects exist already"""
+        resp.set_header('WWW-Authenticate', 'Basic realm="dataset git repo"')
+        if not _check_git_access(req, dataset):
+            return _handle_failed_access(req, resp)
+        ds = self.store.get_dataset(dataset)
+        annex_object_path = os.path.join(ds.path, key_to_path(key))
+        if os.path.exists(annex_object_path):
+            resp.status = falcon.HTTP_OK
+        else:
+            resp.status = falcon.HTTP_NOT_FOUND
+
+    def on_get(self, req, resp, worker, dataset, key):
+        resp.set_header('WWW-Authenticate', 'Basic realm="dataset git repo"')
+        if not _check_git_access(req, dataset):
+            return _handle_failed_access(req, resp)
+        ds = self.store.get_dataset(dataset)
+        annex_object_path = os.path.join(ds.path, key_to_path(key))
+        if os.path.exists(annex_object_path):
+            resp.status = falcon.HTTP_OK
+            fd = open(annex_object_path, 'rb')
+            resp.stream = fd
+            resp.stream_len = os.fstat(fd.fileno()).st_size
+        else:
+            resp.status = falcon.HTTP_NOT_FOUND
+
+    def on_post(self, req, resp, worker, dataset, key):
+        resp.set_header('WWW-Authenticate', 'Basic realm="dataset git repo"')
+        if not _check_git_access(req, dataset):
+            return _handle_failed_access(req, resp)
+        ds = self.store.get_dataset(dataset)
+        annex_object_path = os.path.join(ds.path, key_to_path(key))
+        if os.path.exists(annex_object_path):
+            # Don't allow objects to be replaced
+            resp.status = falcon.HTTP_CONFLICT
+        else:
+            os.makedirs(os.path.dirname(annex_object_path), exist_ok=True)
+            # Begin writing stream to temp file and hard link once done
+            # It should not be written unless the full request completes
+            update_file(annex_object_path, req.stream)
+            resp.status = falcon.HTTP_OK
+
+    def on_delete(self, req, resp, worker, dataset, key):
+        resp.set_header('WWW-Authenticate', 'Basic realm="dataset git repo"')
+        if not _check_git_access(req, dataset):
+            return _handle_failed_access(req, resp)
+        ds = self.store.get_dataset(dataset)
+        annex_object_path = os.path.join(ds.path, key_to_path(key))
+        if os.path.exists(annex_object_path):
+            os.remove(annex_object_path)
+        resp.status = falcon.HTTP_NO_CONTENT

--- a/services/datalad/datalad_service/handlers/git.py
+++ b/services/datalad/datalad_service/handlers/git.py
@@ -86,7 +86,8 @@ class GitReceiveResource(object):
             return _handle_failed_access(req, resp)
         if dataset:
             ds = self.store.get_dataset(dataset)
-            pre_receive_path = os.path.join(ds.path, '.git', 'hooks', 'pre-receive')
+            pre_receive_path = os.path.join(
+                ds.path, '.git', 'hooks', 'pre-receive')
             if not os.path.islink(pre_receive_path):
                 os.symlink('/hooks/pre-receive', pre_receive_path)
             process = subprocess.Popen(

--- a/services/datalad/tests/test_annex_handler.py
+++ b/services/datalad/tests/test_annex_handler.py
@@ -1,0 +1,45 @@
+import falcon
+from falcon import testing
+
+from .dataset_fixtures import *
+from datalad_service.handlers.annex import hashdirmixed, key_to_path
+
+
+test_auth = "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJmZDQ0ZjVjNS1iMjFiLTQyMGItOTU1NS1hZjg1NmVmYzk0NTIiLCJlbWFpbCI6Im5lbGxAc3F1aXNoeW1lZGlhLmNvbSIsInByb3ZpZGVyIjoiZ29vZ2xlIiwibmFtZSI6Ik5lbGwgSGFyZGNhc3RsZSIsImFkbWluIjp0cnVlLCJzY29wZXMiOlsiZGF0YXNldDpnaXQiXSwiZGF0YXNldCI6ImRzMDAwMDAxIiwiaWF0IjoxNjA4NDEwNjEyLCJleHAiOjIxNDc0ODM2NDd9.0aA9cZWMieYr9zbmVrTeFEhpATqmT_X4tVX1VR1uabA"
+
+
+def test_hashdirmixed():
+    assert hashdirmixed(
+        "MD5E-s311112--bc8bbbacfd2ff823c2047ead1afec9b3.nii.gz") == ("z0", "fG")
+
+
+def test_key_to_path():
+    assert key_to_path("MD5E-s311112--bc8bbbacfd2ff823c2047ead1afec9b3.nii.gz") == ".git/annex/objects/z0/fG/MD5E-s311112--bc8bbbacfd2ff823c2047ead1afec9b3.nii.gz/MD5E-s311112--bc8bbbacfd2ff823c2047ead1afec9b3.nii.gz"
+
+
+def test_key_add_remove(client):
+    ds_id = 'ds000001'
+    key = "MD5E-s24--e04bb0391ed06622b018aac26c736870.nii"
+    random_value = b"ooQuieshaz4of2Aip3Niec2e"
+    url = '/git/0/{}/annex/{}'.format(ds_id, key)
+    response = client.simulate_post(
+        url, headers={"authorization": test_auth}, body=random_value)
+    assert response.status == falcon.HTTP_OK
+    response = client.simulate_get(url, headers={"authorization": test_auth})
+    assert response.status == falcon.HTTP_OK
+    assert response.content == random_value
+
+def test_key_get_head(client):
+    ds_id = 'ds000001'
+    key = "MD5E-s24--00e7097e83570b24b69cc509fc8f3cbf.nii"
+    random_value = b"soo2aid1po5teiJoowufah4i"
+    url = '/git/0/{}/annex/{}'.format(ds_id, key)
+    # Test failure first
+    response = client.simulate_head(url, headers={"authorization": test_auth})
+    assert response.status == falcon.HTTP_NOT_FOUND
+    # Add file and check again
+    response = client.simulate_post(
+        url, headers={"authorization": test_auth}, body=random_value)
+    assert response.status == falcon.HTTP_OK
+    response = client.simulate_head(url, headers={"authorization": test_auth})
+    assert response.status == falcon.HTTP_OK


### PR DESCRIPTION
This allows git-annex to export these objects directly to OpenNeuro.

Includes documentation additions, the worker endpoints, and openneuro-cli support for a custom remote.

One minor fix resolves a race condition in datalad_service.common.stream.update_file when updating files, this is needed to prevent issues with receiving git-annex objects rapidly but it may affect other kinds of uploads as well.