### PR TITLE
Add support for create-dataset command line action

### DIFF
--- a/packages/openneuro-cli/src/actions.js
+++ b/packages/openneuro-cli/src/actions.js
@@ -1,21 +1,13 @@
 /* eslint-disable no-console */
 import fs from 'fs'
 import inquirer from 'inquirer'
-import { createClient } from 'openneuro-client'
 import { apm } from './apm.js'
-import { saveConfig, getToken, getUrl } from './config'
+import { saveConfig, getUrl } from './config'
 import { validation, prepareUpload, uploadFiles, finishUpload } from './upload'
 import { getDatasetFiles, createDataset } from './datasets'
 import { getSnapshots } from './snapshots.js'
 import { getDownload } from './download.js'
-
-import { version } from '../package.json'
-
-export const configuredClient = () =>
-  createClient(`${getUrl()}crn/graphql`, {
-    getAuthorization: getToken,
-    clientVersion: version,
-  })
+import { configuredClient } from './configuredClient.js'
 
 /**
  * Login action to save an auth key locally

--- a/packages/openneuro-cli/src/cli.js
+++ b/packages/openneuro-cli/src/cli.js
@@ -5,6 +5,7 @@ import packageJson from '../package.json'
 import { login, upload, download } from './actions.js'
 import { gitCredential } from './gitCredential.js'
 import { gitAnnexRemote } from './gitAnnexRemote.js'
+import { createDataset } from './createDataset.js'
 
 /**
  * display the help text in red on the console
@@ -65,6 +66,14 @@ commander
     'A git credentials helper for easier datalad or git-annex access to datasets.',
   )
   .action(gitCredential)
+
+commander
+  .command('create-dataset')
+  .alias('c')
+  .description(
+    'Create a new empty dataset, useful for adding existing DataLad or git-annex datasets.',
+  )
+  .action(createDataset)
 
 commander.command('*', { noHelp: true, isDefault: true }).action(() => {
   // eslint-disable-next-line no-console

--- a/packages/openneuro-cli/src/configuredClient.js
+++ b/packages/openneuro-cli/src/configuredClient.js
@@ -1,0 +1,9 @@
+import { createClient } from 'openneuro-client'
+import { getToken, getUrl } from './config.js'
+import { version } from '../package.json'
+
+export const configuredClient = () =>
+  createClient(`${getUrl()}crn/graphql`, {
+    getAuthorization: getToken,
+    clientVersion: version,
+  })

--- a/packages/openneuro-cli/src/createDataset.js
+++ b/packages/openneuro-cli/src/createDataset.js
@@ -1,0 +1,32 @@
+import gql from 'graphql-tag'
+import { getUrl } from './config.js'
+import { configuredClient } from './configuredClient.js'
+import { apm } from './apm.js'
+
+const CREATE_DATASET = gql`
+  mutation createDataset {
+    createDataset(label: "") {
+      id
+      worker
+    }
+  }
+`
+
+export const createDataset = async () => {
+  const apmTransaction = apm.startTransaction('createDataset', 'custom')
+  const url = getUrl()
+  const client = configuredClient()
+  try {
+    const { data } = await client.mutate({ mutation: CREATE_DATASET })
+    const datasetId = data.createDataset.id
+    // Full worker value is something like "openneuro-worker-2"
+    const worker = data.createDataset.worker.split('-').pop()
+    console.log(`Dataset ${url}datasets/${datasetId} created.`)
+    console.log(`Git remote: ${url}git/${worker}/${datasetId}`)
+  } catch (err) {
+    console.log(
+      'Dataset creation failed, you may need to rerun setup with "openneuro login" first',
+    )
+  }
+  apmTransaction.end()
+}

--- a/packages/openneuro-cli/src/gitCredential.js
+++ b/packages/openneuro-cli/src/gitCredential.js
@@ -1,5 +1,5 @@
 import readline from 'readline'
-import { configuredClient } from './actions.js'
+import { configuredClient } from './configuredClient.js'
 import gql from 'graphql-tag'
 
 const prepareRepoAccess = gql`


### PR DESCRIPTION
This lets you create an empty dataset to make the initial push of an existing DataLad/git-annex dataset.

`openneuro create-dataset`

It outputs a couple lines of helper text:
```
Dataset https://openneuro.org/datasets/ds002414 created.
Git remote: https://openneuro.org/git/0/ds002414
```