### PR TITLE
Fix crash on draft page when no snapshots are available

### DIFF
--- a/packages/openneuro-app/jestsetup.ts
+++ b/packages/openneuro-app/jestsetup.ts
@@ -19,3 +19,17 @@ if (!Object.fromEntries) {
 }
 
 jest.mock('./config.js')
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: jest.fn().mockImplementation(query => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: jest.fn(), // Deprecated
+    removeListener: jest.fn(), // Deprecated
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    dispatchEvent: jest.fn(),
+  })),
+})

--- a/packages/openneuro-app/src/scripts/datalad/fragments/dataset-uploaded.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/fragments/dataset-uploaded.jsx
@@ -7,7 +7,6 @@ import formatDistanceToNow from 'date-fns/formatDistanceToNow'
 const DatasetUploaded = ({ uploader, created, testDifference }) => {
   const dateAdded = formatDate(created)
   const difference = testDifference || formatDistanceToNow(parseISO(created))
-  console.log(difference)
   return (
     <h6>
       {`uploaded by ${uploader.name} on ${dateAdded} - ${difference} ago`}

--- a/packages/openneuro-app/src/scripts/datalad/routes/__tests__/dataset-content.spec.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/routes/__tests__/dataset-content.spec.jsx
@@ -1,7 +1,14 @@
 import React from 'react'
 import { shallow } from 'enzyme'
-import { HasBeenPublished } from '../dataset-content.jsx'
+import { render, screen } from '@testing-library/react'
+import { DatasetContent, HasBeenPublished } from '../dataset-content.jsx'
 import { hasEditPermissions } from '../../../authentication/profile.js'
+import { BrowserRouter } from 'react-router-dom'
+import cookies from '../../../utils/cookies.js'
+
+jest.mock('../../fragments/dataset-files.jsx', () => () => (
+  <div>Mock File Tree</div>
+))
 
 describe('DatasetContent component', () => {
   describe('HasBeenPublished', () => {
@@ -48,5 +55,50 @@ describe('DatasetContent component', () => {
         ),
       ).toBe(false)
     })
+  })
+  it('renders when no snapshots are present', () => {
+    const datasetDraftOnly = {
+      created: '2021-01-26T17:10:53.738Z',
+      public: false,
+      draft: {
+        modified: '2021-01-26T17:10:53.738Z',
+        head: 'deb75470ec18e8656f4d6f7ad4b0f3b65bad7884',
+        description: {
+          Name: 'test dataset',
+        },
+        files: [{}],
+        issues: [],
+      },
+      permissions: {
+        userPermissions: [
+          {
+            level: 'admin',
+            user: { id: '123456', email: 'tests@example.com' },
+          },
+        ],
+      },
+      analytics: {
+        downloads: 1,
+        views: 1,
+      },
+      snapshots: [],
+      metadata: null,
+      uploader: {
+        name: 'test user',
+      },
+    }
+    cookies.set(
+      'accessToken',
+      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTYiLCJlbWFpbCI6InRlc3RzQGV4YW1wbGUuY29tIiwicHJvdmlkZXIiOiJnb29nbGUiLCJuYW1lIjoiVGVzdCBVc2VyIiwiYWRtaW4iOmZhbHNlLCJpYXQiOjE2MTE2ODEwNjcsImV4cCI6MjE0NzQ4MzY0N30.fDNpHGjvzCodz7OlKrFudHRioPoDSnufi6saeAyAqBA',
+    )
+    render(
+      <BrowserRouter>
+        <DatasetContent dataset={datasetDraftOnly} />
+      </BrowserRouter>,
+    )
+    // Look for some text that's always rendered
+    expect(screen.getByText('README')).toHaveTextContent('README')
+    // Verify something specific to this example dataset
+    expect(screen.getByText('test dataset')).toHaveTextContent('test dataset')
   })
 })

--- a/packages/openneuro-app/src/scripts/datalad/routes/dataset-content.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/routes/dataset-content.jsx
@@ -63,7 +63,7 @@ HasBeenPublished.propTypes = {
 /**
  * Data routing for the main dataset query to display/edit components
  */
-const DatasetContent = ({ dataset }) => {
+export const DatasetContent = ({ dataset }) => {
   const isMobile = useMedia('(max-width: 765px) ')
   const user = getProfile()
   const hasEdit =
@@ -71,8 +71,9 @@ const DatasetContent = ({ dataset }) => {
     hasEditPermissions(dataset.permissions, user && user.sub)
   const mobileClass = isMobile ? 'mobile-class' : 'col-xs-6'
   const hasDraftChanges =
+    dataset.snapshots.length === 0 ||
     dataset.draft.head !==
-    dataset.snapshots[dataset.snapshots.length - 1].hexsha
+      dataset.snapshots[dataset.snapshots.length - 1].hexsha
   return (
     <>
       <LoggedIn>


### PR DESCRIPTION
* Adds a jest mock for window.matchMedia
* Adds a test to render the dataset page with no snapshots (minus file tree) to verify this case automatically
* If no snapshots exist, assume there are edits that need a snapshot created