### PR TITLE
Add custom APM transactions with datasetId/snapshotTag for downloads

### DIFF
--- a/packages/openneuro-app/src/scripts/apm.js
+++ b/packages/openneuro-app/src/scripts/apm.js
@@ -1,0 +1,7 @@
+import { init as initApm } from '@elastic/apm-rum'
+
+export let apm
+
+export function setupApm(apmOptions) {
+  apm = initApm(apmOptions)
+}

--- a/packages/openneuro-app/src/scripts/client.jsx
+++ b/packages/openneuro-app/src/scripts/client.jsx
@@ -1,4 +1,4 @@
-import { init as initApm } from '@elastic/apm-rum'
+import { setupApm } from './apm.js'
 import * as Sentry from '@sentry/browser'
 import React from 'react'
 import ReactDOM from 'react-dom'
@@ -15,11 +15,19 @@ loadConfig().then(config => {
     config.sentry.environment === 'production' ||
     config.sentry.environment === 'staging'
   ) {
-    initApm({
+    setupApm({
       serverUrl: config.url,
       serviceName: 'openneuro-app',
       serviceVersion: packageJson.version,
       environment: config.sentry.environment,
+    })
+  } else {
+    setupApm({
+      serverUrl: config.url,
+      serviceName: 'openneuro-app',
+      serviceVersion: packageJson.version,
+      environment: config.sentry.environment,
+      active: false,
     })
   }
 

--- a/packages/openneuro-cli/package.json
+++ b/packages/openneuro-cli/package.json
@@ -29,6 +29,7 @@
     "find-config": "^1.0.0",
     "graphql-tag": "^2.10.3",
     "inquirer": "^5.2.0",
+    "jwt-decode": "^3.1.2",
     "mkdirp": "^0.5.1",
     "openneuro-client": "^3.28.0"
   },

--- a/packages/openneuro-cli/src/actions.js
+++ b/packages/openneuro-cli/src/actions.js
@@ -2,7 +2,7 @@
 import fs from 'fs'
 import inquirer from 'inquirer'
 import { apm } from './apm.js'
-import { saveConfig, getUrl } from './config'
+import { saveConfig, getUrl, getUser } from './config'
 import { validation, prepareUpload, uploadFiles, finishUpload } from './upload'
 import { getDatasetFiles, createDataset } from './datasets'
 import { getSnapshots } from './snapshots.js'
@@ -221,7 +221,15 @@ const promptTags = snapshots =>
  * @param {Object} cmd
  */
 export const download = (datasetId, destination, cmd) => {
-  const apmTransaction = apm.startTransaction('download', 'custom')
+  const apmTransaction = apm.startTransaction(
+    `download:${datasetId}`,
+    'download',
+  )
+  const { sub } = getUser()
+  apmTransaction.addLabels({ datasetId, userId: sub })
+  if (cmd.snapshot) {
+    apmTransaction.addLabels({ snapshot: cmd.snapshot })
+  }
   if (!cmd.draft && !cmd.snapshot) {
     const client = configuredClient()
     return getSnapshots(client)(datasetId).then(({ data }) => {

--- a/packages/openneuro-cli/src/config.js
+++ b/packages/openneuro-cli/src/config.js
@@ -2,6 +2,7 @@ import fs from 'fs'
 import os from 'os'
 import path from 'path'
 import findConfig from 'find-config'
+import jwt_decode from 'jwt-decode'
 
 /**
  * Get the nearest working configuration
@@ -44,6 +45,15 @@ export const getToken = () => {
       'You must have an API key configured to continue, try `openneuro login` first',
     )
   }
+}
+
+/**
+ * Get the user object from the configured token
+ * @returns {object}
+ */
+export const getUser = () => {
+  const token = getToken()
+  return jwt_decode(token)
 }
 
 export const getUrl = () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -15370,6 +15370,11 @@ jwt-decode@^2.2.0:
   resolved "https://registry.yarnpkg.com/jwt-decode/-/jwt-decode-2.2.0.tgz#7d86bd56679f58ce6a84704a657dd392bba81a79"
   integrity sha1-fYa9VmefWM5qhHBKZX3TkruoGnk=
 
+jwt-decode@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/jwt-decode/-/jwt-decode-3.1.2.tgz#3fb319f3675a2df0c2895c8f5e9fa4b67b04ed59"
+  integrity sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A==
+
 kareem@2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/kareem/-/kareem-2.3.1.tgz#def12d9c941017fabfb00f873af95e9c99e1be87"


### PR DESCRIPTION
Tracks client being used and matches up the transactions to track download issues and compare the CLI/browser clients directly.