### PR TITLE
Error handling

### DIFF
--- a/packages/openneuro-app/package.json
+++ b/packages/openneuro-app/package.json
@@ -30,6 +30,7 @@
     "core-js": "^3.3.2",
     "date-fns": "^2.16.1",
     "draft-js": "^0.10.5",
+    "email-validator": "^2.0.4",
     "enzyme-to-json": "^3.3.5",
     "eslint": "^6.5.1",
     "graphql": "14.6.0",

--- a/packages/openneuro-app/src/scripts/datalad/mutations/update-permissions.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/mutations/update-permissions.jsx
@@ -2,6 +2,9 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import gql from 'graphql-tag'
 import { Mutation } from '@apollo/client/react/components'
+import { toast } from 'react-toastify'
+import ToastContent from '../../common/partials/toast-content.jsx'
+import { validate as isValidEmail } from 'email-validator'
 
 const UPDATE_PERMISSIONS = gql`
   mutation updatePermissions(
@@ -49,10 +52,22 @@ const UpdateDatasetPermissions = ({ datasetId, userEmail, metadata, done }) => (
       <button
         className="btn-modal-action"
         onClick={async () => {
-          await UpdateDatasetPermissions({
-            variables: { datasetId, userEmail, level: metadata },
-          })
-          done()
+          if (isValidEmail(userEmail)) {
+            try {
+              await UpdateDatasetPermissions({
+                variables: { datasetId, userEmail, level: metadata },
+              })
+              done()
+            } catch (err) {
+              toast.error(
+                <ToastContent body="A user with that email address does not exist" />,
+              )
+            }
+          } else {
+            toast.error(
+              <ToastContent body="Please enter a valid email address" />,
+            )
+          }
         }}>
         Share
       </button>

--- a/packages/openneuro-server/src/graphql/resolvers/__tests__/permssions.spec.js
+++ b/packages/openneuro-server/src/graphql/resolvers/__tests__/permssions.spec.js
@@ -1,0 +1,33 @@
+import { updatePermissions } from '../permissions'
+
+jest.mock('../../permissions', () => ({
+  checkDatasetAdmin: async () => {},
+}))
+
+const mockExec = jest.fn()
+
+jest.mock('../../../models/user', () => ({
+  find: () => ({
+    exec: mockExec,
+  }),
+}))
+
+describe('permissions resolvers', () => {
+  describe('updatePermissions()', () => {
+    it('throws an error when no users are found', async () => {
+      mockExec.mockResolvedValue([])
+      let error
+      try {
+        await updatePermissions(
+          {},
+          { datasetId: 'ds01234', userEmail: 'fake@test.com' },
+          {},
+        )
+      } catch (err) {
+        error = err
+      }
+
+      return expect(error).toBeInstanceOf(Error)
+    })
+  })
+})

--- a/packages/openneuro-server/src/graphql/resolvers/permissions.js
+++ b/packages/openneuro-server/src/graphql/resolvers/permissions.js
@@ -45,6 +45,11 @@ export const updatePermissions = async (obj, args, { user, userInfo }) => {
   await checkDatasetAdmin(args.datasetId, user, userInfo)
   // get all users the the email specified by permissions arg
   const users = await User.find({ email: args.userEmail }).exec()
+
+  if (!users.length) {
+    throw new Error('A user with that email address does not exist')
+  }
+
   const userPromises = users.map(user => {
     return new Promise((resolve, reject) => {
       Permission.updateOne(

--- a/yarn.lock
+++ b/yarn.lock
@@ -9687,6 +9687,11 @@ elliptic@^6.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.0"
 
+email-validator@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/email-validator/-/email-validator-2.0.4.tgz#b8dfaa5d0dae28f1b03c95881d904d4e40bfe7ed"
+  integrity sha512-gYCwo7kh5S3IDyZPLZf6hSS0MnZT8QmJFqYvbqlDZSbwdZlY6QZWxJ4i/6UhITOJ4XzyI647Bm2MXKCLqnJ4nQ==
+
 "emoji-regex@>=6.0.0 <=6.1.1":
   version "6.1.1"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-6.1.1.tgz#c6cd0ec1b0642e2a3c67a1137efc5e796da4f88e"


### PR DESCRIPTION
Resolves #1721, #1722 

## Major Changes:
- Made the `updatePermissions` resolver throw an error when a user isn't found
- Added error handling and feedback when a user tries to give permissions to an email address that doesn't have an OpenNeuro account