### PR TITLE
Enable HSTS for staging and production

### DIFF
--- a/packages/openneuro-app/nginx.conf
+++ b/packages/openneuro-app/nginx.conf
@@ -23,6 +23,7 @@ server {
 
   location / {
     gzip_static on;
+    add_header Strict-Transport-Security 'max-age=31536000; includeSubDomains; preload';
     add_header Cache-Control 'max-age=31536000; public';
     try_files $uri $uri/ /index.html;
   }


### PR DESCRIPTION
We've always enforced TLS with redirects but this sets the HSTS header to be sure.