### PR TITLE
Re-enable reset draft head button for dataset admin tools

### DIFF
--- a/packages/openneuro-app/src/scripts/datalad/fragments/dataset-history.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/fragments/dataset-history.jsx
@@ -4,6 +4,7 @@ import styled from '@emotion/styled'
 import gql from 'graphql-tag'
 import { useQuery } from '@apollo/client'
 import Revalidate from '../mutations/revalidate.jsx'
+import UpdateRef from '../mutations/update-ref.jsx'
 
 const GET_HISTORY = gql`
   query getHistory($datasetId: ID!) {
@@ -71,6 +72,7 @@ const DatasetHistory = ({ datasetId }) => {
                   <div className="col-lg-2">{commit.references}</div>
                   <div className="col-lg-2">
                     <Revalidate datasetId={datasetId} revision={commit.id} />
+                    <UpdateRef datasetId={datasetId} revision={commit.id} />
                   </div>
                 </div>
                 <div className="row">

--- a/packages/openneuro-app/src/scripts/datalad/mutations/update-ref.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/mutations/update-ref.jsx
@@ -1,0 +1,38 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import gql from 'graphql-tag'
+import { Mutation } from '@apollo/client/react/components'
+
+const UPDATE_REF = gql`
+  mutation updateRef($datasetId: ID!, $ref: String!) {
+    updateRef(datasetId: $datasetId, ref: $ref)
+  }
+`
+
+const UpdateRef = ({ datasetId, revision }) => (
+  <Mutation mutation={UPDATE_REF}>
+    {updateRef => (
+      <span>
+        <button
+          className="btn-admin-blue"
+          onClick={async () => {
+            await updateRef({
+              variables: {
+                datasetId,
+                ref: revision,
+              },
+            })
+          }}>
+          <i className="fa fa-history" /> Reset Draft Head
+        </button>
+      </span>
+    )}
+  </Mutation>
+)
+
+UpdateRef.propTypes = {
+  datasetId: PropTypes.string,
+  revision: PropTypes.string,
+}
+
+export default UpdateRef

--- a/packages/openneuro-app/src/scripts/datalad/mutations/update-ref.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/mutations/update-ref.jsx
@@ -3,20 +3,20 @@ import PropTypes from 'prop-types'
 import gql from 'graphql-tag'
 import { Mutation } from '@apollo/client/react/components'
 
-const UPDATE_REF = gql`
-  mutation updateRef($datasetId: ID!, $ref: String!) {
-    updateRef(datasetId: $datasetId, ref: $ref)
+const RESET_DRAFT = gql`
+  mutation resetDraft($datasetId: ID!, $ref: String!) {
+    resetDraft(datasetId: $datasetId, ref: $ref)
   }
 `
 
 const UpdateRef = ({ datasetId, revision }) => (
-  <Mutation mutation={UPDATE_REF}>
-    {updateRef => (
+  <Mutation mutation={RESET_DRAFT}>
+    {resetDraft => (
       <span>
         <button
           className="btn-admin-blue"
           onClick={async () => {
-            await updateRef({
+            await resetDraft({
               variables: {
                 datasetId,
                 ref: revision,

--- a/packages/openneuro-server/src/datalad/draft.js
+++ b/packages/openneuro-server/src/datalad/draft.js
@@ -69,3 +69,15 @@ export const updateDatasetRevision = (datasetId, gitRef) => {
     })
     .then(() => publishDraftUpdate(datasetId, gitRef))
 }
+
+/**
+ * Run a git reset on the draft
+ * @param {string} datasetId Accession number
+ * @param {string} ref Git hexsha
+ */
+export const resetDraft = (datasetId, ref) => {
+  const resetUrl = `${getDatasetWorker(
+    datasetId,
+  )}/datasets/${datasetId}/reset/${ref}`
+  return request.post(resetUrl).set('Accept', 'application/json')
+}

--- a/packages/openneuro-server/src/graphql/resolvers/draft.js
+++ b/packages/openneuro-server/src/graphql/resolvers/draft.js
@@ -17,7 +17,9 @@ const draftFiles = (obj, args) => {
 }
 
 /**
- * Mutation to move the draft HEAD reference forward or backward
+ * Deprecated mutation to move the draft HEAD reference forward or backward
+ *
+ * Exists to support existing usage where this would result in the initial snapshot
  */
 export const updateRef = async (
   obj,

--- a/packages/openneuro-server/src/graphql/resolvers/mutation.js
+++ b/packages/openneuro-server/src/graphql/resolvers/mutation.js
@@ -27,6 +27,7 @@ import { prepareUpload, finishUpload } from './upload.js'
 import { prepareRepoAccess } from './git'
 import { cacheClear } from './cache'
 import { reexportRemotes } from './reexporter'
+import { resetDraft } from './reset'
 
 const Mutation = {
   createDataset,
@@ -62,6 +63,7 @@ const Mutation = {
   revalidate,
   prepareRepoAccess,
   reexportRemotes,
+  resetDraft,
 }
 
 export default Mutation

--- a/packages/openneuro-server/src/graphql/resolvers/reset.js
+++ b/packages/openneuro-server/src/graphql/resolvers/reset.js
@@ -1,0 +1,19 @@
+import { checkDatasetWrite } from '../permissions'
+import { resetDraft as resetDraftTask } from '../../datalad/draft'
+
+/**
+ * Mutation to move the draft HEAD reference forward or backward
+ */
+export const resetDraft = async (
+  obj,
+  { datasetId, ref },
+  { user, userInfo },
+) => {
+  await checkDatasetWrite(datasetId, user, userInfo)
+  try {
+    await resetDraftTask(datasetId, ref)
+    return true
+  } catch (err) {
+    return false
+  }
+}

--- a/packages/openneuro-server/src/graphql/schema.js
+++ b/packages/openneuro-server/src/graphql/schema.js
@@ -153,6 +153,8 @@ export const typeDefs = `
     prepareRepoAccess(datasetId: ID!): RepoMetadata
     # Rerun remote exports
     reexportRemotes(datasetId: ID!): Boolean
+    # Reset draft commit
+    resetDraft(datasetId: ID!, ref: String!): Boolean
   }
 
   input UploadFile {

--- a/services/datalad/datalad_service/app.py
+++ b/services/datalad/datalad_service/app.py
@@ -22,6 +22,7 @@ from datalad_service.handlers.validation import ValidationResource
 from datalad_service.handlers.git import GitRefsResource, GitReceiveResource, GitUploadResource
 from datalad_service.handlers.annex import GitAnnexResource
 from datalad_service.handlers.reexporter import ReexporterResource
+from datalad_service.handlers.reset import ResetResource
 from datalad_service.middleware.auth import AuthenticateMiddleware
 
 
@@ -70,6 +71,7 @@ def create_app(annex_path):
     dataset_git_upload_resource = GitUploadResource(store)
     dataset_git_annex_resource = GitAnnexResource(store)
     dataset_reexporter_resources = ReexporterResource(store)
+    dataset_reset_resource = ResetResource(store)
 
     api.add_route('/heartbeat', heartbeat)
 
@@ -80,6 +82,7 @@ def create_app(annex_path):
     api.add_route('/datasets/{dataset}/history', dataset_history)
     api.add_route('/datasets/{dataset}/description', dataset_description)
     api.add_route('/datasets/{dataset}/validate/{hexsha}', dataset_validation)
+    api.add_route('/datasets/{dataset}/reset/{hexsha}', dataset_reset_resource)
 
     api.add_route('/datasets/{dataset}/files', dataset_files)
     api.add_route('/datasets/{dataset}/files/{filename:path}', dataset_files)

--- a/services/datalad/datalad_service/handlers/reset.py
+++ b/services/datalad/datalad_service/handlers/reset.py
@@ -1,0 +1,25 @@
+import falcon
+import subprocess
+
+from datalad_service.common.user import get_user_info
+from datalad_service.tasks.files import commit_files
+
+
+class ResetResource(object):
+    def __init__(self, store):
+        self.store = store
+
+    def on_post(self, req, resp, dataset, hexsha):
+        """Reset master to a given commit."""
+        if dataset and hexsha.isalnum() and len(hexsha) == 40:
+            try:
+                ds = self.store.get_dataset(dataset)
+                gitProcess = subprocess.run(
+                    ['git', 'reset', '--hard', hexsha], check=True, cwd=ds.path)
+                resp.status = falcon.HTTP_OK
+            except subprocess.CalledProcessError:
+                resp.status = falcon.HTTP_INTERNAL_SERVER_ERROR
+        else:
+            resp.media = {
+                'error': 'Missing or malformed dataset or hexsha parameter in request.'}
+            resp.status = falcon.HTTP_UNPROCESSABLE_ENTITY


### PR DESCRIPTION
Brings back the component for this and re-enables it on the admin page with a new icon to differentiate it from the validation button.