### PR TITLE
Reduce git push limit to 10MB for non-annexed objects

### DIFF
--- a/services/datalad/hooks/pre-receive
+++ b/services/datalad/hooks/pre-receive
@@ -9,7 +9,7 @@
 #
 set -o pipefail
 
-readonly MAXSIZE="104857600" # 100MB
+readonly MAXSIZE="10485760" # 10MB
 readonly NULLSHA="0000000000000000000000000000000000000000"
 readonly EXIT_SUCCESS="0"
 readonly EXIT_FAILURE="1"
@@ -94,7 +94,7 @@ function main() {
       if [[ "$status" == 0 ]]; then
         echo ""
         echo "-------------------------------------------------------------------------"
-        echo "Your push was rejected because it contains files larger than 100MB."
+        echo "Your push was rejected because it contains files larger than 10MB."
         echo "Please use git-annex to store larger files."
         echo "-------------------------------------------------------------------------"
         echo ""


### PR DESCRIPTION
I think we should lower this since it really only affects pushes. Some existing datasets break this rule but you can still push to them if you annex the large files in a new commit.