### PR TITLE
Fix TypeError for property startTransaction on download without APM

### DIFF
--- a/packages/openneuro-cli/src/apm.js
+++ b/packages/openneuro-cli/src/apm.js
@@ -2,14 +2,20 @@ import elasticApm from 'elastic-apm-node'
 import { getErrorReporting } from './config.js'
 import packageJson from '../package.json'
 
-export let apm
 const url = getErrorReporting()
-if (url) {
-  apm = elasticApm.start({
+
+/**
+ * Configure APM for error reporting
+ * @param {boolean} active Enable or disable
+ */
+const setupApm = active =>
+  elasticApm.start({
     serverUrl: url,
     serviceName: 'openneuro-cli',
     serviceVersion: packageJson.version,
     environment: 'production',
     logLevel: 'fatal',
+    active,
   })
-}
+
+export const apm = setupApm(url ? true : false)

--- a/packages/openneuro-cli/src/download.js
+++ b/packages/openneuro-cli/src/download.js
@@ -139,7 +139,7 @@ export const getDownload = (destination, datasetId, tag, apmTransaction) => {
           file.urls.pop(),
           apmTransaction,
         )
-        apmDownload.end()
+        if (apmDownload) apmDownload.end()
       } else {
         // eslint-disable-next-line no-console
         console.log(`Skipping present file "${file.filename}"`)


### PR DESCRIPTION
This fixes an issue where openneuro download would fail if error reporting is disabled.