### PR TITLE
1574 Delete Updates

### DIFF
--- a/packages/openneuro-server/src/graphql/resolvers/dataset-change.js
+++ b/packages/openneuro-server/src/graphql/resolvers/dataset-change.js
@@ -1,0 +1,7 @@
+import DatasetChange from '../../models/datasetChange.js'
+
+export const datasetChanges = (_, { limit = 100 }) => {
+  return DatasetChange.find()
+    .sort({ $natural: -1 })
+    .limit(limit)
+}

--- a/packages/openneuro-server/src/graphql/resolvers/query.js
+++ b/packages/openneuro-server/src/graphql/resolvers/query.js
@@ -4,6 +4,7 @@
 import { dataset, datasets } from './dataset.js'
 import { snapshot, participantCount } from './snapshots.js'
 import { user, users } from './user.js'
+import { datasetChanges } from './dataset-change.js'
 
 const Query = {
   dataset,
@@ -12,6 +13,7 @@ const Query = {
   users,
   snapshot,
   participantCount,
+  datasetChanges,
 }
 
 export default Query

--- a/packages/openneuro-server/src/graphql/resolvers/subscriptions.js
+++ b/packages/openneuro-server/src/graphql/resolvers/subscriptions.js
@@ -70,12 +70,19 @@ export const filesUpdated = {
   },
 }
 
+export const datasetChanged = {
+  type: 'DatasetChange',
+  subscribe: () => pubsub.asyncIterator('datasetChanged'),
+  args: {},
+}
+
 const Subscription = {
   datasetDeleted,
   snapshotsUpdated,
   permissionsUpdated,
   draftUpdated,
   filesUpdated,
+  datasetChanged,
 }
 
 export default Subscription

--- a/packages/openneuro-server/src/graphql/schema.js
+++ b/packages/openneuro-server/src/graphql/schema.js
@@ -549,6 +549,15 @@ export const typeDefs = `
     payload: [DatasetFile]
   }
 
+  # Recent changes to datasets
+  type DatasetChange {
+    datasetId: String!
+    created: Boolean
+    modified: Boolean
+    deleted: Boolean
+    timestamp: DateTime
+  }
+
   # Analytics for a dataset
   type Analytic @cacheControl(maxAge: 300, scope: PUBLIC) {
     datasetId: ID!

--- a/packages/openneuro-server/src/graphql/schema.js
+++ b/packages/openneuro-server/src/graphql/schema.js
@@ -84,6 +84,11 @@ export const typeDefs = `
     participantCount: Int @cacheControl(maxAge: 86400, scope: PUBLIC)
     # Request one snapshot
     snapshot(datasetId: ID!, tag: String!): Snapshot
+    # Get recent dataset changes (newest first)
+    datasetChanges(
+      "Limit results, default 100, max 1000"
+      limit: Int = 100
+    ): [DatasetChange]
   }
 
   type Mutation {

--- a/packages/openneuro-server/src/models/changes.js
+++ b/packages/openneuro-server/src/models/changes.js
@@ -1,0 +1,27 @@
+import mongoose from 'mongoose'
+import pubsub from '../graphql/pubsub.js'
+
+const changesSchema = new mongoose.Schema(
+  {
+    datasetId: { type: String, required: true },
+    created: { type: Boolean, default: false },
+    modified: { type: Boolean, default: false },
+    deleted: { type: Boolean, default: false },
+    timestamp: { type: Date, default: Date.now },
+  },
+  {
+    // limits the collection size to 1000 documents
+    // works like a circular buffer
+    capped: 1000,
+  },
+)
+
+changesSchema.post('save', doc => {
+  pubsub.publish('datasetChanged', {
+    datasetChanged: doc,
+  })
+})
+
+const Changes = mongoose.model('Changes', changesSchema)
+
+export default Changes

--- a/packages/openneuro-server/src/models/dataset.js
+++ b/packages/openneuro-server/src/models/dataset.js
@@ -1,4 +1,5 @@
 import mongoose from 'mongoose'
+import Changes from './changes.js'
 
 const datasetSchema = new mongoose.Schema(
   {
@@ -42,6 +43,29 @@ datasetSchema.virtual('subscriptions', {
   foreignField: 'datasetId',
   count: true,
   justOne: true,
+})
+
+datasetSchema.post('save', dataset => {
+  new Changes({
+    datasetId: dataset.id,
+    created: true,
+  }).save()
+})
+
+datasetSchema.post('updateOne', function() {
+  const datasetId = this._conditions ? this._conditions.id : null
+  new Changes({
+    datasetId,
+    modified: true,
+  }).save()
+})
+
+datasetSchema.post('deleteOne', function() {
+  const datasetId = this._conditions ? this._conditions.id : null
+  new Changes({
+    datasetId,
+    deleted: true,
+  }).save()
 })
 
 const Dataset = mongoose.model('Dataset', datasetSchema)

--- a/packages/openneuro-server/src/models/dataset.js
+++ b/packages/openneuro-server/src/models/dataset.js
@@ -1,5 +1,5 @@
 import mongoose from 'mongoose'
-import Changes from './changes.js'
+import DatasetChange from './datasetChange.js'
 
 const datasetSchema = new mongoose.Schema(
   {
@@ -46,7 +46,7 @@ datasetSchema.virtual('subscriptions', {
 })
 
 datasetSchema.post('save', dataset => {
-  new Changes({
+  new DatasetChange({
     datasetId: dataset.id,
     created: true,
   }).save()
@@ -54,7 +54,7 @@ datasetSchema.post('save', dataset => {
 
 datasetSchema.post('updateOne', function() {
   const datasetId = this._conditions ? this._conditions.id : null
-  new Changes({
+  new DatasetChange({
     datasetId,
     modified: true,
   }).save()
@@ -62,7 +62,7 @@ datasetSchema.post('updateOne', function() {
 
 datasetSchema.post('deleteOne', function() {
   const datasetId = this._conditions ? this._conditions.id : null
-  new Changes({
+  new DatasetChange({
     datasetId,
     deleted: true,
   }).save()

--- a/packages/openneuro-server/src/models/datasetChange.js
+++ b/packages/openneuro-server/src/models/datasetChange.js
@@ -1,7 +1,7 @@
 import mongoose from 'mongoose'
 import pubsub from '../graphql/pubsub.js'
 
-const changesSchema = new mongoose.Schema(
+const datasetChangeSchema = new mongoose.Schema(
   {
     datasetId: { type: String, required: true },
     created: { type: Boolean, default: false },
@@ -16,12 +16,12 @@ const changesSchema = new mongoose.Schema(
   },
 )
 
-changesSchema.post('save', doc => {
+datasetChangeSchema.post('save', doc => {
   pubsub.publish('datasetChanged', {
     datasetChanged: doc,
   })
 })
 
-const Changes = mongoose.model('Changes', changesSchema)
+const DatasetChange = mongoose.model('DatasetChange', datasetChangeSchema)
 
-export default Changes
+export default DatasetChange


### PR DESCRIPTION
## Major Changes
- datasetChanges query, which returns up to 1000 of the most recent dataset changes (creations, modifications, or deletions)
- datasetChanged subscription, which pushes a notification whenever a new dataset change is made

### Note:
This is in lieu of sending a notification to Yarik on dataset deletions.