### PR TITLE
Replace react-bootstrap Panel and PanelGroup with simplified versions

### DIFF
--- a/packages/openneuro-app/package.json
+++ b/packages/openneuro-app/package.json
@@ -39,7 +39,7 @@
     "pluralize": "^7.0.0",
     "prop-types": "^15.6.0",
     "react": "^17.0.1",
-    "react-bootstrap": "0.31.3",
+    "react-bootstrap": "0.33.1",
     "react-cookie": "4.0.3",
     "react-copy-to-clipboard": "^5.0.1",
     "react-dom": "^17.0.1",

--- a/packages/openneuro-app/src/scripts/common/partials/login.jsx
+++ b/packages/openneuro-app/src/scripts/common/partials/login.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { Modal, Panel } from 'react-bootstrap'
+import { Modal } from 'react-bootstrap'
 import AuthenticationButtons from '../../authentication/buttons.jsx'
 import { frontPage } from '../../front-page/front-page-content'
 
@@ -9,7 +9,7 @@ const InfoPanel = ({ show, toggle }) => {
     return null
   }
   return (
-    <Panel className="fade-in panel">
+    <div className="fade-in panel">
       <button className="close" onClick={() => toggle(false)}>
         <span className="close-sym" />
         <span className="sr-only">close</span>
@@ -20,7 +20,7 @@ const InfoPanel = ({ show, toggle }) => {
         affiliations, across disciplines, borders, and time.{' '}
         <a href="https://orcid.org/content/about-orcid">Learn more</a>
       </span>
-    </Panel>
+    </div>
   )
 }
 

--- a/packages/openneuro-app/src/scripts/components/panel-group.tsx
+++ b/packages/openneuro-app/src/scripts/components/panel-group.tsx
@@ -1,0 +1,24 @@
+import React, { FC, ReactElement, ReactNode } from 'react'
+
+interface PanelGroupProps {
+  children: ReactNode
+  accordion?: boolean
+  activeKey?: string
+  className?: string
+  onSelect?: () => void
+}
+
+/**
+ * Replacement for react-bootstrap 0.31.0 Panel
+ * Only covers OpenNeuro use case
+ */
+export const PanelGroup: FC<PanelGroupProps> = ({
+  children,
+  className,
+}): ReactElement => {
+  return (
+    <div className={`panel-group ${className}`} role="tablist">
+      {children}
+    </div>
+  )
+}

--- a/packages/openneuro-app/src/scripts/components/panel.tsx
+++ b/packages/openneuro-app/src/scripts/components/panel.tsx
@@ -1,0 +1,42 @@
+import React, { FC, ReactElement, ReactNode, useState } from 'react'
+
+interface PanelProps {
+  children: ReactNode
+  header?: ReactNode
+  eventKey?: string
+  className?: string
+}
+
+/**
+ * Replacement for react-bootstrap 0.31.0 Panel
+ * Only covers OpenNeuro use case
+ */
+export const Panel: FC<PanelProps> = ({
+  header,
+  className,
+  children,
+}): ReactElement => {
+  const [expanded, setExpanded] = useState(false)
+  return (
+    <div className={`panel panel-default ${className}`}>
+      <div className="panel-heading">
+        <div className="panel-title">
+          <a
+            role="tab"
+            className={expanded ? null : 'collapsed'}
+            aria-expanded={expanded}
+            aria-selected={expanded}
+            onClick={(): void => {
+              setExpanded(!expanded)
+            }}>
+            {header}
+          </a>
+        </div>
+      </div>
+      <div
+        className={`panel-collapse ${expanded ? 'collapse in' : 'collapse'}`}>
+        <div className="panel-body">{children}</div>
+      </div>
+    </div>
+  )
+}

--- a/packages/openneuro-app/src/scripts/datalad/fragments/incomplete-dataset.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/fragments/incomplete-dataset.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { Panel, PanelGroup } from 'react-bootstrap'
+import { Panel } from '../../components/panel'
+import { PanelGroup } from '../../components/panel-group'
 import UploadResume from '../../uploader/upload-resume.jsx'
 
 const IncompleteDataset = ({ datasetId }) => (

--- a/packages/openneuro-app/src/scripts/datalad/validation/validation-panel.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/validation/validation-panel.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { Panel, PanelGroup } from 'react-bootstrap'
+import { Panel } from '../../components/panel'
+import { PanelGroup } from '../../components/panel-group'
 
 class ValidationPanel extends React.Component {
   constructor(props) {

--- a/packages/openneuro-app/src/scripts/validation/validation-results.issues.jsx
+++ b/packages/openneuro-app/src/scripts/validation/validation-results.issues.jsx
@@ -2,7 +2,8 @@
 
 import React from 'react'
 import PropTypes from 'prop-types'
-import { Accordion, Panel } from 'react-bootstrap'
+import { Accordion } from 'react-bootstrap'
+import { Panel } from '../components/panel'
 import pluralize from 'pluralize'
 import Issue from './validation-results.issues.issue.jsx'
 

--- a/packages/openneuro-app/src/scripts/validation/validation-results.jsx
+++ b/packages/openneuro-app/src/scripts/validation/validation-results.jsx
@@ -3,7 +3,8 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import pluralize from 'pluralize'
-import { Accordion, Panel } from 'react-bootstrap'
+import { Accordion } from 'react-bootstrap'
+import { Panel } from '../components/panel'
 import Issues from './validation-results.issues.jsx'
 
 // component setup --------------------------------------------------------

--- a/packages/openneuro-app/vite.config.js
+++ b/packages/openneuro-app/vite.config.js
@@ -4,7 +4,7 @@ export default {
     port: 9876,
   },
   build: {
-    sourcemaps: true,
+    sourcemap: true,
   },
   optimizeDeps: {
     include: [

--- a/yarn.lock
+++ b/yarn.lock
@@ -1812,6 +1812,14 @@
     pirates "^4.0.0"
     source-map-support "^0.5.16"
 
+"@babel/runtime-corejs2@^7.0.0":
+  version "7.13.10"
+  resolved "https://registry.yarnpkg.com/@babel/runtime-corejs2/-/runtime-corejs2-7.13.10.tgz#31ba66b951cbd44569d7e70cb58a7b3da866951a"
+  integrity sha512-rZw5P1ZewO6XZTDxtXuAuAFUqfNXyM8HO/9WiaDd34Anka0uFTpo0RvBLeV775AEE/zKw3LQB+poZw/O9lrZBg==
+  dependencies:
+    core-js "^2.6.5"
+    regenerator-runtime "^0.13.4"
+
 "@babel/runtime-corejs3@^7.10.2", "@babel/runtime-corejs3@^7.6.3":
   version "7.13.10"
   resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.13.10.tgz#14c3f4c85de22ba88e8e86685d13e8861a82fe86"
@@ -4325,7 +4333,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*":
+"@types/react@*", "@types/react@>=16.9.11":
   version "17.0.3"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.3.tgz#ba6e215368501ac3826951eef2904574c262cc79"
   integrity sha512-wYOUxIgs2HZZ0ACNiIayItyluADNbONl7kt8lkLjVK8IitMH5QMyAh75Fwhmo37r1m7L2JaFj03sIfxBVDvRAg==
@@ -6051,7 +6059,7 @@ babel-preset-jest@^26.6.2:
     babel-plugin-jest-hoist "^26.6.2"
     babel-preset-current-node-syntax "^1.0.0"
 
-babel-runtime@^6.11.6, babel-runtime@^6.26.0, babel-runtime@^6.6.1:
+babel-runtime@^6.26.0, babel-runtime@^6.6.1:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
   integrity sha1-llxwWGaOgrVde/4E/yM3vItWR/4=
@@ -8950,7 +8958,7 @@ dom-converter@^0.2:
   dependencies:
     utila "~0.4"
 
-dom-helpers@^3.2.0, dom-helpers@^3.2.1:
+dom-helpers@^3.2.0, dom-helpers@^3.2.1, dom-helpers@^3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-3.4.0.tgz#e9b369700f959f62ecde5a6babde4bccd9169af8"
   integrity sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==
@@ -13184,7 +13192,7 @@ into-stream@^3.1.0:
     from2 "^2.1.1"
     p-is-promise "^1.1.0"
 
-invariant@^2.1.0, invariant@^2.2.1, invariant@^2.2.3, invariant@^2.2.4:
+invariant@^2.2.3, invariant@^2.2.4:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
   integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
@@ -14751,7 +14759,7 @@ kareem@2.3.1:
   resolved "https://registry.yarnpkg.com/kareem/-/kareem-2.3.1.tgz#def12d9c941017fabfb00f873af95e9c99e1be87"
   integrity sha512-l3hLhffs9zqoDe8zjmb/mAN4B8VT3L56EUvKNqLFVs9YlFA+zx7ke1DO8STAdDyYNkeSo1nKmjuvQeI12So8Xw==
 
-keycode@^2.1.2:
+keycode@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/keycode/-/keycode-2.2.0.tgz#3d0af56dc7b8b8e5cba8d0a97f107204eec22b04"
   integrity sha1-PQr1bce4uOXLqNCpfxByBO7CKwQ=
@@ -19003,21 +19011,22 @@ react-base16-styling@^0.5.1:
     lodash.flow "^3.3.0"
     pure-color "^1.2.0"
 
-react-bootstrap@0.31.3:
-  version "0.31.3"
-  resolved "https://registry.yarnpkg.com/react-bootstrap/-/react-bootstrap-0.31.3.tgz#db2b7d45b00b5dac1ab8b6de3dd97feb3091b849"
-  integrity sha512-n6OcS2IsxLcv1qmma14zKYBJqCsIS4ccwEtl09PLjbYTkKBLwkBmD7hB9+WQUgGfD21TP2UoEI87kIxjVwkP5Q==
+react-bootstrap@0.33.1:
+  version "0.33.1"
+  resolved "https://registry.yarnpkg.com/react-bootstrap/-/react-bootstrap-0.33.1.tgz#e072592aa143b9792526281272eca754bc9a4940"
+  integrity sha512-qWTRravSds87P8WC82tETy2yIso8qDqlIm0czsrduCaYAFtHuyLu0XDbUlfLXeRzqgwm5sRk2wRaTNoiVkk/YQ==
   dependencies:
-    babel-runtime "^6.11.6"
+    "@babel/runtime-corejs2" "^7.0.0"
     classnames "^2.2.5"
     dom-helpers "^3.2.0"
-    invariant "^2.2.1"
-    keycode "^2.1.2"
-    prop-types "^15.5.10"
+    invariant "^2.2.4"
+    keycode "^2.2.0"
+    prop-types "^15.6.1"
     prop-types-extra "^1.0.1"
-    react-overlays "^0.7.0"
+    react-overlays "^0.9.0"
     react-prop-types "^0.4.0"
-    uncontrollable "^4.1.0"
+    react-transition-group "^2.0.0"
+    uncontrollable "^7.0.2"
     warning "^3.0.0"
 
 react-cookie@4.0.3:
@@ -19223,15 +19232,16 @@ react-native-get-random-values@^1.4.0:
   dependencies:
     fast-base64-decode "^1.0.0"
 
-react-overlays@^0.7.0:
-  version "0.7.4"
-  resolved "https://registry.yarnpkg.com/react-overlays/-/react-overlays-0.7.4.tgz#ef2ec652c3444ab8aa014262b18f662068e56d5c"
-  integrity sha512-7vsooMx3siLAuEfTs8FYeP/lAORWWFXTO8PON3KgX0Htq1Oa+po6ioSjGyO0/GO5CVSMNhpWt6V2opeexHgBuQ==
+react-overlays@^0.9.0:
+  version "0.9.3"
+  resolved "https://registry.yarnpkg.com/react-overlays/-/react-overlays-0.9.3.tgz#5bac8c1e9e7e057a125181dee2d784864dd62902"
+  integrity sha512-u2T7nOLnK+Hrntho4p0Nxh+BsJl0bl4Xuwj/Y0a56xywLMetgAfyjnDVrudLXsNcKGaspoC+t3C1V80W9QQTdQ==
   dependencies:
     classnames "^2.2.5"
     dom-helpers "^3.2.1"
     prop-types "^15.5.10"
     prop-types-extra "^1.0.1"
+    react-transition-group "^2.2.1"
     warning "^3.0.0"
 
 react-prop-types@^0.4.0:
@@ -19340,6 +19350,16 @@ react-toastify@6.0.9:
     classnames "^2.2.6"
     prop-types "^15.7.2"
     react-transition-group "^4.4.1"
+
+react-transition-group@^2.0.0, react-transition-group@^2.2.1:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-2.9.0.tgz#df9cdb025796211151a436c69a8f3b97b5b07c8d"
+  integrity sha512-+HzNTCHpeQyl4MJ/bdE0u6XRMe9+XG/+aL4mCxVN4DnPBQ0/5bfHWPDuOZUzYdMj94daZaZdCCc1Dzt9R/xSSg==
+  dependencies:
+    dom-helpers "^3.4.0"
+    loose-envify "^1.4.0"
+    prop-types "^15.6.2"
+    react-lifecycles-compat "^3.0.4"
 
 react-transition-group@^4.4.1:
   version "4.4.1"
@@ -22746,12 +22766,15 @@ unc-path-regex@^0.1.2:
   resolved "https://registry.yarnpkg.com/unc-path-regex/-/unc-path-regex-0.1.2.tgz#e73dd3d7b0d7c5ed86fbac6b0ae7d8c6a69d50fa"
   integrity sha1-5z3T17DXxe2G+6xrCufYxqadUPo=
 
-uncontrollable@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/uncontrollable/-/uncontrollable-4.1.0.tgz#e0358291252e1865222d90939b19f2f49f81c1a9"
-  integrity sha1-4DWCkSUuGGUiLZCTmxny9J+Bwak=
+uncontrollable@^7.0.2:
+  version "7.2.1"
+  resolved "https://registry.yarnpkg.com/uncontrollable/-/uncontrollable-7.2.1.tgz#1fa70ba0c57a14d5f78905d533cf63916dc75738"
+  integrity sha512-svtcfoTADIB0nT9nltgjujTi7BzVmwjZClOmskKu/E8FW9BXzg9os8OLr4f8Dlnk0rYWJIWr4wv9eKUXiQvQwQ==
   dependencies:
-    invariant "^2.1.0"
+    "@babel/runtime" "^7.6.3"
+    "@types/react" ">=16.9.11"
+    invariant "^2.2.4"
+    react-lifecycles-compat "^3.0.4"
 
 underscore.string@^3.3.5:
   version "3.3.5"


### PR DESCRIPTION
Drops Panel and PanelGroup components from react-bootstrap.

This fixes a production build issue by upgrading react-bootstrap past 0.31.2 which crashes at import once built by Vite because of invalid imports via babel-runtime -> corejs. 0.33 refactored how panel components work, so this replicates the old behavior with simplified components that accept the same signature.