### PR TITLE
Speed up front page participants aggregate with query cache

### DIFF
--- a/packages/openneuro-server/src/cache/types.ts
+++ b/packages/openneuro-server/src/cache/types.ts
@@ -10,4 +10,5 @@ export enum CacheType {
   readme = 'readme',
   snapshot = 'snapshot',
   snapshotIndex = 'snapshotIndex',
+  query = 'query',
 }


### PR DESCRIPTION
This causes a lot of load at startup as our cache has been protecting us from how long this query really takes. This quick fix just caches the query result for 24 hours to avoid stacking queries on MongoDB.