### PR TITLE
feat(server): Enable distributed Apollo cache

### DIFF
--- a/packages/openneuro-server/package.json
+++ b/packages/openneuro-server/package.json
@@ -22,6 +22,7 @@
     "@sentry/node": "^4.5.3",
     "apollo-server": "2.21.0",
     "apollo-server-express": "2.21.0",
+    "apollo-server-cache-redis": "1.4.0",
     "async": "^2.4.1",
     "base64url": "^3.0.0",
     "body-parser": "^1.18.2",

--- a/packages/openneuro-server/src/app.js
+++ b/packages/openneuro-server/src/app.js
@@ -12,12 +12,14 @@ import routes from './routes'
 import morgan from 'morgan'
 import schema from './graphql/schema'
 import { ApolloServer } from 'apollo-server-express'
+import { BaseRedisCache } from 'apollo-server-cache-redis'
 import bodyParser from 'body-parser'
 import cookieParser from 'cookie-parser'
 import * as jwt from './libs/authentication/jwt.js'
 import * as auth from './libs/authentication/states.js'
 import { sitemapHandler } from './handlers/sitemap.js'
 import { setupPassportAuth } from './libs/authentication/passport.js'
+import { redis } from './libs/redis'
 import { version } from './lerna.json'
 
 // test flag disables Sentry for tests
@@ -85,6 +87,9 @@ export default test => {
     formatResponse: response => {
       return { ...response, extensions: { openneuro: { version } } }
     },
+    cache: new BaseRedisCache({
+      client: redis,
+    }),
   })
 
   // Setup pre-GraphQL middleware

--- a/packages/openneuro-server/src/server.js
+++ b/packages/openneuro-server/src/server.js
@@ -32,8 +32,6 @@ Sentry.init({
   environment: config.sentry.ENVIRONMENT,
 })
 
-const app = createApp(false)
-
 mongoose.connect(config.mongo.url, {
   useNewUrlParser: true,
   dbName: config.mongo.dbName,
@@ -42,6 +40,7 @@ mongoose.connect(config.mongo.url, {
 })
 
 redisConnectionSetup().then(() => {
+  const app = createApp(false)
   const server = createServer(app)
   server.listen(config.port, () => {
     // eslint-disable-next-line no-console

--- a/yarn.lock
+++ b/yarn.lock
@@ -5186,6 +5186,16 @@ apollo-reporting-protobuf@^0.6.2:
   dependencies:
     "@apollo/protobufjs" "^1.0.3"
 
+apollo-server-cache-redis@1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/apollo-server-cache-redis/-/apollo-server-cache-redis-1.4.0.tgz#30b66dc6743aa3edd2ba02f2883d166df8a7f07e"
+  integrity sha512-Vt5nXzxCsvVDqFWDDEZi42+s6yy17T/c6q7ESUGbn3sBCn0nyEY/x2TAxmmjy9rsx8oTScBUIgi55Mb5qMXV+A==
+  dependencies:
+    apollo-server-caching "^0.6.0"
+    apollo-server-env "^3.0.0"
+    dataloader "^2.0.0"
+    ioredis "^4.0.0"
+
 apollo-server-caching@^0.5.3:
   version "0.5.3"
   resolved "https://registry.yarnpkg.com/apollo-server-caching/-/apollo-server-caching-0.5.3.tgz#cf42a77ad09a46290a246810075eaa029b5305e1"
@@ -8376,7 +8386,7 @@ data-urls@^2.0.0:
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
 
-dataloader@2.0.0:
+dataloader@2.0.0, dataloader@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/dataloader/-/dataloader-2.0.0.tgz#41eaf123db115987e21ca93c005cd7753c55fe6f"
   integrity sha512-YzhyDAwA4TaQIhM5go+vCLmU0UikghC/t9DTQYZR2M/UvZ1MdOhPezSDZcjj9uqQJOMqjLcpWtyW2iNINdlatQ==
@@ -13231,6 +13241,22 @@ ioredis@4.17.3:
     redis-errors "^1.2.0"
     redis-parser "^3.0.0"
     standard-as-callback "^2.0.1"
+
+ioredis@^4.0.0:
+  version "4.26.0"
+  resolved "https://registry.yarnpkg.com/ioredis/-/ioredis-4.26.0.tgz#dbbfb5e5da085fc2b1de8174db50fa42f9fed66a"
+  integrity sha512-nh39okWezWWZ35/RxXXzHksMFt4WCaev8SNO2kozRDeVdEAJj16EarqPP3JeHz8IEjEXN5CiVtbWMk62Z0eveQ==
+  dependencies:
+    cluster-key-slot "^1.1.0"
+    debug "^4.3.1"
+    denque "^1.1.0"
+    lodash.defaults "^4.2.0"
+    lodash.flatten "^4.4.0"
+    p-map "^2.1.0"
+    redis-commands "1.7.0"
+    redis-errors "^1.2.0"
+    redis-parser "^3.0.0"
+    standard-as-callback "^2.1.0"
 
 ioredis@^4.6.3:
   version "4.25.0"


### PR DESCRIPTION
This reduces some query duplication by sharing the API cache between instances (via Redis).