### PR TITLE
Optimize participiantCount resolver execution time

### DIFF
--- a/packages/openneuro-server/src/graphql/schema.js
+++ b/packages/openneuro-server/src/graphql/schema.js
@@ -82,7 +82,7 @@ export const typeDefs = `
     # Get a list of users
     users: [User]
     # Get the total number of dataset participants
-    participantCount: Int @cacheControl(maxAge: 86400, scope: PUBLIC)
+    participantCount: Int @cacheControl(maxAge: 3600, scope: PUBLIC)
     # Request one snapshot
     snapshot(datasetId: ID!, tag: String!): Snapshot
     # Get recent dataset changes (newest first)

--- a/packages/openneuro-server/src/models/dataset.js
+++ b/packages/openneuro-server/src/models/dataset.js
@@ -14,6 +14,8 @@ const datasetSchema = new mongoose.Schema(
   { toJSON: { virtuals: true }, toObject: { virtuals: true } },
 )
 
+datasetSchema.index({ public: 1 }, { sparse: true })
+
 // Foreign key virtuals for sorting
 
 datasetSchema.virtual('uploadUser', {

--- a/packages/openneuro-server/src/models/snapshot.ts
+++ b/packages/openneuro-server/src/models/snapshot.ts
@@ -16,6 +16,7 @@ const snapshotSchema = new Schema({
 })
 
 snapshotSchema.index({ datasetId: 1, tag: 1 }, { unique: true })
+snapshotSchema.index({ datasetId: 1 })
 
 const Snapshot = model<SnapshotDocument>('Snapshot', snapshotSchema)
 

--- a/packages/openneuro-server/src/models/summary.js
+++ b/packages/openneuro-server/src/models/summary.js
@@ -13,6 +13,8 @@ const summarySchema = new mongoose.Schema({
   dataProcessed: Boolean,
 })
 
+summarySchema.index({ id: 1 })
+
 const Summary = mongoose.model('Summary', summarySchema)
 
 export default Summary


### PR DESCRIPTION
This reduces the database time to resolve participantCount from 5000ms per call to 90ms.

1. Adds a sparse index on dataset.public to locate public datasets in the collection faster
1. The query is inverted to scan starting from the datasets collection allowing an index scan using that index
1. $lookup call to summaries is optimized with a new index on summaries.id
1. $lookup call to snapshots gets a narrower index on only the datasetId field
1. Consolidates some extra steps for a shorter aggregate pipeline