### PR TITLE
fix(datalad-service): Avoid losing bids-validator output on expected errors

### DIFF
--- a/services/datalad/datalad_service/common/elasticsearch.py
+++ b/services/datalad/datalad_service/common/elasticsearch.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from datalad_service.config import ELASTICSEARCH_CONNECTION
 from contextlib import contextmanager
 
+
 class ReexportLogger:
     def __init__(self, dataset_id):
         self.logger = logging.getLogger('datalad_service.' + __name__)
@@ -25,15 +26,18 @@ class ReexportLogger:
         }
         self.es.index(index="logs-reexporter", body=body)
 
+
 class ValidationLogger:
     def __init__(self, dataset_id, user):
         self.es = Elasticsearch([ELASTICSEARCH_CONNECTION])
         self.dataset_id = dataset_id
         self.user = user
 
-    def log(self, error):
+    def log(self, stdout, stderr, error):
         body = {
             'dataset_id': self.dataset_id,
+            'stdout': str(stdout),
+            'stderr': str(stderr),
             'error': str(error),
             'timestamp': datetime.now(),
             'user': self.user

--- a/services/datalad/datalad_service/tasks/validator.py
+++ b/services/datalad/datalad_service/tasks/validator.py
@@ -25,13 +25,13 @@ def validate_dataset_sync(dataset_path, ref, esLogger):
     setup_validator()
     try:
         process = gevent.subprocess.run(
-            ['./node_modules/.bin/bids-validator', '--json', '--ignoreSubjectConsistency', dataset_path], stdout=subprocess.PIPE, timeout=300, check=True)
+            ['./node_modules/.bin/bids-validator', '--json', '--ignoreSubjectConsistency', dataset_path], stdout=subprocess.PIPE, timeout=300)
         return json.loads(process.stdout)
     except subprocess.TimeoutExpired as err:
-        esLogger.log(err)
+        esLogger.log(process.stdout, process.stderr, err)
         sentry_sdk.capture_exception()
-    except subprocess.CalledProcessError as err:
-        esLogger.log(err)
+    except json.decoder.JSONDecodeError as err:
+        esLogger.log(process.stdout, process.stderr, err)
         sentry_sdk.capture_exception()
 
 

--- a/services/datalad/tests/test_validator.py
+++ b/services/datalad/tests/test_validator.py
@@ -3,13 +3,31 @@ import json
 from .dataset_fixtures import *
 from datalad_service.tasks.validator import validate_dataset_sync
 from unittest.mock import Mock
+from types import SimpleNamespace
+from gevent import subprocess
 
-class MockLogger: 
+
+class MockLogger:
     pass
 
-def test_validator(new_dataset):
+
+def test_validator_error(new_dataset):
     logger = MockLogger()
     logger.log = Mock()
     validate_dataset_sync(new_dataset.path, 'HEAD', logger)
-    # new_dataset doesn't pass validation, should catch the error and log it
+    # new_dataset completes validation with errors, should not call logger
+    assert not logger.log.called
+
+
+@pytest.fixture
+def mock_validator_crash(monkeypatch):
+    def return_bad_json(*args, **kwargs):
+        return SimpleNamespace(stdout='{invalidJson', stderr='')
+    monkeypatch.setattr(subprocess, 'run', return_bad_json)
+
+
+def test_validator_bad_json(new_dataset, mock_validator_crash):
+    logger = MockLogger()
+    logger.log = Mock()
+    validate_dataset_sync(new_dataset.path, 'HEAD', logger)
     assert logger.log.called


### PR DESCRIPTION
Fix a regression introduced in #1998, the validation output is useful on non-zero output unless it can't be parsed (which is usually due to bids-validator bugs). Instead of checking for non-zero exit to log failures, we should just catch the JSON parsing exception and log at that point.

This extends the error logging with the full stderr and stdout, which would have helped with tracking this down.