### PR TITLE
fix(cli): Fix missing lerna.json in published bundle

### DIFF
--- a/packages/openneuro-cli/package.json
+++ b/packages/openneuro-cli/package.json
@@ -37,7 +37,9 @@
     "build": "tsc -b",
     "openneuro": "node src/index.js",
     "git-credential-openneuro": "node src/index.js",
-    "git-annex-remote-openneuro": "node src/index.js"
+    "git-annex-remote-openneuro": "node src/index.js",
+    "prepack": "rm src/lerna.json && cp ../../lerna.json src/lerna.json",
+    "postpack": "rm src/lerna.json && ln -sf ../../../lerna.json src/lerna.json"
   },
   "jest": {
     "setupFiles": [

--- a/packages/openneuro-client/package.json
+++ b/packages/openneuro-client/package.json
@@ -8,7 +8,9 @@
   "author": "Squishymedia",
   "license": "MIT",
   "scripts": {
-    "build": "tsc -b"
+    "build": "tsc -b",
+    "prepack": "rm src/lerna.json && cp ../../lerna.json src/lerna.json",
+    "postpack": "rm src/lerna.json && ln -sf ../../../lerna.json src/lerna.json"
   },
   "dependencies": {
     "@apollo/client": "3.3.14",


### PR DESCRIPTION
Here's a quick workaround for an empty symlink in 3.32.0 openneuro-cli and openneuro-client.