### PR TITLE
fix(cli): Handle import resolution difference with yarn pnp

### DIFF
--- a/.pnp.js
+++ b/.pnp.js
@@ -14158,6 +14158,13 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["commander", "npm:6.2.1"]
           ],
           "linkType": "HARD",
+        }],
+        ["npm:7.2.0", {
+          "packageLocation": "./.yarn/cache/commander-npm-7.2.0-19178180f8-bdc0eca5e2.zip/node_modules/commander/",
+          "packageDependencies": [
+            ["commander", "npm:7.2.0"]
+          ],
+          "linkType": "HARD",
         }]
       ]],
       ["common-tags", [
@@ -28767,7 +28774,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["bids-validator", "npm:1.6.3"],
             ["cli-progress", "npm:3.9.0"],
             ["colors", "npm:1.4.0"],
-            ["commander", "npm:2.20.3"],
+            ["commander", "npm:7.2.0"],
             ["core-js", "npm:3.10.1"],
             ["cross-fetch", "npm:3.1.4"],
             ["elastic-apm-node", "npm:3.12.1"],

--- a/packages/openneuro-cli/package.json
+++ b/packages/openneuro-cli/package.json
@@ -22,7 +22,7 @@
     "bids-validator": "1.6.3",
     "cli-progress": "^3.8.2",
     "colors": "1.4.0",
-    "commander": "^2.15.1",
+    "commander": "7.2.0",
     "cross-fetch": "^3.0.5",
     "elastic-apm-node": "3.12.1",
     "esm": "^3.0.16",

--- a/packages/openneuro-cli/src/apm.js
+++ b/packages/openneuro-cli/src/apm.js
@@ -9,13 +9,15 @@ const url = getErrorReporting()
  * @returns {typeof import('elastic-apm-node')}
  */
 const setupApm = active =>
-  elasticApm.start({
-    serverUrl: url,
-    serviceName: 'openneuro-cli',
-    environment: 'production',
-    logLevel: 'fatal',
-    active,
-  })
+  elasticApm.isStarted()
+    ? elasticApm
+    : elasticApm.start({
+        serverUrl: url,
+        serviceName: 'openneuro-cli',
+        environment: 'production',
+        logLevel: 'fatal',
+        active,
+      })
 
 /**
  * @type {typeof import('elastic-apm-node')}

--- a/yarn.lock
+++ b/yarn.lock
@@ -9720,7 +9720,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"commander@npm:^2.15.1, commander@npm:^2.19.0, commander@npm:^2.20.0, commander@npm:^2.20.3, commander@npm:^2.5.0":
+"commander@npm:7.2.0":
+  version: 7.2.0
+  resolution: "commander@npm:7.2.0"
+  checksum: bdc0eca5e25cd24af8440163d3c9a996785bbac4b49a590365699cdc1ed08cefbac8f268153208ab2bc5dc3cb1d3fb573fd1590c681e36e371342186bd331a4c
+  languageName: node
+  linkType: hard
+
+"commander@npm:^2.19.0, commander@npm:^2.20.0, commander@npm:^2.20.3, commander@npm:^2.5.0":
   version: 2.20.3
   resolution: "commander@npm:2.20.3"
   checksum: b73428e97de7624323f81ba13f8ed9271de487017432d18b4da3f07cfc528ad754bbd199004bd5d14e0ccd67d1fdfe0ec8dbbd4c438b401df3c4cc387bfd1daa
@@ -22331,7 +22338,7 @@ fsevents@^1.2.7:
     bids-validator: 1.6.3
     cli-progress: ^3.8.2
     colors: 1.4.0
-    commander: ^2.15.1
+    commander: 7.2.0
     core-js: ^3.10.1
     cross-fetch: ^3.0.5
     elastic-apm-node: 3.12.1


### PR DESCRIPTION
This should be a singleton but isn't when pnp and esm (the npm package) are combined.

Ideally we'll drop esm and use pnp with native esm here when Node 12 is EOL and Yarn supports it (https://github.com/yarnpkg/berry/issues/638)