### PR TITLE
fix(server): Use unified topology and createIndex for Mongoose

### DIFF
--- a/packages/openneuro-server/src/server.js
+++ b/packages/openneuro-server/src/server.js
@@ -37,6 +37,8 @@ mongoose.connect(config.mongo.url, {
   dbName: config.mongo.dbName,
   connectTimeoutMS: config.mongo.connectTimeoutMS,
   useFindAndModify: false,
+  useUnifiedTopology: true,
+  useCreateIndex: true,
 })
 
 redisConnectionSetup().then(() => {


### PR DESCRIPTION
This fixes some deprecation warnings from Mongoose and unified topology should handle connections to Atlas better.