### PR TITLE
fix(cli): Incorrect auth headers and stream type changes from #2017

### DIFF
--- a/packages/openneuro-cli/src/download.js
+++ b/packages/openneuro-cli/src/download.js
@@ -37,7 +37,7 @@ export const testFile = (destination, filename, size) => {
 }
 
 const getFetchHeaders = () => ({
-  Authorization: `Bearer ${getToken()}`,
+  cookie: `accessToken=${getToken()}`,
 })
 
 const handleFetchReject = err => {
@@ -92,8 +92,8 @@ export const downloadFile = async (
       const response = await fetch(fileUrl, {
         headers: getFetchHeaders(),
       })
-      // @ts-expect-error
-      const stream = await response.readable()
+      /** @ts-expect-error @type {import('stream').Readable} */
+      const stream = response.body
       if (response.status === 200) {
         // Setup end/error handler with Promise interface
         const responsePromise = new Promise((resolve, reject) => {


### PR DESCRIPTION
Two fixes for CLI download issues:
1. This does use cookie rather than bearer token auth because it is a REST endpoint.
2. The actual file transfer was reverted to cross-fetch but was still using the fetch-h2 API.