### PR TITLE
EKS configuration for 1.19

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -43,6 +43,13 @@ Example eksctl configurations from the main OpenNeuro instance are available in 
 
 OpenEBS is used to manage volume allocation for worker nodes. Your Kubernetes nodes requires OpenZFS configuration. See [OpenEBS for supported versions](https://github.com/openebs/zfs-localpv#prerequisites). This can be built into the AMI on EKS or installed at node creation by eksctl as in the above example cluster configuration files.
 
+Storage pool nodes should be labeled to allow migration of the EBS disks on EKS updates. Label each node like so - this must be done before installing zfs-localpv the first time.
+
+```bash
+kubectl label node node-1 openebs.io/nodeid=pool-a
+kubectl label node node-2 openebs.io/nodeid=pool-b
+```
+
 Once the cluster is running, initialize the CSI driver for OpenEBS ZFS LocalPV following the [install instructions](https://github.com/openebs/zfs-localpv#setup).
 
 ### Setup and access Kubernetes dashboard

--- a/helm/eksctl-cluster-prod.yaml
+++ b/helm/eksctl-cluster-prod.yaml
@@ -1,14 +1,20 @@
 apiVersion: eksctl.io/v1alpha5
 kind: ClusterConfig
 metadata:
-  name: openneuro-prod
+  name: openneuro-prod-2021
   region: us-west-2
-  version: "1.15"
+  version: "1.19"
+availabilityZones:
+  - us-west-2b
+  - us-west-2c
 nodeGroups:
   - name: general
-    amiFamily: Ubuntu1804
-    instanceType: c5a.xlarge
-    desiredCapacity: 2
+    amiFamily: Ubuntu2004
+    instanceType: r5a.large
+    desiredCapacity: 3
+    availabilityZones:
+      - us-west-2b
+      - us-west-2c
     iam:
       withAddonPolicies:
         ebs: true
@@ -22,9 +28,12 @@ nodeGroups:
       - apt update
       - apt install -y nfs-common zfsutils-linux
   - name: storage
-    amiFamily: Ubuntu1804
-    instanceType: m5ad.xlarge
+    amiFamily: Ubuntu2004
+    instanceType: r5ad.large
     desiredCapacity: 2
+    availabilityZones:
+      - us-west-2b
+      - us-west-2c
     iam:
       withAddonPolicies:
         ebs: true
@@ -39,3 +48,6 @@ nodeGroups:
     preBootstrapCommands:
       - apt update
       - apt install -y nfs-common zfsutils-linux
+cloudWatch:
+  clusterLogging:
+    enableTypes: ["*"]

--- a/helm/eksctl-cluster-prod.yaml
+++ b/helm/eksctl-cluster-prod.yaml
@@ -10,8 +10,15 @@ availabilityZones:
 nodeGroups:
   - name: general
     amiFamily: Ubuntu2004
-    instanceType: r5a.large
+    instanceType: mixed
     desiredCapacity: 3
+    minSize: 2
+    maxSize: 6
+    instancesDistribution:
+      maxPrice: 0.075
+      instanceTypes: ["r5a.large"]
+      onDemandBaseCapacity: 2
+      spotInstancePools: 2
     availabilityZones:
       - us-west-2b
       - us-west-2c

--- a/helm/eksctl-cluster-staging.yaml
+++ b/helm/eksctl-cluster-staging.yaml
@@ -3,25 +3,51 @@ kind: ClusterConfig
 metadata:
   name: openneuro-staging
   region: us-east-1
-  version: "1.15"
+  version: "1.19"
+availabilityZones:
+  - us-east-1a
+  - us-east-1f
 nodeGroups:
   - name: general
-    amiFamily: Ubuntu1804
-    instanceType: c5a.xlarge
+    amiFamily: Ubuntu2004
+    instanceType: r5a.large
     desiredCapacity: 2
+    iam:
+      withAddonPolicies:
+        ebs: true
+        efs: true
+        albIngress: true
+        certManager: true
     ssh:
       allow: true
+    labels: { role: general }
+    availabilityZones:
+      - us-east-1a
+      - us-east-1f
     preBootstrapCommands:
       - apt update
       - apt install -y nfs-common zfsutils-linux
   - name: storage
-    amiFamily: Ubuntu1804
-    instanceType: m5ad.xlarge
+    amiFamily: Ubuntu2004
+    instanceType: r5ad.large
     desiredCapacity: 2
+    iam:
+      withAddonPolicies:
+        ebs: true
+        efs: true
+        albIngress: true
+        certManager: true
     ssh:
       allow: true
     taints:
       storage: "true:NoSchedule"
+    labels: { role: storage }
+    availabilityZones:
+      - us-east-1a
+      - us-east-1f
     preBootstrapCommands:
       - apt update
       - apt install -y nfs-common zfsutils-linux
+cloudWatch:
+  clusterLogging:
+    enableTypes: ["*"]

--- a/helm/openneuro/templates/openebs-pool-statefulset.yaml
+++ b/helm/openneuro/templates/openebs-pool-statefulset.yaml
@@ -21,7 +21,7 @@ spec:
         operator: "Exists"
         effect: "NoSchedule"
       nodeSelector:
-        alpha.eksctl.io/nodegroup-name: storage
+        role: storage
       affinity:
         podAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/helm/openneuro/templates/openebs-pool-storageclass.yaml
+++ b/helm/openneuro/templates/openebs-pool-storageclass.yaml
@@ -3,7 +3,7 @@ kind: StorageClass
 metadata:
   name: openebs-pool-block
 parameters:
-  type: gp2
+  type: gp3
 reclaimPolicy: Retain
 allowVolumeExpansion: true
 provisioner: kubernetes.io/aws-ebs

--- a/helm/openneuro/values.yaml
+++ b/helm/openneuro/values.yaml
@@ -39,12 +39,12 @@ sentryDsn: https://ba0c58863b3e40a2a412132bfd2711ea@o114074.ingest.sentry.io/251
 # Size in bytes
 storagePools:
   # This is the size of the pool disks
-  stripeSize: 2147483648000
+  stripeSize: 1099511627776
   pools:
     - name: a
-      size: 6442450944000
+      size: 1099511627776
     - name: b
-      size: 4294967296000
+      size: 1099511627776
 
 # The underlying EFS volume should be created manually and configured here
 efs-provisioner:


### PR DESCRIPTION
This includes various updates for EKS configuration on staging and production.

Major changes:
* Update to EKS 1.19
* Switches from gp2 -> gp3 which is about 15% cheaper for the same storage
* Switches to Ubuntu 20.04 base images
* Optimize costs with higher memory, lower CPU instances
* Use spot instances for general pool on production

Minor changes:
* Fixes missing iam policies on staging cluster
* Documents how to label storage nodes to prevent locking volumes to specific ec2 instances
* Fixes volume affinity for alternative node group names
* Enables CloudWatch logging