### PR TITLE
fix(client): Fix runtime issues with @openneuro/indexer

### DIFF
--- a/packages/openneuro-client/package.json
+++ b/packages/openneuro-client/package.json
@@ -3,7 +3,10 @@
   "version": "3.32.3",
   "description": "OpenNeuro shared client library.",
   "main": "dist/index.js",
-  "browser": "src/client.js",
+  "browser": "src/index.js",
+  "exports": {
+    ".": "src/index.js"
+  },
   "repository": "git@github.com:OpenNeuroOrg/openneuro.git",
   "author": "Squishymedia",
   "license": "MIT",

--- a/packages/openneuro-client/src/__tests__/datasetGenerator.spec.js
+++ b/packages/openneuro-client/src/__tests__/datasetGenerator.spec.js
@@ -1,4 +1,4 @@
-import datasetGenerator from '../datasetGenerator'
+import { datasetGenerator } from '../datasetGenerator'
 
 const firstResult = Promise.resolve({
   data: {

--- a/packages/openneuro-client/src/client.js
+++ b/packages/openneuro-client/src/client.js
@@ -11,12 +11,6 @@ import { setContext } from '@apollo/client/link/context'
 import { WebSocketLink } from '@apollo/client/link/ws'
 import { getMainDefinition } from '@apollo/client/utilities'
 import semver from 'semver'
-import * as files from './files'
-import * as datasets from './datasets'
-import * as snapshots from './snapshots'
-import * as users from './users'
-import * as uploads from './uploads'
-import datasetGenerator from './datasetGenerator.js'
 
 const authLink = getAuthorization =>
   setContext((_, { headers }) => {
@@ -140,7 +134,7 @@ const createLink = (uri, getAuthorization, fetch) => {
 /**
  * Setup a client for working with the OpenNeuro API
  */
-const createClient = (
+export const createClient = (
   uri,
   {
     getAuthorization = undefined,
@@ -170,14 +164,4 @@ const createClient = (
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore: This actually works but seems to be a typing error somewhere in Apollo
   return new ApolloClient(apolloClientOptions)
-}
-
-export {
-  files,
-  datasets,
-  snapshots,
-  users,
-  datasetGenerator,
-  createClient,
-  uploads,
 }

--- a/packages/openneuro-client/src/datasetGenerator.js
+++ b/packages/openneuro-client/src/datasetGenerator.js
@@ -5,7 +5,7 @@ import { getDatasets } from './datasets.js'
  * @param {import('@apollo/client').ApolloClient} client
  * @param {*} query
  */
-export default async function* datasetGenerator(client, query = getDatasets) {
+export async function* datasetGenerator(client, query = getDatasets) {
   let cursor
   while (true) {
     try {

--- a/packages/openneuro-client/src/index.js
+++ b/packages/openneuro-client/src/index.js
@@ -1,1 +1,7 @@
-export * from './client'
+export { createClient } from './client'
+export * as files from './files'
+export * as datasets from './datasets'
+export * as snapshots from './snapshots'
+export * as users from './users'
+export * as uploads from './uploads'
+export { datasetGenerator } from './datasetGenerator'

--- a/packages/openneuro-indexer/Dockerfile
+++ b/packages/openneuro-indexer/Dockerfile
@@ -1,4 +1,4 @@
 FROM openneuro/node AS build
 
 WORKDIR /srv/packages/openneuro-indexer
-CMD ["yarn", "openneuro-indexer"]
+CMD ["yarn", "node", "/srv/packages/openneuro-indexer/dist/index.js"]

--- a/packages/openneuro-indexer/package.json
+++ b/packages/openneuro-indexer/package.json
@@ -21,8 +21,7 @@
   },
   "scripts": {
     "build": "tsc -b",
-    "start": "tsc-watch -b --onSuccess 'node --enable-source-maps ./dist/index.js'",
-    "openneuro-indexer": "ts-node --type-check src/index.ts"
+    "start": "tsc-watch -b --onSuccess 'node --enable-source-maps ./dist/index.js'"
   },
   "files": [
     "lib/**/*"


### PR DESCRIPTION
This cleans up the exports from @openneuro/client which was causing a reference error running the production build of @openneuro/indexer.