### PR TITLE
fix(docker): Run node containers as non-root

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ version: '2.3'
 services:
   # This dummy service provides shared configuration for all Node deps
   node:
+    user: $UID
     image: node:14.16.1
     env_file: ./config.env
     working_dir: /srv


### PR DESCRIPTION
This helps avoid permission conflicts on files that are shared by the host and these containers do not depend on root access.