### PR TITLE
feat: update to bids-validator@1.7.1 and enable PET support

### DIFF
--- a/.pnp.js
+++ b/.pnp.js
@@ -9225,7 +9225,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["babel-runtime", "npm:6.26.0"],
             ["bids-validator", [
               "@squishymedia/bids-validator",
-              "npm:1.7.1"
+              "npm:1.7.1-1"
             ]],
             ["bytes", "npm:3.1.0"],
             ["cache-loader", "virtual:4112afb9dad10978c159910bf10db9840b981b1333117623c8a4a8cf77481344a0a24735a5506e2920c18e3cfa2cc179489824b6a56c988bb070f4f60da40974#npm:1.2.5"],
@@ -10048,10 +10048,10 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
         }]
       ]],
       ["@squishymedia/bids-validator", [
-        ["npm:1.7.1", {
-          "packageLocation": "./.yarn/cache/@squishymedia-bids-validator-npm-1.7.1-f10bbfbb8d-d6ed6ad15b.zip/node_modules/@squishymedia/bids-validator/",
+        ["npm:1.7.1-1", {
+          "packageLocation": "./.yarn/cache/@squishymedia-bids-validator-npm-1.7.1-1-6c9fde3d90-51d052a7a3.zip/node_modules/@squishymedia/bids-validator/",
           "packageDependencies": [
-            ["@squishymedia/bids-validator", "npm:1.7.1"],
+            ["@squishymedia/bids-validator", "npm:1.7.1-1"],
             ["@aws-sdk/client-s3", "npm:3.13.1"],
             ["ajv", "npm:6.12.6"],
             ["bytes", "npm:3.1.0"],

--- a/.pnp.js
+++ b/.pnp.js
@@ -9224,8 +9224,8 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["babel-loader", "virtual:4112afb9dad10978c159910bf10db9840b981b1333117623c8a4a8cf77481344a0a24735a5506e2920c18e3cfa2cc179489824b6a56c988bb070f4f60da40974#npm:8.2.2"],
             ["babel-runtime", "npm:6.26.0"],
             ["bids-validator", [
-              "@squishymedia/bids-validator-debug",
-              "npm:1.6.2-dev.15"
+              "@squishymedia/bids-validator",
+              "npm:1.7.1"
             ]],
             ["bytes", "npm:3.1.0"],
             ["cache-loader", "virtual:4112afb9dad10978c159910bf10db9840b981b1333117623c8a4a8cf77481344a0a24735a5506e2920c18e3cfa2cc179489824b6a56c988bb070f4f60da40974#npm:1.2.5"],
@@ -9311,7 +9311,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@types/colors", "npm:1.1.3"],
             ["@types/mkdirp", "npm:1.0.1"],
             ["@types/node", "npm:14.14.43"],
-            ["bids-validator", "npm:1.6.3"],
+            ["bids-validator", "npm:1.7.1"],
             ["cli-progress", "npm:3.9.0"],
             ["colors", "npm:1.4.0"],
             ["commander", "npm:7.2.0"],
@@ -10047,18 +10047,17 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "linkType": "HARD",
         }]
       ]],
-      ["@squishymedia/bids-validator-debug", [
-        ["npm:1.6.2-dev.15", {
-          "packageLocation": "./.yarn/cache/@squishymedia-bids-validator-debug-npm-1.6.2-dev.15-628c82b092-60a6f251f1.zip/node_modules/@squishymedia/bids-validator-debug/",
+      ["@squishymedia/bids-validator", [
+        ["npm:1.7.1", {
+          "packageLocation": "./.yarn/cache/@squishymedia-bids-validator-npm-1.7.1-f10bbfbb8d-d6ed6ad15b.zip/node_modules/@squishymedia/bids-validator/",
           "packageDependencies": [
-            ["@squishymedia/bids-validator-debug", "npm:1.6.2-dev.15"],
+            ["@squishymedia/bids-validator", "npm:1.7.1"],
             ["@aws-sdk/client-s3", "npm:3.13.1"],
             ["ajv", "npm:6.12.6"],
             ["bytes", "npm:3.1.0"],
             ["colors", "npm:1.4.0"],
             ["cross-fetch", "npm:3.1.4"],
             ["date-fns", "npm:2.21.1"],
-            ["esm", "npm:3.2.25"],
             ["events", "npm:3.3.0"],
             ["hed-validator", "npm:3.0.5"],
             ["ignore", "npm:4.0.6"],
@@ -16342,10 +16341,10 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
         }]
       ]],
       ["bids-validator", [
-        ["npm:1.6.3", {
-          "packageLocation": "./.yarn/cache/bids-validator-npm-1.6.3-4996311f44-af4c39e8dc.zip/node_modules/bids-validator/",
+        ["npm:1.7.1", {
+          "packageLocation": "./.yarn/cache/bids-validator-npm-1.7.1-ec5009e963-21016741a9.zip/node_modules/bids-validator/",
           "packageDependencies": [
-            ["bids-validator", "npm:1.6.3"],
+            ["bids-validator", "npm:1.7.1"],
             ["@aws-sdk/client-s3", "npm:3.13.1"],
             ["ajv", "npm:6.12.6"],
             ["bytes", "npm:3.1.0"],
@@ -25115,7 +25114,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
       ]],
       ["git-win", [
         ["npm:2.3.0", {
-          "packageLocation": "./.yarn/cache/git-win-npm-2.3.0-b98f2b7122-a273c79c22.zip/node_modules/git-win/",
+          "packageLocation": "./.yarn/unplugged/git-win-npm-2.3.0-b98f2b7122/node_modules/git-win/",
           "packageDependencies": [
             ["git-win", "npm:2.3.0"],
             ["@babel/runtime", "npm:7.14.0"],

--- a/packages/openneuro-app/package.json
+++ b/packages/openneuro-app/package.json
@@ -23,7 +23,7 @@
     "@openneuro/client": "^3.32.3",
     "@sentry/browser": "^4.5.3",
     "babel-runtime": "^6.26.0",
-    "bids-validator": "npm:@squishymedia/bids-validator-debug@1.6.2-dev.15",
+    "bids-validator": "npm:@squishymedia/bids-validator@1.7.1",
     "bytes": "^3.0.0",
     "comlink": "^4.0.5",
     "core-js": "^3.3.2",

--- a/packages/openneuro-app/package.json
+++ b/packages/openneuro-app/package.json
@@ -23,7 +23,7 @@
     "@openneuro/client": "^3.32.3",
     "@sentry/browser": "^4.5.3",
     "babel-runtime": "^6.26.0",
-    "bids-validator": "npm:@squishymedia/bids-validator@1.7.1",
+    "bids-validator": "npm:@squishymedia/bids-validator@1.7.1-1",
     "bytes": "^3.0.0",
     "comlink": "^4.0.5",
     "core-js": "^3.3.2",

--- a/packages/openneuro-app/src/scripts/front-page/front-page-content.ts
+++ b/packages/openneuro-app/src/scripts/front-page/front-page-content.ts
@@ -15,7 +15,7 @@ export const frontPage = {
     holder: 'Stanford Center for Reproducible Neuroscience',
   },
   pageDescription:
-    'A free and open platform for sharing MRI, MEG, EEG, iEEG, ECoG, and ASL data',
+    'A free and open platform for sharing MRI, MEG, EEG, iEEG, ECoG, ASL, and PET data',
   titlePanel: {
     logos: [
       {

--- a/packages/openneuro-cli/package.json
+++ b/packages/openneuro-cli/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@apollo/client": "3.3.14",
     "@openneuro/client": "^3.32.3",
-    "bids-validator": "1.6.3",
+    "bids-validator": "1.7.1",
     "cli-progress": "^3.8.2",
     "colors": "1.4.0",
     "commander": "7.2.0",

--- a/services/datalad/package.json
+++ b/services/datalad/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "bids-validator": "1.6.3"
+    "bids-validator": "1.7.1"
   }
 }

--- a/services/datalad/yarn.lock
+++ b/services/datalad/yarn.lock
@@ -1055,9 +1055,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bids-validator@npm:1.6.3":
-  version: 1.6.3
-  resolution: "bids-validator@npm:1.6.3"
+"bids-validator@npm:1.7.1":
+  version: 1.7.1
+  resolution: "bids-validator@npm:1.7.1"
   dependencies:
     "@aws-sdk/client-s3": ^3.9.0
     ajv: ^6.5.2
@@ -1081,7 +1081,7 @@ __metadata:
     yargs: ^16.2.0
   bin:
     bids-validator: bin/bids-validator
-  checksum: af4c39e8dc8b2c69d8133e0ef24eea6c5891a443de487f2beae2c71ff51ceddf8c39bbd0a24e3e0a4c0560fa36354c88b3070e7b2a41796e4024cf46c0dcd34e
+  checksum: 21016741a9c4e8ea5c7a0558e8d7add9fddab063e4f26e1c809292f8cef27f53187c8ce635b948a73a6b18f38e3a8b335a6d3fb9fd728e76937d800dfe7305e9
   languageName: node
   linkType: hard
 
@@ -2344,7 +2344,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "root-workspace-0b6124@workspace:."
   dependencies:
-    bids-validator: 1.6.3
+    bids-validator: 1.7.1
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4724,7 +4724,7 @@ __metadata:
     babel-jest: ^24.9.0
     babel-loader: ^8.0.4
     babel-runtime: ^6.26.0
-    bids-validator: "npm:@squishymedia/bids-validator@1.7.1"
+    bids-validator: "npm:@squishymedia/bids-validator@1.7.1-1"
     bytes: ^3.0.0
     cache-loader: ^1.2.2
     clean-webpack-plugin: ^0.1.19
@@ -9980,9 +9980,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bids-validator@npm:@squishymedia/bids-validator@1.7.1":
-  version: 1.7.1
-  resolution: "@squishymedia/bids-validator@npm:1.7.1"
+"bids-validator@npm:@squishymedia/bids-validator@1.7.1-1":
+  version: 1.7.1-1
+  resolution: "@squishymedia/bids-validator@npm:1.7.1-1"
   dependencies:
     "@aws-sdk/client-s3": ^3.9.0
     ajv: ^6.5.2
@@ -10007,7 +10007,7 @@ __metadata:
     yargs: ^16.2.0
   bin:
     bids-validator: bin/bids-validator
-  checksum: d6ed6ad15b7e4e2a5f31f434d72c5ad8d5d7fb64c4f576f9d3a49140495608593d0e59cba922cab630b3c71b4552de1040bf7ab4bf0c22777e1af26626a2a171
+  checksum: 51d052a7a3b91057266297c8b5ce2735a167e3c704477b70c6012bbd37e0a9a21fc7c2edf899a38f12ad34c04f6ed87102182ca67a177b519b3c36cc1c174020
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4724,7 +4724,7 @@ __metadata:
     babel-jest: ^24.9.0
     babel-loader: ^8.0.4
     babel-runtime: ^6.26.0
-    bids-validator: "npm:@squishymedia/bids-validator-debug@1.6.2-dev.15"
+    bids-validator: "npm:@squishymedia/bids-validator@1.7.1"
     bytes: ^3.0.0
     cache-loader: ^1.2.2
     clean-webpack-plugin: ^0.1.19
@@ -4807,7 +4807,7 @@ __metadata:
     "@types/colors": ^1
     "@types/mkdirp": ^1.0.1
     "@types/node": ^14.14.41
-    bids-validator: 1.6.3
+    bids-validator: 1.7.1
     cli-progress: ^3.8.2
     colors: 1.4.0
     commander: 7.2.0
@@ -9950,9 +9950,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bids-validator@npm:1.6.3":
-  version: 1.6.3
-  resolution: "bids-validator@npm:1.6.3"
+"bids-validator@npm:1.7.1":
+  version: 1.7.1
+  resolution: "bids-validator@npm:1.7.1"
   dependencies:
     "@aws-sdk/client-s3": ^3.9.0
     ajv: ^6.5.2
@@ -9976,13 +9976,13 @@ __metadata:
     yargs: ^16.2.0
   bin:
     bids-validator: bin/bids-validator
-  checksum: af4c39e8dc8b2c69d8133e0ef24eea6c5891a443de487f2beae2c71ff51ceddf8c39bbd0a24e3e0a4c0560fa36354c88b3070e7b2a41796e4024cf46c0dcd34e
+  checksum: 21016741a9c4e8ea5c7a0558e8d7add9fddab063e4f26e1c809292f8cef27f53187c8ce635b948a73a6b18f38e3a8b335a6d3fb9fd728e76937d800dfe7305e9
   languageName: node
   linkType: hard
 
-"bids-validator@npm:@squishymedia/bids-validator-debug@1.6.2-dev.15":
-  version: 1.6.2-dev.15
-  resolution: "@squishymedia/bids-validator-debug@npm:1.6.2-dev.15"
+"bids-validator@npm:@squishymedia/bids-validator@1.7.1":
+  version: 1.7.1
+  resolution: "@squishymedia/bids-validator@npm:1.7.1"
   dependencies:
     "@aws-sdk/client-s3": ^3.9.0
     ajv: ^6.5.2
@@ -9990,7 +9990,6 @@ __metadata:
     colors: ^1.3.1
     cross-fetch: ^3.0.6
     date-fns: ^2.7.0
-    esm: ^3.2.25
     events: ^3.3.0
     hed-validator: 3.0.5
     ignore: ^4.0.2
@@ -10008,7 +10007,7 @@ __metadata:
     yargs: ^16.2.0
   bin:
     bids-validator: bin/bids-validator
-  checksum: 60a6f251f14a9fc3349322a1f31c331aa9f64583748b1ff5ae3e5e51de71a2baa4e2c6bf3f28f87733cd31b4e6779affb4b1ec6ab9a4e3f98ef47b70b84a5384
+  checksum: d6ed6ad15b7e4e2a5f31f434d72c5ad8d5d7fb64c4f576f9d3a49140495608593d0e59cba922cab630b3c71b4552de1040bf7ab4bf0c22777e1af26626a2a171
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Adds PET to the front page now that it's in bids-validator.