### PR TITLE
fix: Simplify testing of production builds on local dev

### DIFF
--- a/nginx/nginx.dev.conf
+++ b/nginx/nginx.dev.conf
@@ -76,7 +76,7 @@ server {
     root /srv/app/dist;
 
     location / {
-        proxy_pass http://app:9876;
+        proxy_pass http://app;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";

--- a/packages/openneuro-app/src/ssr.ts
+++ b/packages/openneuro-app/src/ssr.ts
@@ -158,7 +158,7 @@ async function createServer(): Promise<void> {
     void ssrHandler()
   })
 
-  app.listen(development ? 9876 : 80)
+  app.listen(80)
 }
 
 void createServer()


### PR DESCRIPTION
This allows you to set NODE_ENV=production in docker-compose.yaml to run the production build.