### PR TITLE
fix(ssr): Use cache-and-network for drafts

### DIFF
--- a/packages/openneuro-app/src/scripts/datalad/dataset/dataset-query.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/dataset/dataset-query.jsx
@@ -111,6 +111,7 @@ export const DatasetQueryHook = ({ datasetId, draft, history }) => {
     {
       variables: { datasetId },
       errorPolicy: 'all',
+      fetchPolicy: draft ? 'cache-and-network' : 'cache-first',
     },
   )
   usePermissionsSubscription([datasetId])


### PR DESCRIPTION
Prevents SSR cache age from displaying incorrect drafts after load.