### PR TITLE
fix(app): Hide top level file tree delete button

### DIFF
--- a/packages/openneuro-app/src/scripts/file-tree/file-tree.jsx
+++ b/packages/openneuro-app/src/scripts/file-tree/file-tree.jsx
@@ -58,8 +58,9 @@ const FileTree = ({
                   directory>
                   <i className="fa fa-plus" /> Add Directory
                 </UpdateFile>
-                <DeleteDir datasetId={datasetId} path={path} />
-                {bulkDeleteButton}
+                {bulkDeleteButton || (
+                  <DeleteDir datasetId={datasetId} path={path} />
+                )}
               </span>
             </Media>
           )}


### PR DESCRIPTION
This very dangerous button serves no purpose but to mess up your draft when you click it.