### PR TITLE
Annexed file access worker optimization

### DIFF
--- a/services/datalad/datalad_service/handlers/files.py
+++ b/services/datalad/datalad_service/handlers/files.py
@@ -1,11 +1,9 @@
 import logging
 import os
-import json
 from subprocess import CalledProcessError
 
 import falcon
 
-import git
 from datalad_service.common.git import git_show
 from datalad_service.common.user import get_user_info
 from datalad_service.common.stream import update_file
@@ -26,20 +24,21 @@ class FilesResource(object):
         ds_path = self.store.get_dataset_path(dataset)
         if filename:
             try:
-                ds = self.store.get_dataset(dataset)
-                if ds.repo.is_under_annex([filename])[0]:
-                    path = git_show(ds_path, snapshot + ':' + filename)
-                    # remove leading relative folder paths
-                    fd = path[path.find('.git/annex'):]
-
-                    # if fd fails, that means the file is not present in the annex and we need to get it from s3
-                    # so we send the client a 404 to indicate the file was not found locally.
-                    fd = open(os.path.join(ds_path, fd), 'rb')
-                    resp.stream = fd
-                    resp.stream_len = os.fstat(fd.fileno()).st_size
-                    resp.status = falcon.HTTP_OK
+                file_content = git_show(ds_path, snapshot + ':' + filename)
+                # If the file begins with an annex path, return that path
+                if file_content[0:4096].find('.git/annex') != -1:
+                    target_path = os.path.join(ds_path, file_content)
+                    # Verify the annex path is within the dataset dir
+                    if ds_path == os.path.commonpath((ds_path, target_path)):
+                        fd = open(target_path, 'rb')
+                        resp.stream = fd
+                        resp.stream_len = os.fstat(fd.fileno()).st_size
+                        resp.status = falcon.HTTP_OK
+                    else:
+                        resp.media = {'error': 'file not found in git tree'}
+                        resp.status = falcon.HTTP_NOT_FOUND
                 else:
-                    resp.body = git_show(ds_path, snapshot + ':' + filename)
+                    resp.body = file_content
                     resp.status = falcon.HTTP_OK
             except CalledProcessError:
                 # File is not present in tree
@@ -125,23 +124,27 @@ class FilesResource(object):
                     paths_not_found.append(filename)
 
             if len(paths_not_found) == 0:
-                media_dict = { 'deleted': dirs_to_delete + files_to_delete }
+                media_dict = {'deleted': dirs_to_delete + files_to_delete}
                 name, email = get_user_info(req)
                 if name and email:
                     media_dict['name'] = name
                     media_dict['email'] = email
-                try: 
+                try:
                     if len(dirs_to_delete) > 0:
-                        remove_recursive(self.store, dataset, dirs_to_delete, name=name, email=email, cookies=req.cookies)
+                        remove_recursive(
+                            self.store, dataset, dirs_to_delete, name=name, email=email, cookies=req.cookies)
                         resp.status = falcon.HTTP_INTERNAL_SERVER_ERROR
                     if len(files_to_delete) > 0:
-                        remove_files(self.store, dataset, files=files_to_delete, name=name, email=email, cookies=req.cookies)
+                        remove_files(self.store, dataset, files=files_to_delete,
+                                     name=name, email=email, cookies=req.cookies)
                     resp.media = media_dict
                     resp.status = falcon.HTTP_OK
                 except:
                     resp.status = falcon.HTTP_INTERNAL_SERVER_ERROR
             else:
-                resp.media = { 'error': f'the following files not found: {", ".join(paths_not_found)}' }
+                resp.media = {
+                    'error': f'the following files not found: {", ".join(paths_not_found)}'}
         else:
-            resp.media = {'error': 'recursive query or request body is missing'}
+            resp.media = {
+                'error': 'recursive query or request body is missing'}
             resp.status = falcon.HTTP_BAD_REQUEST

--- a/services/datalad/datalad_service/handlers/files.py
+++ b/services/datalad/datalad_service/handlers/files.py
@@ -27,7 +27,9 @@ class FilesResource(object):
                 file_content = git_show(ds_path, snapshot + ':' + filename)
                 # If the file begins with an annex path, return that path
                 if file_content[0:4096].find('.git/annex') != -1:
-                    target_path = os.path.join(ds_path, file_content)
+                    # Resolve absolute path for annex target
+                    target_path = os.path.join(
+                        ds_path, os.path.dirname(filename), file_content)
                     # Verify the annex path is within the dataset dir
                     if ds_path == os.path.commonpath((ds_path, target_path)):
                         fd = open(target_path, 'rb')

--- a/services/datalad/tests/test_files.py
+++ b/services/datalad/tests/test_files.py
@@ -32,6 +32,21 @@ def test_get_annexed_file(client):
     assert result.content.decode() == file_data
 
 
+def test_get_annexed_file_nested(client):
+    ds_id = 'ds000001'
+    file_data = 'test image, please ignore'
+    response = client.simulate_post(
+        '/datasets/{}/files/sub-01:data.nii.gz'.format(ds_id), body=file_data)
+    assert response.status == falcon.HTTP_OK
+    response = client.simulate_post('/datasets/{}/draft'.format(ds_id))
+    assert response.status == falcon.HTTP_OK
+    result = client.simulate_get(
+        '/datasets/{}/files/sub-01:data.nii.gz'.format(ds_id), file_wrapper=FileWrapper)
+    content_len = int(result.headers['content-length'])
+    assert content_len == len(result.content)
+    assert result.content.decode() == file_data
+
+
 def test_get_missing_file(client):
     ds_id = 'ds000001'
     result = client.simulate_get(

--- a/services/datalad/tests/test_files.py
+++ b/services/datalad/tests/test_files.py
@@ -17,6 +17,21 @@ def test_get_file(client):
     assert json.loads(result.content)['BIDSVersion'] == '1.0.2'
 
 
+def test_get_annexed_file(client):
+    ds_id = 'ds000001'
+    file_data = 'test image, please ignore'
+    response = client.simulate_post(
+        '/datasets/{}/files/data.nii.gz'.format(ds_id), body=file_data)
+    assert response.status == falcon.HTTP_OK
+    response = client.simulate_post('/datasets/{}/draft'.format(ds_id))
+    assert response.status == falcon.HTTP_OK
+    result = client.simulate_get(
+        '/datasets/{}/files/data.nii.gz'.format(ds_id), file_wrapper=FileWrapper)
+    content_len = int(result.headers['content-length'])
+    assert content_len == len(result.content)
+    assert result.content.decode() == file_data
+
+
 def test_get_missing_file(client):
     ds_id = 'ds000001'
     result = client.simulate_get(
@@ -213,16 +228,22 @@ def test_untracked_dir_index(client, new_dataset):
         else:
             assert False
 
+
 def test_delete_file(client, new_dataset):
     ds_id = os.path.basename(new_dataset.path)
-    response = client.simulate_delete('/datasets/{}/files'.format(ds_id), body='{ "filenames": ["dataset_description.json", "CHANGES"] }')
+    response = client.simulate_delete('/datasets/{}/files'.format(
+        ds_id), body='{ "filenames": ["dataset_description.json", "CHANGES"] }')
     assert response.status == falcon.HTTP_OK
     print(response.content)
-    assert json.loads(response.content)['deleted'] == ['dataset_description.json', 'CHANGES']
+    assert json.loads(response.content)['deleted'] == [
+        'dataset_description.json', 'CHANGES']
+
 
 def test_delete_non_existing_file(client, new_dataset):
     ds_id = os.path.basename(new_dataset.path)
-    response = client.simulate_delete('/datasets/{}/files'.format(ds_id), body='{ "filenames": ["fake", "test"]}')
+    response = client.simulate_delete(
+        '/datasets/{}/files'.format(ds_id), body='{ "filenames": ["fake", "test"]}')
     assert response.status == falcon.HTTP_OK
     print(response.content)
-    assert json.loads(response.content)['error'] == 'the following files not found: fake, test'
+    assert json.loads(response.content)[
+        'error'] == 'the following files not found: fake, test'


### PR DESCRIPTION
This eliminates a couple API calls which lead to significant slowdown for certain datasets even when doing something simple like getting the contents of one top level file (dataset_description.json). OpenNeuro can use a simpler test since we control the structure of the datasets, instead we just read the file regardless and test if points to an annex path in the first 4k block. If it does and the path is within the dataset, it's safe to return it without the additional checks.

There was missing test coverage for this case when the file was annexed, added that in ee4897c.