### PR TITLE
test: Improve TypeScript and Jest setup for component tests

### DIFF
--- a/.pnp.js
+++ b/.pnp.js
@@ -3325,6 +3325,20 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             "@types/babel__core"
           ],
           "linkType": "HARD",
+        }],
+        ["virtual:afe501dbd5cd31397dbc608dda7d7344230762a90ac8240d0edbc7247e1ad2e46968c90a370bafbbf7fc4626fb476eebd10da3016965960749d0067640b7805e#npm:7.8.4", {
+          "packageLocation": "./.yarn/$$virtual/@babel-plugin-syntax-async-generators-virtual-d1234c3dcf/0/cache/@babel-plugin-syntax-async-generators-npm-7.8.4-d10cf993c9-39685944ff.zip/node_modules/@babel/plugin-syntax-async-generators/",
+          "packageDependencies": [
+            ["@babel/plugin-syntax-async-generators", "virtual:afe501dbd5cd31397dbc608dda7d7344230762a90ac8240d0edbc7247e1ad2e46968c90a370bafbbf7fc4626fb476eebd10da3016965960749d0067640b7805e#npm:7.8.4"],
+            ["@babel/core", null],
+            ["@babel/helper-plugin-utils", "npm:7.13.0"],
+            ["@types/babel__core", "npm:7.1.14"]
+          ],
+          "packagePeers": [
+            "@babel/core",
+            "@types/babel__core"
+          ],
+          "linkType": "HARD",
         }]
       ]],
       ["@babel/plugin-syntax-bigint", [
@@ -3356,6 +3370,20 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@babel/core", "npm:7.14.6"],
             ["@babel/helper-plugin-utils", "npm:7.13.0"],
             ["@types/babel__core", null]
+          ],
+          "packagePeers": [
+            "@babel/core",
+            "@types/babel__core"
+          ],
+          "linkType": "HARD",
+        }],
+        ["virtual:afe501dbd5cd31397dbc608dda7d7344230762a90ac8240d0edbc7247e1ad2e46968c90a370bafbbf7fc4626fb476eebd10da3016965960749d0067640b7805e#npm:7.8.3", {
+          "packageLocation": "./.yarn/$$virtual/@babel-plugin-syntax-bigint-virtual-ee2077edce/0/cache/@babel-plugin-syntax-bigint-npm-7.8.3-b05d971e6c-8c9b610377.zip/node_modules/@babel/plugin-syntax-bigint/",
+          "packageDependencies": [
+            ["@babel/plugin-syntax-bigint", "virtual:afe501dbd5cd31397dbc608dda7d7344230762a90ac8240d0edbc7247e1ad2e46968c90a370bafbbf7fc4626fb476eebd10da3016965960749d0067640b7805e#npm:7.8.3"],
+            ["@babel/core", null],
+            ["@babel/helper-plugin-utils", "npm:7.13.0"],
+            ["@types/babel__core", "npm:7.1.14"]
           ],
           "packagePeers": [
             "@babel/core",
@@ -3421,6 +3449,20 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@babel/core", "npm:7.14.6"],
             ["@babel/helper-plugin-utils", "npm:7.13.0"],
             ["@types/babel__core", null]
+          ],
+          "packagePeers": [
+            "@babel/core",
+            "@types/babel__core"
+          ],
+          "linkType": "HARD",
+        }],
+        ["virtual:afe501dbd5cd31397dbc608dda7d7344230762a90ac8240d0edbc7247e1ad2e46968c90a370bafbbf7fc4626fb476eebd10da3016965960749d0067640b7805e#npm:7.12.13", {
+          "packageLocation": "./.yarn/$$virtual/@babel-plugin-syntax-class-properties-virtual-f5e87bfd16/0/cache/@babel-plugin-syntax-class-properties-npm-7.12.13-002ee9d930-3023dec8ac.zip/node_modules/@babel/plugin-syntax-class-properties/",
+          "packageDependencies": [
+            ["@babel/plugin-syntax-class-properties", "virtual:afe501dbd5cd31397dbc608dda7d7344230762a90ac8240d0edbc7247e1ad2e46968c90a370bafbbf7fc4626fb476eebd10da3016965960749d0067640b7805e#npm:7.12.13"],
+            ["@babel/core", null],
+            ["@babel/helper-plugin-utils", "npm:7.13.0"],
+            ["@types/babel__core", "npm:7.1.14"]
           ],
           "packagePeers": [
             "@babel/core",
@@ -3686,6 +3728,20 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             "@types/babel__core"
           ],
           "linkType": "HARD",
+        }],
+        ["virtual:afe501dbd5cd31397dbc608dda7d7344230762a90ac8240d0edbc7247e1ad2e46968c90a370bafbbf7fc4626fb476eebd10da3016965960749d0067640b7805e#npm:7.10.4", {
+          "packageLocation": "./.yarn/$$virtual/@babel-plugin-syntax-import-meta-virtual-f1351afeb0/0/cache/@babel-plugin-syntax-import-meta-npm-7.10.4-4a0a0158bc-685ee8f0b5.zip/node_modules/@babel/plugin-syntax-import-meta/",
+          "packageDependencies": [
+            ["@babel/plugin-syntax-import-meta", "virtual:afe501dbd5cd31397dbc608dda7d7344230762a90ac8240d0edbc7247e1ad2e46968c90a370bafbbf7fc4626fb476eebd10da3016965960749d0067640b7805e#npm:7.10.4"],
+            ["@babel/core", null],
+            ["@babel/helper-plugin-utils", "npm:7.13.0"],
+            ["@types/babel__core", "npm:7.1.14"]
+          ],
+          "packagePeers": [
+            "@babel/core",
+            "@types/babel__core"
+          ],
+          "linkType": "HARD",
         }]
       ]],
       ["@babel/plugin-syntax-json-strings", [
@@ -3745,6 +3801,20 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@babel/core", "npm:7.14.6"],
             ["@babel/helper-plugin-utils", "npm:7.13.0"],
             ["@types/babel__core", null]
+          ],
+          "packagePeers": [
+            "@babel/core",
+            "@types/babel__core"
+          ],
+          "linkType": "HARD",
+        }],
+        ["virtual:afe501dbd5cd31397dbc608dda7d7344230762a90ac8240d0edbc7247e1ad2e46968c90a370bafbbf7fc4626fb476eebd10da3016965960749d0067640b7805e#npm:7.8.3", {
+          "packageLocation": "./.yarn/$$virtual/@babel-plugin-syntax-json-strings-virtual-3b1c5db9d0/0/cache/@babel-plugin-syntax-json-strings-npm-7.8.3-6dc7848179-1a7dabf0a4.zip/node_modules/@babel/plugin-syntax-json-strings/",
+          "packageDependencies": [
+            ["@babel/plugin-syntax-json-strings", "virtual:afe501dbd5cd31397dbc608dda7d7344230762a90ac8240d0edbc7247e1ad2e46968c90a370bafbbf7fc4626fb476eebd10da3016965960749d0067640b7805e#npm:7.8.3"],
+            ["@babel/core", null],
+            ["@babel/helper-plugin-utils", "npm:7.13.0"],
+            ["@types/babel__core", "npm:7.1.14"]
           ],
           "packagePeers": [
             "@babel/core",
@@ -3909,6 +3979,20 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             "@types/babel__core"
           ],
           "linkType": "HARD",
+        }],
+        ["virtual:afe501dbd5cd31397dbc608dda7d7344230762a90ac8240d0edbc7247e1ad2e46968c90a370bafbbf7fc4626fb476eebd10da3016965960749d0067640b7805e#npm:7.10.4", {
+          "packageLocation": "./.yarn/$$virtual/@babel-plugin-syntax-logical-assignment-operators-virtual-08cdc4d610/0/cache/@babel-plugin-syntax-logical-assignment-operators-npm-7.10.4-72ae00fdf6-5b82f71770.zip/node_modules/@babel/plugin-syntax-logical-assignment-operators/",
+          "packageDependencies": [
+            ["@babel/plugin-syntax-logical-assignment-operators", "virtual:afe501dbd5cd31397dbc608dda7d7344230762a90ac8240d0edbc7247e1ad2e46968c90a370bafbbf7fc4626fb476eebd10da3016965960749d0067640b7805e#npm:7.10.4"],
+            ["@babel/core", null],
+            ["@babel/helper-plugin-utils", "npm:7.13.0"],
+            ["@types/babel__core", "npm:7.1.14"]
+          ],
+          "packagePeers": [
+            "@babel/core",
+            "@types/babel__core"
+          ],
+          "linkType": "HARD",
         }]
       ]],
       ["@babel/plugin-syntax-nullish-coalescing-operator", [
@@ -3974,6 +4058,20 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             "@types/babel__core"
           ],
           "linkType": "HARD",
+        }],
+        ["virtual:afe501dbd5cd31397dbc608dda7d7344230762a90ac8240d0edbc7247e1ad2e46968c90a370bafbbf7fc4626fb476eebd10da3016965960749d0067640b7805e#npm:7.8.3", {
+          "packageLocation": "./.yarn/$$virtual/@babel-plugin-syntax-nullish-coalescing-operator-virtual-9721455bb1/0/cache/@babel-plugin-syntax-nullish-coalescing-operator-npm-7.8.3-8a723173b5-4ba0375375.zip/node_modules/@babel/plugin-syntax-nullish-coalescing-operator/",
+          "packageDependencies": [
+            ["@babel/plugin-syntax-nullish-coalescing-operator", "virtual:afe501dbd5cd31397dbc608dda7d7344230762a90ac8240d0edbc7247e1ad2e46968c90a370bafbbf7fc4626fb476eebd10da3016965960749d0067640b7805e#npm:7.8.3"],
+            ["@babel/core", null],
+            ["@babel/helper-plugin-utils", "npm:7.13.0"],
+            ["@types/babel__core", "npm:7.1.14"]
+          ],
+          "packagePeers": [
+            "@babel/core",
+            "@types/babel__core"
+          ],
+          "linkType": "HARD",
         }]
       ]],
       ["@babel/plugin-syntax-numeric-separator", [
@@ -4033,6 +4131,20 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@babel/core", "npm:7.14.6"],
             ["@babel/helper-plugin-utils", "npm:7.13.0"],
             ["@types/babel__core", null]
+          ],
+          "packagePeers": [
+            "@babel/core",
+            "@types/babel__core"
+          ],
+          "linkType": "HARD",
+        }],
+        ["virtual:afe501dbd5cd31397dbc608dda7d7344230762a90ac8240d0edbc7247e1ad2e46968c90a370bafbbf7fc4626fb476eebd10da3016965960749d0067640b7805e#npm:7.10.4", {
+          "packageLocation": "./.yarn/$$virtual/@babel-plugin-syntax-numeric-separator-virtual-349fec565b/0/cache/@babel-plugin-syntax-numeric-separator-npm-7.10.4-81444be605-47ae878293.zip/node_modules/@babel/plugin-syntax-numeric-separator/",
+          "packageDependencies": [
+            ["@babel/plugin-syntax-numeric-separator", "virtual:afe501dbd5cd31397dbc608dda7d7344230762a90ac8240d0edbc7247e1ad2e46968c90a370bafbbf7fc4626fb476eebd10da3016965960749d0067640b7805e#npm:7.10.4"],
+            ["@babel/core", null],
+            ["@babel/helper-plugin-utils", "npm:7.13.0"],
+            ["@types/babel__core", "npm:7.1.14"]
           ],
           "packagePeers": [
             "@babel/core",
@@ -4119,6 +4231,20 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           ],
           "linkType": "HARD",
         }],
+        ["virtual:afe501dbd5cd31397dbc608dda7d7344230762a90ac8240d0edbc7247e1ad2e46968c90a370bafbbf7fc4626fb476eebd10da3016965960749d0067640b7805e#npm:7.8.3", {
+          "packageLocation": "./.yarn/$$virtual/@babel-plugin-syntax-object-rest-spread-virtual-1b8775036e/0/cache/@babel-plugin-syntax-object-rest-spread-npm-7.8.3-60bd05b6ae-db5dfb39fa.zip/node_modules/@babel/plugin-syntax-object-rest-spread/",
+          "packageDependencies": [
+            ["@babel/plugin-syntax-object-rest-spread", "virtual:afe501dbd5cd31397dbc608dda7d7344230762a90ac8240d0edbc7247e1ad2e46968c90a370bafbbf7fc4626fb476eebd10da3016965960749d0067640b7805e#npm:7.8.3"],
+            ["@babel/core", null],
+            ["@babel/helper-plugin-utils", "npm:7.13.0"],
+            ["@types/babel__core", "npm:7.1.14"]
+          ],
+          "packagePeers": [
+            "@babel/core",
+            "@types/babel__core"
+          ],
+          "linkType": "HARD",
+        }],
         ["virtual:f6ad346c03ca00bdd6689dddf792d9d913ccc565d113120ca12f09dc9a367146e863108f86c9c8f114b10becd648148f6352be7102e5a67baf7715a5fe2553a8#npm:7.8.3", {
           "packageLocation": "./.yarn/$$virtual/@babel-plugin-syntax-object-rest-spread-virtual-7049db6edc/0/cache/@babel-plugin-syntax-object-rest-spread-npm-7.8.3-60bd05b6ae-db5dfb39fa.zip/node_modules/@babel/plugin-syntax-object-rest-spread/",
           "packageDependencies": [
@@ -4197,6 +4323,20 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             "@types/babel__core"
           ],
           "linkType": "HARD",
+        }],
+        ["virtual:afe501dbd5cd31397dbc608dda7d7344230762a90ac8240d0edbc7247e1ad2e46968c90a370bafbbf7fc4626fb476eebd10da3016965960749d0067640b7805e#npm:7.8.3", {
+          "packageLocation": "./.yarn/$$virtual/@babel-plugin-syntax-optional-catch-binding-virtual-10d4d16c39/0/cache/@babel-plugin-syntax-optional-catch-binding-npm-7.8.3-ce337427d8-f03d075266.zip/node_modules/@babel/plugin-syntax-optional-catch-binding/",
+          "packageDependencies": [
+            ["@babel/plugin-syntax-optional-catch-binding", "virtual:afe501dbd5cd31397dbc608dda7d7344230762a90ac8240d0edbc7247e1ad2e46968c90a370bafbbf7fc4626fb476eebd10da3016965960749d0067640b7805e#npm:7.8.3"],
+            ["@babel/core", null],
+            ["@babel/helper-plugin-utils", "npm:7.13.0"],
+            ["@types/babel__core", "npm:7.1.14"]
+          ],
+          "packagePeers": [
+            "@babel/core",
+            "@types/babel__core"
+          ],
+          "linkType": "HARD",
         }]
       ]],
       ["@babel/plugin-syntax-optional-chaining", [
@@ -4256,6 +4396,20 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@babel/core", "npm:7.14.6"],
             ["@babel/helper-plugin-utils", "npm:7.13.0"],
             ["@types/babel__core", null]
+          ],
+          "packagePeers": [
+            "@babel/core",
+            "@types/babel__core"
+          ],
+          "linkType": "HARD",
+        }],
+        ["virtual:afe501dbd5cd31397dbc608dda7d7344230762a90ac8240d0edbc7247e1ad2e46968c90a370bafbbf7fc4626fb476eebd10da3016965960749d0067640b7805e#npm:7.8.3", {
+          "packageLocation": "./.yarn/$$virtual/@babel-plugin-syntax-optional-chaining-virtual-b14d848313/0/cache/@babel-plugin-syntax-optional-chaining-npm-7.8.3-f3f3c79579-2a50685d02.zip/node_modules/@babel/plugin-syntax-optional-chaining/",
+          "packageDependencies": [
+            ["@babel/plugin-syntax-optional-chaining", "virtual:afe501dbd5cd31397dbc608dda7d7344230762a90ac8240d0edbc7247e1ad2e46968c90a370bafbbf7fc4626fb476eebd10da3016965960749d0067640b7805e#npm:7.8.3"],
+            ["@babel/core", null],
+            ["@babel/helper-plugin-utils", "npm:7.13.0"],
+            ["@types/babel__core", "npm:7.1.14"]
           ],
           "packagePeers": [
             "@babel/core",
@@ -4372,6 +4526,20 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@babel/core", "npm:7.14.6"],
             ["@babel/helper-plugin-utils", "npm:7.13.0"],
             ["@types/babel__core", null]
+          ],
+          "packagePeers": [
+            "@babel/core",
+            "@types/babel__core"
+          ],
+          "linkType": "HARD",
+        }],
+        ["virtual:afe501dbd5cd31397dbc608dda7d7344230762a90ac8240d0edbc7247e1ad2e46968c90a370bafbbf7fc4626fb476eebd10da3016965960749d0067640b7805e#npm:7.12.13", {
+          "packageLocation": "./.yarn/$$virtual/@babel-plugin-syntax-top-level-await-virtual-114fcd969f/0/cache/@babel-plugin-syntax-top-level-await-npm-7.12.13-6ac12f7c33-5bd0a65b01.zip/node_modules/@babel/plugin-syntax-top-level-await/",
+          "packageDependencies": [
+            ["@babel/plugin-syntax-top-level-await", "virtual:afe501dbd5cd31397dbc608dda7d7344230762a90ac8240d0edbc7247e1ad2e46968c90a370bafbbf7fc4626fb476eebd10da3016965960749d0067640b7805e#npm:7.12.13"],
+            ["@babel/core", null],
+            ["@babel/helper-plugin-utils", "npm:7.13.0"],
+            ["@types/babel__core", "npm:7.1.14"]
           ],
           "packagePeers": [
             "@babel/core",
@@ -7028,6 +7196,15 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "packageDependencies": [
             ["@babel/runtime-corejs3", "npm:7.14.0"],
             ["core-js-pure", "npm:3.12.1"],
+            ["regenerator-runtime", "npm:0.13.8"]
+          ],
+          "linkType": "HARD",
+        }],
+        ["npm:7.14.6", {
+          "packageLocation": "./.yarn/cache/@babel-runtime-corejs3-npm-7.14.6-e5f8b5a303-aa0271b4e8.zip/node_modules/@babel/runtime-corejs3/",
+          "packageDependencies": [
+            ["@babel/runtime-corejs3", "npm:7.14.6"],
+            ["core-js-pure", "npm:3.14.0"],
             ["regenerator-runtime", "npm:0.13.8"]
           ],
           "linkType": "HARD",
@@ -10030,6 +10207,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "packageLocation": "./packages/openneuro-components/",
           "packageDependencies": [
             ["@openneuro/components", "workspace:packages/openneuro-components"],
+            ["@babel/runtime-corejs3", "npm:7.14.6"],
             ["@mdx-js/react", "virtual:0f7d3aee8f4ba1ddd800f44d0aa4455a1e4b9ae1a24c9eda9668f886bc29f684a49cc3e1c10c4481252ea0f7eec58c4be3167e18e5c332f257a51ab3e50e4f7a#npm:1.6.22"],
             ["@storybook/addon-a11y", "virtual:bb4ed02b339ed801b02d2ec15b42a5aa7b1afdaf44119aefaab128a59d6e16cc6018880c169f24bf2107550e914562ee9e1780db01a12e1bc3c492ad0a049c36#npm:6.2.9"],
             ["@storybook/addon-actions", "virtual:bb4ed02b339ed801b02d2ec15b42a5aa7b1afdaf44119aefaab128a59d6e16cc6018880c169f24bf2107550e914562ee9e1780db01a12e1bc3c492ad0a049c36#npm:6.2.9"],
@@ -10051,6 +10229,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@types/react-slick", "npm:0.23.4"],
             ["@types/slick-carousel", "npm:1.6.34"],
             ["@wojtekmaj/react-daterange-picker", "virtual:bb4ed02b339ed801b02d2ec15b42a5aa7b1afdaf44119aefaab128a59d6e16cc6018880c169f24bf2107550e914562ee9e1780db01a12e1bc3c492ad0a049c36#npm:3.2.0"],
+            ["babel-jest", "virtual:bb4ed02b339ed801b02d2ec15b42a5aa7b1afdaf44119aefaab128a59d6e16cc6018880c169f24bf2107550e914562ee9e1780db01a12e1bc3c492ad0a049c36#npm:27.0.2"],
             ["bytes", "npm:3.1.0"],
             ["commafy", "npm:0.0.6"],
             ["css-loader", "virtual:bb4ed02b339ed801b02d2ec15b42a5aa7b1afdaf44119aefaab128a59d6e16cc6018880c169f24bf2107550e914562ee9e1780db01a12e1bc3c492ad0a049c36#npm:5.2.4"],
@@ -16689,6 +16868,25 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           ],
           "linkType": "HARD",
         }],
+        ["virtual:bb4ed02b339ed801b02d2ec15b42a5aa7b1afdaf44119aefaab128a59d6e16cc6018880c169f24bf2107550e914562ee9e1780db01a12e1bc3c492ad0a049c36#npm:27.0.2", {
+          "packageLocation": "./.yarn/$$virtual/babel-jest-virtual-fd764c1a64/0/cache/babel-jest-npm-27.0.2-760775130b-f12d789701.zip/node_modules/babel-jest/",
+          "packageDependencies": [
+            ["babel-jest", "virtual:bb4ed02b339ed801b02d2ec15b42a5aa7b1afdaf44119aefaab128a59d6e16cc6018880c169f24bf2107550e914562ee9e1780db01a12e1bc3c492ad0a049c36#npm:27.0.2"],
+            ["@babel/core", null],
+            ["@jest/transform", "npm:27.0.2"],
+            ["@jest/types", "npm:27.0.2"],
+            ["@types/babel__core", "npm:7.1.14"],
+            ["babel-plugin-istanbul", "npm:6.0.0"],
+            ["babel-preset-jest", "virtual:fd764c1a649245a65e484d99795bff4213e6b2593154b7b79685481df48858018ed5b418c01f78cb92c5f7540eb109ab4e2f41899cdfe2fd5154a97f58aaeab2#npm:27.0.1"],
+            ["chalk", "npm:4.1.1"],
+            ["graceful-fs", "npm:4.2.6"],
+            ["slash", "npm:3.0.0"]
+          ],
+          "packagePeers": [
+            "@babel/core"
+          ],
+          "linkType": "HARD",
+        }],
         ["virtual:caddf51df4928b33a437ca87b8f5ddfb6205ebd6d8231f74d4ee7223f3866e6f815b221aa1e2bd33e98915f701e95bae72a93d2288b49a34a6246bdbc2a4a132#npm:26.6.3", {
           "packageLocation": "./.yarn/$$virtual/babel-jest-virtual-9f33f3a3f1/0/cache/babel-jest-npm-26.6.3-5630fee2b8-89231d00e6.zip/node_modules/babel-jest/",
           "packageDependencies": [
@@ -17325,6 +17523,31 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             "@types/babel__core"
           ],
           "linkType": "HARD",
+        }],
+        ["virtual:f23cfb2f5f69b61ff41c97faea14966c791471cff43fdc91c95a53ebf94e5200c77eafb95535f32a8a18133237268bd857043e313c0fd14d61bcdc6052099aba#npm:1.0.1", {
+          "packageLocation": "./.yarn/$$virtual/babel-preset-current-node-syntax-virtual-afe501dbd5/0/cache/babel-preset-current-node-syntax-npm-1.0.1-849ec71e32-bba41cc95a.zip/node_modules/babel-preset-current-node-syntax/",
+          "packageDependencies": [
+            ["babel-preset-current-node-syntax", "virtual:f23cfb2f5f69b61ff41c97faea14966c791471cff43fdc91c95a53ebf94e5200c77eafb95535f32a8a18133237268bd857043e313c0fd14d61bcdc6052099aba#npm:1.0.1"],
+            ["@babel/core", null],
+            ["@babel/plugin-syntax-async-generators", "virtual:afe501dbd5cd31397dbc608dda7d7344230762a90ac8240d0edbc7247e1ad2e46968c90a370bafbbf7fc4626fb476eebd10da3016965960749d0067640b7805e#npm:7.8.4"],
+            ["@babel/plugin-syntax-bigint", "virtual:afe501dbd5cd31397dbc608dda7d7344230762a90ac8240d0edbc7247e1ad2e46968c90a370bafbbf7fc4626fb476eebd10da3016965960749d0067640b7805e#npm:7.8.3"],
+            ["@babel/plugin-syntax-class-properties", "virtual:afe501dbd5cd31397dbc608dda7d7344230762a90ac8240d0edbc7247e1ad2e46968c90a370bafbbf7fc4626fb476eebd10da3016965960749d0067640b7805e#npm:7.12.13"],
+            ["@babel/plugin-syntax-import-meta", "virtual:afe501dbd5cd31397dbc608dda7d7344230762a90ac8240d0edbc7247e1ad2e46968c90a370bafbbf7fc4626fb476eebd10da3016965960749d0067640b7805e#npm:7.10.4"],
+            ["@babel/plugin-syntax-json-strings", "virtual:afe501dbd5cd31397dbc608dda7d7344230762a90ac8240d0edbc7247e1ad2e46968c90a370bafbbf7fc4626fb476eebd10da3016965960749d0067640b7805e#npm:7.8.3"],
+            ["@babel/plugin-syntax-logical-assignment-operators", "virtual:afe501dbd5cd31397dbc608dda7d7344230762a90ac8240d0edbc7247e1ad2e46968c90a370bafbbf7fc4626fb476eebd10da3016965960749d0067640b7805e#npm:7.10.4"],
+            ["@babel/plugin-syntax-nullish-coalescing-operator", "virtual:afe501dbd5cd31397dbc608dda7d7344230762a90ac8240d0edbc7247e1ad2e46968c90a370bafbbf7fc4626fb476eebd10da3016965960749d0067640b7805e#npm:7.8.3"],
+            ["@babel/plugin-syntax-numeric-separator", "virtual:afe501dbd5cd31397dbc608dda7d7344230762a90ac8240d0edbc7247e1ad2e46968c90a370bafbbf7fc4626fb476eebd10da3016965960749d0067640b7805e#npm:7.10.4"],
+            ["@babel/plugin-syntax-object-rest-spread", "virtual:afe501dbd5cd31397dbc608dda7d7344230762a90ac8240d0edbc7247e1ad2e46968c90a370bafbbf7fc4626fb476eebd10da3016965960749d0067640b7805e#npm:7.8.3"],
+            ["@babel/plugin-syntax-optional-catch-binding", "virtual:afe501dbd5cd31397dbc608dda7d7344230762a90ac8240d0edbc7247e1ad2e46968c90a370bafbbf7fc4626fb476eebd10da3016965960749d0067640b7805e#npm:7.8.3"],
+            ["@babel/plugin-syntax-optional-chaining", "virtual:afe501dbd5cd31397dbc608dda7d7344230762a90ac8240d0edbc7247e1ad2e46968c90a370bafbbf7fc4626fb476eebd10da3016965960749d0067640b7805e#npm:7.8.3"],
+            ["@babel/plugin-syntax-top-level-await", "virtual:afe501dbd5cd31397dbc608dda7d7344230762a90ac8240d0edbc7247e1ad2e46968c90a370bafbbf7fc4626fb476eebd10da3016965960749d0067640b7805e#npm:7.12.13"],
+            ["@types/babel__core", "npm:7.1.14"]
+          ],
+          "packagePeers": [
+            "@babel/core",
+            "@types/babel__core"
+          ],
+          "linkType": "HARD",
         }]
       ]],
       ["babel-preset-gatsby", [
@@ -17428,6 +17651,21 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@types/babel__core", "npm:7.1.14"],
             ["babel-plugin-jest-hoist", "npm:27.0.1"],
             ["babel-preset-current-node-syntax", "virtual:953f19a93f1fd76e03de2418470b56b6b69d974bef4780f65029f0a9afcdf2f0130bfb897370a8fe1bd125d7f8113ee186caf42ece0a92789a64117e47028619#npm:1.0.1"]
+          ],
+          "packagePeers": [
+            "@babel/core",
+            "@types/babel__core"
+          ],
+          "linkType": "HARD",
+        }],
+        ["virtual:fd764c1a649245a65e484d99795bff4213e6b2593154b7b79685481df48858018ed5b418c01f78cb92c5f7540eb109ab4e2f41899cdfe2fd5154a97f58aaeab2#npm:27.0.1", {
+          "packageLocation": "./.yarn/$$virtual/babel-preset-jest-virtual-f23cfb2f5f/0/cache/babel-preset-jest-npm-27.0.1-9446ad2444-46a36c790f.zip/node_modules/babel-preset-jest/",
+          "packageDependencies": [
+            ["babel-preset-jest", "virtual:fd764c1a649245a65e484d99795bff4213e6b2593154b7b79685481df48858018ed5b418c01f78cb92c5f7540eb109ab4e2f41899cdfe2fd5154a97f58aaeab2#npm:27.0.1"],
+            ["@babel/core", null],
+            ["@types/babel__core", "npm:7.1.14"],
+            ["babel-plugin-jest-hoist", "npm:27.0.1"],
+            ["babel-preset-current-node-syntax", "virtual:f23cfb2f5f69b61ff41c97faea14966c791471cff43fdc91c95a53ebf94e5200c77eafb95535f32a8a18133237268bd857043e313c0fd14d61bcdc6052099aba#npm:1.0.1"]
           ],
           "packagePeers": [
             "@babel/core",
@@ -20107,6 +20345,13 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "packageLocation": "./.yarn/unplugged/core-js-pure-npm-3.12.1-ac3be20f93/node_modules/core-js-pure/",
           "packageDependencies": [
             ["core-js-pure", "npm:3.12.1"]
+          ],
+          "linkType": "HARD",
+        }],
+        ["npm:3.14.0", {
+          "packageLocation": "./.yarn/unplugged/core-js-pure-npm-3.14.0-9a85e5a133/node_modules/core-js-pure/",
+          "packageDependencies": [
+            ["core-js-pure", "npm:3.14.0"]
           ],
           "linkType": "HARD",
         }]

--- a/.pnp.js
+++ b/.pnp.js
@@ -82,6 +82,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@types/babel__core", "npm:7.1.14"],
             ["@types/babel__plugin-transform-runtime", "npm:7.9.1"],
             ["@types/babel__preset-env", "npm:7.9.1"],
+            ["@types/jest", "npm:26.0.23"],
             ["@typescript-eslint/eslint-plugin", "virtual:dc3fc578bfa5e06182a4d2be39ede0bc5b74940b1ffe0d70c26892ab140a4699787750fba175dc306292e80b4aa2c8c5f68c2a821e69b2c37e360c0dff36ff66#npm:4.24.0"],
             ["@typescript-eslint/parser", "virtual:dc3fc578bfa5e06182a4d2be39ede0bc5b74940b1ffe0d70c26892ab140a4699787750fba175dc306292e80b4aa2c8c5f68c2a821e69b2c37e360c0dff36ff66#npm:4.24.0"],
             ["babel-eslint", "virtual:dc3fc578bfa5e06182a4d2be39ede0bc5b74940b1ffe0d70c26892ab140a4699787750fba175dc306292e80b4aa2c8c5f68c2a821e69b2c37e360c0dff36ff66#npm:10.0.3"],
@@ -1443,6 +1444,14 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@babel/highlight", "npm:7.14.0"]
           ],
           "linkType": "HARD",
+        }],
+        ["npm:7.14.5", {
+          "packageLocation": "./.yarn/cache/@babel-code-frame-npm-7.14.5-4dc9115988-48c584cad9.zip/node_modules/@babel/code-frame/",
+          "packageDependencies": [
+            ["@babel/code-frame", "npm:7.14.5"],
+            ["@babel/highlight", "npm:7.14.5"]
+          ],
+          "linkType": "HARD",
         }]
       ]],
       ["@babel/compat-data", [
@@ -1450,6 +1459,13 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "packageLocation": "./.yarn/cache/@babel-compat-data-npm-7.14.0-150bea01c2-d2d9de745e.zip/node_modules/@babel/compat-data/",
           "packageDependencies": [
             ["@babel/compat-data", "npm:7.14.0"]
+          ],
+          "linkType": "HARD",
+        }],
+        ["npm:7.14.5", {
+          "packageLocation": "./.yarn/cache/@babel-compat-data-npm-7.14.5-112dec2d45-6ebae20f0d.zip/node_modules/@babel/compat-data/",
+          "packageDependencies": [
+            ["@babel/compat-data", "npm:7.14.5"]
           ],
           "linkType": "HARD",
         }]
@@ -1522,6 +1538,28 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["source-map", "npm:0.5.7"]
           ],
           "linkType": "HARD",
+        }],
+        ["npm:7.14.6", {
+          "packageLocation": "./.yarn/cache/@babel-core-npm-7.14.6-903c8775cb-239c4892d5.zip/node_modules/@babel/core/",
+          "packageDependencies": [
+            ["@babel/core", "npm:7.14.6"],
+            ["@babel/code-frame", "npm:7.14.5"],
+            ["@babel/generator", "npm:7.14.5"],
+            ["@babel/helper-compilation-targets", "virtual:903c8775cb0379658ab56ed3a64ed12967b8bb18efb0d35a2b93f57ec507e9b0a60e0b3f62bc0d002f3f7ca1eec436e47e329f33f7a698c7bf2c2a010c67440a#npm:7.14.5"],
+            ["@babel/helper-module-transforms", "npm:7.14.5"],
+            ["@babel/helpers", "npm:7.14.6"],
+            ["@babel/parser", "npm:7.14.6"],
+            ["@babel/template", "npm:7.14.5"],
+            ["@babel/traverse", "npm:7.14.5"],
+            ["@babel/types", "npm:7.14.5"],
+            ["convert-source-map", "npm:1.7.0"],
+            ["debug", "virtual:5dffae5dceca8d383e37ce1404983ff3eaf566153fb551aede58a16b625356caee63d9240a4386c2b8b44a2ff32b72c5d4444045ea31775b520ccbc9788f7985#npm:4.3.2"],
+            ["gensync", "npm:1.0.0-beta.2"],
+            ["json5", "npm:2.2.0"],
+            ["semver", "npm:6.3.0"],
+            ["source-map", "npm:0.5.7"]
+          ],
+          "linkType": "HARD",
         }]
       ]],
       ["@babel/generator", [
@@ -1530,6 +1568,16 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "packageDependencies": [
             ["@babel/generator", "npm:7.14.3"],
             ["@babel/types", "npm:7.14.2"],
+            ["jsesc", "npm:2.5.2"],
+            ["source-map", "npm:0.5.7"]
+          ],
+          "linkType": "HARD",
+        }],
+        ["npm:7.14.5", {
+          "packageLocation": "./.yarn/cache/@babel-generator-npm-7.14.5-296ef77bb1-3ba48b75f7.zip/node_modules/@babel/generator/",
+          "packageDependencies": [
+            ["@babel/generator", "npm:7.14.5"],
+            ["@babel/types", "npm:7.14.5"],
             ["jsesc", "npm:2.5.2"],
             ["source-map", "npm:0.5.7"]
           ],
@@ -1565,6 +1613,13 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           ],
           "linkType": "SOFT",
         }],
+        ["npm:7.14.5", {
+          "packageLocation": "./.yarn/cache/@babel-helper-compilation-targets-npm-7.14.5-6e863fed9a-db7d58fc73.zip/node_modules/@babel/helper-compilation-targets/",
+          "packageDependencies": [
+            ["@babel/helper-compilation-targets", "npm:7.14.5"]
+          ],
+          "linkType": "SOFT",
+        }],
         ["virtual:3ce37a0e936e0efde19b67518238fc700260331b3f5d66e3dea953b92e5b89323378bc39738c97f2bf98ea98037cfa4fe88db4210846658d54ce2e6cbab4b0a4#npm:7.13.16", {
           "packageLocation": "./.yarn/$$virtual/@babel-helper-compilation-targets-virtual-c7001ee5eb/0/cache/@babel-helper-compilation-targets-npm-7.13.16-e8eed91d8d-baa1e4cdd5.zip/node_modules/@babel/helper-compilation-targets/",
           "packageDependencies": [
@@ -1589,6 +1644,23 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@babel/compat-data", "npm:7.14.0"],
             ["@babel/core", null],
             ["@babel/helper-validator-option", "npm:7.12.17"],
+            ["@types/babel__core", null],
+            ["browserslist", "npm:4.16.6"],
+            ["semver", "npm:6.3.0"]
+          ],
+          "packagePeers": [
+            "@babel/core",
+            "@types/babel__core"
+          ],
+          "linkType": "HARD",
+        }],
+        ["virtual:903c8775cb0379658ab56ed3a64ed12967b8bb18efb0d35a2b93f57ec507e9b0a60e0b3f62bc0d002f3f7ca1eec436e47e329f33f7a698c7bf2c2a010c67440a#npm:7.14.5", {
+          "packageLocation": "./.yarn/$$virtual/@babel-helper-compilation-targets-virtual-f2e7833ef5/0/cache/@babel-helper-compilation-targets-npm-7.14.5-6e863fed9a-db7d58fc73.zip/node_modules/@babel/helper-compilation-targets/",
+          "packageDependencies": [
+            ["@babel/helper-compilation-targets", "virtual:903c8775cb0379658ab56ed3a64ed12967b8bb18efb0d35a2b93f57ec507e9b0a60e0b3f62bc0d002f3f7ca1eec436e47e329f33f7a698c7bf2c2a010c67440a#npm:7.14.5"],
+            ["@babel/compat-data", "npm:7.14.5"],
+            ["@babel/core", "npm:7.14.6"],
+            ["@babel/helper-validator-option", "npm:7.14.5"],
             ["@types/babel__core", null],
             ["browserslist", "npm:4.16.6"],
             ["semver", "npm:6.3.0"]
@@ -1857,6 +1929,16 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@babel/types", "npm:7.14.2"]
           ],
           "linkType": "HARD",
+        }],
+        ["npm:7.14.5", {
+          "packageLocation": "./.yarn/cache/@babel-helper-function-name-npm-7.14.5-5fe13634f6-bf2172f932.zip/node_modules/@babel/helper-function-name/",
+          "packageDependencies": [
+            ["@babel/helper-function-name", "npm:7.14.5"],
+            ["@babel/helper-get-function-arity", "npm:7.14.5"],
+            ["@babel/template", "npm:7.14.5"],
+            ["@babel/types", "npm:7.14.5"]
+          ],
+          "linkType": "HARD",
         }]
       ]],
       ["@babel/helper-get-function-arity", [
@@ -1865,6 +1947,14 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "packageDependencies": [
             ["@babel/helper-get-function-arity", "npm:7.12.13"],
             ["@babel/types", "npm:7.14.2"]
+          ],
+          "linkType": "HARD",
+        }],
+        ["npm:7.14.5", {
+          "packageLocation": "./.yarn/cache/@babel-helper-get-function-arity-npm-7.14.5-e6a90e49c5-1bd0ae6c25.zip/node_modules/@babel/helper-get-function-arity/",
+          "packageDependencies": [
+            ["@babel/helper-get-function-arity", "npm:7.14.5"],
+            ["@babel/types", "npm:7.14.5"]
           ],
           "linkType": "HARD",
         }]
@@ -1878,6 +1968,14 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@babel/types", "npm:7.14.2"]
           ],
           "linkType": "HARD",
+        }],
+        ["npm:7.14.5", {
+          "packageLocation": "./.yarn/cache/@babel-helper-hoist-variables-npm-7.14.5-e24b531b4d-c2fdc5a239.zip/node_modules/@babel/helper-hoist-variables/",
+          "packageDependencies": [
+            ["@babel/helper-hoist-variables", "npm:7.14.5"],
+            ["@babel/types", "npm:7.14.5"]
+          ],
+          "linkType": "HARD",
         }]
       ]],
       ["@babel/helper-member-expression-to-functions", [
@@ -1888,6 +1986,14 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@babel/types", "npm:7.14.2"]
           ],
           "linkType": "HARD",
+        }],
+        ["npm:7.14.5", {
+          "packageLocation": "./.yarn/cache/@babel-helper-member-expression-to-functions-npm-7.14.5-3c6b23a39a-9dc1a8a5de.zip/node_modules/@babel/helper-member-expression-to-functions/",
+          "packageDependencies": [
+            ["@babel/helper-member-expression-to-functions", "npm:7.14.5"],
+            ["@babel/types", "npm:7.14.5"]
+          ],
+          "linkType": "HARD",
         }]
       ]],
       ["@babel/helper-module-imports", [
@@ -1896,6 +2002,14 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "packageDependencies": [
             ["@babel/helper-module-imports", "npm:7.13.12"],
             ["@babel/types", "npm:7.14.2"]
+          ],
+          "linkType": "HARD",
+        }],
+        ["npm:7.14.5", {
+          "packageLocation": "./.yarn/cache/@babel-helper-module-imports-npm-7.14.5-11d168065b-483919bf31.zip/node_modules/@babel/helper-module-imports/",
+          "packageDependencies": [
+            ["@babel/helper-module-imports", "npm:7.14.5"],
+            ["@babel/types", "npm:7.14.5"]
           ],
           "linkType": "HARD",
         }]
@@ -1915,6 +2029,21 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@babel/types", "npm:7.14.2"]
           ],
           "linkType": "HARD",
+        }],
+        ["npm:7.14.5", {
+          "packageLocation": "./.yarn/cache/@babel-helper-module-transforms-npm-7.14.5-6e33b6adf7-b6f47b812d.zip/node_modules/@babel/helper-module-transforms/",
+          "packageDependencies": [
+            ["@babel/helper-module-transforms", "npm:7.14.5"],
+            ["@babel/helper-module-imports", "npm:7.14.5"],
+            ["@babel/helper-replace-supers", "npm:7.14.5"],
+            ["@babel/helper-simple-access", "npm:7.14.5"],
+            ["@babel/helper-split-export-declaration", "npm:7.14.5"],
+            ["@babel/helper-validator-identifier", "npm:7.14.5"],
+            ["@babel/template", "npm:7.14.5"],
+            ["@babel/traverse", "npm:7.14.5"],
+            ["@babel/types", "npm:7.14.5"]
+          ],
+          "linkType": "HARD",
         }]
       ]],
       ["@babel/helper-optimise-call-expression", [
@@ -1923,6 +2052,14 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "packageDependencies": [
             ["@babel/helper-optimise-call-expression", "npm:7.12.13"],
             ["@babel/types", "npm:7.14.2"]
+          ],
+          "linkType": "HARD",
+        }],
+        ["npm:7.14.5", {
+          "packageLocation": "./.yarn/cache/@babel-helper-optimise-call-expression-npm-7.14.5-9d0e7b0f83-68845ee7fb.zip/node_modules/@babel/helper-optimise-call-expression/",
+          "packageDependencies": [
+            ["@babel/helper-optimise-call-expression", "npm:7.14.5"],
+            ["@babel/types", "npm:7.14.5"]
           ],
           "linkType": "HARD",
         }]
@@ -1939,6 +2076,13 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "packageLocation": "./.yarn/cache/@babel-helper-plugin-utils-npm-7.13.0-5266a343c1-229ac1917b.zip/node_modules/@babel/helper-plugin-utils/",
           "packageDependencies": [
             ["@babel/helper-plugin-utils", "npm:7.13.0"]
+          ],
+          "linkType": "HARD",
+        }],
+        ["npm:7.14.5", {
+          "packageLocation": "./.yarn/cache/@babel-helper-plugin-utils-npm-7.14.5-e35eef11cb-76404ef3aa.zip/node_modules/@babel/helper-plugin-utils/",
+          "packageDependencies": [
+            ["@babel/helper-plugin-utils", "npm:7.14.5"]
           ],
           "linkType": "HARD",
         }]
@@ -1966,6 +2110,17 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@babel/types", "npm:7.14.2"]
           ],
           "linkType": "HARD",
+        }],
+        ["npm:7.14.5", {
+          "packageLocation": "./.yarn/cache/@babel-helper-replace-supers-npm-7.14.5-871214921c-368aba02e7.zip/node_modules/@babel/helper-replace-supers/",
+          "packageDependencies": [
+            ["@babel/helper-replace-supers", "npm:7.14.5"],
+            ["@babel/helper-member-expression-to-functions", "npm:7.14.5"],
+            ["@babel/helper-optimise-call-expression", "npm:7.14.5"],
+            ["@babel/traverse", "npm:7.14.5"],
+            ["@babel/types", "npm:7.14.5"]
+          ],
+          "linkType": "HARD",
         }]
       ]],
       ["@babel/helper-simple-access", [
@@ -1974,6 +2129,14 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "packageDependencies": [
             ["@babel/helper-simple-access", "npm:7.13.12"],
             ["@babel/types", "npm:7.14.2"]
+          ],
+          "linkType": "HARD",
+        }],
+        ["npm:7.14.5", {
+          "packageLocation": "./.yarn/cache/@babel-helper-simple-access-npm-7.14.5-fbcf0c968b-dd6de62de5.zip/node_modules/@babel/helper-simple-access/",
+          "packageDependencies": [
+            ["@babel/helper-simple-access", "npm:7.14.5"],
+            ["@babel/types", "npm:7.14.5"]
           ],
           "linkType": "HARD",
         }]
@@ -1996,6 +2159,14 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@babel/types", "npm:7.14.2"]
           ],
           "linkType": "HARD",
+        }],
+        ["npm:7.14.5", {
+          "packageLocation": "./.yarn/cache/@babel-helper-split-export-declaration-npm-7.14.5-193bcc5a6e-8096562768.zip/node_modules/@babel/helper-split-export-declaration/",
+          "packageDependencies": [
+            ["@babel/helper-split-export-declaration", "npm:7.14.5"],
+            ["@babel/types", "npm:7.14.5"]
+          ],
+          "linkType": "HARD",
         }]
       ]],
       ["@babel/helper-validator-identifier", [
@@ -2005,6 +2176,13 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@babel/helper-validator-identifier", "npm:7.14.0"]
           ],
           "linkType": "HARD",
+        }],
+        ["npm:7.14.5", {
+          "packageLocation": "./.yarn/cache/@babel-helper-validator-identifier-npm-7.14.5-d29d30a813-778312189a.zip/node_modules/@babel/helper-validator-identifier/",
+          "packageDependencies": [
+            ["@babel/helper-validator-identifier", "npm:7.14.5"]
+          ],
+          "linkType": "HARD",
         }]
       ]],
       ["@babel/helper-validator-option", [
@@ -2012,6 +2190,13 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "packageLocation": "./.yarn/cache/@babel-helper-validator-option-npm-7.12.17-098722d989-9201d17a56.zip/node_modules/@babel/helper-validator-option/",
           "packageDependencies": [
             ["@babel/helper-validator-option", "npm:7.12.17"]
+          ],
+          "linkType": "HARD",
+        }],
+        ["npm:7.14.5", {
+          "packageLocation": "./.yarn/cache/@babel-helper-validator-option-npm-7.14.5-fd38dcf0bc-aded46b377.zip/node_modules/@babel/helper-validator-option/",
+          "packageDependencies": [
+            ["@babel/helper-validator-option", "npm:7.14.5"]
           ],
           "linkType": "HARD",
         }]
@@ -2039,6 +2224,16 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@babel/types", "npm:7.14.2"]
           ],
           "linkType": "HARD",
+        }],
+        ["npm:7.14.6", {
+          "packageLocation": "./.yarn/cache/@babel-helpers-npm-7.14.6-98a6c32cb0-c5c3bd0f96.zip/node_modules/@babel/helpers/",
+          "packageDependencies": [
+            ["@babel/helpers", "npm:7.14.6"],
+            ["@babel/template", "npm:7.14.5"],
+            ["@babel/traverse", "npm:7.14.5"],
+            ["@babel/types", "npm:7.14.5"]
+          ],
+          "linkType": "HARD",
         }]
       ]],
       ["@babel/highlight", [
@@ -2051,6 +2246,16 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["js-tokens", "npm:4.0.0"]
           ],
           "linkType": "HARD",
+        }],
+        ["npm:7.14.5", {
+          "packageLocation": "./.yarn/cache/@babel-highlight-npm-7.14.5-4a18106cbc-a1ed599c26.zip/node_modules/@babel/highlight/",
+          "packageDependencies": [
+            ["@babel/highlight", "npm:7.14.5"],
+            ["@babel/helper-validator-identifier", "npm:7.14.5"],
+            ["chalk", "npm:2.4.2"],
+            ["js-tokens", "npm:4.0.0"]
+          ],
+          "linkType": "HARD",
         }]
       ]],
       ["@babel/parser", [
@@ -2058,6 +2263,14 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "packageLocation": "./.yarn/cache/@babel-parser-npm-7.14.3-4c3311dd2f-5e8d1b2bfc.zip/node_modules/@babel/parser/",
           "packageDependencies": [
             ["@babel/parser", "npm:7.14.3"],
+            ["@babel/types", "npm:7.14.2"]
+          ],
+          "linkType": "HARD",
+        }],
+        ["npm:7.14.6", {
+          "packageLocation": "./.yarn/cache/@babel-parser-npm-7.14.6-c6c1f6245c-447ca2627e.zip/node_modules/@babel/parser/",
+          "packageDependencies": [
+            ["@babel/parser", "npm:7.14.6"],
             ["@babel/types", "npm:7.14.2"]
           ],
           "linkType": "HARD",
@@ -3098,6 +3311,20 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             "@types/babel__core"
           ],
           "linkType": "HARD",
+        }],
+        ["virtual:a3a4f4643e7d0c65c31a712cd46aba0b8487b675872907335e0bceb93bb44d826cbe3d594988130623f39063afba3a66553732003e67403b25195eeb5a26aa62#npm:7.8.4", {
+          "packageLocation": "./.yarn/$$virtual/@babel-plugin-syntax-async-generators-virtual-55039447d2/0/cache/@babel-plugin-syntax-async-generators-npm-7.8.4-d10cf993c9-39685944ff.zip/node_modules/@babel/plugin-syntax-async-generators/",
+          "packageDependencies": [
+            ["@babel/plugin-syntax-async-generators", "virtual:a3a4f4643e7d0c65c31a712cd46aba0b8487b675872907335e0bceb93bb44d826cbe3d594988130623f39063afba3a66553732003e67403b25195eeb5a26aa62#npm:7.8.4"],
+            ["@babel/core", "npm:7.14.6"],
+            ["@babel/helper-plugin-utils", "npm:7.13.0"],
+            ["@types/babel__core", null]
+          ],
+          "packagePeers": [
+            "@babel/core",
+            "@types/babel__core"
+          ],
+          "linkType": "HARD",
         }]
       ]],
       ["@babel/plugin-syntax-bigint", [
@@ -3115,6 +3342,20 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@babel/core", "npm:7.14.3"],
             ["@babel/helper-plugin-utils", "npm:7.13.0"],
             ["@types/babel__core", "npm:7.1.14"]
+          ],
+          "packagePeers": [
+            "@babel/core",
+            "@types/babel__core"
+          ],
+          "linkType": "HARD",
+        }],
+        ["virtual:a3a4f4643e7d0c65c31a712cd46aba0b8487b675872907335e0bceb93bb44d826cbe3d594988130623f39063afba3a66553732003e67403b25195eeb5a26aa62#npm:7.8.3", {
+          "packageLocation": "./.yarn/$$virtual/@babel-plugin-syntax-bigint-virtual-7d2b4916be/0/cache/@babel-plugin-syntax-bigint-npm-7.8.3-b05d971e6c-8c9b610377.zip/node_modules/@babel/plugin-syntax-bigint/",
+          "packageDependencies": [
+            ["@babel/plugin-syntax-bigint", "virtual:a3a4f4643e7d0c65c31a712cd46aba0b8487b675872907335e0bceb93bb44d826cbe3d594988130623f39063afba3a66553732003e67403b25195eeb5a26aa62#npm:7.8.3"],
+            ["@babel/core", "npm:7.14.6"],
+            ["@babel/helper-plugin-utils", "npm:7.13.0"],
+            ["@types/babel__core", null]
           ],
           "packagePeers": [
             "@babel/core",
@@ -3166,6 +3407,20 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@babel/core", "npm:7.14.3"],
             ["@babel/helper-plugin-utils", "npm:7.13.0"],
             ["@types/babel__core", "npm:7.1.14"]
+          ],
+          "packagePeers": [
+            "@babel/core",
+            "@types/babel__core"
+          ],
+          "linkType": "HARD",
+        }],
+        ["virtual:a3a4f4643e7d0c65c31a712cd46aba0b8487b675872907335e0bceb93bb44d826cbe3d594988130623f39063afba3a66553732003e67403b25195eeb5a26aa62#npm:7.12.13", {
+          "packageLocation": "./.yarn/$$virtual/@babel-plugin-syntax-class-properties-virtual-f06f44bd0c/0/cache/@babel-plugin-syntax-class-properties-npm-7.12.13-002ee9d930-3023dec8ac.zip/node_modules/@babel/plugin-syntax-class-properties/",
+          "packageDependencies": [
+            ["@babel/plugin-syntax-class-properties", "virtual:a3a4f4643e7d0c65c31a712cd46aba0b8487b675872907335e0bceb93bb44d826cbe3d594988130623f39063afba3a66553732003e67403b25195eeb5a26aa62#npm:7.12.13"],
+            ["@babel/core", "npm:7.14.6"],
+            ["@babel/helper-plugin-utils", "npm:7.13.0"],
+            ["@types/babel__core", null]
           ],
           "packagePeers": [
             "@babel/core",
@@ -3417,6 +3672,20 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             "@types/babel__core"
           ],
           "linkType": "HARD",
+        }],
+        ["virtual:a3a4f4643e7d0c65c31a712cd46aba0b8487b675872907335e0bceb93bb44d826cbe3d594988130623f39063afba3a66553732003e67403b25195eeb5a26aa62#npm:7.10.4", {
+          "packageLocation": "./.yarn/$$virtual/@babel-plugin-syntax-import-meta-virtual-ecddd0e7c7/0/cache/@babel-plugin-syntax-import-meta-npm-7.10.4-4a0a0158bc-685ee8f0b5.zip/node_modules/@babel/plugin-syntax-import-meta/",
+          "packageDependencies": [
+            ["@babel/plugin-syntax-import-meta", "virtual:a3a4f4643e7d0c65c31a712cd46aba0b8487b675872907335e0bceb93bb44d826cbe3d594988130623f39063afba3a66553732003e67403b25195eeb5a26aa62#npm:7.10.4"],
+            ["@babel/core", "npm:7.14.6"],
+            ["@babel/helper-plugin-utils", "npm:7.13.0"],
+            ["@types/babel__core", null]
+          ],
+          "packagePeers": [
+            "@babel/core",
+            "@types/babel__core"
+          ],
+          "linkType": "HARD",
         }]
       ]],
       ["@babel/plugin-syntax-json-strings", [
@@ -3462,6 +3731,20 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@babel/core", "npm:7.14.3"],
             ["@babel/helper-plugin-utils", "npm:7.13.0"],
             ["@types/babel__core", "npm:7.1.14"]
+          ],
+          "packagePeers": [
+            "@babel/core",
+            "@types/babel__core"
+          ],
+          "linkType": "HARD",
+        }],
+        ["virtual:a3a4f4643e7d0c65c31a712cd46aba0b8487b675872907335e0bceb93bb44d826cbe3d594988130623f39063afba3a66553732003e67403b25195eeb5a26aa62#npm:7.8.3", {
+          "packageLocation": "./.yarn/$$virtual/@babel-plugin-syntax-json-strings-virtual-9b6be0846e/0/cache/@babel-plugin-syntax-json-strings-npm-7.8.3-6dc7848179-1a7dabf0a4.zip/node_modules/@babel/plugin-syntax-json-strings/",
+          "packageDependencies": [
+            ["@babel/plugin-syntax-json-strings", "virtual:a3a4f4643e7d0c65c31a712cd46aba0b8487b675872907335e0bceb93bb44d826cbe3d594988130623f39063afba3a66553732003e67403b25195eeb5a26aa62#npm:7.8.3"],
+            ["@babel/core", "npm:7.14.6"],
+            ["@babel/helper-plugin-utils", "npm:7.13.0"],
+            ["@types/babel__core", null]
           ],
           "packagePeers": [
             "@babel/core",
@@ -3612,6 +3895,20 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             "@types/babel__core"
           ],
           "linkType": "HARD",
+        }],
+        ["virtual:a3a4f4643e7d0c65c31a712cd46aba0b8487b675872907335e0bceb93bb44d826cbe3d594988130623f39063afba3a66553732003e67403b25195eeb5a26aa62#npm:7.10.4", {
+          "packageLocation": "./.yarn/$$virtual/@babel-plugin-syntax-logical-assignment-operators-virtual-c16947b781/0/cache/@babel-plugin-syntax-logical-assignment-operators-npm-7.10.4-72ae00fdf6-5b82f71770.zip/node_modules/@babel/plugin-syntax-logical-assignment-operators/",
+          "packageDependencies": [
+            ["@babel/plugin-syntax-logical-assignment-operators", "virtual:a3a4f4643e7d0c65c31a712cd46aba0b8487b675872907335e0bceb93bb44d826cbe3d594988130623f39063afba3a66553732003e67403b25195eeb5a26aa62#npm:7.10.4"],
+            ["@babel/core", "npm:7.14.6"],
+            ["@babel/helper-plugin-utils", "npm:7.13.0"],
+            ["@types/babel__core", null]
+          ],
+          "packagePeers": [
+            "@babel/core",
+            "@types/babel__core"
+          ],
+          "linkType": "HARD",
         }]
       ]],
       ["@babel/plugin-syntax-nullish-coalescing-operator", [
@@ -3663,6 +3960,20 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             "@types/babel__core"
           ],
           "linkType": "HARD",
+        }],
+        ["virtual:a3a4f4643e7d0c65c31a712cd46aba0b8487b675872907335e0bceb93bb44d826cbe3d594988130623f39063afba3a66553732003e67403b25195eeb5a26aa62#npm:7.8.3", {
+          "packageLocation": "./.yarn/$$virtual/@babel-plugin-syntax-nullish-coalescing-operator-virtual-b6f910b647/0/cache/@babel-plugin-syntax-nullish-coalescing-operator-npm-7.8.3-8a723173b5-4ba0375375.zip/node_modules/@babel/plugin-syntax-nullish-coalescing-operator/",
+          "packageDependencies": [
+            ["@babel/plugin-syntax-nullish-coalescing-operator", "virtual:a3a4f4643e7d0c65c31a712cd46aba0b8487b675872907335e0bceb93bb44d826cbe3d594988130623f39063afba3a66553732003e67403b25195eeb5a26aa62#npm:7.8.3"],
+            ["@babel/core", "npm:7.14.6"],
+            ["@babel/helper-plugin-utils", "npm:7.13.0"],
+            ["@types/babel__core", null]
+          ],
+          "packagePeers": [
+            "@babel/core",
+            "@types/babel__core"
+          ],
+          "linkType": "HARD",
         }]
       ]],
       ["@babel/plugin-syntax-numeric-separator", [
@@ -3708,6 +4019,20 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@babel/core", "npm:7.14.3"],
             ["@babel/helper-plugin-utils", "npm:7.13.0"],
             ["@types/babel__core", "npm:7.1.14"]
+          ],
+          "packagePeers": [
+            "@babel/core",
+            "@types/babel__core"
+          ],
+          "linkType": "HARD",
+        }],
+        ["virtual:a3a4f4643e7d0c65c31a712cd46aba0b8487b675872907335e0bceb93bb44d826cbe3d594988130623f39063afba3a66553732003e67403b25195eeb5a26aa62#npm:7.10.4", {
+          "packageLocation": "./.yarn/$$virtual/@babel-plugin-syntax-numeric-separator-virtual-de2cefea48/0/cache/@babel-plugin-syntax-numeric-separator-npm-7.10.4-81444be605-47ae878293.zip/node_modules/@babel/plugin-syntax-numeric-separator/",
+          "packageDependencies": [
+            ["@babel/plugin-syntax-numeric-separator", "virtual:a3a4f4643e7d0c65c31a712cd46aba0b8487b675872907335e0bceb93bb44d826cbe3d594988130623f39063afba3a66553732003e67403b25195eeb5a26aa62#npm:7.10.4"],
+            ["@babel/core", "npm:7.14.6"],
+            ["@babel/helper-plugin-utils", "npm:7.13.0"],
+            ["@types/babel__core", null]
           ],
           "packagePeers": [
             "@babel/core",
@@ -3780,6 +4105,20 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           ],
           "linkType": "HARD",
         }],
+        ["virtual:a3a4f4643e7d0c65c31a712cd46aba0b8487b675872907335e0bceb93bb44d826cbe3d594988130623f39063afba3a66553732003e67403b25195eeb5a26aa62#npm:7.8.3", {
+          "packageLocation": "./.yarn/$$virtual/@babel-plugin-syntax-object-rest-spread-virtual-dd915509a1/0/cache/@babel-plugin-syntax-object-rest-spread-npm-7.8.3-60bd05b6ae-db5dfb39fa.zip/node_modules/@babel/plugin-syntax-object-rest-spread/",
+          "packageDependencies": [
+            ["@babel/plugin-syntax-object-rest-spread", "virtual:a3a4f4643e7d0c65c31a712cd46aba0b8487b675872907335e0bceb93bb44d826cbe3d594988130623f39063afba3a66553732003e67403b25195eeb5a26aa62#npm:7.8.3"],
+            ["@babel/core", "npm:7.14.6"],
+            ["@babel/helper-plugin-utils", "npm:7.13.0"],
+            ["@types/babel__core", null]
+          ],
+          "packagePeers": [
+            "@babel/core",
+            "@types/babel__core"
+          ],
+          "linkType": "HARD",
+        }],
         ["virtual:f6ad346c03ca00bdd6689dddf792d9d913ccc565d113120ca12f09dc9a367146e863108f86c9c8f114b10becd648148f6352be7102e5a67baf7715a5fe2553a8#npm:7.8.3", {
           "packageLocation": "./.yarn/$$virtual/@babel-plugin-syntax-object-rest-spread-virtual-7049db6edc/0/cache/@babel-plugin-syntax-object-rest-spread-npm-7.8.3-60bd05b6ae-db5dfb39fa.zip/node_modules/@babel/plugin-syntax-object-rest-spread/",
           "packageDependencies": [
@@ -3844,6 +4183,20 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             "@types/babel__core"
           ],
           "linkType": "HARD",
+        }],
+        ["virtual:a3a4f4643e7d0c65c31a712cd46aba0b8487b675872907335e0bceb93bb44d826cbe3d594988130623f39063afba3a66553732003e67403b25195eeb5a26aa62#npm:7.8.3", {
+          "packageLocation": "./.yarn/$$virtual/@babel-plugin-syntax-optional-catch-binding-virtual-5a2403b89c/0/cache/@babel-plugin-syntax-optional-catch-binding-npm-7.8.3-ce337427d8-f03d075266.zip/node_modules/@babel/plugin-syntax-optional-catch-binding/",
+          "packageDependencies": [
+            ["@babel/plugin-syntax-optional-catch-binding", "virtual:a3a4f4643e7d0c65c31a712cd46aba0b8487b675872907335e0bceb93bb44d826cbe3d594988130623f39063afba3a66553732003e67403b25195eeb5a26aa62#npm:7.8.3"],
+            ["@babel/core", "npm:7.14.6"],
+            ["@babel/helper-plugin-utils", "npm:7.13.0"],
+            ["@types/babel__core", null]
+          ],
+          "packagePeers": [
+            "@babel/core",
+            "@types/babel__core"
+          ],
+          "linkType": "HARD",
         }]
       ]],
       ["@babel/plugin-syntax-optional-chaining", [
@@ -3889,6 +4242,20 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@babel/core", "npm:7.14.3"],
             ["@babel/helper-plugin-utils", "npm:7.13.0"],
             ["@types/babel__core", "npm:7.1.14"]
+          ],
+          "packagePeers": [
+            "@babel/core",
+            "@types/babel__core"
+          ],
+          "linkType": "HARD",
+        }],
+        ["virtual:a3a4f4643e7d0c65c31a712cd46aba0b8487b675872907335e0bceb93bb44d826cbe3d594988130623f39063afba3a66553732003e67403b25195eeb5a26aa62#npm:7.8.3", {
+          "packageLocation": "./.yarn/$$virtual/@babel-plugin-syntax-optional-chaining-virtual-95d33322b2/0/cache/@babel-plugin-syntax-optional-chaining-npm-7.8.3-f3f3c79579-2a50685d02.zip/node_modules/@babel/plugin-syntax-optional-chaining/",
+          "packageDependencies": [
+            ["@babel/plugin-syntax-optional-chaining", "virtual:a3a4f4643e7d0c65c31a712cd46aba0b8487b675872907335e0bceb93bb44d826cbe3d594988130623f39063afba3a66553732003e67403b25195eeb5a26aa62#npm:7.8.3"],
+            ["@babel/core", "npm:7.14.6"],
+            ["@babel/helper-plugin-utils", "npm:7.13.0"],
+            ["@types/babel__core", null]
           ],
           "packagePeers": [
             "@babel/core",
@@ -3997,6 +4364,20 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             "@types/babel__core"
           ],
           "linkType": "HARD",
+        }],
+        ["virtual:a3a4f4643e7d0c65c31a712cd46aba0b8487b675872907335e0bceb93bb44d826cbe3d594988130623f39063afba3a66553732003e67403b25195eeb5a26aa62#npm:7.12.13", {
+          "packageLocation": "./.yarn/$$virtual/@babel-plugin-syntax-top-level-await-virtual-3be30b8619/0/cache/@babel-plugin-syntax-top-level-await-npm-7.12.13-6ac12f7c33-5bd0a65b01.zip/node_modules/@babel/plugin-syntax-top-level-await/",
+          "packageDependencies": [
+            ["@babel/plugin-syntax-top-level-await", "virtual:a3a4f4643e7d0c65c31a712cd46aba0b8487b675872907335e0bceb93bb44d826cbe3d594988130623f39063afba3a66553732003e67403b25195eeb5a26aa62#npm:7.12.13"],
+            ["@babel/core", "npm:7.14.6"],
+            ["@babel/helper-plugin-utils", "npm:7.13.0"],
+            ["@types/babel__core", null]
+          ],
+          "packagePeers": [
+            "@babel/core",
+            "@types/babel__core"
+          ],
+          "linkType": "HARD",
         }]
       ]],
       ["@babel/plugin-syntax-typescript", [
@@ -4007,12 +4388,33 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           ],
           "linkType": "SOFT",
         }],
+        ["npm:7.14.5", {
+          "packageLocation": "./.yarn/cache/@babel-plugin-syntax-typescript-npm-7.14.5-78c2a6af3a-1b26952c0f.zip/node_modules/@babel/plugin-syntax-typescript/",
+          "packageDependencies": [
+            ["@babel/plugin-syntax-typescript", "npm:7.14.5"]
+          ],
+          "linkType": "SOFT",
+        }],
         ["virtual:00a260e6341c114b60f992e6c65cfdc44979e10c4015bf8981b733a320e508ce9438531bec7006a7047035e77503a195ff27123d45ed7b27138de3bab8fb454f#npm:7.12.13", {
           "packageLocation": "./.yarn/$$virtual/@babel-plugin-syntax-typescript-virtual-b7104eacf1/0/cache/@babel-plugin-syntax-typescript-npm-7.12.13-17e8d888d4-ea2b4aad35.zip/node_modules/@babel/plugin-syntax-typescript/",
           "packageDependencies": [
             ["@babel/plugin-syntax-typescript", "virtual:00a260e6341c114b60f992e6c65cfdc44979e10c4015bf8981b733a320e508ce9438531bec7006a7047035e77503a195ff27123d45ed7b27138de3bab8fb454f#npm:7.12.13"],
             ["@babel/core", "npm:7.14.3"],
             ["@babel/helper-plugin-utils", "npm:7.13.0"],
+            ["@types/babel__core", null]
+          ],
+          "packagePeers": [
+            "@babel/core",
+            "@types/babel__core"
+          ],
+          "linkType": "HARD",
+        }],
+        ["virtual:41adfef6e7fb7a1ecc1b7290eb28a8b5de0de3de8c9b7f3ffb7686a1ef14c1f8879217dd2210057b268490babbb69c4162520cfa0f9012288af824f2f508c134#npm:7.14.5", {
+          "packageLocation": "./.yarn/$$virtual/@babel-plugin-syntax-typescript-virtual-c129a12993/0/cache/@babel-plugin-syntax-typescript-npm-7.14.5-78c2a6af3a-1b26952c0f.zip/node_modules/@babel/plugin-syntax-typescript/",
+          "packageDependencies": [
+            ["@babel/plugin-syntax-typescript", "virtual:41adfef6e7fb7a1ecc1b7290eb28a8b5de0de3de8c9b7f3ffb7686a1ef14c1f8879217dd2210057b268490babbb69c4162520cfa0f9012288af824f2f508c134#npm:7.14.5"],
+            ["@babel/core", "npm:7.14.6"],
+            ["@babel/helper-plugin-utils", "npm:7.14.5"],
             ["@types/babel__core", null]
           ],
           "packagePeers": [
@@ -6650,6 +7052,16 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@babel/types", "npm:7.14.2"]
           ],
           "linkType": "HARD",
+        }],
+        ["npm:7.14.5", {
+          "packageLocation": "./.yarn/cache/@babel-template-npm-7.14.5-98e7aff771-71619e2e3d.zip/node_modules/@babel/template/",
+          "packageDependencies": [
+            ["@babel/template", "npm:7.14.5"],
+            ["@babel/code-frame", "npm:7.14.5"],
+            ["@babel/parser", "npm:7.14.6"],
+            ["@babel/types", "npm:7.14.5"]
+          ],
+          "linkType": "HARD",
         }]
       ]],
       ["@babel/traverse", [
@@ -6667,6 +7079,22 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["globals", "npm:11.12.0"]
           ],
           "linkType": "HARD",
+        }],
+        ["npm:7.14.5", {
+          "packageLocation": "./.yarn/cache/@babel-traverse-npm-7.14.5-3d930726ec-3104bd5c4c.zip/node_modules/@babel/traverse/",
+          "packageDependencies": [
+            ["@babel/traverse", "npm:7.14.5"],
+            ["@babel/code-frame", "npm:7.14.5"],
+            ["@babel/generator", "npm:7.14.5"],
+            ["@babel/helper-function-name", "npm:7.14.5"],
+            ["@babel/helper-hoist-variables", "npm:7.14.5"],
+            ["@babel/helper-split-export-declaration", "npm:7.14.5"],
+            ["@babel/parser", "npm:7.14.6"],
+            ["@babel/types", "npm:7.14.5"],
+            ["debug", "virtual:5dffae5dceca8d383e37ce1404983ff3eaf566153fb551aede58a16b625356caee63d9240a4386c2b8b44a2ff32b72c5d4444045ea31775b520ccbc9788f7985#npm:4.3.2"],
+            ["globals", "npm:11.12.0"]
+          ],
+          "linkType": "HARD",
         }]
       ]],
       ["@babel/types", [
@@ -6675,6 +7103,15 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "packageDependencies": [
             ["@babel/types", "npm:7.14.2"],
             ["@babel/helper-validator-identifier", "npm:7.14.0"],
+            ["to-fast-properties", "npm:2.0.0"]
+          ],
+          "linkType": "HARD",
+        }],
+        ["npm:7.14.5", {
+          "packageLocation": "./.yarn/cache/@babel-types-npm-7.14.5-2e4e3fee48-45575b46df.zip/node_modules/@babel/types/",
+          "packageDependencies": [
+            ["@babel/types", "npm:7.14.5"],
+            ["@babel/helper-validator-identifier", "npm:7.14.5"],
             ["to-fast-properties", "npm:2.0.0"]
           ],
           "linkType": "HARD",
@@ -7648,6 +8085,19 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["slash", "npm:3.0.0"]
           ],
           "linkType": "HARD",
+        }],
+        ["npm:27.0.2", {
+          "packageLocation": "./.yarn/cache/@jest-console-npm-27.0.2-3f0dc49490-98757eeaca.zip/node_modules/@jest/console/",
+          "packageDependencies": [
+            ["@jest/console", "npm:27.0.2"],
+            ["@jest/types", "npm:27.0.2"],
+            ["@types/node", "npm:15.3.0"],
+            ["chalk", "npm:4.1.1"],
+            ["jest-message-util", "npm:27.0.2"],
+            ["jest-util", "npm:27.0.2"],
+            ["slash", "npm:3.0.0"]
+          ],
+          "linkType": "HARD",
         }]
       ]],
       ["@jest/core", [
@@ -7685,6 +8135,55 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["strip-ansi", "npm:6.0.0"]
           ],
           "linkType": "HARD",
+        }],
+        ["npm:27.0.4", {
+          "packageLocation": "./.yarn/cache/@jest-core-npm-27.0.4-ffa396ed48-7e5d68833b.zip/node_modules/@jest/core/",
+          "packageDependencies": [
+            ["@jest/core", "npm:27.0.4"]
+          ],
+          "linkType": "SOFT",
+        }],
+        ["virtual:3a21d4c5ab7e57dfaa7047df58b774128a702592515a6444685d3b9447b9baf5a413b0aff71a24c5e4b0934ea65463e05d393d18549c768d11a66586d4242a93#npm:27.0.4", {
+          "packageLocation": "./.yarn/$$virtual/@jest-core-virtual-55bd781c22/0/cache/@jest-core-npm-27.0.4-ffa396ed48-7e5d68833b.zip/node_modules/@jest/core/",
+          "packageDependencies": [
+            ["@jest/core", "virtual:3a21d4c5ab7e57dfaa7047df58b774128a702592515a6444685d3b9447b9baf5a413b0aff71a24c5e4b0934ea65463e05d393d18549c768d11a66586d4242a93#npm:27.0.4"],
+            ["@jest/console", "npm:27.0.2"],
+            ["@jest/reporters", "virtual:55bd781c22801fbd4317531d4792c74a607f1113bbab001b387919255dc5fd97bcd8d5ce303cbd520f9bf8a03c6659bbfe110a4518c679a64d68444bfb35d8de#npm:27.0.4"],
+            ["@jest/test-result", "npm:27.0.2"],
+            ["@jest/transform", "npm:27.0.2"],
+            ["@jest/types", "npm:27.0.2"],
+            ["@types/node", "npm:15.3.0"],
+            ["@types/node-notifier", null],
+            ["ansi-escapes", "npm:4.3.2"],
+            ["chalk", "npm:4.1.1"],
+            ["emittery", "npm:0.8.1"],
+            ["exit", "npm:0.1.2"],
+            ["graceful-fs", "npm:4.2.6"],
+            ["jest-changed-files", "npm:27.0.2"],
+            ["jest-config", "virtual:55bd781c22801fbd4317531d4792c74a607f1113bbab001b387919255dc5fd97bcd8d5ce303cbd520f9bf8a03c6659bbfe110a4518c679a64d68444bfb35d8de#npm:27.0.4"],
+            ["jest-haste-map", "npm:27.0.2"],
+            ["jest-message-util", "npm:27.0.2"],
+            ["jest-regex-util", "npm:27.0.1"],
+            ["jest-resolve", "npm:27.0.4"],
+            ["jest-resolve-dependencies", "npm:27.0.4"],
+            ["jest-runner", "npm:27.0.4"],
+            ["jest-runtime", "npm:27.0.4"],
+            ["jest-snapshot", "npm:27.0.4"],
+            ["jest-util", "npm:27.0.2"],
+            ["jest-validate", "npm:27.0.2"],
+            ["jest-watcher", "npm:27.0.2"],
+            ["micromatch", "npm:4.0.4"],
+            ["node-notifier", null],
+            ["p-each-series", "npm:2.2.0"],
+            ["rimraf", "npm:3.0.2"],
+            ["slash", "npm:3.0.0"],
+            ["strip-ansi", "npm:6.0.0"]
+          ],
+          "packagePeers": [
+            "@types/node-notifier",
+            "node-notifier"
+          ],
+          "linkType": "HARD",
         }]
       ]],
       ["@jest/environment", [
@@ -7696,6 +8195,17 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@jest/types", "npm:26.6.2"],
             ["@types/node", "npm:15.3.0"],
             ["jest-mock", "npm:26.6.2"]
+          ],
+          "linkType": "HARD",
+        }],
+        ["npm:27.0.3", {
+          "packageLocation": "./.yarn/cache/@jest-environment-npm-27.0.3-02985c658c-a73ef6b82c.zip/node_modules/@jest/environment/",
+          "packageDependencies": [
+            ["@jest/environment", "npm:27.0.3"],
+            ["@jest/fake-timers", "npm:27.0.3"],
+            ["@jest/types", "npm:27.0.2"],
+            ["@types/node", "npm:15.3.0"],
+            ["jest-mock", "npm:27.0.3"]
           ],
           "linkType": "HARD",
         }]
@@ -7723,6 +8233,19 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["jest-util", "npm:26.6.2"]
           ],
           "linkType": "HARD",
+        }],
+        ["npm:27.0.3", {
+          "packageLocation": "./.yarn/cache/@jest-fake-timers-npm-27.0.3-5d90fdb420-915cedba7f.zip/node_modules/@jest/fake-timers/",
+          "packageDependencies": [
+            ["@jest/fake-timers", "npm:27.0.3"],
+            ["@jest/types", "npm:27.0.2"],
+            ["@sinonjs/fake-timers", "npm:7.1.2"],
+            ["@types/node", "npm:15.3.0"],
+            ["jest-message-util", "npm:27.0.2"],
+            ["jest-mock", "npm:27.0.3"],
+            ["jest-util", "npm:27.0.2"]
+          ],
+          "linkType": "HARD",
         }]
       ]],
       ["@jest/globals", [
@@ -7733,6 +8256,16 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@jest/environment", "npm:26.6.2"],
             ["@jest/types", "npm:26.6.2"],
             ["expect", "npm:26.6.2"]
+          ],
+          "linkType": "HARD",
+        }],
+        ["npm:27.0.3", {
+          "packageLocation": "./.yarn/cache/@jest-globals-npm-27.0.3-cac79a361c-c7e473c19c.zip/node_modules/@jest/globals/",
+          "packageDependencies": [
+            ["@jest/globals", "npm:27.0.3"],
+            ["@jest/environment", "npm:27.0.3"],
+            ["@jest/types", "npm:27.0.2"],
+            ["expect", "npm:27.0.2"]
           ],
           "linkType": "HARD",
         }]
@@ -7769,6 +8302,50 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["v8-to-istanbul", "npm:7.1.2"]
           ],
           "linkType": "HARD",
+        }],
+        ["npm:27.0.4", {
+          "packageLocation": "./.yarn/cache/@jest-reporters-npm-27.0.4-13f50d68df-52a5ecea31.zip/node_modules/@jest/reporters/",
+          "packageDependencies": [
+            ["@jest/reporters", "npm:27.0.4"]
+          ],
+          "linkType": "SOFT",
+        }],
+        ["virtual:55bd781c22801fbd4317531d4792c74a607f1113bbab001b387919255dc5fd97bcd8d5ce303cbd520f9bf8a03c6659bbfe110a4518c679a64d68444bfb35d8de#npm:27.0.4", {
+          "packageLocation": "./.yarn/$$virtual/@jest-reporters-virtual-2f61a616fe/0/cache/@jest-reporters-npm-27.0.4-13f50d68df-52a5ecea31.zip/node_modules/@jest/reporters/",
+          "packageDependencies": [
+            ["@jest/reporters", "virtual:55bd781c22801fbd4317531d4792c74a607f1113bbab001b387919255dc5fd97bcd8d5ce303cbd520f9bf8a03c6659bbfe110a4518c679a64d68444bfb35d8de#npm:27.0.4"],
+            ["@bcoe/v8-coverage", "npm:0.2.3"],
+            ["@jest/console", "npm:27.0.2"],
+            ["@jest/test-result", "npm:27.0.2"],
+            ["@jest/transform", "npm:27.0.2"],
+            ["@jest/types", "npm:27.0.2"],
+            ["@types/node-notifier", null],
+            ["chalk", "npm:4.1.1"],
+            ["collect-v8-coverage", "npm:1.0.1"],
+            ["exit", "npm:0.1.2"],
+            ["glob", "npm:7.1.7"],
+            ["graceful-fs", "npm:4.2.6"],
+            ["istanbul-lib-coverage", "npm:3.0.0"],
+            ["istanbul-lib-instrument", "npm:4.0.3"],
+            ["istanbul-lib-report", "npm:3.0.0"],
+            ["istanbul-lib-source-maps", "npm:4.0.0"],
+            ["istanbul-reports", "npm:3.0.2"],
+            ["jest-haste-map", "npm:27.0.2"],
+            ["jest-resolve", "npm:27.0.4"],
+            ["jest-util", "npm:27.0.2"],
+            ["jest-worker", "npm:27.0.2"],
+            ["node-notifier", null],
+            ["slash", "npm:3.0.0"],
+            ["source-map", "npm:0.6.1"],
+            ["string-length", "npm:4.0.2"],
+            ["terminal-link", "npm:2.1.1"],
+            ["v8-to-istanbul", "npm:7.1.2"]
+          ],
+          "packagePeers": [
+            "@types/node-notifier",
+            "node-notifier"
+          ],
+          "linkType": "HARD",
         }]
       ]],
       ["@jest/source-map", [
@@ -7786,6 +8363,16 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "packageLocation": "./.yarn/cache/@jest-source-map-npm-26.6.2-a3b9d7d3b0-9a6d3e6506.zip/node_modules/@jest/source-map/",
           "packageDependencies": [
             ["@jest/source-map", "npm:26.6.2"],
+            ["callsites", "npm:3.1.0"],
+            ["graceful-fs", "npm:4.2.6"],
+            ["source-map", "npm:0.6.1"]
+          ],
+          "linkType": "HARD",
+        }],
+        ["npm:27.0.1", {
+          "packageLocation": "./.yarn/cache/@jest-source-map-npm-27.0.1-b1fbee8f81-0c69ae000e.zip/node_modules/@jest/source-map/",
+          "packageDependencies": [
+            ["@jest/source-map", "npm:27.0.1"],
             ["callsites", "npm:3.1.0"],
             ["graceful-fs", "npm:4.2.6"],
             ["source-map", "npm:0.6.1"]
@@ -7814,6 +8401,17 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["collect-v8-coverage", "npm:1.0.1"]
           ],
           "linkType": "HARD",
+        }],
+        ["npm:27.0.2", {
+          "packageLocation": "./.yarn/cache/@jest-test-result-npm-27.0.2-4add172036-578a75168a.zip/node_modules/@jest/test-result/",
+          "packageDependencies": [
+            ["@jest/test-result", "npm:27.0.2"],
+            ["@jest/console", "npm:27.0.2"],
+            ["@jest/types", "npm:27.0.2"],
+            ["@types/istanbul-lib-coverage", "npm:2.0.3"],
+            ["collect-v8-coverage", "npm:1.0.1"]
+          ],
+          "linkType": "HARD",
         }]
       ]],
       ["@jest/test-sequencer", [
@@ -7826,6 +8424,17 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["jest-haste-map", "npm:26.6.2"],
             ["jest-runner", "npm:26.6.3"],
             ["jest-runtime", "npm:26.6.3"]
+          ],
+          "linkType": "HARD",
+        }],
+        ["npm:27.0.4", {
+          "packageLocation": "./.yarn/cache/@jest-test-sequencer-npm-27.0.4-438adff1f0-ff13677535.zip/node_modules/@jest/test-sequencer/",
+          "packageDependencies": [
+            ["@jest/test-sequencer", "npm:27.0.4"],
+            ["@jest/test-result", "npm:27.0.2"],
+            ["graceful-fs", "npm:4.2.6"],
+            ["jest-haste-map", "npm:27.0.2"],
+            ["jest-runtime", "npm:27.0.4"]
           ],
           "linkType": "HARD",
         }]
@@ -7875,6 +8484,28 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["write-file-atomic", "npm:3.0.3"]
           ],
           "linkType": "HARD",
+        }],
+        ["npm:27.0.2", {
+          "packageLocation": "./.yarn/cache/@jest-transform-npm-27.0.2-6839550ac0-3ba8c4f064.zip/node_modules/@jest/transform/",
+          "packageDependencies": [
+            ["@jest/transform", "npm:27.0.2"],
+            ["@babel/core", "npm:7.14.3"],
+            ["@jest/types", "npm:27.0.2"],
+            ["babel-plugin-istanbul", "npm:6.0.0"],
+            ["chalk", "npm:4.1.1"],
+            ["convert-source-map", "npm:1.7.0"],
+            ["fast-json-stable-stringify", "npm:2.1.0"],
+            ["graceful-fs", "npm:4.2.6"],
+            ["jest-haste-map", "npm:27.0.2"],
+            ["jest-regex-util", "npm:27.0.1"],
+            ["jest-util", "npm:27.0.2"],
+            ["micromatch", "npm:4.0.4"],
+            ["pirates", "npm:4.0.1"],
+            ["slash", "npm:3.0.0"],
+            ["source-map", "npm:0.6.1"],
+            ["write-file-atomic", "npm:3.0.3"]
+          ],
+          "linkType": "HARD",
         }]
       ]],
       ["@jest/types", [
@@ -7907,6 +8538,18 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@types/istanbul-reports", "npm:3.0.0"],
             ["@types/node", "npm:15.3.0"],
             ["@types/yargs", "npm:15.0.13"],
+            ["chalk", "npm:4.1.1"]
+          ],
+          "linkType": "HARD",
+        }],
+        ["npm:27.0.2", {
+          "packageLocation": "./.yarn/cache/@jest-types-npm-27.0.2-11212898dc-7c1ef76bcb.zip/node_modules/@jest/types/",
+          "packageDependencies": [
+            ["@jest/types", "npm:27.0.2"],
+            ["@types/istanbul-lib-coverage", "npm:2.0.3"],
+            ["@types/istanbul-reports", "npm:3.0.0"],
+            ["@types/node", "npm:15.3.0"],
+            ["@types/yargs", "npm:16.0.3"],
             ["chalk", "npm:4.1.1"]
           ],
           "linkType": "HARD",
@@ -9249,6 +9892,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@types/node", "npm:14.17.0"],
             ["@types/react", "npm:17.0.8"],
             ["@types/react-dom", "npm:17.0.5"],
+            ["@types/testing-library__jest-dom", "npm:5.14.0"],
             ["@wojtekmaj/enzyme-adapter-react-17", "virtual:4112afb9dad10978c159910bf10db9840b981b1333117623c8a4a8cf77481344a0a24735a5506e2920c18e3cfa2cc179489824b6a56c988bb070f4f60da40974#npm:0.6.1"],
             ["babel-core", "virtual:8d3a83663eeb52526f1a370f37823b207ef94fd6f29876d8d32441147013da1c410e0af99127da61a03b76c1f782c4ec6a3e8818ca584076ab02a5fafc1465eb#npm:7.0.0-bridge.0"],
             ["babel-jest", "virtual:4112afb9dad10978c159910bf10db9840b981b1333117623c8a4a8cf77481344a0a24735a5506e2920c18e3cfa2cc179489824b6a56c988bb070f4f60da40974#npm:24.9.0"],
@@ -9399,6 +10043,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@testing-library/jest-dom", "npm:5.12.0"],
             ["@testing-library/react", "virtual:bb4ed02b339ed801b02d2ec15b42a5aa7b1afdaf44119aefaab128a59d6e16cc6018880c169f24bf2107550e914562ee9e1780db01a12e1bc3c492ad0a049c36#npm:11.2.7"],
             ["@types/bytes", "npm:3.1.0"],
+            ["@types/jest", "npm:26.0.23"],
             ["@types/md5", "npm:2.3.0"],
             ["@types/mdx-js__react", "npm:1.5.3"],
             ["@types/prop-types", "npm:15.7.3"],
@@ -9410,6 +10055,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["commafy", "npm:0.0.6"],
             ["css-loader", "virtual:bb4ed02b339ed801b02d2ec15b42a5aa7b1afdaf44119aefaab128a59d6e16cc6018880c169f24bf2107550e914562ee9e1780db01a12e1bc3c492ad0a049c36#npm:5.2.4"],
             ["date-fns", "npm:2.21.3"],
+            ["jest", "virtual:bb4ed02b339ed801b02d2ec15b42a5aa7b1afdaf44119aefaab128a59d6e16cc6018880c169f24bf2107550e914562ee9e1780db01a12e1bc3c492ad0a049c36#npm:27.0.4"],
             ["markdown-to-jsx", "virtual:bb4ed02b339ed801b02d2ec15b42a5aa7b1afdaf44119aefaab128a59d6e16cc6018880c169f24bf2107550e914562ee9e1780db01a12e1bc3c492ad0a049c36#npm:7.1.3"],
             ["md5", "npm:2.3.0"],
             ["pluralize", "npm:8.0.0"],
@@ -9471,6 +10117,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@sentry/node", "npm:4.6.6"],
             ["@types/draft-js", "npm:0.10.45"],
             ["@types/ioredis", "npm:4.26.4"],
+            ["@types/jest", "npm:26.0.23"],
             ["@types/nodemailer", "npm:6.4.1"],
             ["apollo-link-schema", "virtual:6d9c0fee0b376eb0bb6824eb7a3246834ef21d870b31f75eebe59bb4d027e50f2607ba168fd29d446567f4e9c2a5cad2442c4741fa92c92e0b7e9145c3a3e3a7#npm:1.2.5"],
             ["apollo-server", "virtual:6d9c0fee0b376eb0bb6824eb7a3246834ef21d870b31f75eebe59bb4d027e50f2607ba168fd29d446567f4e9c2a5cad2442c4741fa92c92e0b7e9145c3a3e3a7#npm:2.21.0"],
@@ -10090,6 +10737,14 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "packageLocation": "./.yarn/cache/@sinonjs-fake-timers-npm-6.0.1-cebf4d0bfb-64458b9087.zip/node_modules/@sinonjs/fake-timers/",
           "packageDependencies": [
             ["@sinonjs/fake-timers", "npm:6.0.1"],
+            ["@sinonjs/commons", "npm:1.8.3"]
+          ],
+          "linkType": "HARD",
+        }],
+        ["npm:7.1.2", {
+          "packageLocation": "./.yarn/cache/@sinonjs-fake-timers-npm-7.1.2-2a6b119ac7-5ce48e40db.zip/node_modules/@sinonjs/fake-timers/",
+          "packageDependencies": [
+            ["@sinonjs/fake-timers", "npm:7.1.2"],
             ["@sinonjs/commons", "npm:1.8.3"]
           ],
           "linkType": "HARD",
@@ -12951,6 +13606,13 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@types/prettier", "npm:2.2.3"]
           ],
           "linkType": "HARD",
+        }],
+        ["npm:2.3.0", {
+          "packageLocation": "./.yarn/cache/@types-prettier-npm-2.3.0-b1be4bd841-7c1ef16234.zip/node_modules/@types/prettier/",
+          "packageDependencies": [
+            ["@types/prettier", "npm:2.3.0"]
+          ],
+          "linkType": "HARD",
         }]
       ]],
       ["@types/pretty-hrtime", [
@@ -13226,6 +13888,14 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
         }]
       ]],
       ["@types/testing-library__jest-dom", [
+        ["npm:5.14.0", {
+          "packageLocation": "./.yarn/cache/@types-testing-library__jest-dom-npm-5.14.0-e92742093c-7d34c6e361.zip/node_modules/@types/testing-library__jest-dom/",
+          "packageDependencies": [
+            ["@types/testing-library__jest-dom", "npm:5.14.0"],
+            ["@types/jest", "npm:26.0.23"]
+          ],
+          "linkType": "HARD",
+        }],
         ["npm:5.9.5", {
           "packageLocation": "./.yarn/cache/@types-testing-library__jest-dom-npm-5.9.5-5a42b58918-32aa324a83.zip/node_modules/@types/testing-library__jest-dom/",
           "packageDependencies": [
@@ -13374,6 +14044,14 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "packageLocation": "./.yarn/cache/@types-yargs-npm-15.0.13-d1172b1fcd-fa1a5b0a07.zip/node_modules/@types/yargs/",
           "packageDependencies": [
             ["@types/yargs", "npm:15.0.13"],
+            ["@types/yargs-parser", "npm:20.2.0"]
+          ],
+          "linkType": "HARD",
+        }],
+        ["npm:16.0.3", {
+          "packageLocation": "./.yarn/cache/@types-yargs-npm-16.0.3-b6f52df1c2-84b8f61774.zip/node_modules/@types/yargs/",
+          "packageDependencies": [
+            ["@types/yargs", "npm:16.0.3"],
             ["@types/yargs-parser", "npm:20.2.0"]
           ],
           "linkType": "HARD",
@@ -14143,6 +14821,13 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["acorn", "npm:8.2.4"]
           ],
           "linkType": "HARD",
+        }],
+        ["npm:8.4.0", {
+          "packageLocation": "./.yarn/cache/acorn-npm-8.4.0-7923a905e2-51d8d3ec3e.zip/node_modules/acorn/",
+          "packageDependencies": [
+            ["acorn", "npm:8.4.0"]
+          ],
+          "linkType": "HARD",
         }]
       ]],
       ["acorn-globals", [
@@ -14532,6 +15217,13 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "packageDependencies": [
             ["ansi-styles", "npm:4.3.0"],
             ["color-convert", "npm:2.0.1"]
+          ],
+          "linkType": "HARD",
+        }],
+        ["npm:5.2.0", {
+          "packageLocation": "./.yarn/cache/ansi-styles-npm-5.2.0-72fc7003e3-10b01465c7.zip/node_modules/ansi-styles/",
+          "packageDependencies": [
+            ["ansi-styles", "npm:5.2.0"]
           ],
           "linkType": "HARD",
         }]
@@ -15972,6 +16664,13 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           ],
           "linkType": "SOFT",
         }],
+        ["npm:27.0.2", {
+          "packageLocation": "./.yarn/cache/babel-jest-npm-27.0.2-760775130b-f12d789701.zip/node_modules/babel-jest/",
+          "packageDependencies": [
+            ["babel-jest", "npm:27.0.2"]
+          ],
+          "linkType": "SOFT",
+        }],
         ["virtual:4112afb9dad10978c159910bf10db9840b981b1333117623c8a4a8cf77481344a0a24735a5506e2920c18e3cfa2cc179489824b6a56c988bb070f4f60da40974#npm:24.9.0", {
           "packageLocation": "./.yarn/$$virtual/babel-jest-virtual-502e72ae2a/0/cache/babel-jest-npm-24.9.0-2ea261318a-b8b74b2af2.zip/node_modules/babel-jest/",
           "packageDependencies": [
@@ -16000,6 +16699,25 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@types/babel__core", "npm:7.1.14"],
             ["babel-plugin-istanbul", "npm:6.0.0"],
             ["babel-preset-jest", "virtual:9f33f3a3f1029c851d4fc6512707159198b8a9185a8bf2a04087a9e7410eb7514881ea8169195fe0d559191ceae65b7d1a505a59d1ebb3a00c8619a55d48aa40#npm:26.6.2"],
+            ["chalk", "npm:4.1.1"],
+            ["graceful-fs", "npm:4.2.6"],
+            ["slash", "npm:3.0.0"]
+          ],
+          "packagePeers": [
+            "@babel/core"
+          ],
+          "linkType": "HARD",
+        }],
+        ["virtual:e173d6db820a165ff79250498ea34cbdfa468ccf1c0f7e7e75885bc50ecdaf5b80d8b54158a6ab53f5463daf26065e95998189377f9edfb5cf6b13deb4e5e8b7#npm:27.0.2", {
+          "packageLocation": "./.yarn/$$virtual/babel-jest-virtual-d4ed6316fc/0/cache/babel-jest-npm-27.0.2-760775130b-f12d789701.zip/node_modules/babel-jest/",
+          "packageDependencies": [
+            ["babel-jest", "virtual:e173d6db820a165ff79250498ea34cbdfa468ccf1c0f7e7e75885bc50ecdaf5b80d8b54158a6ab53f5463daf26065e95998189377f9edfb5cf6b13deb4e5e8b7#npm:27.0.2"],
+            ["@babel/core", "npm:7.14.3"],
+            ["@jest/transform", "npm:27.0.2"],
+            ["@jest/types", "npm:27.0.2"],
+            ["@types/babel__core", "npm:7.1.14"],
+            ["babel-plugin-istanbul", "npm:6.0.0"],
+            ["babel-preset-jest", "virtual:d4ed6316fc5ad94039681d3795244059a2e3bea4e50799345aa8f2e32349c3a0c0708835963e93bd0f0b3559c6997ac67fc81f25c6f9ef6d447f8045791f208f#npm:27.0.1"],
             ["chalk", "npm:4.1.1"],
             ["graceful-fs", "npm:4.2.6"],
             ["slash", "npm:3.0.0"]
@@ -16216,6 +16934,17 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "packageLocation": "./.yarn/cache/babel-plugin-jest-hoist-npm-26.6.2-1a51633e87-e9c1de0fce.zip/node_modules/babel-plugin-jest-hoist/",
           "packageDependencies": [
             ["babel-plugin-jest-hoist", "npm:26.6.2"],
+            ["@babel/template", "npm:7.12.13"],
+            ["@babel/types", "npm:7.14.2"],
+            ["@types/babel__core", "npm:7.1.14"],
+            ["@types/babel__traverse", "npm:7.11.1"]
+          ],
+          "linkType": "HARD",
+        }],
+        ["npm:27.0.1", {
+          "packageLocation": "./.yarn/cache/babel-plugin-jest-hoist-npm-27.0.1-a04d3c5add-d8c17b65b4.zip/node_modules/babel-plugin-jest-hoist/",
+          "packageDependencies": [
+            ["babel-plugin-jest-hoist", "npm:27.0.1"],
             ["@babel/template", "npm:7.12.13"],
             ["@babel/types", "npm:7.14.2"],
             ["@types/babel__core", "npm:7.1.14"],
@@ -16547,6 +17276,31 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           ],
           "linkType": "SOFT",
         }],
+        ["virtual:41adfef6e7fb7a1ecc1b7290eb28a8b5de0de3de8c9b7f3ffb7686a1ef14c1f8879217dd2210057b268490babbb69c4162520cfa0f9012288af824f2f508c134#npm:1.0.1", {
+          "packageLocation": "./.yarn/$$virtual/babel-preset-current-node-syntax-virtual-a3a4f4643e/0/cache/babel-preset-current-node-syntax-npm-1.0.1-849ec71e32-bba41cc95a.zip/node_modules/babel-preset-current-node-syntax/",
+          "packageDependencies": [
+            ["babel-preset-current-node-syntax", "virtual:41adfef6e7fb7a1ecc1b7290eb28a8b5de0de3de8c9b7f3ffb7686a1ef14c1f8879217dd2210057b268490babbb69c4162520cfa0f9012288af824f2f508c134#npm:1.0.1"],
+            ["@babel/core", "npm:7.14.6"],
+            ["@babel/plugin-syntax-async-generators", "virtual:a3a4f4643e7d0c65c31a712cd46aba0b8487b675872907335e0bceb93bb44d826cbe3d594988130623f39063afba3a66553732003e67403b25195eeb5a26aa62#npm:7.8.4"],
+            ["@babel/plugin-syntax-bigint", "virtual:a3a4f4643e7d0c65c31a712cd46aba0b8487b675872907335e0bceb93bb44d826cbe3d594988130623f39063afba3a66553732003e67403b25195eeb5a26aa62#npm:7.8.3"],
+            ["@babel/plugin-syntax-class-properties", "virtual:a3a4f4643e7d0c65c31a712cd46aba0b8487b675872907335e0bceb93bb44d826cbe3d594988130623f39063afba3a66553732003e67403b25195eeb5a26aa62#npm:7.12.13"],
+            ["@babel/plugin-syntax-import-meta", "virtual:a3a4f4643e7d0c65c31a712cd46aba0b8487b675872907335e0bceb93bb44d826cbe3d594988130623f39063afba3a66553732003e67403b25195eeb5a26aa62#npm:7.10.4"],
+            ["@babel/plugin-syntax-json-strings", "virtual:a3a4f4643e7d0c65c31a712cd46aba0b8487b675872907335e0bceb93bb44d826cbe3d594988130623f39063afba3a66553732003e67403b25195eeb5a26aa62#npm:7.8.3"],
+            ["@babel/plugin-syntax-logical-assignment-operators", "virtual:a3a4f4643e7d0c65c31a712cd46aba0b8487b675872907335e0bceb93bb44d826cbe3d594988130623f39063afba3a66553732003e67403b25195eeb5a26aa62#npm:7.10.4"],
+            ["@babel/plugin-syntax-nullish-coalescing-operator", "virtual:a3a4f4643e7d0c65c31a712cd46aba0b8487b675872907335e0bceb93bb44d826cbe3d594988130623f39063afba3a66553732003e67403b25195eeb5a26aa62#npm:7.8.3"],
+            ["@babel/plugin-syntax-numeric-separator", "virtual:a3a4f4643e7d0c65c31a712cd46aba0b8487b675872907335e0bceb93bb44d826cbe3d594988130623f39063afba3a66553732003e67403b25195eeb5a26aa62#npm:7.10.4"],
+            ["@babel/plugin-syntax-object-rest-spread", "virtual:a3a4f4643e7d0c65c31a712cd46aba0b8487b675872907335e0bceb93bb44d826cbe3d594988130623f39063afba3a66553732003e67403b25195eeb5a26aa62#npm:7.8.3"],
+            ["@babel/plugin-syntax-optional-catch-binding", "virtual:a3a4f4643e7d0c65c31a712cd46aba0b8487b675872907335e0bceb93bb44d826cbe3d594988130623f39063afba3a66553732003e67403b25195eeb5a26aa62#npm:7.8.3"],
+            ["@babel/plugin-syntax-optional-chaining", "virtual:a3a4f4643e7d0c65c31a712cd46aba0b8487b675872907335e0bceb93bb44d826cbe3d594988130623f39063afba3a66553732003e67403b25195eeb5a26aa62#npm:7.8.3"],
+            ["@babel/plugin-syntax-top-level-await", "virtual:a3a4f4643e7d0c65c31a712cd46aba0b8487b675872907335e0bceb93bb44d826cbe3d594988130623f39063afba3a66553732003e67403b25195eeb5a26aa62#npm:7.12.13"],
+            ["@types/babel__core", null]
+          ],
+          "packagePeers": [
+            "@babel/core",
+            "@types/babel__core"
+          ],
+          "linkType": "HARD",
+        }],
         ["virtual:953f19a93f1fd76e03de2418470b56b6b69d974bef4780f65029f0a9afcdf2f0130bfb897370a8fe1bd125d7f8113ee186caf42ece0a92789a64117e47028619#npm:1.0.1", {
           "packageLocation": "./.yarn/$$virtual/babel-preset-current-node-syntax-virtual-8f974720c8/0/cache/babel-preset-current-node-syntax-npm-1.0.1-849ec71e32-bba41cc95a.zip/node_modules/babel-preset-current-node-syntax/",
           "packageDependencies": [
@@ -16629,6 +17383,13 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           ],
           "linkType": "SOFT",
         }],
+        ["npm:27.0.1", {
+          "packageLocation": "./.yarn/cache/babel-preset-jest-npm-27.0.1-9446ad2444-46a36c790f.zip/node_modules/babel-preset-jest/",
+          "packageDependencies": [
+            ["babel-preset-jest", "npm:27.0.1"]
+          ],
+          "linkType": "SOFT",
+        }],
         ["virtual:502e72ae2af92cdd281b5d606c889b0799152571e1f717c0de258431765d79271a46dfd72cd4ef1afe3ee526bb4e36e88bf946678b6533b4d68862a8e66d7fb2#npm:24.9.0", {
           "packageLocation": "./.yarn/$$virtual/babel-preset-jest-virtual-5382786a3f/0/cache/babel-preset-jest-npm-24.9.0-4ca5b59098-6b85c399b8.zip/node_modules/babel-preset-jest/",
           "packageDependencies": [
@@ -16651,6 +17412,21 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@babel/core", "npm:7.14.3"],
             ["@types/babel__core", "npm:7.1.14"],
             ["babel-plugin-jest-hoist", "npm:26.6.2"],
+            ["babel-preset-current-node-syntax", "virtual:953f19a93f1fd76e03de2418470b56b6b69d974bef4780f65029f0a9afcdf2f0130bfb897370a8fe1bd125d7f8113ee186caf42ece0a92789a64117e47028619#npm:1.0.1"]
+          ],
+          "packagePeers": [
+            "@babel/core",
+            "@types/babel__core"
+          ],
+          "linkType": "HARD",
+        }],
+        ["virtual:d4ed6316fc5ad94039681d3795244059a2e3bea4e50799345aa8f2e32349c3a0c0708835963e93bd0f0b3559c6997ac67fc81f25c6f9ef6d447f8045791f208f#npm:27.0.1", {
+          "packageLocation": "./.yarn/$$virtual/babel-preset-jest-virtual-1b911f38aa/0/cache/babel-preset-jest-npm-27.0.1-9446ad2444-46a36c790f.zip/node_modules/babel-preset-jest/",
+          "packageDependencies": [
+            ["babel-preset-jest", "virtual:d4ed6316fc5ad94039681d3795244059a2e3bea4e50799345aa8f2e32349c3a0c0708835963e93bd0f0b3559c6997ac67fc81f25c6f9ef6d447f8045791f208f#npm:27.0.1"],
+            ["@babel/core", "npm:7.14.3"],
+            ["@types/babel__core", "npm:7.1.14"],
+            ["babel-plugin-jest-hoist", "npm:27.0.1"],
             ["babel-preset-current-node-syntax", "virtual:953f19a93f1fd76e03de2418470b56b6b69d974bef4780f65029f0a9afcdf2f0130bfb897370a8fe1bd125d7f8113ee186caf42ece0a92789a64117e47028619#npm:1.0.1"]
           ],
           "packagePeers": [
@@ -18108,6 +18884,13 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["ci-info", "npm:2.0.0"]
           ],
           "linkType": "HARD",
+        }],
+        ["npm:3.2.0", {
+          "packageLocation": "./.yarn/cache/ci-info-npm-3.2.0-90f4cf0660-d4a898d601.zip/node_modules/ci-info/",
+          "packageDependencies": [
+            ["ci-info", "npm:3.2.0"]
+          ],
+          "linkType": "HARD",
         }]
       ]],
       ["cipher-base", [
@@ -18126,6 +18909,13 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "packageLocation": "./.yarn/cache/cjs-module-lexer-npm-0.6.0-e80f3766d3-333671db7f.zip/node_modules/cjs-module-lexer/",
           "packageDependencies": [
             ["cjs-module-lexer", "npm:0.6.0"]
+          ],
+          "linkType": "HARD",
+        }],
+        ["npm:1.2.1", {
+          "packageLocation": "./.yarn/cache/cjs-module-lexer-npm-1.2.1-11eb01eaf4-5c41324f07.zip/node_modules/cjs-module-lexer/",
+          "packageDependencies": [
+            ["cjs-module-lexer", "npm:1.2.1"]
           ],
           "linkType": "HARD",
         }]
@@ -20840,6 +21630,13 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["diff-sequences", "npm:26.6.2"]
           ],
           "linkType": "HARD",
+        }],
+        ["npm:27.0.1", {
+          "packageLocation": "./.yarn/cache/diff-sequences-npm-27.0.1-65556e2cb7-7dc8775043.zip/node_modules/diff-sequences/",
+          "packageDependencies": [
+            ["diff-sequences", "npm:27.0.1"]
+          ],
+          "linkType": "HARD",
         }]
       ]],
       ["diffie-hellman", [
@@ -21640,6 +22437,13 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "packageLocation": "./.yarn/cache/emittery-npm-0.7.2-4a6f20265e-34acfef519.zip/node_modules/emittery/",
           "packageDependencies": [
             ["emittery", "npm:0.7.2"]
+          ],
+          "linkType": "HARD",
+        }],
+        ["npm:0.8.1", {
+          "packageLocation": "./.yarn/cache/emittery-npm-0.8.1-9771f0f260-1c9cd9a104.zip/node_modules/emittery/",
+          "packageDependencies": [
+            ["emittery", "npm:0.8.1"]
           ],
           "linkType": "HARD",
         }]
@@ -23209,6 +24013,22 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["strip-final-newline", "npm:2.0.0"]
           ],
           "linkType": "HARD",
+        }],
+        ["npm:5.1.1", {
+          "packageLocation": "./.yarn/cache/execa-npm-5.1.1-191347acf5-4286ade8cd.zip/node_modules/execa/",
+          "packageDependencies": [
+            ["execa", "npm:5.1.1"],
+            ["cross-spawn", "npm:7.0.3"],
+            ["get-stream", "npm:6.0.1"],
+            ["human-signals", "npm:2.1.0"],
+            ["is-stream", "npm:2.0.0"],
+            ["merge-stream", "npm:2.0.0"],
+            ["npm-run-path", "npm:4.0.1"],
+            ["onetime", "npm:5.1.2"],
+            ["signal-exit", "npm:3.0.3"],
+            ["strip-final-newline", "npm:2.0.0"]
+          ],
+          "linkType": "HARD",
         }]
       ]],
       ["exit", [
@@ -23257,6 +24077,19 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["jest-matcher-utils", "npm:26.6.2"],
             ["jest-message-util", "npm:26.6.2"],
             ["jest-regex-util", "npm:26.0.0"]
+          ],
+          "linkType": "HARD",
+        }],
+        ["npm:27.0.2", {
+          "packageLocation": "./.yarn/cache/expect-npm-27.0.2-d2be5f87e0-7a2bc04659.zip/node_modules/expect/",
+          "packageDependencies": [
+            ["expect", "npm:27.0.2"],
+            ["@jest/types", "npm:27.0.2"],
+            ["ansi-styles", "npm:5.2.0"],
+            ["jest-get-type", "npm:27.0.1"],
+            ["jest-matcher-utils", "npm:27.0.2"],
+            ["jest-message-util", "npm:27.0.2"],
+            ["jest-regex-util", "npm:27.0.1"]
           ],
           "linkType": "HARD",
         }]
@@ -27566,6 +28399,13 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["human-signals", "npm:1.1.1"]
           ],
           "linkType": "HARD",
+        }],
+        ["npm:2.1.0", {
+          "packageLocation": "./.yarn/cache/human-signals-npm-2.1.0-f75815481d-70bfd94d27.zip/node_modules/human-signals/",
+          "packageDependencies": [
+            ["human-signals", "npm:2.1.0"]
+          ],
+          "linkType": "HARD",
         }]
       ]],
       ["humanize-ms", [
@@ -28394,6 +29234,14 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "packageDependencies": [
             ["is-ci", "npm:2.0.0"],
             ["ci-info", "npm:2.0.0"]
+          ],
+          "linkType": "HARD",
+        }],
+        ["npm:3.0.0", {
+          "packageLocation": "./.yarn/cache/is-ci-npm-3.0.0-8cc50ac1f6-1e26d3ba66.zip/node_modules/is-ci/",
+          "packageDependencies": [
+            ["is-ci", "npm:3.0.0"],
+            ["ci-info", "npm:3.2.0"]
           ],
           "linkType": "HARD",
         }]
@@ -29393,6 +30241,29 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["jest-cli", "npm:26.6.3"]
           ],
           "linkType": "HARD",
+        }],
+        ["npm:27.0.4", {
+          "packageLocation": "./.yarn/cache/jest-npm-27.0.4-f6f5ed6be6-4cab553739.zip/node_modules/jest/",
+          "packageDependencies": [
+            ["jest", "npm:27.0.4"]
+          ],
+          "linkType": "SOFT",
+        }],
+        ["virtual:bb4ed02b339ed801b02d2ec15b42a5aa7b1afdaf44119aefaab128a59d6e16cc6018880c169f24bf2107550e914562ee9e1780db01a12e1bc3c492ad0a049c36#npm:27.0.4", {
+          "packageLocation": "./.yarn/$$virtual/jest-virtual-3a21d4c5ab/0/cache/jest-npm-27.0.4-f6f5ed6be6-4cab553739.zip/node_modules/jest/",
+          "packageDependencies": [
+            ["jest", "virtual:bb4ed02b339ed801b02d2ec15b42a5aa7b1afdaf44119aefaab128a59d6e16cc6018880c169f24bf2107550e914562ee9e1780db01a12e1bc3c492ad0a049c36#npm:27.0.4"],
+            ["@jest/core", "virtual:3a21d4c5ab7e57dfaa7047df58b774128a702592515a6444685d3b9447b9baf5a413b0aff71a24c5e4b0934ea65463e05d393d18549c768d11a66586d4242a93#npm:27.0.4"],
+            ["@types/node-notifier", null],
+            ["import-local", "npm:3.0.2"],
+            ["jest-cli", "virtual:3a21d4c5ab7e57dfaa7047df58b774128a702592515a6444685d3b9447b9baf5a413b0aff71a24c5e4b0934ea65463e05d393d18549c768d11a66586d4242a93#npm:27.0.4"],
+            ["node-notifier", null]
+          ],
+          "packagePeers": [
+            "@types/node-notifier",
+            "node-notifier"
+          ],
+          "linkType": "HARD",
         }]
       ]],
       ["jest-changed-files", [
@@ -29403,6 +30274,44 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@jest/types", "npm:26.6.2"],
             ["execa", "npm:4.1.0"],
             ["throat", "npm:5.0.0"]
+          ],
+          "linkType": "HARD",
+        }],
+        ["npm:27.0.2", {
+          "packageLocation": "./.yarn/cache/jest-changed-files-npm-27.0.2-d43bfae442-75e77350a8.zip/node_modules/jest-changed-files/",
+          "packageDependencies": [
+            ["jest-changed-files", "npm:27.0.2"],
+            ["@jest/types", "npm:27.0.2"],
+            ["execa", "npm:5.1.1"],
+            ["throat", "npm:6.0.1"]
+          ],
+          "linkType": "HARD",
+        }]
+      ]],
+      ["jest-circus", [
+        ["npm:27.0.4", {
+          "packageLocation": "./.yarn/cache/jest-circus-npm-27.0.4-c2a1fe4bb5-96f7a437a2.zip/node_modules/jest-circus/",
+          "packageDependencies": [
+            ["jest-circus", "npm:27.0.4"],
+            ["@jest/environment", "npm:27.0.3"],
+            ["@jest/test-result", "npm:27.0.2"],
+            ["@jest/types", "npm:27.0.2"],
+            ["@types/node", "npm:15.3.0"],
+            ["chalk", "npm:4.1.1"],
+            ["co", "npm:4.6.0"],
+            ["dedent", "npm:0.7.0"],
+            ["expect", "npm:27.0.2"],
+            ["is-generator-fn", "npm:2.1.0"],
+            ["jest-each", "npm:27.0.2"],
+            ["jest-matcher-utils", "npm:27.0.2"],
+            ["jest-message-util", "npm:27.0.2"],
+            ["jest-runtime", "npm:27.0.4"],
+            ["jest-snapshot", "npm:27.0.4"],
+            ["jest-util", "npm:27.0.2"],
+            ["pretty-format", "npm:27.0.2"],
+            ["slash", "npm:3.0.0"],
+            ["stack-utils", "npm:2.0.3"],
+            ["throat", "npm:6.0.1"]
           ],
           "linkType": "HARD",
         }]
@@ -29427,6 +30336,38 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["yargs", "npm:15.4.1"]
           ],
           "linkType": "HARD",
+        }],
+        ["npm:27.0.4", {
+          "packageLocation": "./.yarn/cache/jest-cli-npm-27.0.4-1c40df1857-da9188c670.zip/node_modules/jest-cli/",
+          "packageDependencies": [
+            ["jest-cli", "npm:27.0.4"]
+          ],
+          "linkType": "SOFT",
+        }],
+        ["virtual:3a21d4c5ab7e57dfaa7047df58b774128a702592515a6444685d3b9447b9baf5a413b0aff71a24c5e4b0934ea65463e05d393d18549c768d11a66586d4242a93#npm:27.0.4", {
+          "packageLocation": "./.yarn/$$virtual/jest-cli-virtual-854d95b96b/0/cache/jest-cli-npm-27.0.4-1c40df1857-da9188c670.zip/node_modules/jest-cli/",
+          "packageDependencies": [
+            ["jest-cli", "virtual:3a21d4c5ab7e57dfaa7047df58b774128a702592515a6444685d3b9447b9baf5a413b0aff71a24c5e4b0934ea65463e05d393d18549c768d11a66586d4242a93#npm:27.0.4"],
+            ["@jest/core", "virtual:3a21d4c5ab7e57dfaa7047df58b774128a702592515a6444685d3b9447b9baf5a413b0aff71a24c5e4b0934ea65463e05d393d18549c768d11a66586d4242a93#npm:27.0.4"],
+            ["@jest/test-result", "npm:27.0.2"],
+            ["@jest/types", "npm:27.0.2"],
+            ["@types/node-notifier", null],
+            ["chalk", "npm:4.1.1"],
+            ["exit", "npm:0.1.2"],
+            ["graceful-fs", "npm:4.2.6"],
+            ["import-local", "npm:3.0.2"],
+            ["jest-config", "virtual:55bd781c22801fbd4317531d4792c74a607f1113bbab001b387919255dc5fd97bcd8d5ce303cbd520f9bf8a03c6659bbfe110a4518c679a64d68444bfb35d8de#npm:27.0.4"],
+            ["jest-util", "npm:27.0.2"],
+            ["jest-validate", "npm:27.0.2"],
+            ["node-notifier", null],
+            ["prompts", "npm:2.4.1"],
+            ["yargs", "npm:16.2.0"]
+          ],
+          "packagePeers": [
+            "@types/node-notifier",
+            "node-notifier"
+          ],
+          "linkType": "HARD",
         }]
       ]],
       ["jest-config", [
@@ -29436,6 +30377,47 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["jest-config", "npm:26.6.3"]
           ],
           "linkType": "SOFT",
+        }],
+        ["npm:27.0.4", {
+          "packageLocation": "./.yarn/cache/jest-config-npm-27.0.4-a3cf5198bf-f0a591b351.zip/node_modules/jest-config/",
+          "packageDependencies": [
+            ["jest-config", "npm:27.0.4"]
+          ],
+          "linkType": "SOFT",
+        }],
+        ["virtual:55bd781c22801fbd4317531d4792c74a607f1113bbab001b387919255dc5fd97bcd8d5ce303cbd520f9bf8a03c6659bbfe110a4518c679a64d68444bfb35d8de#npm:27.0.4", {
+          "packageLocation": "./.yarn/$$virtual/jest-config-virtual-e173d6db82/0/cache/jest-config-npm-27.0.4-a3cf5198bf-f0a591b351.zip/node_modules/jest-config/",
+          "packageDependencies": [
+            ["jest-config", "virtual:55bd781c22801fbd4317531d4792c74a607f1113bbab001b387919255dc5fd97bcd8d5ce303cbd520f9bf8a03c6659bbfe110a4518c679a64d68444bfb35d8de#npm:27.0.4"],
+            ["@babel/core", "npm:7.14.3"],
+            ["@jest/test-sequencer", "npm:27.0.4"],
+            ["@jest/types", "npm:27.0.2"],
+            ["@types/ts-node", null],
+            ["babel-jest", "virtual:e173d6db820a165ff79250498ea34cbdfa468ccf1c0f7e7e75885bc50ecdaf5b80d8b54158a6ab53f5463daf26065e95998189377f9edfb5cf6b13deb4e5e8b7#npm:27.0.2"],
+            ["chalk", "npm:4.1.1"],
+            ["deepmerge", "npm:4.2.2"],
+            ["glob", "npm:7.1.7"],
+            ["graceful-fs", "npm:4.2.6"],
+            ["is-ci", "npm:3.0.0"],
+            ["jest-circus", "npm:27.0.4"],
+            ["jest-environment-jsdom", "npm:27.0.3"],
+            ["jest-environment-node", "npm:27.0.3"],
+            ["jest-get-type", "npm:27.0.1"],
+            ["jest-jasmine2", "npm:27.0.4"],
+            ["jest-regex-util", "npm:27.0.1"],
+            ["jest-resolve", "npm:27.0.4"],
+            ["jest-runner", "npm:27.0.4"],
+            ["jest-util", "npm:27.0.2"],
+            ["jest-validate", "npm:27.0.2"],
+            ["micromatch", "npm:4.0.4"],
+            ["pretty-format", "npm:27.0.2"],
+            ["ts-node", null]
+          ],
+          "packagePeers": [
+            "@types/ts-node",
+            "ts-node"
+          ],
+          "linkType": "HARD",
         }],
         ["virtual:bf7a8695861ccc96c7503a95daba2b038c9b3eca0fc65dc5ea7e5ae0e56354c6c3e3ee05f1c8d4420e3a01abf48ad9e2dea477db48ad56147605b32adf33b489#npm:26.6.3", {
           "packageLocation": "./.yarn/$$virtual/jest-config-virtual-caddf51df4/0/cache/jest-config-npm-26.6.3-ac5d27f4ad-974e7690ba.zip/node_modules/jest-config/",
@@ -29491,6 +30473,17 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["pretty-format", "npm:26.6.2"]
           ],
           "linkType": "HARD",
+        }],
+        ["npm:27.0.2", {
+          "packageLocation": "./.yarn/cache/jest-diff-npm-27.0.2-10b7ae1f33-2335c861c5.zip/node_modules/jest-diff/",
+          "packageDependencies": [
+            ["jest-diff", "npm:27.0.2"],
+            ["chalk", "npm:4.1.1"],
+            ["diff-sequences", "npm:27.0.1"],
+            ["jest-get-type", "npm:27.0.1"],
+            ["pretty-format", "npm:27.0.2"]
+          ],
+          "linkType": "HARD",
         }]
       ]],
       ["jest-docblock", [
@@ -29498,6 +30491,14 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "packageLocation": "./.yarn/cache/jest-docblock-npm-26.0.0-7d0129b0be-54b8ea1c84.zip/node_modules/jest-docblock/",
           "packageDependencies": [
             ["jest-docblock", "npm:26.0.0"],
+            ["detect-newline", "npm:3.1.0"]
+          ],
+          "linkType": "HARD",
+        }],
+        ["npm:27.0.1", {
+          "packageLocation": "./.yarn/cache/jest-docblock-npm-27.0.1-20d82eae71-64a346c264.zip/node_modules/jest-docblock/",
+          "packageDependencies": [
+            ["jest-docblock", "npm:27.0.1"],
             ["detect-newline", "npm:3.1.0"]
           ],
           "linkType": "HARD",
@@ -29513,6 +30514,18 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["jest-get-type", "npm:26.3.0"],
             ["jest-util", "npm:26.6.2"],
             ["pretty-format", "npm:26.6.2"]
+          ],
+          "linkType": "HARD",
+        }],
+        ["npm:27.0.2", {
+          "packageLocation": "./.yarn/cache/jest-each-npm-27.0.2-e44fb469a9-c0451c1283.zip/node_modules/jest-each/",
+          "packageDependencies": [
+            ["jest-each", "npm:27.0.2"],
+            ["@jest/types", "npm:27.0.2"],
+            ["chalk", "npm:4.1.1"],
+            ["jest-get-type", "npm:27.0.1"],
+            ["jest-util", "npm:27.0.2"],
+            ["pretty-format", "npm:27.0.2"]
           ],
           "linkType": "HARD",
         }]
@@ -29531,6 +30544,20 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["jsdom", "virtual:defa486869c88441047200a53b3aa18d79743b272095f3ee31b5b7b80b2c93d87f722added867470dcb94104504489a1a89040ea8fd89dffb9cfb1864d4bf54e#npm:16.5.3"]
           ],
           "linkType": "HARD",
+        }],
+        ["npm:27.0.3", {
+          "packageLocation": "./.yarn/cache/jest-environment-jsdom-npm-27.0.3-cf9425c76e-00f240aca7.zip/node_modules/jest-environment-jsdom/",
+          "packageDependencies": [
+            ["jest-environment-jsdom", "npm:27.0.3"],
+            ["@jest/environment", "npm:27.0.3"],
+            ["@jest/fake-timers", "npm:27.0.3"],
+            ["@jest/types", "npm:27.0.2"],
+            ["@types/node", "npm:15.3.0"],
+            ["jest-mock", "npm:27.0.3"],
+            ["jest-util", "npm:27.0.2"],
+            ["jsdom", "virtual:cf9425c76e2475783f68a1c89e1c5ccedac641213d48bb64a9a4218b53e64288435ef83646c7ac87ef4e4b74eb5bc26c4dcb983406b2061bb6234f588ab6f6a5#npm:16.6.0"]
+          ],
+          "linkType": "HARD",
         }]
       ]],
       ["jest-environment-node", [
@@ -29544,6 +30571,19 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@types/node", "npm:15.3.0"],
             ["jest-mock", "npm:26.6.2"],
             ["jest-util", "npm:26.6.2"]
+          ],
+          "linkType": "HARD",
+        }],
+        ["npm:27.0.3", {
+          "packageLocation": "./.yarn/cache/jest-environment-node-npm-27.0.3-1f3bf742d9-5272cb6fb9.zip/node_modules/jest-environment-node/",
+          "packageDependencies": [
+            ["jest-environment-node", "npm:27.0.3"],
+            ["@jest/environment", "npm:27.0.3"],
+            ["@jest/fake-timers", "npm:27.0.3"],
+            ["@jest/types", "npm:27.0.2"],
+            ["@types/node", "npm:15.3.0"],
+            ["jest-mock", "npm:27.0.3"],
+            ["jest-util", "npm:27.0.2"]
           ],
           "linkType": "HARD",
         }]
@@ -29580,6 +30620,13 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "packageLocation": "./.yarn/cache/jest-get-type-npm-26.3.0-a481f14d96-fc3e2d2b90.zip/node_modules/jest-get-type/",
           "packageDependencies": [
             ["jest-get-type", "npm:26.3.0"]
+          ],
+          "linkType": "HARD",
+        }],
+        ["npm:27.0.1", {
+          "packageLocation": "./.yarn/cache/jest-get-type-npm-27.0.1-aa40b7f8ce-bb816bd1e5.zip/node_modules/jest-get-type/",
+          "packageDependencies": [
+            ["jest-get-type", "npm:27.0.1"]
           ],
           "linkType": "HARD",
         }]
@@ -29624,6 +30671,26 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["walker", "npm:1.0.7"]
           ],
           "linkType": "HARD",
+        }],
+        ["npm:27.0.2", {
+          "packageLocation": "./.yarn/cache/jest-haste-map-npm-27.0.2-d6810375d3-2abd562615.zip/node_modules/jest-haste-map/",
+          "packageDependencies": [
+            ["jest-haste-map", "npm:27.0.2"],
+            ["@jest/types", "npm:27.0.2"],
+            ["@types/graceful-fs", "npm:4.1.5"],
+            ["@types/node", "npm:15.3.0"],
+            ["anymatch", "npm:3.1.2"],
+            ["fb-watchman", "npm:2.0.1"],
+            ["fsevents", "patch:fsevents@npm%3A2.3.2#builtin<compat/fsevents>::version=2.3.2&hash=11e9ea"],
+            ["graceful-fs", "npm:4.2.6"],
+            ["jest-regex-util", "npm:27.0.1"],
+            ["jest-serializer", "npm:27.0.1"],
+            ["jest-util", "npm:27.0.2"],
+            ["jest-worker", "npm:27.0.2"],
+            ["micromatch", "npm:4.0.4"],
+            ["walker", "npm:1.0.7"]
+          ],
+          "linkType": "HARD",
         }]
       ]],
       ["jest-jasmine2", [
@@ -29651,6 +30718,31 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["throat", "npm:5.0.0"]
           ],
           "linkType": "HARD",
+        }],
+        ["npm:27.0.4", {
+          "packageLocation": "./.yarn/cache/jest-jasmine2-npm-27.0.4-2ee7daa2ae-2826d49257.zip/node_modules/jest-jasmine2/",
+          "packageDependencies": [
+            ["jest-jasmine2", "npm:27.0.4"],
+            ["@babel/traverse", "npm:7.14.2"],
+            ["@jest/environment", "npm:27.0.3"],
+            ["@jest/source-map", "npm:27.0.1"],
+            ["@jest/test-result", "npm:27.0.2"],
+            ["@jest/types", "npm:27.0.2"],
+            ["@types/node", "npm:15.3.0"],
+            ["chalk", "npm:4.1.1"],
+            ["co", "npm:4.6.0"],
+            ["expect", "npm:27.0.2"],
+            ["is-generator-fn", "npm:2.1.0"],
+            ["jest-each", "npm:27.0.2"],
+            ["jest-matcher-utils", "npm:27.0.2"],
+            ["jest-message-util", "npm:27.0.2"],
+            ["jest-runtime", "npm:27.0.4"],
+            ["jest-snapshot", "npm:27.0.4"],
+            ["jest-util", "npm:27.0.2"],
+            ["pretty-format", "npm:27.0.2"],
+            ["throat", "npm:6.0.1"]
+          ],
+          "linkType": "HARD",
         }]
       ]],
       ["jest-leak-detector", [
@@ -29660,6 +30752,15 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["jest-leak-detector", "npm:26.6.2"],
             ["jest-get-type", "npm:26.3.0"],
             ["pretty-format", "npm:26.6.2"]
+          ],
+          "linkType": "HARD",
+        }],
+        ["npm:27.0.2", {
+          "packageLocation": "./.yarn/cache/jest-leak-detector-npm-27.0.2-d26b012860-6ebd03ecaf.zip/node_modules/jest-leak-detector/",
+          "packageDependencies": [
+            ["jest-leak-detector", "npm:27.0.2"],
+            ["jest-get-type", "npm:27.0.1"],
+            ["pretty-format", "npm:27.0.2"]
           ],
           "linkType": "HARD",
         }]
@@ -29673,6 +30774,17 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["jest-diff", "npm:26.6.2"],
             ["jest-get-type", "npm:26.3.0"],
             ["pretty-format", "npm:26.6.2"]
+          ],
+          "linkType": "HARD",
+        }],
+        ["npm:27.0.2", {
+          "packageLocation": "./.yarn/cache/jest-matcher-utils-npm-27.0.2-e0586ec40a-b2c0cc40c3.zip/node_modules/jest-matcher-utils/",
+          "packageDependencies": [
+            ["jest-matcher-utils", "npm:27.0.2"],
+            ["chalk", "npm:4.1.1"],
+            ["jest-diff", "npm:27.0.2"],
+            ["jest-get-type", "npm:27.0.1"],
+            ["pretty-format", "npm:27.0.2"]
           ],
           "linkType": "HARD",
         }]
@@ -29708,6 +30820,22 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["stack-utils", "npm:2.0.3"]
           ],
           "linkType": "HARD",
+        }],
+        ["npm:27.0.2", {
+          "packageLocation": "./.yarn/cache/jest-message-util-npm-27.0.2-b37b426cca-a94309f9f1.zip/node_modules/jest-message-util/",
+          "packageDependencies": [
+            ["jest-message-util", "npm:27.0.2"],
+            ["@babel/code-frame", "npm:7.12.13"],
+            ["@jest/types", "npm:27.0.2"],
+            ["@types/stack-utils", "npm:2.0.0"],
+            ["chalk", "npm:4.1.1"],
+            ["graceful-fs", "npm:4.2.6"],
+            ["micromatch", "npm:4.0.4"],
+            ["pretty-format", "npm:27.0.2"],
+            ["slash", "npm:3.0.0"],
+            ["stack-utils", "npm:2.0.3"]
+          ],
+          "linkType": "HARD",
         }]
       ]],
       ["jest-mock", [
@@ -29727,6 +30855,15 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@types/node", "npm:15.3.0"]
           ],
           "linkType": "HARD",
+        }],
+        ["npm:27.0.3", {
+          "packageLocation": "./.yarn/cache/jest-mock-npm-27.0.3-e7f02fb624-59ac90d5fe.zip/node_modules/jest-mock/",
+          "packageDependencies": [
+            ["jest-mock", "npm:27.0.3"],
+            ["@jest/types", "npm:27.0.2"],
+            ["@types/node", "npm:15.3.0"]
+          ],
+          "linkType": "HARD",
         }]
       ]],
       ["jest-pnp-resolver", [
@@ -29736,6 +30873,19 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["jest-pnp-resolver", "npm:1.2.2"]
           ],
           "linkType": "SOFT",
+        }],
+        ["virtual:1909eb3211ec0d33f7d16e1766e37ee39a99c96c4418bb71b3cbbfb7dc9d845bbed9f737bd8807e5800d5c7b49ed0cc4e1d4fc8ceff443668a8c2abbdfcba927#npm:1.2.2", {
+          "packageLocation": "./.yarn/$$virtual/jest-pnp-resolver-virtual-9525cd9c06/0/cache/jest-pnp-resolver-npm-1.2.2-da20f8bdfe-d91c86e389.zip/node_modules/jest-pnp-resolver/",
+          "packageDependencies": [
+            ["jest-pnp-resolver", "virtual:1909eb3211ec0d33f7d16e1766e37ee39a99c96c4418bb71b3cbbfb7dc9d845bbed9f737bd8807e5800d5c7b49ed0cc4e1d4fc8ceff443668a8c2abbdfcba927#npm:1.2.2"],
+            ["@types/jest-resolve", null],
+            ["jest-resolve", "npm:27.0.4"]
+          ],
+          "packagePeers": [
+            "@types/jest-resolve",
+            "jest-resolve"
+          ],
+          "linkType": "HARD",
         }],
         ["virtual:6ad3c87f852a744f0ca052ddcf60cfb1d20f148e44c4d3bc933aed1297626798d738b65c746a40d5eb58079971d680449b7c0894918212fabb0b9f5575e9f921#npm:1.2.2", {
           "packageLocation": "./.yarn/$$virtual/jest-pnp-resolver-virtual-c95d0051b1/0/cache/jest-pnp-resolver-npm-1.2.2-da20f8bdfe-d91c86e389.zip/node_modules/jest-pnp-resolver/",
@@ -29765,6 +30915,13 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["jest-regex-util", "npm:26.0.0"]
           ],
           "linkType": "HARD",
+        }],
+        ["npm:27.0.1", {
+          "packageLocation": "./.yarn/cache/jest-regex-util-npm-27.0.1-d1632ee0e1-8240b7ca4a.zip/node_modules/jest-regex-util/",
+          "packageDependencies": [
+            ["jest-regex-util", "npm:27.0.1"]
+          ],
+          "linkType": "HARD",
         }]
       ]],
       ["jest-resolve", [
@@ -29782,6 +30939,22 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["slash", "npm:3.0.0"]
           ],
           "linkType": "HARD",
+        }],
+        ["npm:27.0.4", {
+          "packageLocation": "./.yarn/cache/jest-resolve-npm-27.0.4-1909eb3211-77aa75ba94.zip/node_modules/jest-resolve/",
+          "packageDependencies": [
+            ["jest-resolve", "npm:27.0.4"],
+            ["@jest/types", "npm:27.0.2"],
+            ["chalk", "npm:4.1.1"],
+            ["escalade", "npm:3.1.1"],
+            ["graceful-fs", "npm:4.2.6"],
+            ["jest-pnp-resolver", "virtual:1909eb3211ec0d33f7d16e1766e37ee39a99c96c4418bb71b3cbbfb7dc9d845bbed9f737bd8807e5800d5c7b49ed0cc4e1d4fc8ceff443668a8c2abbdfcba927#npm:1.2.2"],
+            ["jest-util", "npm:27.0.2"],
+            ["jest-validate", "npm:27.0.2"],
+            ["resolve", "patch:resolve@npm%3A1.20.0#builtin<compat/resolve>::version=1.20.0&hash=3388aa"],
+            ["slash", "npm:3.0.0"]
+          ],
+          "linkType": "HARD",
         }]
       ]],
       ["jest-resolve-dependencies", [
@@ -29792,6 +30965,16 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@jest/types", "npm:26.6.2"],
             ["jest-regex-util", "npm:26.0.0"],
             ["jest-snapshot", "npm:26.6.2"]
+          ],
+          "linkType": "HARD",
+        }],
+        ["npm:27.0.4", {
+          "packageLocation": "./.yarn/cache/jest-resolve-dependencies-npm-27.0.4-aa41296e81-76f9608dff.zip/node_modules/jest-resolve-dependencies/",
+          "packageDependencies": [
+            ["jest-resolve-dependencies", "npm:27.0.4"],
+            ["@jest/types", "npm:27.0.2"],
+            ["jest-regex-util", "npm:27.0.1"],
+            ["jest-snapshot", "npm:27.0.4"]
           ],
           "linkType": "HARD",
         }]
@@ -29821,6 +31004,35 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["jest-worker", "npm:26.6.2"],
             ["source-map-support", "npm:0.5.19"],
             ["throat", "npm:5.0.0"]
+          ],
+          "linkType": "HARD",
+        }],
+        ["npm:27.0.4", {
+          "packageLocation": "./.yarn/cache/jest-runner-npm-27.0.4-2961cd612d-3c87f03766.zip/node_modules/jest-runner/",
+          "packageDependencies": [
+            ["jest-runner", "npm:27.0.4"],
+            ["@jest/console", "npm:27.0.2"],
+            ["@jest/environment", "npm:27.0.3"],
+            ["@jest/test-result", "npm:27.0.2"],
+            ["@jest/transform", "npm:27.0.2"],
+            ["@jest/types", "npm:27.0.2"],
+            ["@types/node", "npm:15.3.0"],
+            ["chalk", "npm:4.1.1"],
+            ["emittery", "npm:0.8.1"],
+            ["exit", "npm:0.1.2"],
+            ["graceful-fs", "npm:4.2.6"],
+            ["jest-docblock", "npm:27.0.1"],
+            ["jest-environment-jsdom", "npm:27.0.3"],
+            ["jest-environment-node", "npm:27.0.3"],
+            ["jest-haste-map", "npm:27.0.2"],
+            ["jest-leak-detector", "npm:27.0.2"],
+            ["jest-message-util", "npm:27.0.2"],
+            ["jest-resolve", "npm:27.0.4"],
+            ["jest-runtime", "npm:27.0.4"],
+            ["jest-util", "npm:27.0.2"],
+            ["jest-worker", "npm:27.0.2"],
+            ["source-map-support", "npm:0.5.19"],
+            ["throat", "npm:6.0.1"]
           ],
           "linkType": "HARD",
         }]
@@ -29859,6 +31071,39 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["yargs", "npm:15.4.1"]
           ],
           "linkType": "HARD",
+        }],
+        ["npm:27.0.4", {
+          "packageLocation": "./.yarn/cache/jest-runtime-npm-27.0.4-614e4abe4f-ece777fda5.zip/node_modules/jest-runtime/",
+          "packageDependencies": [
+            ["jest-runtime", "npm:27.0.4"],
+            ["@jest/console", "npm:27.0.2"],
+            ["@jest/environment", "npm:27.0.3"],
+            ["@jest/fake-timers", "npm:27.0.3"],
+            ["@jest/globals", "npm:27.0.3"],
+            ["@jest/source-map", "npm:27.0.1"],
+            ["@jest/test-result", "npm:27.0.2"],
+            ["@jest/transform", "npm:27.0.2"],
+            ["@jest/types", "npm:27.0.2"],
+            ["@types/yargs", "npm:16.0.3"],
+            ["chalk", "npm:4.1.1"],
+            ["cjs-module-lexer", "npm:1.2.1"],
+            ["collect-v8-coverage", "npm:1.0.1"],
+            ["exit", "npm:0.1.2"],
+            ["glob", "npm:7.1.7"],
+            ["graceful-fs", "npm:4.2.6"],
+            ["jest-haste-map", "npm:27.0.2"],
+            ["jest-message-util", "npm:27.0.2"],
+            ["jest-mock", "npm:27.0.3"],
+            ["jest-regex-util", "npm:27.0.1"],
+            ["jest-resolve", "npm:27.0.4"],
+            ["jest-snapshot", "npm:27.0.4"],
+            ["jest-util", "npm:27.0.2"],
+            ["jest-validate", "npm:27.0.2"],
+            ["slash", "npm:3.0.0"],
+            ["strip-bom", "npm:4.0.0"],
+            ["yargs", "npm:16.2.0"]
+          ],
+          "linkType": "HARD",
         }]
       ]],
       ["jest-serializer", [
@@ -29873,6 +31118,15 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "packageLocation": "./.yarn/cache/jest-serializer-npm-26.6.2-0907990487-62802ac809.zip/node_modules/jest-serializer/",
           "packageDependencies": [
             ["jest-serializer", "npm:26.6.2"],
+            ["@types/node", "npm:15.3.0"],
+            ["graceful-fs", "npm:4.2.6"]
+          ],
+          "linkType": "HARD",
+        }],
+        ["npm:27.0.1", {
+          "packageLocation": "./.yarn/cache/jest-serializer-npm-27.0.1-aa547af7bf-4f8812fdae.zip/node_modules/jest-serializer/",
+          "packageDependencies": [
+            ["jest-serializer", "npm:27.0.1"],
             ["@types/node", "npm:15.3.0"],
             ["graceful-fs", "npm:4.2.6"]
           ],
@@ -29899,6 +31153,37 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["jest-resolve", "npm:26.6.2"],
             ["natural-compare", "npm:1.4.0"],
             ["pretty-format", "npm:26.6.2"],
+            ["semver", "npm:7.3.5"]
+          ],
+          "linkType": "HARD",
+        }],
+        ["npm:27.0.4", {
+          "packageLocation": "./.yarn/cache/jest-snapshot-npm-27.0.4-41adfef6e7-7224d27ad2.zip/node_modules/jest-snapshot/",
+          "packageDependencies": [
+            ["jest-snapshot", "npm:27.0.4"],
+            ["@babel/core", "npm:7.14.6"],
+            ["@babel/generator", "npm:7.14.5"],
+            ["@babel/parser", "npm:7.14.6"],
+            ["@babel/plugin-syntax-typescript", "virtual:41adfef6e7fb7a1ecc1b7290eb28a8b5de0de3de8c9b7f3ffb7686a1ef14c1f8879217dd2210057b268490babbb69c4162520cfa0f9012288af824f2f508c134#npm:7.14.5"],
+            ["@babel/traverse", "npm:7.14.5"],
+            ["@babel/types", "npm:7.14.2"],
+            ["@jest/transform", "npm:27.0.2"],
+            ["@jest/types", "npm:27.0.2"],
+            ["@types/babel__traverse", "npm:7.11.1"],
+            ["@types/prettier", "npm:2.3.0"],
+            ["babel-preset-current-node-syntax", "virtual:41adfef6e7fb7a1ecc1b7290eb28a8b5de0de3de8c9b7f3ffb7686a1ef14c1f8879217dd2210057b268490babbb69c4162520cfa0f9012288af824f2f508c134#npm:1.0.1"],
+            ["chalk", "npm:4.1.1"],
+            ["expect", "npm:27.0.2"],
+            ["graceful-fs", "npm:4.2.6"],
+            ["jest-diff", "npm:27.0.2"],
+            ["jest-get-type", "npm:27.0.1"],
+            ["jest-haste-map", "npm:27.0.2"],
+            ["jest-matcher-utils", "npm:27.0.2"],
+            ["jest-message-util", "npm:27.0.2"],
+            ["jest-resolve", "npm:27.0.4"],
+            ["jest-util", "npm:27.0.2"],
+            ["natural-compare", "npm:1.4.0"],
+            ["pretty-format", "npm:27.0.2"],
             ["semver", "npm:7.3.5"]
           ],
           "linkType": "HARD",
@@ -29936,6 +31221,19 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["micromatch", "npm:4.0.4"]
           ],
           "linkType": "HARD",
+        }],
+        ["npm:27.0.2", {
+          "packageLocation": "./.yarn/cache/jest-util-npm-27.0.2-543ecb60f0-5a4b507119.zip/node_modules/jest-util/",
+          "packageDependencies": [
+            ["jest-util", "npm:27.0.2"],
+            ["@jest/types", "npm:27.0.2"],
+            ["@types/node", "npm:15.3.0"],
+            ["chalk", "npm:4.1.1"],
+            ["graceful-fs", "npm:4.2.6"],
+            ["is-ci", "npm:3.0.0"],
+            ["picomatch", "npm:2.2.3"]
+          ],
+          "linkType": "HARD",
         }]
       ]],
       ["jest-validate", [
@@ -29951,6 +31249,19 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["pretty-format", "npm:26.6.2"]
           ],
           "linkType": "HARD",
+        }],
+        ["npm:27.0.2", {
+          "packageLocation": "./.yarn/cache/jest-validate-npm-27.0.2-11208a2a7c-ec4799a884.zip/node_modules/jest-validate/",
+          "packageDependencies": [
+            ["jest-validate", "npm:27.0.2"],
+            ["@jest/types", "npm:27.0.2"],
+            ["camelcase", "npm:6.2.0"],
+            ["chalk", "npm:4.1.1"],
+            ["jest-get-type", "npm:27.0.1"],
+            ["leven", "npm:3.1.0"],
+            ["pretty-format", "npm:27.0.2"]
+          ],
+          "linkType": "HARD",
         }]
       ]],
       ["jest-watcher", [
@@ -29964,6 +31275,20 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["ansi-escapes", "npm:4.3.2"],
             ["chalk", "npm:4.1.1"],
             ["jest-util", "npm:26.6.2"],
+            ["string-length", "npm:4.0.2"]
+          ],
+          "linkType": "HARD",
+        }],
+        ["npm:27.0.2", {
+          "packageLocation": "./.yarn/cache/jest-watcher-npm-27.0.2-55e546b64d-f55c41487c.zip/node_modules/jest-watcher/",
+          "packageDependencies": [
+            ["jest-watcher", "npm:27.0.2"],
+            ["@jest/test-result", "npm:27.0.2"],
+            ["@jest/types", "npm:27.0.2"],
+            ["@types/node", "npm:15.3.0"],
+            ["ansi-escapes", "npm:4.3.2"],
+            ["chalk", "npm:4.1.1"],
+            ["jest-util", "npm:27.0.2"],
             ["string-length", "npm:4.0.2"]
           ],
           "linkType": "HARD",
@@ -29995,6 +31320,16 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@types/node", "npm:15.3.0"],
             ["merge-stream", "npm:2.0.0"],
             ["supports-color", "npm:7.2.0"]
+          ],
+          "linkType": "HARD",
+        }],
+        ["npm:27.0.2", {
+          "packageLocation": "./.yarn/cache/jest-worker-npm-27.0.2-256c4c36d7-bfbfd3d0af.zip/node_modules/jest-worker/",
+          "packageDependencies": [
+            ["jest-worker", "npm:27.0.2"],
+            ["@types/node", "npm:15.3.0"],
+            ["merge-stream", "npm:2.0.0"],
+            ["supports-color", "npm:8.1.1"]
           ],
           "linkType": "HARD",
         }]
@@ -30116,6 +31451,53 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["jsdom", "npm:16.5.3"]
           ],
           "linkType": "SOFT",
+        }],
+        ["npm:16.6.0", {
+          "packageLocation": "./.yarn/cache/jsdom-npm-16.6.0-f5f949a44e-ee0c9ef2cf.zip/node_modules/jsdom/",
+          "packageDependencies": [
+            ["jsdom", "npm:16.6.0"]
+          ],
+          "linkType": "SOFT",
+        }],
+        ["virtual:cf9425c76e2475783f68a1c89e1c5ccedac641213d48bb64a9a4218b53e64288435ef83646c7ac87ef4e4b74eb5bc26c4dcb983406b2061bb6234f588ab6f6a5#npm:16.6.0", {
+          "packageLocation": "./.yarn/$$virtual/jsdom-virtual-198c144d41/0/cache/jsdom-npm-16.6.0-f5f949a44e-ee0c9ef2cf.zip/node_modules/jsdom/",
+          "packageDependencies": [
+            ["jsdom", "virtual:cf9425c76e2475783f68a1c89e1c5ccedac641213d48bb64a9a4218b53e64288435ef83646c7ac87ef4e4b74eb5bc26c4dcb983406b2061bb6234f588ab6f6a5#npm:16.6.0"],
+            ["@types/canvas", null],
+            ["abab", "npm:2.0.5"],
+            ["acorn", "npm:8.4.0"],
+            ["acorn-globals", "npm:6.0.0"],
+            ["canvas", null],
+            ["cssom", "npm:0.4.4"],
+            ["cssstyle", "npm:2.3.0"],
+            ["data-urls", "npm:2.0.0"],
+            ["decimal.js", "npm:10.2.1"],
+            ["domexception", "npm:2.0.1"],
+            ["escodegen", "npm:2.0.0"],
+            ["form-data", "npm:3.0.1"],
+            ["html-encoding-sniffer", "npm:2.0.1"],
+            ["http-proxy-agent", "npm:4.0.1"],
+            ["https-proxy-agent", "npm:5.0.0"],
+            ["is-potential-custom-element-name", "npm:1.0.1"],
+            ["nwsapi", "npm:2.2.0"],
+            ["parse5", "npm:6.0.1"],
+            ["saxes", "npm:5.0.1"],
+            ["symbol-tree", "npm:3.2.4"],
+            ["tough-cookie", "npm:4.0.0"],
+            ["w3c-hr-time", "npm:1.0.2"],
+            ["w3c-xmlserializer", "npm:2.0.0"],
+            ["webidl-conversions", "npm:6.1.0"],
+            ["whatwg-encoding", "npm:1.0.5"],
+            ["whatwg-mimetype", "npm:2.3.0"],
+            ["whatwg-url", "npm:8.5.0"],
+            ["ws", "virtual:198c144d41cbcd2b6bb3ceaefa83d545067f9216d63e709afc15e02bdc948bb226ae3ca92d70551276aa6e56ab75995f6aaecc55b48bb698d0dafb0b343ce094#npm:7.5.0"],
+            ["xml-name-validator", "npm:3.0.0"]
+          ],
+          "packagePeers": [
+            "@types/canvas",
+            "canvas"
+          ],
+          "linkType": "HARD",
         }],
         ["virtual:defa486869c88441047200a53b3aa18d79743b272095f3ee31b5b7b80b2c93d87f722added867470dcb94104504489a1a89040ea8fd89dffb9cfb1864d4bf54e#npm:16.5.3", {
           "packageLocation": "./.yarn/$$virtual/jsdom-virtual-96f830aa00/0/cache/jsdom-npm-16.5.3-a7674d3b6b-02f6e3b5bb.zip/node_modules/jsdom/",
@@ -36410,6 +37792,17 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["react-is", "npm:17.0.2"]
           ],
           "linkType": "HARD",
+        }],
+        ["npm:27.0.2", {
+          "packageLocation": "./.yarn/cache/pretty-format-npm-27.0.2-d193adf249-d55daeb157.zip/node_modules/pretty-format/",
+          "packageDependencies": [
+            ["pretty-format", "npm:27.0.2"],
+            ["@jest/types", "npm:27.0.2"],
+            ["ansi-regex", "npm:5.0.0"],
+            ["ansi-styles", "npm:5.2.0"],
+            ["react-is", "npm:17.0.2"]
+          ],
+          "linkType": "HARD",
         }]
       ]],
       ["pretty-hrtime", [
@@ -40244,6 +41637,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@types/babel__core", "npm:7.1.14"],
             ["@types/babel__plugin-transform-runtime", "npm:7.9.1"],
             ["@types/babel__preset-env", "npm:7.9.1"],
+            ["@types/jest", "npm:26.0.23"],
             ["@typescript-eslint/eslint-plugin", "virtual:dc3fc578bfa5e06182a4d2be39ede0bc5b74940b1ffe0d70c26892ab140a4699787750fba175dc306292e80b4aa2c8c5f68c2a821e69b2c37e360c0dff36ff66#npm:4.24.0"],
             ["@typescript-eslint/parser", "virtual:dc3fc578bfa5e06182a4d2be39ede0bc5b74940b1ffe0d70c26892ab140a4699787750fba175dc306292e80b4aa2c8c5f68c2a821e69b2c37e360c0dff36ff66#npm:4.24.0"],
             ["babel-eslint", "virtual:dc3fc578bfa5e06182a4d2be39ede0bc5b74940b1ffe0d70c26892ab140a4699787750fba175dc306292e80b4aa2c8c5f68c2a821e69b2c37e360c0dff36ff66#npm:10.0.3"],
@@ -42697,6 +44091,14 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["has-flag", "npm:4.0.0"]
           ],
           "linkType": "HARD",
+        }],
+        ["npm:8.1.1", {
+          "packageLocation": "./.yarn/cache/supports-color-npm-8.1.1-289e937149-0219f5c917.zip/node_modules/supports-color/",
+          "packageDependencies": [
+            ["supports-color", "npm:8.1.1"],
+            ["has-flag", "npm:4.0.0"]
+          ],
+          "linkType": "HARD",
         }]
       ]],
       ["supports-hyperlinks", [
@@ -43212,6 +44614,13 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "packageLocation": "./.yarn/cache/throat-npm-5.0.0-288ce6540a-2fa41c09cc.zip/node_modules/throat/",
           "packageDependencies": [
             ["throat", "npm:5.0.0"]
+          ],
+          "linkType": "HARD",
+        }],
+        ["npm:6.0.1", {
+          "packageLocation": "./.yarn/cache/throat-npm-6.0.1-1308a37a10-c984a40b47.zip/node_modules/throat/",
+          "packageDependencies": [
+            ["throat", "npm:6.0.1"]
           ],
           "linkType": "HARD",
         }]
@@ -46512,6 +47921,30 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["ws", "npm:7.4.5"]
           ],
           "linkType": "SOFT",
+        }],
+        ["npm:7.5.0", {
+          "packageLocation": "./.yarn/cache/ws-npm-7.5.0-2736efb7e8-f9ac36310e.zip/node_modules/ws/",
+          "packageDependencies": [
+            ["ws", "npm:7.5.0"]
+          ],
+          "linkType": "SOFT",
+        }],
+        ["virtual:198c144d41cbcd2b6bb3ceaefa83d545067f9216d63e709afc15e02bdc948bb226ae3ca92d70551276aa6e56ab75995f6aaecc55b48bb698d0dafb0b343ce094#npm:7.5.0", {
+          "packageLocation": "./.yarn/$$virtual/ws-virtual-9d66b8c404/0/cache/ws-npm-7.5.0-2736efb7e8-f9ac36310e.zip/node_modules/ws/",
+          "packageDependencies": [
+            ["ws", "virtual:198c144d41cbcd2b6bb3ceaefa83d545067f9216d63e709afc15e02bdc948bb226ae3ca92d70551276aa6e56ab75995f6aaecc55b48bb698d0dafb0b343ce094#npm:7.5.0"],
+            ["@types/bufferutil", null],
+            ["@types/utf-8-validate", null],
+            ["bufferutil", null],
+            ["utf-8-validate", null]
+          ],
+          "packagePeers": [
+            "@types/bufferutil",
+            "@types/utf-8-validate",
+            "bufferutil",
+            "utf-8-validate"
+          ],
+          "linkType": "HARD",
         }],
         ["virtual:607c990b5641c2072404a9c40d24228008970dcd4f1f81af7c20cf09a0c9f1a96faeb09b70d7e22067eaf6a498a51416685f0dba00384196cd05d62c720e232a#npm:5.2.2", {
           "packageLocation": "./.yarn/$$virtual/ws-virtual-d9585679ca/0/cache/ws-npm-5.2.2-173bcd57b2-c8217b5482.zip/node_modules/ws/",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@types/babel__core": "^7",
     "@types/babel__plugin-transform-runtime": "^7",
     "@types/babel__preset-env": "^7",
+    "@types/jest": "^26.0.23",
     "@typescript-eslint/eslint-plugin": "^4.19.0",
     "@typescript-eslint/parser": "^4.19.0",
     "babel-eslint": "10.0.3",
@@ -68,6 +69,9 @@
       "!**/node_modules/**",
       "!**/vendor/**",
       "!.docz/**"
+    ],
+    "testPathIgnorePatterns": [
+      "dist"
     ]
   },
   "dependencies": {

--- a/packages/openneuro-app/jestsetup.ts
+++ b/packages/openneuro-app/jestsetup.ts
@@ -1,5 +1,5 @@
-// Make Enzyme functions available in all test files without importing
 import React from 'react'
+// Make Enzyme functions available in all test files without importing
 import Enzyme, { shallow, render, mount } from 'enzyme'
 import Adapter from '@wojtekmaj/enzyme-adapter-react-17'
 import moment from 'moment-timezone'
@@ -7,6 +7,7 @@ import fetch from 'jest-fetch-mock'
 import fromEntries from 'object.fromentries'
 import { jest } from '@jest/globals'
 import '@testing-library/jest-dom'
+import '@testing-library/jest-dom/extend-expect'
 
 Enzyme.configure({ adapter: new Adapter() })
 

--- a/packages/openneuro-app/package.json
+++ b/packages/openneuro-app/package.json
@@ -86,6 +86,7 @@
     "@types/node": "^14.14.37",
     "@types/react": "^17.0.8",
     "@types/react-dom": "^17.0.5",
+    "@types/testing-library__jest-dom": "^5.14.0",
     "@wojtekmaj/enzyme-adapter-react-17": "^0.6.1",
     "babel-core": "^7.0.0-bridge.0",
     "babel-jest": "^24.9.0",
@@ -138,6 +139,9 @@
     },
     "transformIgnorePatterns": [
       "/node_modules/(?!bids-validator).+\\.js$"
+    ],
+    "testPathIgnorePatterns": [
+      "dist"
     ]
   },
   "publishConfig": {

--- a/packages/openneuro-components/package.json
+++ b/packages/openneuro-components/package.json
@@ -41,6 +41,7 @@
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",
     "@types/bytes": "^3",
+    "@types/jest": "^26.0.23",
     "@types/md5": "^2",
     "@types/mdx-js__react": "^1",
     "@types/prop-types": "^15",
@@ -48,6 +49,7 @@
     "@types/react-slick": "^0",
     "@types/slick-carousel": "^1",
     "css-loader": "^5.2.1",
+    "jest": "^27.0.4",
     "sass": "^1.32.8",
     "sass-loader": "^10.1.1",
     "style-loader": "^2.0.0",
@@ -67,6 +69,11 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "jest": {
+    "testPathIgnorePatterns": [
+      "dist"
+    ]
   },
   "gitHead": "dbbc1c2c6a8ffbf82ce814bce981ccf9fde116fb"
 }

--- a/packages/openneuro-components/package.json
+++ b/packages/openneuro-components/package.json
@@ -29,6 +29,7 @@
     "slick-carousel": "^1.8.1"
   },
   "devDependencies": {
+    "@babel/runtime-corejs3": "^7.14.6",
     "@storybook/addon-a11y": "^6.2.8",
     "@storybook/addon-actions": "^6.2.8",
     "@storybook/addon-docs": "^6.2.8",
@@ -48,6 +49,7 @@
     "@types/react-router-dom": "^5",
     "@types/react-slick": "^0",
     "@types/slick-carousel": "^1",
+    "babel-jest": "^27.0.2",
     "css-loader": "^5.2.1",
     "jest": "^27.0.4",
     "sass": "^1.32.8",
@@ -73,7 +75,10 @@
   "jest": {
     "testPathIgnorePatterns": [
       "dist"
-    ]
+    ],
+    "moduleNameMapper": {
+      "^.+\\.(css|less|scss)$": "babel-jest"
+    }
   },
   "gitHead": "dbbc1c2c6a8ffbf82ce814bce981ccf9fde116fb"
 }

--- a/packages/openneuro-components/tsconfig.json
+++ b/packages/openneuro-components/tsconfig.json
@@ -3,9 +3,7 @@
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist",
-    "tsBuildInfoFile": "../../.build-cache/components.tsbuildinfo",
-    "composite": true,
-    "jsx": "react"
+    "tsBuildInfoFile": "../../.build-cache/components.tsbuildinfo"
   },
   "include": ["src"],
   "files": ["src/lerna.json"]

--- a/packages/openneuro-indexer/src/indexDatasets.ts
+++ b/packages/openneuro-indexer/src/indexDatasets.ts
@@ -10,6 +10,9 @@ import Datasets from './indexes/datasets'
 // TODO: This would be better to generate from the GraphQL schema
 interface DatasetQueryResult {
   id: string
+  metadata: Record<string, any>
+  latestSnapshot: Record<string, any>
+  __typename: string
 }
 
 /**

--- a/packages/openneuro-server/package.json
+++ b/packages/openneuro-server/package.json
@@ -79,6 +79,7 @@
     "@babel/runtime-corejs3": "^7.13.10",
     "@types/draft-js": "^0.10.43",
     "@types/ioredis": "^4.17.1",
+    "@types/jest": "^26.0.23",
     "@types/nodemailer": "^6.4.1",
     "apollo-link-schema": "^1.2.5",
     "babel-eslint": "^10.1.0",
@@ -93,7 +94,10 @@
     "tsc-watch": "^4.2.9"
   },
   "jest": {
-    "testEnvironment": "node"
+    "testEnvironment": "node",
+    "testPathIgnorePatterns": [
+      "dist"
+    ]
   },
   "publishConfig": {
     "access": "public"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,8 +28,6 @@
     "**/__mocks__/*",
     "**/*.spec.js",
     "**/*.spec.jsx",
-    "**/*.spec.ts",
-    "**/*.spec.tsx",
     "coverage"
   ],
   "references": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -2849,6 +2849,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/runtime-corejs3@npm:^7.14.6":
+  version: 7.14.6
+  resolution: "@babel/runtime-corejs3@npm:7.14.6"
+  dependencies:
+    core-js-pure: ^3.14.0
+    regenerator-runtime: ^0.13.4
+  checksum: aa0271b4e850d95a41474ee8e81029aee5a6407242935d551cf454561b161ed893194f58a79f5e57aafa91fb73c27434f103f517bed9b83568aa6fd5d5a357d3
+  languageName: node
+  linkType: hard
+
 "@babel/runtime@npm:^7.0.0, @babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.10.0, @babel/runtime@npm:^7.10.1, @babel/runtime@npm:^7.10.2, @babel/runtime@npm:^7.11.1, @babel/runtime@npm:^7.11.2, @babel/runtime@npm:^7.12.1, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.13.10, @babel/runtime@npm:^7.13.17, @babel/runtime@npm:^7.2.0, @babel/runtime@npm:^7.3.1, @babel/runtime@npm:^7.5.0, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.6.3, @babel/runtime@npm:^7.7.2, @babel/runtime@npm:^7.7.6, @babel/runtime@npm:^7.7.7, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.8.7, @babel/runtime@npm:^7.9.2":
   version: 7.14.0
   resolution: "@babel/runtime@npm:7.14.0"
@@ -5322,6 +5332,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@openneuro/components@workspace:packages/openneuro-components"
   dependencies:
+    "@babel/runtime-corejs3": ^7.14.6
     "@mdx-js/react": ^1.6.22
     "@storybook/addon-a11y": ^6.2.8
     "@storybook/addon-actions": ^6.2.8
@@ -5343,6 +5354,7 @@ __metadata:
     "@types/react-slick": ^0
     "@types/slick-carousel": ^1
     "@wojtekmaj/react-daterange-picker": ^3.2.0
+    babel-jest: ^27.0.2
     bytes: ^3.1.0
     commafy: ^0.0.6
     css-loader: ^5.2.1
@@ -12896,6 +12908,13 @@ __metadata:
   version: 3.12.1
   resolution: "core-js-pure@npm:3.12.1"
   checksum: f1f797aaccb4a612ddb24293bfad478bbec212353021019d3763557c737b0c9a00b445e3ff2ca80b2b8b14422181859a1c2b4a941f58e89c605ff9a8f66a6166
+  languageName: node
+  linkType: hard
+
+"core-js-pure@npm:^3.14.0":
+  version: 3.14.0
+  resolution: "core-js-pure@npm:3.14.0"
+  checksum: 8afceb673f05fd3fa384783f063b69f20f4f9a7963a66ac2330e3c63c14cb1e63b520e0195eba7019ee64bc3d5c3389000ef225b612dbadc8e1cfce7de54c907
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1075,10 +1075,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/code-frame@npm:^7.14.5":
+  version: 7.14.5
+  resolution: "@babel/code-frame@npm:7.14.5"
+  dependencies:
+    "@babel/highlight": ^7.14.5
+  checksum: 48c584cad9aa05ff16fa965b4572deae0343d51abe658a2fb72640e924c229d47f71f880a474cc1e14e613f88a4bfd576609b1e0d8073bbc4e50e60f7e678626
+  languageName: node
+  linkType: hard
+
 "@babel/compat-data@npm:^7.13.11, @babel/compat-data@npm:^7.13.15, @babel/compat-data@npm:^7.14.0":
   version: 7.14.0
   resolution: "@babel/compat-data@npm:7.14.0"
   checksum: d2d9de745e7a6f83ddf699865656e9298025bda5d350497845c57af440685723de28e7c1f34315e0028c6ad08bca0173436252ada7ac38eb2227c069d40916dd
+  languageName: node
+  linkType: hard
+
+"@babel/compat-data@npm:^7.14.5":
+  version: 7.14.5
+  resolution: "@babel/compat-data@npm:7.14.5"
+  checksum: 6ebae20f0d460a81cbca4c897ddf0053f40bc3a3b02634a4bf6f503b85279b6d65b3f6b2e8b9709825f5b99a5b9781959122707a1b220fb8c9c69f64a409650d
   languageName: node
   linkType: hard
 
@@ -1153,6 +1169,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/core@npm:7.14.6, @babel/core@npm:^7.7.2":
+  version: 7.14.6
+  resolution: "@babel/core@npm:7.14.6"
+  dependencies:
+    "@babel/code-frame": ^7.14.5
+    "@babel/generator": ^7.14.5
+    "@babel/helper-compilation-targets": ^7.14.5
+    "@babel/helper-module-transforms": ^7.14.5
+    "@babel/helpers": ^7.14.6
+    "@babel/parser": ^7.14.6
+    "@babel/template": ^7.14.5
+    "@babel/traverse": ^7.14.5
+    "@babel/types": ^7.14.5
+    convert-source-map: ^1.7.0
+    debug: ^4.1.0
+    gensync: ^1.0.0-beta.2
+    json5: ^2.1.2
+    semver: ^6.3.0
+    source-map: ^0.5.0
+  checksum: 239c4892d54f1d6e3a9a3972a7579138da6ff5308b9c08e4c80c9cd09282b6a921f58338851675fdb80b1cf9dd14f4176674917b97aa430bf1d50c0052bbb13a
+  languageName: node
+  linkType: hard
+
 "@babel/generator@npm:^7.10.5, @babel/generator@npm:^7.12.11, @babel/generator@npm:^7.12.5, @babel/generator@npm:^7.14.2, @babel/generator@npm:^7.14.3, @babel/generator@npm:^7.4.0, @babel/generator@npm:^7.5.5":
   version: 7.14.3
   resolution: "@babel/generator@npm:7.14.3"
@@ -1161,6 +1200,17 @@ __metadata:
     jsesc: ^2.5.1
     source-map: ^0.5.0
   checksum: 519fce36f3663dd346522d50d13b8549c02c0a340650c62db1bee0595a47f910b433f3bbdb513cc582bd932c5045b2673c8ef6a97913f9335fb16aa06085f274
+  languageName: node
+  linkType: hard
+
+"@babel/generator@npm:^7.14.5, @babel/generator@npm:^7.7.2":
+  version: 7.14.5
+  resolution: "@babel/generator@npm:7.14.5"
+  dependencies:
+    "@babel/types": ^7.14.5
+    jsesc: ^2.5.1
+    source-map: ^0.5.0
+  checksum: 3ba48b75f7680d17b4c3657063339252cf63ea0038b05e24d1611dff2c8f136fc8ca5cb1c293fbc1abc79b153e264bc23a01dc5f440030282e4da0631f12e0b7
   languageName: node
   linkType: hard
 
@@ -1194,6 +1244,20 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0
   checksum: baa1e4cdd562996c6af0a8cedb097cd72f67c44577faf4b657015f477d4930ebcc40ca21dc1e5fcffe91a1517de6e4114bc21f805ca701dfac2ddd2e9b006228
+  languageName: node
+  linkType: hard
+
+"@babel/helper-compilation-targets@npm:^7.14.5":
+  version: 7.14.5
+  resolution: "@babel/helper-compilation-targets@npm:7.14.5"
+  dependencies:
+    "@babel/compat-data": ^7.14.5
+    "@babel/helper-validator-option": ^7.14.5
+    browserslist: ^4.16.6
+    semver: ^6.3.0
+  peerDependencies:
+    "@babel/core": ^7.0.0
+  checksum: db7d58fc7309fcd925ee3cbf724fd796fc5779545de4da97badc772c7f05f087155538fb8ed503cf2e8075fb939c79a6e806fb5b7901c20dbe09c1d194a12ed2
   languageName: node
   linkType: hard
 
@@ -1281,12 +1345,32 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-function-name@npm:^7.14.5":
+  version: 7.14.5
+  resolution: "@babel/helper-function-name@npm:7.14.5"
+  dependencies:
+    "@babel/helper-get-function-arity": ^7.14.5
+    "@babel/template": ^7.14.5
+    "@babel/types": ^7.14.5
+  checksum: bf2172f932ce3bd8fdaa6df5464a581eee47484952c69115361439727e87d3289925a292655957b39446b6052119896da358022337985eed795444c550f7e4f3
+  languageName: node
+  linkType: hard
+
 "@babel/helper-get-function-arity@npm:^7.12.13":
   version: 7.12.13
   resolution: "@babel/helper-get-function-arity@npm:7.12.13"
   dependencies:
     "@babel/types": ^7.12.13
   checksum: cfb5c39959ea9f1cc21ee0f4a23054be66a615fa5392f25763ea98f0c690a5b47500af9a63f28a42a2fb3f699684c113c45a95c4ce6303dfecb3358e32e56c76
+  languageName: node
+  linkType: hard
+
+"@babel/helper-get-function-arity@npm:^7.14.5":
+  version: 7.14.5
+  resolution: "@babel/helper-get-function-arity@npm:7.14.5"
+  dependencies:
+    "@babel/types": ^7.14.5
+  checksum: 1bd0ae6c25af61a7795032452500362bb3f63042aadb1076184ebccc0afcb38e0565da3f02534f806ea0acb915efd75bc1de8530417f7be10f74c4a3efbacb3a
   languageName: node
   linkType: hard
 
@@ -1300,6 +1384,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-hoist-variables@npm:^7.14.5":
+  version: 7.14.5
+  resolution: "@babel/helper-hoist-variables@npm:7.14.5"
+  dependencies:
+    "@babel/types": ^7.14.5
+  checksum: c2fdc5a2391f13fac73089c563f2a3fcfbec460bd866d6ceb4f97e7138b38a5e16703e6ced3ff1a0e6058aece138e19c30fe11e9e2a65d564d73a6c4a34313e2
+  languageName: node
+  linkType: hard
+
 "@babel/helper-member-expression-to-functions@npm:^7.13.12":
   version: 7.13.12
   resolution: "@babel/helper-member-expression-to-functions@npm:7.13.12"
@@ -1309,12 +1402,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-member-expression-to-functions@npm:^7.14.5":
+  version: 7.14.5
+  resolution: "@babel/helper-member-expression-to-functions@npm:7.14.5"
+  dependencies:
+    "@babel/types": ^7.14.5
+  checksum: 9dc1a8a5de887cb3160e4890d4a68a3f43b09f910cdd1b5268c0882c6d5f9b5ba4e4e4f451dc8ed27691fe89a480aec578007503a9204052c381b0eb0d714997
+  languageName: node
+  linkType: hard
+
 "@babel/helper-module-imports@npm:^7.0.0, @babel/helper-module-imports@npm:^7.0.0-beta.49, @babel/helper-module-imports@npm:^7.12.13, @babel/helper-module-imports@npm:^7.13.12":
   version: 7.13.12
   resolution: "@babel/helper-module-imports@npm:7.13.12"
   dependencies:
     "@babel/types": ^7.13.12
   checksum: 4d1d3364bec0820e50c782b5a5c81e7987c260c14772bc594ca8dbfdb3b6e43bd9b4e5071fd2a5f777c822dc7440781fa904f643e2069755db9ba5033cb2beac
+  languageName: node
+  linkType: hard
+
+"@babel/helper-module-imports@npm:^7.14.5":
+  version: 7.14.5
+  resolution: "@babel/helper-module-imports@npm:7.14.5"
+  dependencies:
+    "@babel/types": ^7.14.5
+  checksum: 483919bf31611dc5905acb6a01b888fad1264ddcecaae706c0dde46ff81fa708d98c4a093ab0d4ad71791eb0a30b6dafbfa5364003e71486d6b3c5c718eccf7d
   languageName: node
   linkType: hard
 
@@ -1334,12 +1445,37 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-module-transforms@npm:^7.14.5":
+  version: 7.14.5
+  resolution: "@babel/helper-module-transforms@npm:7.14.5"
+  dependencies:
+    "@babel/helper-module-imports": ^7.14.5
+    "@babel/helper-replace-supers": ^7.14.5
+    "@babel/helper-simple-access": ^7.14.5
+    "@babel/helper-split-export-declaration": ^7.14.5
+    "@babel/helper-validator-identifier": ^7.14.5
+    "@babel/template": ^7.14.5
+    "@babel/traverse": ^7.14.5
+    "@babel/types": ^7.14.5
+  checksum: b6f47b812d264ea204802d98d6b5a8e47b8fad5a4406a349e7a913b7b881d9be509f95f405a06d5416e95d07539386fa5c50f46eb07e033f0fb9a35f06632bf5
+  languageName: node
+  linkType: hard
+
 "@babel/helper-optimise-call-expression@npm:^7.12.13":
   version: 7.12.13
   resolution: "@babel/helper-optimise-call-expression@npm:7.12.13"
   dependencies:
     "@babel/types": ^7.12.13
   checksum: 5e4df5da4a45d7b7c100307efdc11f9fb460f943b4db1c60ddbdf57c3a7cbeecc8dea8980f4a9d4f3c38071b04d0e7c95af213229bcc1c13f17eb7293a6298a9
+  languageName: node
+  linkType: hard
+
+"@babel/helper-optimise-call-expression@npm:^7.14.5":
+  version: 7.14.5
+  resolution: "@babel/helper-optimise-call-expression@npm:7.14.5"
+  dependencies:
+    "@babel/types": ^7.14.5
+  checksum: 68845ee7fb88cf7bfbea9635d3fddcc953818b86732985f3fb228f77012652b36f4e41f00d8e7b5e3be2b2d41b6b9f189a36fd49874e58a29dd2e3b1dc753f5c
   languageName: node
   linkType: hard
 
@@ -1354,6 +1490,13 @@ __metadata:
   version: 7.13.0
   resolution: "@babel/helper-plugin-utils@npm:7.13.0"
   checksum: 229ac1917b43ad38732d2d4a9a826f87d8945719249efe1d6191f3e25ba6027a289af70380d82d62a03fc9e82558a0ea6f12739cbb55b64bb280d6b511b4ca65
+  languageName: node
+  linkType: hard
+
+"@babel/helper-plugin-utils@npm:^7.14.5":
+  version: 7.14.5
+  resolution: "@babel/helper-plugin-utils@npm:7.14.5"
+  checksum: 76404ef3aadc25879f7b4c5945bafcca935d4af0cf451a95ff9f131f29ac3dc589e2ed19904ce746c7cf6c2a8a7ea33fa4eaf881b9b272d31f2be91984f505d6
   languageName: node
   linkType: hard
 
@@ -1380,12 +1523,33 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-replace-supers@npm:^7.14.5":
+  version: 7.14.5
+  resolution: "@babel/helper-replace-supers@npm:7.14.5"
+  dependencies:
+    "@babel/helper-member-expression-to-functions": ^7.14.5
+    "@babel/helper-optimise-call-expression": ^7.14.5
+    "@babel/traverse": ^7.14.5
+    "@babel/types": ^7.14.5
+  checksum: 368aba02e75a3bdae7e79d424c7ec98c72a3d8ced95920899e9efc39d274a414c7ab0ac9ed49c9af21e6430a5c5063e382de93d2dd83ff27c8f469a011a658a0
+  languageName: node
+  linkType: hard
+
 "@babel/helper-simple-access@npm:^7.13.12":
   version: 7.13.12
   resolution: "@babel/helper-simple-access@npm:7.13.12"
   dependencies:
     "@babel/types": ^7.13.12
   checksum: eff532a1572a4ac562c5918a409871ddf9baee9ece197b98a54622184d3b9e01bdd465597f27ca3d452e71638c913a14819cf261dc095a466032dfd92a88bc73
+  languageName: node
+  linkType: hard
+
+"@babel/helper-simple-access@npm:^7.14.5":
+  version: 7.14.5
+  resolution: "@babel/helper-simple-access@npm:7.14.5"
+  dependencies:
+    "@babel/types": ^7.14.5
+  checksum: dd6de62de59ab05121aa1198d01080415584ac4a4d4f5d4e53fd22a1c8d5359d19667cd61663937dffa9ab7761aecbe66eee9e1d266def6a59b4ede2dc15ea57
   languageName: node
   linkType: hard
 
@@ -1407,6 +1571,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-split-export-declaration@npm:^7.14.5":
+  version: 7.14.5
+  resolution: "@babel/helper-split-export-declaration@npm:7.14.5"
+  dependencies:
+    "@babel/types": ^7.14.5
+  checksum: 80965627683125d6e4d3ead34f685219933203d7852f2f8af87883702367da5b43bde05b772040434841d7259a4e7045b3ab0ff1768a37c90b6563928191a562
+  languageName: node
+  linkType: hard
+
 "@babel/helper-validator-identifier@npm:^7.12.11, @babel/helper-validator-identifier@npm:^7.14.0":
   version: 7.14.0
   resolution: "@babel/helper-validator-identifier@npm:7.14.0"
@@ -1414,10 +1587,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-validator-identifier@npm:^7.14.5":
+  version: 7.14.5
+  resolution: "@babel/helper-validator-identifier@npm:7.14.5"
+  checksum: 778312189a7c5228daac9f7767795a74f11d1eac595ca38bfea248324666459b24aaae6aef43c957ce01bbe61672039ea1c08c5623067c3701beeb1bb1f1ee33
+  languageName: node
+  linkType: hard
+
 "@babel/helper-validator-option@npm:^7.12.17":
   version: 7.12.17
   resolution: "@babel/helper-validator-option@npm:7.12.17"
   checksum: 9201d17a5634b05a6f3d561b95e73a4e4f9ba2e56c55cfc3b9a2a9618c4090b4b507720ac7a2e77209e68dc9bdc00a59b5ba7ad9ecbca3fb2c9217e814b7b5a5
+  languageName: node
+  linkType: hard
+
+"@babel/helper-validator-option@npm:^7.14.5":
+  version: 7.14.5
+  resolution: "@babel/helper-validator-option@npm:7.14.5"
+  checksum: aded46b377d25f5966aab30506cdb95908bae18ea5d062e86c646e9afcef911327da80e637e06c3542ea2ba01cab903d18e91fc8a12fbf7b15e0b3e8ee0b9d3b
   languageName: node
   linkType: hard
 
@@ -1444,6 +1631,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helpers@npm:^7.14.6":
+  version: 7.14.6
+  resolution: "@babel/helpers@npm:7.14.6"
+  dependencies:
+    "@babel/template": ^7.14.5
+    "@babel/traverse": ^7.14.5
+    "@babel/types": ^7.14.5
+  checksum: c5c3bd0f9618cdb8895d89171fe0b89c0b119bf8c9f96aff869d95b9208628172a882a132f8f76a218e0e68d8c3316f65b60af9b3a3a778d9b9adce004ca52c7
+  languageName: node
+  linkType: hard
+
 "@babel/highlight@npm:^7.10.4, @babel/highlight@npm:^7.12.13":
   version: 7.14.0
   resolution: "@babel/highlight@npm:7.14.0"
@@ -1455,12 +1653,32 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/highlight@npm:^7.14.5":
+  version: 7.14.5
+  resolution: "@babel/highlight@npm:7.14.5"
+  dependencies:
+    "@babel/helper-validator-identifier": ^7.14.5
+    chalk: ^2.0.0
+    js-tokens: ^4.0.0
+  checksum: a1ed599c2655eb0b13134875ba2626b547a2634940e532c86a02896fb403f197cd56d1adaa474c7859ae4f53fabc5f1621e90770e75d235ca3350952ba78aa5c
+  languageName: node
+  linkType: hard
+
 "@babel/parser@npm:^7.0.0, @babel/parser@npm:^7.1.0, @babel/parser@npm:^7.10.5, @babel/parser@npm:^7.12.11, @babel/parser@npm:^7.12.13, @babel/parser@npm:^7.12.5, @babel/parser@npm:^7.12.7, @babel/parser@npm:^7.14.2, @babel/parser@npm:^7.14.3, @babel/parser@npm:^7.4.3, @babel/parser@npm:^7.5.5, @babel/parser@npm:^7.7.0":
   version: 7.14.3
   resolution: "@babel/parser@npm:7.14.3"
   bin:
     parser: ./bin/babel-parser.js
   checksum: 5e8d1b2bfc53b59c7476c32adee20c8a4d19fdab58b04b6b177d89319bd76526219dad2f6ab6f51a80a518d0cbcdc3980b73c18bde16017aeee2dd8a50687fe3
+  languageName: node
+  linkType: hard
+
+"@babel/parser@npm:^7.14.5, @babel/parser@npm:^7.14.6, @babel/parser@npm:^7.7.2":
+  version: 7.14.6
+  resolution: "@babel/parser@npm:7.14.6"
+  bin:
+    parser: ./bin/babel-parser.js
+  checksum: 447ca2627e356e4507cf8c89adcf0865217d4c7ee69daeaea1a93207c68923e01d27a492df0809a2d9a51d82b2b0cc70375a2dc2cb3262c46eb0ca911c360fd2
   languageName: node
   linkType: hard
 
@@ -1966,6 +2184,17 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: ea2b4aad35c62fc66c9e1629b70ece2ac060550f2fd10c814d568946121ec0790690c5dc65c8888bc3b543e71691e553e2ed8becac769384484c27ae6ddcb21e
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-syntax-typescript@npm:^7.7.2":
+  version: 7.14.5
+  resolution: "@babel/plugin-syntax-typescript@npm:7.14.5"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.14.5
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 1b26952c0fa586460c8be3422e755fcd28a0cbddf5fb5647ade091facddc7a314b0320cb7a63072f32fd63702332ec837dc0e2b21a111c427c21d243596da180
   languageName: node
   linkType: hard
 
@@ -2647,6 +2876,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/template@npm:^7.14.5":
+  version: 7.14.5
+  resolution: "@babel/template@npm:7.14.5"
+  dependencies:
+    "@babel/code-frame": ^7.14.5
+    "@babel/parser": ^7.14.5
+    "@babel/types": ^7.14.5
+  checksum: 71619e2e3d6d518bf6c40ebd610379b050a6e8e9a2ec0cda8b5c28aea5105f69006758b575dae63a21a6d4f64f854e92c0cb6cf8841d59f5585596165df78060
+  languageName: node
+  linkType: hard
+
 "@babel/traverse@npm:^7.0.0, @babel/traverse@npm:^7.1.0, @babel/traverse@npm:^7.1.6, @babel/traverse@npm:^7.10.5, @babel/traverse@npm:^7.12.5, @babel/traverse@npm:^7.12.9, @babel/traverse@npm:^7.13.0, @babel/traverse@npm:^7.13.15, @babel/traverse@npm:^7.14.0, @babel/traverse@npm:^7.14.2, @babel/traverse@npm:^7.4.3, @babel/traverse@npm:^7.5.5, @babel/traverse@npm:^7.7.0":
   version: 7.14.2
   resolution: "@babel/traverse@npm:7.14.2"
@@ -2663,6 +2903,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/traverse@npm:^7.14.5, @babel/traverse@npm:^7.7.2":
+  version: 7.14.5
+  resolution: "@babel/traverse@npm:7.14.5"
+  dependencies:
+    "@babel/code-frame": ^7.14.5
+    "@babel/generator": ^7.14.5
+    "@babel/helper-function-name": ^7.14.5
+    "@babel/helper-hoist-variables": ^7.14.5
+    "@babel/helper-split-export-declaration": ^7.14.5
+    "@babel/parser": ^7.14.5
+    "@babel/types": ^7.14.5
+    debug: ^4.1.0
+    globals: ^11.1.0
+  checksum: 3104bd5c4cd26403964234a22e30ec69a10d61504acb8b5198af32a69a3a2f9ad1fb74b4321e475394ed3d6582bb518e53a765f1e27d61ac54a8627764ab222a
+  languageName: node
+  linkType: hard
+
 "@babel/types@npm:^7.0.0, @babel/types@npm:^7.0.0-beta.49, @babel/types@npm:^7.10.5, @babel/types@npm:^7.12.1, @babel/types@npm:^7.12.13, @babel/types@npm:^7.12.6, @babel/types@npm:^7.12.7, @babel/types@npm:^7.13.0, @babel/types@npm:^7.13.12, @babel/types@npm:^7.13.16, @babel/types@npm:^7.14.0, @babel/types@npm:^7.14.2, @babel/types@npm:^7.2.0, @babel/types@npm:^7.3.0, @babel/types@npm:^7.3.3, @babel/types@npm:^7.4.0, @babel/types@npm:^7.4.4, @babel/types@npm:^7.5.5, @babel/types@npm:^7.7.0, @babel/types@npm:^7.8.3":
   version: 7.14.2
   resolution: "@babel/types@npm:7.14.2"
@@ -2670,6 +2927,16 @@ __metadata:
     "@babel/helper-validator-identifier": ^7.14.0
     to-fast-properties: ^2.0.0
   checksum: 34893ac415826cd2ddead0511be9c3cb876bf626148b00b0a471c4630b193939ba46a9bf9d8b2be88e46fceb3ae9204ed7488ceb6a08a67550211d40df65a7c7
+  languageName: node
+  linkType: hard
+
+"@babel/types@npm:^7.14.5":
+  version: 7.14.5
+  resolution: "@babel/types@npm:7.14.5"
+  dependencies:
+    "@babel/helper-validator-identifier": ^7.14.5
+    to-fast-properties: ^2.0.0
+  checksum: 45575b46df5ec0e63454b794a60f362596c6f16beda7df3693b134db5be15eb43f7b98ca7b2a5a9628171db5192eed5b8965e43c0a6f5383bca4ddefd0ea8d30
   languageName: node
   linkType: hard
 
@@ -3305,6 +3572,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jest/console@npm:^27.0.2":
+  version: 27.0.2
+  resolution: "@jest/console@npm:27.0.2"
+  dependencies:
+    "@jest/types": ^27.0.2
+    "@types/node": "*"
+    chalk: ^4.0.0
+    jest-message-util: ^27.0.2
+    jest-util: ^27.0.2
+    slash: ^3.0.0
+  checksum: 98757eeacade42f4757a644d5ebadce0a63324ef7a89a10bce356c604445d486ab5ca48611cf50ee272f75367cec657d89d2f44666a8f144de02b3ceae29d701
+  languageName: node
+  linkType: hard
+
 "@jest/core@npm:^26.6.3":
   version: 26.6.3
   resolution: "@jest/core@npm:26.6.3"
@@ -3341,6 +3622,48 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jest/core@npm:^27.0.4":
+  version: 27.0.4
+  resolution: "@jest/core@npm:27.0.4"
+  dependencies:
+    "@jest/console": ^27.0.2
+    "@jest/reporters": ^27.0.4
+    "@jest/test-result": ^27.0.2
+    "@jest/transform": ^27.0.2
+    "@jest/types": ^27.0.2
+    "@types/node": "*"
+    ansi-escapes: ^4.2.1
+    chalk: ^4.0.0
+    emittery: ^0.8.1
+    exit: ^0.1.2
+    graceful-fs: ^4.2.4
+    jest-changed-files: ^27.0.2
+    jest-config: ^27.0.4
+    jest-haste-map: ^27.0.2
+    jest-message-util: ^27.0.2
+    jest-regex-util: ^27.0.1
+    jest-resolve: ^27.0.4
+    jest-resolve-dependencies: ^27.0.4
+    jest-runner: ^27.0.4
+    jest-runtime: ^27.0.4
+    jest-snapshot: ^27.0.4
+    jest-util: ^27.0.2
+    jest-validate: ^27.0.2
+    jest-watcher: ^27.0.2
+    micromatch: ^4.0.4
+    p-each-series: ^2.1.0
+    rimraf: ^3.0.0
+    slash: ^3.0.0
+    strip-ansi: ^6.0.0
+  peerDependencies:
+    node-notifier: ^8.0.1 || ^9.0.0
+  peerDependenciesMeta:
+    node-notifier:
+      optional: true
+  checksum: 7e5d68833bff3ea0ad6e9f1dc64b1ef75a354f3c89fb2a92f4815f6626e7cd67652344fd347e0e9c43eb20ee00a67320adccb10eb453c19c84a920bbd79cdbb9
+  languageName: node
+  linkType: hard
+
 "@jest/environment@npm:^26.6.2":
   version: 26.6.2
   resolution: "@jest/environment@npm:26.6.2"
@@ -3350,6 +3673,18 @@ __metadata:
     "@types/node": "*"
     jest-mock: ^26.6.2
   checksum: a4f426546801e79d2f5d1a516d80c330ccbe1638f7a7705f65110ac33f8a3ded08ccef75ad648610618122f2bfeba34e0c1e616eccc219a315956d63ff30d8fc
+  languageName: node
+  linkType: hard
+
+"@jest/environment@npm:^27.0.3":
+  version: 27.0.3
+  resolution: "@jest/environment@npm:27.0.3"
+  dependencies:
+    "@jest/fake-timers": ^27.0.3
+    "@jest/types": ^27.0.2
+    "@types/node": "*"
+    jest-mock: ^27.0.3
+  checksum: a73ef6b82c68647e00b90a84e836cfc1d8dc6fdf86cd7216c64707d07648655c20e842ac458459fffb40045903d062ed3801e481958342ac3a821d5f48c1965c
   languageName: node
   linkType: hard
 
@@ -3378,6 +3713,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jest/fake-timers@npm:^27.0.3":
+  version: 27.0.3
+  resolution: "@jest/fake-timers@npm:27.0.3"
+  dependencies:
+    "@jest/types": ^27.0.2
+    "@sinonjs/fake-timers": ^7.0.2
+    "@types/node": "*"
+    jest-message-util: ^27.0.2
+    jest-mock: ^27.0.3
+    jest-util: ^27.0.2
+  checksum: 915cedba7f40e2d8cd2f9188771284803daba0c7588a09ab4ae68802341dd51b058e752d265054895a2345d620fb5be6750ad07a9a70d5e21a06f368b6b61ee3
+  languageName: node
+  linkType: hard
+
 "@jest/globals@npm:^26.6.2":
   version: 26.6.2
   resolution: "@jest/globals@npm:26.6.2"
@@ -3386,6 +3735,17 @@ __metadata:
     "@jest/types": ^26.6.2
     expect: ^26.6.2
   checksum: d8f68a24adf87f6e32ba34ec884502ec067ed79a2855852ed64daa50383a53daf2b97487dd049e77c6fd6cade28b32f8cad4f0a2d02ce6b8aa23f95a136db8a7
+  languageName: node
+  linkType: hard
+
+"@jest/globals@npm:^27.0.3":
+  version: 27.0.3
+  resolution: "@jest/globals@npm:27.0.3"
+  dependencies:
+    "@jest/environment": ^27.0.3
+    "@jest/types": ^27.0.2
+    expect: ^27.0.2
+  checksum: c7e473c19cec428d2dcad03ec63c52849c55c8617351e11deac303064cd9463882800a5b4044302769daa77394907d4bf2d580914396fa8af1e18da6ec66e09b
   languageName: node
   linkType: hard
 
@@ -3425,6 +3785,43 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jest/reporters@npm:^27.0.4":
+  version: 27.0.4
+  resolution: "@jest/reporters@npm:27.0.4"
+  dependencies:
+    "@bcoe/v8-coverage": ^0.2.3
+    "@jest/console": ^27.0.2
+    "@jest/test-result": ^27.0.2
+    "@jest/transform": ^27.0.2
+    "@jest/types": ^27.0.2
+    chalk: ^4.0.0
+    collect-v8-coverage: ^1.0.0
+    exit: ^0.1.2
+    glob: ^7.1.2
+    graceful-fs: ^4.2.4
+    istanbul-lib-coverage: ^3.0.0
+    istanbul-lib-instrument: ^4.0.3
+    istanbul-lib-report: ^3.0.0
+    istanbul-lib-source-maps: ^4.0.0
+    istanbul-reports: ^3.0.2
+    jest-haste-map: ^27.0.2
+    jest-resolve: ^27.0.4
+    jest-util: ^27.0.2
+    jest-worker: ^27.0.2
+    slash: ^3.0.0
+    source-map: ^0.6.0
+    string-length: ^4.0.1
+    terminal-link: ^2.0.0
+    v8-to-istanbul: ^7.0.0
+  peerDependencies:
+    node-notifier: ^8.0.1 || ^9.0.0
+  peerDependenciesMeta:
+    node-notifier:
+      optional: true
+  checksum: 52a5ecea31b616885c4718554ce60f8d593ca58e5b98eac0731988b8e2184a3fc09b78ecd309d61fd0b0956443fecde5161e33289e51c856786c2ab1abe68ae2
+  languageName: node
+  linkType: hard
+
 "@jest/source-map@npm:^24.9.0":
   version: 24.9.0
   resolution: "@jest/source-map@npm:24.9.0"
@@ -3444,6 +3841,17 @@ __metadata:
     graceful-fs: ^4.2.4
     source-map: ^0.6.0
   checksum: 9a6d3e650660229fadfcf4d9789cdf99d645d3827b05cbce7676f39d19af2ab00cca728420ef188cf44b92289e06e2a5f3e5299085e3ae080cc0472ea1fa4cc9
+  languageName: node
+  linkType: hard
+
+"@jest/source-map@npm:^27.0.1":
+  version: 27.0.1
+  resolution: "@jest/source-map@npm:27.0.1"
+  dependencies:
+    callsites: ^3.0.0
+    graceful-fs: ^4.2.4
+    source-map: ^0.6.0
+  checksum: 0c69ae000ef7bc20474381721e4d76f3270789b50a66af3124cdff24bc9feefaf203442bf82d5d29f5e7baba10f859cafdd2268bc0d023d07b7aa8b3468fc894
   languageName: node
   linkType: hard
 
@@ -3470,6 +3878,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jest/test-result@npm:^27.0.2":
+  version: 27.0.2
+  resolution: "@jest/test-result@npm:27.0.2"
+  dependencies:
+    "@jest/console": ^27.0.2
+    "@jest/types": ^27.0.2
+    "@types/istanbul-lib-coverage": ^2.0.0
+    collect-v8-coverage: ^1.0.0
+  checksum: 578a75168a0922f9ffa36dc6fecf90116917e5ffcf9dd25a9ffddf785b6f56277e46bd8663bb6ffe7a0adb56594fd6834cf10173d51b6b0edc2ac83cf020f94d
+  languageName: node
+  linkType: hard
+
 "@jest/test-sequencer@npm:^26.6.3":
   version: 26.6.3
   resolution: "@jest/test-sequencer@npm:26.6.3"
@@ -3480,6 +3900,18 @@ __metadata:
     jest-runner: ^26.6.3
     jest-runtime: ^26.6.3
   checksum: c0c2c7917a0b6e25414b0ed570701c9cd5b2ba18fe0c55ac3a2d53ccf6aeeaf7ec388c14c78d13c27c4a7e7ee87bdca52d09d820c0ebf80a3e7d47f3fc52e9ef
+  languageName: node
+  linkType: hard
+
+"@jest/test-sequencer@npm:^27.0.4":
+  version: 27.0.4
+  resolution: "@jest/test-sequencer@npm:27.0.4"
+  dependencies:
+    "@jest/test-result": ^27.0.2
+    graceful-fs: ^4.2.4
+    jest-haste-map: ^27.0.2
+    jest-runtime: ^27.0.4
+  checksum: ff13677535ffde500c0ae74e67b009770b3e24efe5de9aab35fa2923a9181ee7db1a59bb34e9c68f355759b9c5535956781c16e2bd1033709cf94526aeb44d57
   languageName: node
   linkType: hard
 
@@ -3530,6 +3962,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jest/transform@npm:^27.0.2":
+  version: 27.0.2
+  resolution: "@jest/transform@npm:27.0.2"
+  dependencies:
+    "@babel/core": ^7.1.0
+    "@jest/types": ^27.0.2
+    babel-plugin-istanbul: ^6.0.0
+    chalk: ^4.0.0
+    convert-source-map: ^1.4.0
+    fast-json-stable-stringify: ^2.0.0
+    graceful-fs: ^4.2.4
+    jest-haste-map: ^27.0.2
+    jest-regex-util: ^27.0.1
+    jest-util: ^27.0.2
+    micromatch: ^4.0.4
+    pirates: ^4.0.1
+    slash: ^3.0.0
+    source-map: ^0.6.1
+    write-file-atomic: ^3.0.0
+  checksum: 3ba8c4f064ab80e33360623e855b963365a7480b7f7bee80f6e2ae44f9ee0b4449715610da05d36fcb9327629fdc6aa9b83492b81cfb307ddb0662995dfb26e7
+  languageName: node
+  linkType: hard
+
 "@jest/types@npm:^24.9.0":
   version: 24.9.0
   resolution: "@jest/types@npm:24.9.0"
@@ -3563,6 +4018,19 @@ __metadata:
     "@types/yargs": ^15.0.0
     chalk: ^4.0.0
   checksum: 5c511d7807f414b298299ae4a053abf265f39984942e0eefdfb17a7986a36f1047e0fd9a6f785bdddbf7343a5737595dfabe148719a80e118dd77486502009cc
+  languageName: node
+  linkType: hard
+
+"@jest/types@npm:^27.0.2":
+  version: 27.0.2
+  resolution: "@jest/types@npm:27.0.2"
+  dependencies:
+    "@types/istanbul-lib-coverage": ^2.0.0
+    "@types/istanbul-reports": ^3.0.0
+    "@types/node": "*"
+    "@types/yargs": ^16.0.0
+    chalk: ^4.0.0
+  checksum: 7c1ef76bcb799a9010e6f1d5485ebb49b4052dcbc98f17f2979cd028688bb96f7b0072822e0e252659ef989d82c6c0a5cdd750b97b27e11c041efc735a0f84f4
   languageName: node
   linkType: hard
 
@@ -4721,6 +5189,7 @@ __metadata:
     "@types/node": ^14.14.37
     "@types/react": ^17.0.8
     "@types/react-dom": ^17.0.5
+    "@types/testing-library__jest-dom": ^5.14.0
     "@wojtekmaj/enzyme-adapter-react-17": ^0.6.1
     babel-core: ^7.0.0-bridge.0
     babel-jest: ^24.9.0
@@ -4866,6 +5335,7 @@ __metadata:
     "@testing-library/jest-dom": ^5.11.4
     "@testing-library/react": ^11.1.0
     "@types/bytes": ^3
+    "@types/jest": ^26.0.23
     "@types/md5": ^2
     "@types/mdx-js__react": ^1
     "@types/prop-types": ^15
@@ -4877,6 +5347,7 @@ __metadata:
     commafy: ^0.0.6
     css-loader: ^5.2.1
     date-fns: ^2.21.1
+    jest: ^27.0.4
     markdown-to-jsx: ^7.1.3
     md5: ^2.3.0
     pluralize: ^8.0.0
@@ -4936,6 +5407,7 @@ __metadata:
     "@sentry/node": ^4.5.3
     "@types/draft-js": ^0.10.43
     "@types/ioredis": ^4.17.1
+    "@types/jest": ^26.0.23
     "@types/nodemailer": ^6.4.1
     apollo-link-schema: ^1.2.5
     apollo-server: 2.21.0
@@ -5379,6 +5851,15 @@ __metadata:
   dependencies:
     "@sinonjs/commons": ^1.7.0
   checksum: 64458b908773638dda08b555a00e6fbbbc679735348291dc1b7f437ada2f60242537fdc48e4ee82d2573d86984ec87e755b66a96c0ed9ebf0f46b4c6687ccde2
+  languageName: node
+  linkType: hard
+
+"@sinonjs/fake-timers@npm:^7.0.2":
+  version: 7.1.2
+  resolution: "@sinonjs/fake-timers@npm:7.1.2"
+  dependencies:
+    "@sinonjs/commons": ^1.7.0
+  checksum: 5ce48e40db14d7e1419bae287b84559133d580cb56130b51d7479dff318bfafed87531f8b48f618f07e3c9a6113c9e3f00286805d55de64986b9cccb8eb6d5cf
   languageName: node
   linkType: hard
 
@@ -6455,7 +6936,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/babel__core@npm:^7, @types/babel__core@npm:^7.0.0, @types/babel__core@npm:^7.1.0, @types/babel__core@npm:^7.1.7":
+"@types/babel__core@npm:^7, @types/babel__core@npm:^7.0.0, @types/babel__core@npm:^7.1.0, @types/babel__core@npm:^7.1.14, @types/babel__core@npm:^7.1.7":
   version: 7.1.14
   resolution: "@types/babel__core@npm:7.1.14"
   dependencies:
@@ -6923,7 +7404,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/jest@npm:*, @types/jest@npm:^26.0.22":
+"@types/jest@npm:*, @types/jest@npm:^26.0.22, @types/jest@npm:^26.0.23":
   version: 26.0.23
   resolution: "@types/jest@npm:26.0.23"
   dependencies:
@@ -7226,6 +7707,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/prettier@npm:^2.1.5":
+  version: 2.3.0
+  resolution: "@types/prettier@npm:2.3.0"
+  checksum: 7c1ef16234220519d52b8a154723caf5c5dc9d5eaa85bfe06e367ba57472dab7f7fdac1ca7c29d9010d58f74f3b5235a9f8bad0111d9bad74018eb8141371e7e
+  languageName: node
+  linkType: hard
+
 "@types/pretty-hrtime@npm:^1.0.0":
   version: 1.0.0
   resolution: "@types/pretty-hrtime@npm:1.0.0"
@@ -7460,6 +7948,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/testing-library__jest-dom@npm:^5.14.0":
+  version: 5.14.0
+  resolution: "@types/testing-library__jest-dom@npm:5.14.0"
+  dependencies:
+    "@types/jest": "*"
+  checksum: 7d34c6e3619cb5c1a20ed263293b5c7a38af4bb3b8795031a957b8c98fcdfad2b394e44f72a8793a40dcdaf8ba0df30bb66b46320b2d589dc8c128077cdafa86
+  languageName: node
+  linkType: hard
+
 "@types/testing-library__jest-dom@npm:^5.9.1":
   version: 5.9.5
   resolution: "@types/testing-library__jest-dom@npm:5.9.5"
@@ -7601,6 +8098,15 @@ __metadata:
   dependencies:
     "@types/yargs-parser": "*"
   checksum: fa1a5b0a07dbbff1657a27d1191d586632412d170321000f6f417f279547a8c191d7058dbf4d4187c188a5a1aeb2473ddb25fe316b206fccdfe1de6fad976619
+  languageName: node
+  linkType: hard
+
+"@types/yargs@npm:^16.0.0":
+  version: 16.0.3
+  resolution: "@types/yargs@npm:16.0.3"
+  dependencies:
+    "@types/yargs-parser": "*"
+  checksum: 84b8f617742b4a86f334838152cbc8d2fae4cc2568a81c4d54a9a9c7a6dc926f4fb21c3cb9d34cad895ab4f020041e28bcfe16348a34d370a2833450750ccd66
   languageName: node
   linkType: hard
 
@@ -8217,6 +8723,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"acorn@npm:^8.2.4":
+  version: 8.4.0
+  resolution: "acorn@npm:8.4.0"
+  bin:
+    acorn: bin/acorn
+  checksum: 51d8d3ec3e33dcf325e5887909a1ac36afb351522b0179afadcb44ae8eb612417c6db1bcd4abdfaff58fea969d272baf8e809801075e15b5d5993933139ea2f9
+  languageName: node
+  linkType: hard
+
 "address@npm:1.0.3":
   version: 1.0.3
   resolution: "address@npm:1.0.3"
@@ -8490,6 +9005,13 @@ __metadata:
   dependencies:
     color-convert: ^2.0.1
   checksum: ea02c0179f3dd089a161f5fdd7ccd89dd84f31d82b68869f1134bf5c5b9e1313dadd2ff9edb02b44f46243f285ef5b785f6cb61c84a293694221417c42934407
+  languageName: node
+  linkType: hard
+
+"ansi-styles@npm:^5.0.0":
+  version: 5.2.0
+  resolution: "ansi-styles@npm:5.2.0"
+  checksum: 10b01465c7a49cbfcc055188e3b79b00db6283319bb53c0d20ca9ad114d1477d6f48c1d01a3ed9678f616566ec33f11116926dfaa162fa7be9ee7d5d2c2ea7e1
   languageName: node
   linkType: hard
 
@@ -9577,6 +10099,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"babel-jest@npm:^27.0.2":
+  version: 27.0.2
+  resolution: "babel-jest@npm:27.0.2"
+  dependencies:
+    "@jest/transform": ^27.0.2
+    "@jest/types": ^27.0.2
+    "@types/babel__core": ^7.1.14
+    babel-plugin-istanbul: ^6.0.0
+    babel-preset-jest: ^27.0.1
+    chalk: ^4.0.0
+    graceful-fs: ^4.2.4
+    slash: ^3.0.0
+  peerDependencies:
+    "@babel/core": ^7.8.0
+  checksum: f12d78970186b4b85e7159eb6f67238c2ff56d51b96843fc273ce3cbaa180162c63adc5e9c7afaeb8f1f921887cd5eff920538021d9e01a89c046f96b7f3da7c
+  languageName: node
+  linkType: hard
+
 "babel-loader@npm:^8.0.4, babel-loader@npm:^8.1.0, babel-loader@npm:^8.2.2":
   version: 8.2.2
   resolution: "babel-loader@npm:8.2.2"
@@ -9711,6 +10251,18 @@ __metadata:
     "@types/babel__core": ^7.0.0
     "@types/babel__traverse": ^7.0.6
   checksum: e9c1de0fced1c8220590a0d6f37631f5b975964a8e876f0426fc7fd224f4c154b01f156e87401de47556b873bf4414eb2a9632fb56765f35fc07fe69e5b76d31
+  languageName: node
+  linkType: hard
+
+"babel-plugin-jest-hoist@npm:^27.0.1":
+  version: 27.0.1
+  resolution: "babel-plugin-jest-hoist@npm:27.0.1"
+  dependencies:
+    "@babel/template": ^7.3.3
+    "@babel/types": ^7.3.3
+    "@types/babel__core": ^7.0.0
+    "@types/babel__traverse": ^7.0.6
+  checksum: d8c17b65b484e6534de2af411268292b463a6a1d98f02f3cf735100401862cbf3e487f9b84e288aac1dcedfe413fed1f5e7ac9b00d3ef7e655a83079fd9ff27f
   languageName: node
   linkType: hard
 
@@ -9910,6 +10462,18 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0
   checksum: 466ca17bba2638cadda5c25f3108dab1867b30e5d728366d0d2309be5d6555db8738a6cacd2c43284bee2ce7917e3285194c223a22b3d9817794f00c2775fdb2
+  languageName: node
+  linkType: hard
+
+"babel-preset-jest@npm:^27.0.1":
+  version: 27.0.1
+  resolution: "babel-preset-jest@npm:27.0.1"
+  dependencies:
+    babel-plugin-jest-hoist: ^27.0.1
+    babel-preset-current-node-syntax: ^1.0.0
+  peerDependencies:
+    "@babel/core": ^7.0.0
+  checksum: 46a36c790f9158d60953f64fffbeaf82bf27e306003db519121cfc15fe02d6ae6c676d39d75055a594927a9eabdf2fe678a39f3b3dd5709f3009e2d0c591dc95
   languageName: node
   linkType: hard
 
@@ -11262,6 +11826,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ci-info@npm:^3.1.1":
+  version: 3.2.0
+  resolution: "ci-info@npm:3.2.0"
+  checksum: d4a898d60111d00f2b7a06a349162971fe0603aefa208fe8d1343ce9e93c48e3d37311c47211d5c9040d25b43038c817588e5b7d8eab5d17b00aec49c7b5fade
+  languageName: node
+  linkType: hard
+
 "cipher-base@npm:^1.0.0, cipher-base@npm:^1.0.1, cipher-base@npm:^1.0.3":
   version: 1.0.4
   resolution: "cipher-base@npm:1.0.4"
@@ -11276,6 +11847,13 @@ __metadata:
   version: 0.6.0
   resolution: "cjs-module-lexer@npm:0.6.0"
   checksum: 333671db7fb916d9c569a52fba714a86051881c69a4df784a07cb1dfec2a1796c7bcd7ba46ff9035cccb6e7aaff612a83f6505437c01a5ae14c4ebc6c36f762c
+  languageName: node
+  linkType: hard
+
+"cjs-module-lexer@npm:^1.0.0":
+  version: 1.2.1
+  resolution: "cjs-module-lexer@npm:1.2.1"
+  checksum: 5c41324f072e70bb6fd0be6e7d28905231cbf71a62f96fec79d232df51226cb9a0750cd785933d5afdecd8efebb50327fb395d6e0fc3b67fb370b8025b980c17
   languageName: node
   linkType: hard
 
@@ -13606,6 +14184,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"diff-sequences@npm:^27.0.1":
+  version: 27.0.1
+  resolution: "diff-sequences@npm:27.0.1"
+  checksum: 7dc8775043a368d94c2b7c9e4c06d6761275039a8304c8fc67ff9a8aa5f3c28c4932105e098968520ad3e5b8ce702cba126ed1e8c93499c6644142550153550f
+  languageName: node
+  linkType: hard
+
 "diff@npm:^4.0.1":
   version: 4.0.2
   resolution: "diff@npm:4.0.2"
@@ -14266,6 +14851,13 @@ __metadata:
   version: 0.7.2
   resolution: "emittery@npm:0.7.2"
   checksum: 34acfef51922a1b73d75cb658bf43ecb279633b263ffa831fb87697abbbd3aa4241ef15d204eeaa6a3c62656bd7563de7145c416a2bb18c4805e54ce6d7cdac6
+  languageName: node
+  linkType: hard
+
+"emittery@npm:^0.8.1":
+  version: 0.8.1
+  resolution: "emittery@npm:0.8.1"
+  checksum: 1c9cd9a1045ce8e50e41b4433a6d3adf109cbb7585fe5d504399f2a035f423adb9b9bc6735aad672368575532007948d4483645e188fe99759c302a39542479d
   languageName: node
   linkType: hard
 
@@ -15533,6 +16125,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"execa@npm:^5.0.0":
+  version: 5.1.1
+  resolution: "execa@npm:5.1.1"
+  dependencies:
+    cross-spawn: ^7.0.3
+    get-stream: ^6.0.0
+    human-signals: ^2.1.0
+    is-stream: ^2.0.0
+    merge-stream: ^2.0.0
+    npm-run-path: ^4.0.1
+    onetime: ^5.1.2
+    signal-exit: ^3.0.3
+    strip-final-newline: ^2.0.0
+  checksum: 4286ade8cdb267bfb982bddbf894a58df29ff4f3bb871252a4832c4608e485dd71e5a8bbfde9f95d7db4af864f5de1aa6a1780017217bd946a16409b8e022987
+  languageName: node
+  linkType: hard
+
 "exit@npm:0.1.2, exit@npm:0.1.x, exit@npm:^0.1.2":
   version: 0.1.2
   resolution: "exit@npm:0.1.2"
@@ -15575,6 +16184,20 @@ __metadata:
     jest-message-util: ^26.6.2
     jest-regex-util: ^26.0.0
   checksum: a4ec4cbafac8b05eb02a8af5f086dede84a3a701abbfdafeadca24a1d286bd07035b32b2864a6ff012a733009beb0b96c10469b40832c5ee0d2dd0bb6b50a5b0
+  languageName: node
+  linkType: hard
+
+"expect@npm:^27.0.2":
+  version: 27.0.2
+  resolution: "expect@npm:27.0.2"
+  dependencies:
+    "@jest/types": ^27.0.2
+    ansi-styles: ^5.0.0
+    jest-get-type: ^27.0.1
+    jest-matcher-utils: ^27.0.2
+    jest-message-util: ^27.0.2
+    jest-regex-util: ^27.0.1
+  checksum: 7a2bc046598801e5edefc03699c8ebf457acff3affb68708a11c7f5c064bbd4582cd44bb90fe4045c73b04d57f18c6435e94f893f213d03f3271de620d6e23ea
   languageName: node
   linkType: hard
 
@@ -16592,7 +17215,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"fsevents@^2.1.2, fsevents@~2.3.1":
+"fsevents@^2.1.2, fsevents@^2.3.2, fsevents@~2.3.1":
   version: 2.3.2
   resolution: "fsevents@npm:2.3.2"
   dependencies:
@@ -16611,7 +17234,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"fsevents@patch:fsevents@^2.1.2#builtin<compat/fsevents>, fsevents@patch:fsevents@~2.3.1#builtin<compat/fsevents>":
+"fsevents@patch:fsevents@^2.1.2#builtin<compat/fsevents>, fsevents@patch:fsevents@^2.3.2#builtin<compat/fsevents>, fsevents@patch:fsevents@~2.3.1#builtin<compat/fsevents>":
   version: 2.3.2
   resolution: "fsevents@patch:fsevents@npm%3A2.3.2#builtin<compat/fsevents>::version=2.3.2&hash=11e9ea"
   dependencies:
@@ -19069,6 +19692,13 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"human-signals@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "human-signals@npm:2.1.0"
+  checksum: 70bfd94d27b8ca94f76f92f56d294694860c15264393a8ffee83f49535a08da02e477064d91e2b511cc642ec5c7922675d2babcca2b6bf6f45e4d037b632759d
+  languageName: node
+  linkType: hard
+
 "humanize-ms@npm:^1.2.1":
   version: 1.2.1
   resolution: "humanize-ms@npm:1.2.1"
@@ -19820,6 +20450,17 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"is-ci@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "is-ci@npm:3.0.0"
+  dependencies:
+    ci-info: ^3.1.1
+  bin:
+    is-ci: bin.js
+  checksum: 1e26d3ba6634ebee83f9d22f260354c5d950eada4d609c30cc2642069f8ba52f3aeb4c9bbf8099aaf04a2f44a1ed7beef2a24485f988753c8c078a57e9b3a2fd
+  languageName: node
+  linkType: hard
+
 "is-color-stop@npm:^1.0.0":
   version: 1.1.0
   resolution: "is-color-stop@npm:1.1.0"
@@ -20250,7 +20891,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"is-potential-custom-element-name@npm:^1.0.0":
+"is-potential-custom-element-name@npm:^1.0.0, is-potential-custom-element-name@npm:^1.0.1":
   version: 1.0.1
   resolution: "is-potential-custom-element-name@npm:1.0.1"
   checksum: 25520ce8de393b87c8a2ce4d410c424d16baab0d5a43cbf76af148940725e489dbf3541a43371bcc0881fcb186d9a4ed18b774a11ac8743dd064303cea8de50d
@@ -20687,6 +21328,44 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"jest-changed-files@npm:^27.0.2":
+  version: 27.0.2
+  resolution: "jest-changed-files@npm:27.0.2"
+  dependencies:
+    "@jest/types": ^27.0.2
+    execa: ^5.0.0
+    throat: ^6.0.1
+  checksum: 75e77350a8bdcfa3cabfdd5b8014a7008fe2e93e63eea390faa4873cc1dd65de629db0dca87af24df9310b373b241af92a7eb7ba0567f13fada7480c331790c4
+  languageName: node
+  linkType: hard
+
+"jest-circus@npm:^27.0.4":
+  version: 27.0.4
+  resolution: "jest-circus@npm:27.0.4"
+  dependencies:
+    "@jest/environment": ^27.0.3
+    "@jest/test-result": ^27.0.2
+    "@jest/types": ^27.0.2
+    "@types/node": "*"
+    chalk: ^4.0.0
+    co: ^4.6.0
+    dedent: ^0.7.0
+    expect: ^27.0.2
+    is-generator-fn: ^2.0.0
+    jest-each: ^27.0.2
+    jest-matcher-utils: ^27.0.2
+    jest-message-util: ^27.0.2
+    jest-runtime: ^27.0.4
+    jest-snapshot: ^27.0.4
+    jest-util: ^27.0.2
+    pretty-format: ^27.0.2
+    slash: ^3.0.0
+    stack-utils: ^2.0.3
+    throat: ^6.0.1
+  checksum: 96f7a437a2f9f104e23cf6b8be0a9220f0d15605fbe6bcdbb247fffd97e46e3ff3aabb7630e47516121357d0ab9686887a50fcc38c7699fc04ae0e3795a4be71
+  languageName: node
+  linkType: hard
+
 "jest-cli@npm:^26.6.3":
   version: 26.6.3
   resolution: "jest-cli@npm:26.6.3"
@@ -20707,6 +21386,33 @@ fsevents@^1.2.7:
   bin:
     jest: bin/jest.js
   checksum: 2d32e7e4b2802d230625cb041630abe25a8764fcea6a8ecf46a5ad68f23bd1498e5297bc43d1ba714832d433de6676d2bd3ac93d0fecec230665fe8421f23863
+  languageName: node
+  linkType: hard
+
+"jest-cli@npm:^27.0.4":
+  version: 27.0.4
+  resolution: "jest-cli@npm:27.0.4"
+  dependencies:
+    "@jest/core": ^27.0.4
+    "@jest/test-result": ^27.0.2
+    "@jest/types": ^27.0.2
+    chalk: ^4.0.0
+    exit: ^0.1.2
+    graceful-fs: ^4.2.4
+    import-local: ^3.0.2
+    jest-config: ^27.0.4
+    jest-util: ^27.0.2
+    jest-validate: ^27.0.2
+    prompts: ^2.0.1
+    yargs: ^16.0.3
+  peerDependencies:
+    node-notifier: ^8.0.1 || ^9.0.0
+  peerDependenciesMeta:
+    node-notifier:
+      optional: true
+  bin:
+    jest: bin/jest.js
+  checksum: da9188c670aa91bc4317ac7abb0c5828fd3d33010919d7161d2d8b249550976aba9df279d98c9e01bff8f82e5450b6180b326821cab2ae8a3327f660960eff6f
   languageName: node
   linkType: hard
 
@@ -20741,6 +21447,40 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"jest-config@npm:^27.0.4":
+  version: 27.0.4
+  resolution: "jest-config@npm:27.0.4"
+  dependencies:
+    "@babel/core": ^7.1.0
+    "@jest/test-sequencer": ^27.0.4
+    "@jest/types": ^27.0.2
+    babel-jest: ^27.0.2
+    chalk: ^4.0.0
+    deepmerge: ^4.2.2
+    glob: ^7.1.1
+    graceful-fs: ^4.2.4
+    is-ci: ^3.0.0
+    jest-circus: ^27.0.4
+    jest-environment-jsdom: ^27.0.3
+    jest-environment-node: ^27.0.3
+    jest-get-type: ^27.0.1
+    jest-jasmine2: ^27.0.4
+    jest-regex-util: ^27.0.1
+    jest-resolve: ^27.0.4
+    jest-runner: ^27.0.4
+    jest-util: ^27.0.2
+    jest-validate: ^27.0.2
+    micromatch: ^4.0.4
+    pretty-format: ^27.0.2
+  peerDependencies:
+    ts-node: ">=9.0.0"
+  peerDependenciesMeta:
+    ts-node:
+      optional: true
+  checksum: f0a591b3515988f952623d50350367c0ba11224ad92abc64d0942ce2a25bafbbdba7186455ef36db53c0c2e8169b4d0182d00b43ac4eb11a13731a83a1ff41e4
+  languageName: node
+  linkType: hard
+
 "jest-diff@npm:^25.5.0":
   version: 25.5.0
   resolution: "jest-diff@npm:25.5.0"
@@ -20765,12 +21505,33 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"jest-diff@npm:^27.0.2":
+  version: 27.0.2
+  resolution: "jest-diff@npm:27.0.2"
+  dependencies:
+    chalk: ^4.0.0
+    diff-sequences: ^27.0.1
+    jest-get-type: ^27.0.1
+    pretty-format: ^27.0.2
+  checksum: 2335c861c51c2d83e74ccbbb123ea6ae484cf217f447d7ec6ea5db69c32cae3c6f19d52b70fa8e13a7003287f13f63cf06575a569e16b4765248dd7f4e2d3b11
+  languageName: node
+  linkType: hard
+
 "jest-docblock@npm:^26.0.0":
   version: 26.0.0
   resolution: "jest-docblock@npm:26.0.0"
   dependencies:
     detect-newline: ^3.0.0
   checksum: 54b8ea1c8445a4b15e9ee5035f1bd60b0d492b87258995133a1b5df43a07803c93b54e8adaa45eae05778bd61ad57745491c625e7aa65198a9aa4f0c79030b56
+  languageName: node
+  linkType: hard
+
+"jest-docblock@npm:^27.0.1":
+  version: 27.0.1
+  resolution: "jest-docblock@npm:27.0.1"
+  dependencies:
+    detect-newline: ^3.0.0
+  checksum: 64a346c2648a3d5a192b3ec00af26d3d0fab28fb547b8fdce8106ea6f6dd99b0f81095d388244d1bb1be3704541873eee3c5104862f6f27a45b6d5616667fc2b
   languageName: node
   linkType: hard
 
@@ -20784,6 +21545,19 @@ fsevents@^1.2.7:
     jest-util: ^26.6.2
     pretty-format: ^26.6.2
   checksum: 628eaeca647adb4d6cf75bdc17c9ceb8cbcbb6921d838a583cd4de3db188e3e49b62209e3a0703f1281db379d1b2c07254900e5d97e85d61dd193d7b40361d3a
+  languageName: node
+  linkType: hard
+
+"jest-each@npm:^27.0.2":
+  version: 27.0.2
+  resolution: "jest-each@npm:27.0.2"
+  dependencies:
+    "@jest/types": ^27.0.2
+    chalk: ^4.0.0
+    jest-get-type: ^27.0.1
+    jest-util: ^27.0.2
+    pretty-format: ^27.0.2
+  checksum: c0451c12830927b3709e72cd8bb35ab2276c507e682ed662878a31b9a0c9281c00e96447a0e85b195d0914f4ff2c5d081e31982a5a929659de3fbfac62501e0d
   languageName: node
   linkType: hard
 
@@ -20802,6 +21576,21 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"jest-environment-jsdom@npm:^27.0.3":
+  version: 27.0.3
+  resolution: "jest-environment-jsdom@npm:27.0.3"
+  dependencies:
+    "@jest/environment": ^27.0.3
+    "@jest/fake-timers": ^27.0.3
+    "@jest/types": ^27.0.2
+    "@types/node": "*"
+    jest-mock: ^27.0.3
+    jest-util: ^27.0.2
+    jsdom: ^16.6.0
+  checksum: 00f240aca719801e7f7ee231b71fe45669c8f9643748481f680a24e4133c661cb2932e3df5081358ed9ec0896b9d6cff585c6b7f2a6bd6e9bf78e9b125d768a0
+  languageName: node
+  linkType: hard
+
 "jest-environment-node@npm:^26.6.2":
   version: 26.6.2
   resolution: "jest-environment-node@npm:26.6.2"
@@ -20813,6 +21602,20 @@ fsevents@^1.2.7:
     jest-mock: ^26.6.2
     jest-util: ^26.6.2
   checksum: 68ea035d62b35faf1991c0a0a432c1d9547ce93949e9460761071748cbf4b1d818e47421df1eb7b15a3eda7c0846e284b4a5ece5d99122307a0ad742ea765a57
+  languageName: node
+  linkType: hard
+
+"jest-environment-node@npm:^27.0.3":
+  version: 27.0.3
+  resolution: "jest-environment-node@npm:27.0.3"
+  dependencies:
+    "@jest/environment": ^27.0.3
+    "@jest/fake-timers": ^27.0.3
+    "@jest/types": ^27.0.2
+    "@types/node": "*"
+    jest-mock: ^27.0.3
+    jest-util: ^27.0.2
+  checksum: 5272cb6fb9d2aba2dceac739de3a99bc5c6788d6b64783f40fcddcbedcd219c695ddffcad38627f035fcf5be646f9671bca63cbaee2c84f5c1668f1713e17e89
   languageName: node
   linkType: hard
 
@@ -20847,6 +21650,13 @@ fsevents@^1.2.7:
   version: 26.3.0
   resolution: "jest-get-type@npm:26.3.0"
   checksum: fc3e2d2b90cca74597c4ad6234c2fcc2ccb62894d0f7afe22fc55b5d93a2f02d3080ccef50f09c979d4b5a060bc76c4343911556d75ed9e892e0ebda6d54c44b
+  languageName: node
+  linkType: hard
+
+"jest-get-type@npm:^27.0.1":
+  version: 27.0.1
+  resolution: "jest-get-type@npm:27.0.1"
+  checksum: bb816bd1e5bf64848448cceb8c441cd5a41881eb744a255ee76833b5bac3e32e4f3ac2735b7af2f5f541cabe4d8eb72937c50bc54349a3db2477969c01f92f54
   languageName: node
   linkType: hard
 
@@ -20898,6 +21708,30 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"jest-haste-map@npm:^27.0.2":
+  version: 27.0.2
+  resolution: "jest-haste-map@npm:27.0.2"
+  dependencies:
+    "@jest/types": ^27.0.2
+    "@types/graceful-fs": ^4.1.2
+    "@types/node": "*"
+    anymatch: ^3.0.3
+    fb-watchman: ^2.0.0
+    fsevents: ^2.3.2
+    graceful-fs: ^4.2.4
+    jest-regex-util: ^27.0.1
+    jest-serializer: ^27.0.1
+    jest-util: ^27.0.2
+    jest-worker: ^27.0.2
+    micromatch: ^4.0.4
+    walker: ^1.0.7
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  checksum: 2abd562615eb6990502cae7462f99bef6bf528ce239c5247caab55d9389d415783c39a3f1f82d056879926cd3e785c863ebfca28ded592d441002b38f89a0e76
+  languageName: node
+  linkType: hard
+
 "jest-jasmine2@npm:^26.6.3":
   version: 26.6.3
   resolution: "jest-jasmine2@npm:26.6.3"
@@ -20924,6 +21758,32 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"jest-jasmine2@npm:^27.0.4":
+  version: 27.0.4
+  resolution: "jest-jasmine2@npm:27.0.4"
+  dependencies:
+    "@babel/traverse": ^7.1.0
+    "@jest/environment": ^27.0.3
+    "@jest/source-map": ^27.0.1
+    "@jest/test-result": ^27.0.2
+    "@jest/types": ^27.0.2
+    "@types/node": "*"
+    chalk: ^4.0.0
+    co: ^4.6.0
+    expect: ^27.0.2
+    is-generator-fn: ^2.0.0
+    jest-each: ^27.0.2
+    jest-matcher-utils: ^27.0.2
+    jest-message-util: ^27.0.2
+    jest-runtime: ^27.0.4
+    jest-snapshot: ^27.0.4
+    jest-util: ^27.0.2
+    pretty-format: ^27.0.2
+    throat: ^6.0.1
+  checksum: 2826d49257a73de9b97b702f3e41b71219e1620a013b6698742ff5508a95eb9a7a6c3e288babb9c5c8d38878e826a2166fde5e90a5c9b4cfe05f0d6e0a8f0986
+  languageName: node
+  linkType: hard
+
 "jest-leak-detector@npm:^26.6.2":
   version: 26.6.2
   resolution: "jest-leak-detector@npm:26.6.2"
@@ -20931,6 +21791,16 @@ fsevents@^1.2.7:
     jest-get-type: ^26.3.0
     pretty-format: ^26.6.2
   checksum: 08c1bbb628c46d22bead4de7bcbe6a4c9d5761d55f15a1d938b9409473eeb6175545ebade44318f9ae950fcdf484e1cbffbbcdcce8600b946e21300d7d1ed206
+  languageName: node
+  linkType: hard
+
+"jest-leak-detector@npm:^27.0.2":
+  version: 27.0.2
+  resolution: "jest-leak-detector@npm:27.0.2"
+  dependencies:
+    jest-get-type: ^27.0.1
+    pretty-format: ^27.0.2
+  checksum: 6ebd03ecaf4aca3045e5c6fe205bb478b7046db362d1ababa97b6e65dd74bd4849cdec3f1179d41ef809192a7da93d661fa38016c85a54852aa5053679ab3a85
   languageName: node
   linkType: hard
 
@@ -20943,6 +21813,18 @@ fsevents@^1.2.7:
     jest-get-type: ^26.3.0
     pretty-format: ^26.6.2
   checksum: c6db72f19e90d8c3b3f949bc174e4a1b95db5973080eaf716b69df0069faa9b9da2de4502cf9b5c1376387b49705611259f45f04efb7dfc3deb72bcf3602a6a1
+  languageName: node
+  linkType: hard
+
+"jest-matcher-utils@npm:^27.0.2":
+  version: 27.0.2
+  resolution: "jest-matcher-utils@npm:27.0.2"
+  dependencies:
+    chalk: ^4.0.0
+    jest-diff: ^27.0.2
+    jest-get-type: ^27.0.1
+    pretty-format: ^27.0.2
+  checksum: b2c0cc40c35d2101bca3ee2f057a65f346aee210232f6fcb14fb18abf1a6c91a031848e71eaa00afa4c6a40105aa1e8957dc3e0cfda583089325eb81827d1c74
   languageName: node
   linkType: hard
 
@@ -20979,6 +21861,23 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"jest-message-util@npm:^27.0.2":
+  version: 27.0.2
+  resolution: "jest-message-util@npm:27.0.2"
+  dependencies:
+    "@babel/code-frame": ^7.12.13
+    "@jest/types": ^27.0.2
+    "@types/stack-utils": ^2.0.0
+    chalk: ^4.0.0
+    graceful-fs: ^4.2.4
+    micromatch: ^4.0.4
+    pretty-format: ^27.0.2
+    slash: ^3.0.0
+    stack-utils: ^2.0.3
+  checksum: a94309f9f184ad1ed8d2da5cefc9a3949ec0c36caee88e5801961a51c7db4c2122ebdb0db19217892a31cdc2ef2eb3599af1fe4e58cad59b01310be1c762e18e
+  languageName: node
+  linkType: hard
+
 "jest-mock@npm:^24.9.0":
   version: 24.9.0
   resolution: "jest-mock@npm:24.9.0"
@@ -20995,6 +21894,16 @@ fsevents@^1.2.7:
     "@jest/types": ^26.6.2
     "@types/node": "*"
   checksum: 98e658beca866a5391fd5c0503a985a928231fd0652dea31809efa706a043ac4c4559769215ba8c8d0cde758f5c5463fbf99f233441e82641cace68023308fb6
+  languageName: node
+  linkType: hard
+
+"jest-mock@npm:^27.0.3":
+  version: 27.0.3
+  resolution: "jest-mock@npm:27.0.3"
+  dependencies:
+    "@jest/types": ^27.0.2
+    "@types/node": "*"
+  checksum: 59ac90d5fed90384065d306cadb43b96f6f6182fa624b3b60cc2cf2d9a0a48ddabff48f60bc002d4c7a56e9677997b7be93af9836538d5f5da374a4cf937141c
   languageName: node
   linkType: hard
 
@@ -21024,6 +21933,13 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"jest-regex-util@npm:^27.0.1":
+  version: 27.0.1
+  resolution: "jest-regex-util@npm:27.0.1"
+  checksum: 8240b7ca4a240eb5a28149e11b3a559f39f5067ff27032ed20ded5e50d91334ade58a616ddf7803eda85dd36c8ea39c9aa99430cb7a08f814ef67fa1a89e9f68
+  languageName: node
+  linkType: hard
+
 "jest-resolve-dependencies@npm:^26.6.3":
   version: 26.6.3
   resolution: "jest-resolve-dependencies@npm:26.6.3"
@@ -21032,6 +21948,17 @@ fsevents@^1.2.7:
     jest-regex-util: ^26.0.0
     jest-snapshot: ^26.6.2
   checksum: 72e7a200c404197f1c06aff7faa77de13e12c2bfdc1a0a6bd9f8b96cd23317b64e2b614a26b67beece86d51249c3ec7dbeb3dfe17d284930307cd769712ace25
+  languageName: node
+  linkType: hard
+
+"jest-resolve-dependencies@npm:^27.0.4":
+  version: 27.0.4
+  resolution: "jest-resolve-dependencies@npm:27.0.4"
+  dependencies:
+    "@jest/types": ^27.0.2
+    jest-regex-util: ^27.0.1
+    jest-snapshot: ^27.0.4
+  checksum: 76f9608dffe1d32209b4dc3f60e463195c3268a718ec0516b6cfb3f5dc4208aeb34e312ce8c77a79333fdaa47aededd4ade33d6c8352fc6d58bf1cbde3a284e6
   languageName: node
   linkType: hard
 
@@ -21048,6 +21975,23 @@ fsevents@^1.2.7:
     resolve: ^1.18.1
     slash: ^3.0.0
   checksum: 61e8884462b4bcdaa26dc8544b497f2e2dae0b0701c363d433afb482c7f2faa6d0ce691250ad64eddb7fff552dc025315c388e0449411c1522a4dd013cbe49ae
+  languageName: node
+  linkType: hard
+
+"jest-resolve@npm:27.0.4, jest-resolve@npm:^27.0.4":
+  version: 27.0.4
+  resolution: "jest-resolve@npm:27.0.4"
+  dependencies:
+    "@jest/types": ^27.0.2
+    chalk: ^4.0.0
+    escalade: ^3.1.1
+    graceful-fs: ^4.2.4
+    jest-pnp-resolver: ^1.2.2
+    jest-util: ^27.0.2
+    jest-validate: ^27.0.2
+    resolve: ^1.20.0
+    slash: ^3.0.0
+  checksum: 77aa75ba949c4400520f6c2bc27a648e2b4665da52f509e32978c1686d67f6a22e396e02c017593d59bc89ee809759b37633abca00276c6e5453047a5971db9c
   languageName: node
   linkType: hard
 
@@ -21076,6 +22020,36 @@ fsevents@^1.2.7:
     source-map-support: ^0.5.6
     throat: ^5.0.0
   checksum: 7cac133ccfb4df461d32f536e7593c21e03b9b01fc97582f51b8487e673648444fe59ea3a96f1f6afddddecf62be86b1d8249723e3a3575cc04fa95f07a163c7
+  languageName: node
+  linkType: hard
+
+"jest-runner@npm:^27.0.4":
+  version: 27.0.4
+  resolution: "jest-runner@npm:27.0.4"
+  dependencies:
+    "@jest/console": ^27.0.2
+    "@jest/environment": ^27.0.3
+    "@jest/test-result": ^27.0.2
+    "@jest/transform": ^27.0.2
+    "@jest/types": ^27.0.2
+    "@types/node": "*"
+    chalk: ^4.0.0
+    emittery: ^0.8.1
+    exit: ^0.1.2
+    graceful-fs: ^4.2.4
+    jest-docblock: ^27.0.1
+    jest-environment-jsdom: ^27.0.3
+    jest-environment-node: ^27.0.3
+    jest-haste-map: ^27.0.2
+    jest-leak-detector: ^27.0.2
+    jest-message-util: ^27.0.2
+    jest-resolve: ^27.0.4
+    jest-runtime: ^27.0.4
+    jest-util: ^27.0.2
+    jest-worker: ^27.0.2
+    source-map-support: ^0.5.6
+    throat: ^6.0.1
+  checksum: 3c87f03766cab12afa9ba40d6ed9121498dab338694b2a7e9661156c3669486c531fa6a7fb7c6776ff6f9b32338e837dd370765e2111aaa424f7cf95618f3a7f
   languageName: node
   linkType: hard
 
@@ -21116,6 +22090,40 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"jest-runtime@npm:^27.0.4":
+  version: 27.0.4
+  resolution: "jest-runtime@npm:27.0.4"
+  dependencies:
+    "@jest/console": ^27.0.2
+    "@jest/environment": ^27.0.3
+    "@jest/fake-timers": ^27.0.3
+    "@jest/globals": ^27.0.3
+    "@jest/source-map": ^27.0.1
+    "@jest/test-result": ^27.0.2
+    "@jest/transform": ^27.0.2
+    "@jest/types": ^27.0.2
+    "@types/yargs": ^16.0.0
+    chalk: ^4.0.0
+    cjs-module-lexer: ^1.0.0
+    collect-v8-coverage: ^1.0.0
+    exit: ^0.1.2
+    glob: ^7.1.3
+    graceful-fs: ^4.2.4
+    jest-haste-map: ^27.0.2
+    jest-message-util: ^27.0.2
+    jest-mock: ^27.0.3
+    jest-regex-util: ^27.0.1
+    jest-resolve: ^27.0.4
+    jest-snapshot: ^27.0.4
+    jest-util: ^27.0.2
+    jest-validate: ^27.0.2
+    slash: ^3.0.0
+    strip-bom: ^4.0.0
+    yargs: ^16.0.3
+  checksum: ece777fda5789512dbd8aadccc4873d770ab1fcc7123e87a1d6d2408a24d94f4debce9de09953407d6e0755b6167c7ea384c81c3d10c00a69d0f673384501454
+  languageName: node
+  linkType: hard
+
 "jest-serializer@npm:^24.9.0":
   version: 24.9.0
   resolution: "jest-serializer@npm:24.9.0"
@@ -21130,6 +22138,16 @@ fsevents@^1.2.7:
     "@types/node": "*"
     graceful-fs: ^4.2.4
   checksum: 62802ac809f7af3386b3640a3a01b6a979a093f48085c5b76a05c186a862b8dd3c1b2ea2d62373fd9fe31c0f893631006623079d30d8f8ebf32dff5ef279059e
+  languageName: node
+  linkType: hard
+
+"jest-serializer@npm:^27.0.1":
+  version: 27.0.1
+  resolution: "jest-serializer@npm:27.0.1"
+  dependencies:
+    "@types/node": "*"
+    graceful-fs: ^4.2.4
+  checksum: 4f8812fdae263382887ad1fa75547191cb1e8ce4a840e813732eaf0ab8768e8897d92e96af1340c6ad3ebb8cd88ca6ef0a6d3607f1e7be169b592bc438d4a163
   languageName: node
   linkType: hard
 
@@ -21154,6 +22172,38 @@ fsevents@^1.2.7:
     pretty-format: ^26.6.2
     semver: ^7.3.2
   checksum: 9cf50bd7b7b31736f914ea71f8049ddf8a9ebcfdbb663d262ad55045f1dd74cb599152946844193503363b9fbb32ee84f882ceae5067181e1dac537846801ae7
+  languageName: node
+  linkType: hard
+
+"jest-snapshot@npm:^27.0.4":
+  version: 27.0.4
+  resolution: "jest-snapshot@npm:27.0.4"
+  dependencies:
+    "@babel/core": ^7.7.2
+    "@babel/generator": ^7.7.2
+    "@babel/parser": ^7.7.2
+    "@babel/plugin-syntax-typescript": ^7.7.2
+    "@babel/traverse": ^7.7.2
+    "@babel/types": ^7.0.0
+    "@jest/transform": ^27.0.2
+    "@jest/types": ^27.0.2
+    "@types/babel__traverse": ^7.0.4
+    "@types/prettier": ^2.1.5
+    babel-preset-current-node-syntax: ^1.0.0
+    chalk: ^4.0.0
+    expect: ^27.0.2
+    graceful-fs: ^4.2.4
+    jest-diff: ^27.0.2
+    jest-get-type: ^27.0.1
+    jest-haste-map: ^27.0.2
+    jest-matcher-utils: ^27.0.2
+    jest-message-util: ^27.0.2
+    jest-resolve: ^27.0.4
+    jest-util: ^27.0.2
+    natural-compare: ^1.4.0
+    pretty-format: ^27.0.2
+    semver: ^7.3.2
+  checksum: 7224d27ad2c4781fa266b50a558a2e3f6ffa646779557a59c6c76f704456428eee8e2a0354ce836a4f64528f23f15c4b29c4a6a744a40333028a13e75648097d
   languageName: node
   linkType: hard
 
@@ -21191,6 +22241,20 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"jest-util@npm:^27.0.2":
+  version: 27.0.2
+  resolution: "jest-util@npm:27.0.2"
+  dependencies:
+    "@jest/types": ^27.0.2
+    "@types/node": "*"
+    chalk: ^4.0.0
+    graceful-fs: ^4.2.4
+    is-ci: ^3.0.0
+    picomatch: ^2.2.3
+  checksum: 5a4b50711989aab8b0403c93f3f747daabb3dde90d2a93ffe6ee3e28cae6760ec8107032742e146cbe7f0ec18112f8894caeaf5821b76cd624d6bbe7935dafe7
+  languageName: node
+  linkType: hard
+
 "jest-validate@npm:^26.6.2":
   version: 26.6.2
   resolution: "jest-validate@npm:26.6.2"
@@ -21202,6 +22266,20 @@ fsevents@^1.2.7:
     leven: ^3.1.0
     pretty-format: ^26.6.2
   checksum: b19fd33b8667a45fea08a56353189b70532ebe360a6ac2e2320eac5e047be410053dcb3a6bcfe99d5e580e03580710af722119268d26ad5185871f5bfa0f6ca2
+  languageName: node
+  linkType: hard
+
+"jest-validate@npm:^27.0.2":
+  version: 27.0.2
+  resolution: "jest-validate@npm:27.0.2"
+  dependencies:
+    "@jest/types": ^27.0.2
+    camelcase: ^6.2.0
+    chalk: ^4.0.0
+    jest-get-type: ^27.0.1
+    leven: ^3.1.0
+    pretty-format: ^27.0.2
+  checksum: ec4799a88425c59c8baf897e2f4508a8aed37556b78067f838c914546789b8367911efff55193906f83ea555de677580cc9a315aed1e7ab0d66e0cbca6d1e1d6
   languageName: node
   linkType: hard
 
@@ -21217,6 +22295,21 @@ fsevents@^1.2.7:
     jest-util: ^26.6.2
     string-length: ^4.0.1
   checksum: d4a13c17c7b9bd98616d7a4ff087c0c16346038ba6b6db6f4a15acbce2ea9a9c7b8b873d174ade3f458c9ad5607f7cadd29309aa13f03a844f984d3711b57805
+  languageName: node
+  linkType: hard
+
+"jest-watcher@npm:^27.0.2":
+  version: 27.0.2
+  resolution: "jest-watcher@npm:27.0.2"
+  dependencies:
+    "@jest/test-result": ^27.0.2
+    "@jest/types": ^27.0.2
+    "@types/node": "*"
+    ansi-escapes: ^4.2.1
+    chalk: ^4.0.0
+    jest-util: ^27.0.2
+    string-length: ^4.0.1
+  checksum: f55c41487c5964263753fcc1e35922bbd61193f7d4feac288b1ad96ffa8907bb44e78616b8f021d6fbce61d44e50a2a0dce253d53469c0b1af150eec4c9f02aa
   languageName: node
   linkType: hard
 
@@ -21251,6 +22344,17 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"jest-worker@npm:^27.0.2":
+  version: 27.0.2
+  resolution: "jest-worker@npm:27.0.2"
+  dependencies:
+    "@types/node": "*"
+    merge-stream: ^2.0.0
+    supports-color: ^8.0.0
+  checksum: bfbfd3d0af94a5505e841719bba4f57823305a3333b3dcecad333eea517c18ee3ba528e8fab017444ad93666ca15b73f1969b71fe0ba9f9abec8843a74b081e7
+  languageName: node
+  linkType: hard
+
 "jest@npm:^26.6.3":
   version: 26.6.3
   resolution: "jest@npm:26.6.3"
@@ -21261,6 +22365,24 @@ fsevents@^1.2.7:
   bin:
     jest: bin/jest.js
   checksum: 4ffcfefa2b30999a71c205e1aacf2b3d7af10f36c17ba1baf45677684116ad5aa6a5bb162ad2dd418f9ea99d18f24b70d8c83fb317b765a3acac361a50e9db9f
+  languageName: node
+  linkType: hard
+
+"jest@npm:^27.0.4":
+  version: 27.0.4
+  resolution: "jest@npm:27.0.4"
+  dependencies:
+    "@jest/core": ^27.0.4
+    import-local: ^3.0.2
+    jest-cli: ^27.0.4
+  peerDependencies:
+    node-notifier: ^8.0.1 || ^9.0.0
+  peerDependenciesMeta:
+    node-notifier:
+      optional: true
+  bin:
+    jest: bin/jest.js
+  checksum: 4cab553739be5f2e2f897fcbc0c6afa5444307bfdcb1412b36309038fc0ef44022b4a60f6e915c5403fe117102cf7135d8782c65f45201410c32c9b4d978ab46
   languageName: node
   linkType: hard
 
@@ -21401,6 +22523,46 @@ fsevents@^1.2.7:
     canvas:
       optional: true
   checksum: 02f6e3b5bb6c75f70b256f9fb522ce67cdf035c8e073a61f152876570d29453f164a4f1ea38a62e419511f81f6f75ced793e6332b66a647dc8012daacff27b8e
+  languageName: node
+  linkType: hard
+
+"jsdom@npm:^16.6.0":
+  version: 16.6.0
+  resolution: "jsdom@npm:16.6.0"
+  dependencies:
+    abab: ^2.0.5
+    acorn: ^8.2.4
+    acorn-globals: ^6.0.0
+    cssom: ^0.4.4
+    cssstyle: ^2.3.0
+    data-urls: ^2.0.0
+    decimal.js: ^10.2.1
+    domexception: ^2.0.1
+    escodegen: ^2.0.0
+    form-data: ^3.0.0
+    html-encoding-sniffer: ^2.0.1
+    http-proxy-agent: ^4.0.1
+    https-proxy-agent: ^5.0.0
+    is-potential-custom-element-name: ^1.0.1
+    nwsapi: ^2.2.0
+    parse5: 6.0.1
+    saxes: ^5.0.1
+    symbol-tree: ^3.2.4
+    tough-cookie: ^4.0.0
+    w3c-hr-time: ^1.0.2
+    w3c-xmlserializer: ^2.0.0
+    webidl-conversions: ^6.1.0
+    whatwg-encoding: ^1.0.5
+    whatwg-mimetype: ^2.3.0
+    whatwg-url: ^8.5.0
+    ws: ^7.4.5
+    xml-name-validator: ^3.0.0
+  peerDependencies:
+    canvas: ^2.5.0
+  peerDependenciesMeta:
+    canvas:
+      optional: true
+  checksum: ee0c9ef2cf499d01d6186622a3788df72fa970a2eb695a237efebace6d99875a3402062842420badddad02cf1e90a0de88c65a266366721a45732144f7616db6
   languageName: node
   linkType: hard
 
@@ -23438,7 +24600,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"micromatch@npm:^4.0.2":
+"micromatch@npm:^4.0.2, micromatch@npm:^4.0.4":
   version: 4.0.4
   resolution: "micromatch@npm:4.0.4"
   dependencies:
@@ -24710,7 +25872,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"npm-run-path@npm:^4.0.0":
+"npm-run-path@npm:^4.0.0, npm-run-path@npm:^4.0.1":
   version: 4.0.1
   resolution: "npm-run-path@npm:4.0.1"
   dependencies:
@@ -25054,7 +26216,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"onetime@npm:^5.1.0":
+"onetime@npm:^5.1.0, onetime@npm:^5.1.2":
   version: 5.1.2
   resolution: "onetime@npm:5.1.2"
   dependencies:
@@ -26947,6 +28109,18 @@ fsevents@^1.2.7:
     ansi-styles: ^4.0.0
     react-is: ^17.0.1
   checksum: 5ad34fc128218485732cf0271d396158a00584708fc97bf063c1c3c000fe14da572e9a1d3d7b92d95c5e24965434656c56ed0e45804dea2435ca59a1f86f1b07
+  languageName: node
+  linkType: hard
+
+"pretty-format@npm:^27.0.2":
+  version: 27.0.2
+  resolution: "pretty-format@npm:27.0.2"
+  dependencies:
+    "@jest/types": ^27.0.2
+    ansi-regex: ^5.0.0
+    ansi-styles: ^5.0.0
+    react-is: ^17.0.1
+  checksum: d55daeb15770d46953e2e58b1f7568f91a0b8d4b4e4ccc788fcfa81a7638eb0f024181616da1f30073136d595137fcfef400413d7e0c2387baeb094dc72b0a0b
   languageName: node
   linkType: hard
 
@@ -29742,6 +30916,7 @@ resolve@^2.0.0-next.3:
     "@types/babel__core": ^7
     "@types/babel__plugin-transform-runtime": ^7
     "@types/babel__preset-env": ^7
+    "@types/jest": ^26.0.23
     "@typescript-eslint/eslint-plugin": ^4.19.0
     "@typescript-eslint/parser": ^4.19.0
     babel-eslint: 10.0.3
@@ -31204,7 +32379,7 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"stack-utils@npm:^2.0.2":
+"stack-utils@npm:^2.0.2, stack-utils@npm:^2.0.3":
   version: 2.0.3
   resolution: "stack-utils@npm:2.0.3"
   dependencies:
@@ -31959,6 +33134,15 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
+"supports-color@npm:^8.0.0":
+  version: 8.1.1
+  resolution: "supports-color@npm:8.1.1"
+  dependencies:
+    has-flag: ^4.0.0
+  checksum: 0219f5c91753fea8dc8046cd4b18d39458b5dc0c6421c67c1072209faae9ba93b89283252e3b05d5c18901fd9f8b95001e3247fb93e2265f66d584a676522c75
+  languageName: node
+  linkType: hard
+
 "supports-hyperlinks@npm:^2.0.0":
   version: 2.2.0
   resolution: "supports-hyperlinks@npm:2.2.0"
@@ -32355,6 +33539,13 @@ resolve@^2.0.0-next.3:
   version: 5.0.0
   resolution: "throat@npm:5.0.0"
   checksum: 2fa41c09ccd97982cd6601eca704913f5d8ef5cc4070fcd71c67e7240da7c0df86f65f5cb23f5c3132ab5567154740114cc92379663aa098b6076a39481b0f5f
+  languageName: node
+  linkType: hard
+
+"throat@npm:^6.0.1":
+  version: 6.0.1
+  resolution: "throat@npm:6.0.1"
+  checksum: c984a40b4725bbd6e8c49d57b2bd36ab36c5534e8a1bed0d278d480171fdf908f16ba343d61c3e9c2e3ed4b327a59c28432cfa44594453b756ec219a772395a8
   languageName: node
   linkType: hard
 
@@ -34995,6 +36186,21 @@ typescript@4.0.6:
   languageName: node
   linkType: hard
 
+"ws@npm:^7.4.5":
+  version: 7.5.0
+  resolution: "ws@npm:7.5.0"
+  peerDependencies:
+    bufferutil: ^4.0.1
+    utf-8-validate: ^5.0.2
+  peerDependenciesMeta:
+    bufferutil:
+      optional: true
+    utf-8-validate:
+      optional: true
+  checksum: f9ac36310e795995f13ac7abff9c3b104b2460864de7f0b6233d285f62c6929529e24f386ff87740c3646f818fefa014be587371aa9a5a6fffae2cd9d1e9e008
+  languageName: node
+  linkType: hard
+
 "x-is-string@npm:^0.1.0":
   version: 0.1.0
   resolution: "x-is-string@npm:0.1.0"
@@ -35281,7 +36487,7 @@ typescript@4.0.6:
   languageName: node
   linkType: hard
 
-"yargs@npm:^16.1.0, yargs@npm:^16.2.0":
+"yargs@npm:^16.0.3, yargs@npm:^16.1.0, yargs@npm:^16.2.0":
   version: 16.2.0
   resolution: "yargs@npm:16.2.0"
   dependencies:


### PR DESCRIPTION
Enables TypeScript checks in ts/tsx spec files. This is a prerequisite for the redesign integration tests.