### PR TITLE
chore: Add storybook to docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -148,6 +148,18 @@ services:
       datalad:
         condition: service_healthy
 
+  storybook:
+    extends:
+      service: node
+    command: bash -c 'yarn workspace @openneuro/components storybook'
+    ports:
+      - '6006:6006'
+    environment:
+      - NODE_ENV=development
+    depends_on:
+      node:
+        condition: service_healthy
+
   elasticsearch:
     image: elasticsearch:7.10.1
     environment:


### PR DESCRIPTION
Ran into environment issues with Storybook, so I just enabled it for docker-compose to use the same environment as the other containers.