### PR TITLE
Accordion and Icon tests

### DIFF
--- a/.pnp.js
+++ b/.pnp.js
@@ -79,10 +79,12 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@babel/runtime-corejs3", "npm:7.14.0"],
             ["@loadable/babel-plugin", "virtual:dc3fc578bfa5e06182a4d2be39ede0bc5b74940b1ffe0d70c26892ab140a4699787750fba175dc306292e80b4aa2c8c5f68c2a821e69b2c37e360c0dff36ff66#npm:5.13.2"],
             ["@sentry/cli", "npm:1.37.4"],
+            ["@testing-library/jest-dom", "npm:5.14.1"],
             ["@types/babel__core", "npm:7.1.14"],
             ["@types/babel__plugin-transform-runtime", "npm:7.9.1"],
             ["@types/babel__preset-env", "npm:7.9.1"],
             ["@types/jest", "npm:26.0.23"],
+            ["@types/testing-library__jest-dom", "npm:5.14.0"],
             ["@typescript-eslint/eslint-plugin", "virtual:dc3fc578bfa5e06182a4d2be39ede0bc5b74940b1ffe0d70c26892ab140a4699787750fba175dc306292e80b4aa2c8c5f68c2a821e69b2c37e360c0dff36ff66#npm:4.24.0"],
             ["@typescript-eslint/parser", "virtual:dc3fc578bfa5e06182a4d2be39ede0bc5b74940b1ffe0d70c26892ab140a4699787750fba175dc306292e80b4aa2c8c5f68c2a821e69b2c37e360c0dff36ff66#npm:4.24.0"],
             ["babel-eslint", "virtual:dc3fc578bfa5e06182a4d2be39ede0bc5b74940b1ffe0d70c26892ab140a4699787750fba175dc306292e80b4aa2c8c5f68c2a821e69b2c37e360c0dff36ff66#npm:10.0.3"],
@@ -10218,7 +10220,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@storybook/preset-scss", "virtual:bb4ed02b339ed801b02d2ec15b42a5aa7b1afdaf44119aefaab128a59d6e16cc6018880c169f24bf2107550e914562ee9e1780db01a12e1bc3c492ad0a049c36#npm:1.0.3"],
             ["@storybook/react", "virtual:bb4ed02b339ed801b02d2ec15b42a5aa7b1afdaf44119aefaab128a59d6e16cc6018880c169f24bf2107550e914562ee9e1780db01a12e1bc3c492ad0a049c36#npm:6.2.9"],
             ["@storybook/theming", "virtual:bb4ed02b339ed801b02d2ec15b42a5aa7b1afdaf44119aefaab128a59d6e16cc6018880c169f24bf2107550e914562ee9e1780db01a12e1bc3c492ad0a049c36#npm:6.2.9"],
-            ["@testing-library/jest-dom", "npm:5.12.0"],
+            ["@testing-library/jest-dom", "npm:5.14.1"],
             ["@testing-library/react", "virtual:bb4ed02b339ed801b02d2ec15b42a5aa7b1afdaf44119aefaab128a59d6e16cc6018880c169f24bf2107550e914562ee9e1780db01a12e1bc3c492ad0a049c36#npm:11.2.7"],
             ["@types/bytes", "npm:3.1.0"],
             ["@types/jest", "npm:26.0.23"],
@@ -10228,10 +10230,12 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@types/react-router-dom", "npm:5.1.7"],
             ["@types/react-slick", "npm:0.23.4"],
             ["@types/slick-carousel", "npm:1.6.34"],
+            ["@types/testing-library__jest-dom", "npm:5.14.0"],
             ["@wojtekmaj/react-daterange-picker", "virtual:bb4ed02b339ed801b02d2ec15b42a5aa7b1afdaf44119aefaab128a59d6e16cc6018880c169f24bf2107550e914562ee9e1780db01a12e1bc3c492ad0a049c36#npm:3.2.0"],
             ["babel-jest", "virtual:bb4ed02b339ed801b02d2ec15b42a5aa7b1afdaf44119aefaab128a59d6e16cc6018880c169f24bf2107550e914562ee9e1780db01a12e1bc3c492ad0a049c36#npm:27.0.2"],
             ["bytes", "npm:3.1.0"],
             ["commafy", "npm:0.0.6"],
+            ["core-js", "npm:3.14.0"],
             ["css-loader", "virtual:bb4ed02b339ed801b02d2ec15b42a5aa7b1afdaf44119aefaab128a59d6e16cc6018880c169f24bf2107550e914562ee9e1780db01a12e1bc3c492ad0a049c36#npm:5.2.4"],
             ["date-fns", "npm:2.21.3"],
             ["jest", "virtual:bb4ed02b339ed801b02d2ec15b42a5aa7b1afdaf44119aefaab128a59d6e16cc6018880c169f24bf2107550e914562ee9e1780db01a12e1bc3c492ad0a049c36#npm:27.0.4"],
@@ -12753,6 +12757,22 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["chalk", "npm:3.0.0"],
             ["css", "npm:3.0.0"],
             ["css.escape", "npm:1.5.1"],
+            ["lodash", "npm:4.17.21"],
+            ["redent", "npm:3.0.0"]
+          ],
+          "linkType": "HARD",
+        }],
+        ["npm:5.14.1", {
+          "packageLocation": "./.yarn/cache/@testing-library-jest-dom-npm-5.14.1-1ece992419-b0c4b4ffa1.zip/node_modules/@testing-library/jest-dom/",
+          "packageDependencies": [
+            ["@testing-library/jest-dom", "npm:5.14.1"],
+            ["@babel/runtime", "npm:7.14.0"],
+            ["@types/testing-library__jest-dom", "npm:5.9.5"],
+            ["aria-query", "npm:4.2.2"],
+            ["chalk", "npm:3.0.0"],
+            ["css", "npm:3.0.0"],
+            ["css.escape", "npm:1.5.1"],
+            ["dom-accessibility-api", "npm:0.5.6"],
             ["lodash", "npm:4.17.21"],
             ["redent", "npm:3.0.0"]
           ],
@@ -20327,6 +20347,13 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["core-js", "npm:3.12.1"]
           ],
           "linkType": "HARD",
+        }],
+        ["npm:3.14.0", {
+          "packageLocation": "./.yarn/unplugged/core-js-npm-3.14.0-29d8f94441/node_modules/core-js/",
+          "packageDependencies": [
+            ["core-js", "npm:3.14.0"]
+          ],
+          "linkType": "HARD",
         }]
       ]],
       ["core-js-compat", [
@@ -22090,6 +22117,13 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "packageLocation": "./.yarn/cache/dom-accessibility-api-npm-0.5.4-dd3e7035e5-39351d26a3.zip/node_modules/dom-accessibility-api/",
           "packageDependencies": [
             ["dom-accessibility-api", "npm:0.5.4"]
+          ],
+          "linkType": "HARD",
+        }],
+        ["npm:0.5.6", {
+          "packageLocation": "./.yarn/cache/dom-accessibility-api-npm-0.5.6-0bcdb9d71b-b579681083.zip/node_modules/dom-accessibility-api/",
+          "packageDependencies": [
+            ["dom-accessibility-api", "npm:0.5.6"]
           ],
           "linkType": "HARD",
         }]
@@ -35935,7 +35969,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
       ]],
       ["open", [
         ["npm:7.4.2", {
-          "packageLocation": "./.yarn/cache/open-npm-7.4.2-a378c23959-07545fa768.zip/node_modules/open/",
+          "packageLocation": "./.yarn/unplugged/open-npm-7.4.2-a378c23959/node_modules/open/",
           "packageDependencies": [
             ["open", "npm:7.4.2"],
             ["is-docker", "npm:2.2.1"],
@@ -41879,10 +41913,12 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@babel/runtime-corejs3", "npm:7.14.0"],
             ["@loadable/babel-plugin", "virtual:dc3fc578bfa5e06182a4d2be39ede0bc5b74940b1ffe0d70c26892ab140a4699787750fba175dc306292e80b4aa2c8c5f68c2a821e69b2c37e360c0dff36ff66#npm:5.13.2"],
             ["@sentry/cli", "npm:1.37.4"],
+            ["@testing-library/jest-dom", "npm:5.14.1"],
             ["@types/babel__core", "npm:7.1.14"],
             ["@types/babel__plugin-transform-runtime", "npm:7.9.1"],
             ["@types/babel__preset-env", "npm:7.9.1"],
             ["@types/jest", "npm:26.0.23"],
+            ["@types/testing-library__jest-dom", "npm:5.14.0"],
             ["@typescript-eslint/eslint-plugin", "virtual:dc3fc578bfa5e06182a4d2be39ede0bc5b74940b1ffe0d70c26892ab140a4699787750fba175dc306292e80b4aa2c8c5f68c2a821e69b2c37e360c0dff36ff66#npm:4.24.0"],
             ["@typescript-eslint/parser", "virtual:dc3fc578bfa5e06182a4d2be39ede0bc5b74940b1ffe0d70c26892ab140a4699787750fba175dc306292e80b4aa2c8c5f68c2a821e69b2c37e360c0dff36ff66#npm:4.24.0"],
             ["babel-eslint", "virtual:dc3fc578bfa5e06182a4d2be39ede0bc5b74940b1ffe0d70c26892ab140a4699787750fba175dc306292e80b4aa2c8c5f68c2a821e69b2c37e360c0dff36ff66#npm:10.0.3"],

--- a/package.json
+++ b/package.json
@@ -26,10 +26,12 @@
     "@babel/runtime-corejs3": "^7.13.10",
     "@loadable/babel-plugin": "^5.13.2",
     "@sentry/cli": "1.37.4",
+    "@testing-library/jest-dom": "^5.14.1",
     "@types/babel__core": "^7",
     "@types/babel__plugin-transform-runtime": "^7",
     "@types/babel__preset-env": "^7",
     "@types/jest": "^26.0.23",
+    "@types/testing-library__jest-dom": "^5",
     "@typescript-eslint/eslint-plugin": "^4.19.0",
     "@typescript-eslint/parser": "^4.19.0",
     "babel-eslint": "10.0.3",
@@ -79,5 +81,10 @@
     "gatsby-plugin-s3": "^0.3.3",
     "react": "^17.0.1",
     "react-dom": "^17.0.1"
+  },
+  "dependenciesMeta": {
+    "open@7.4.2": {
+      "unplugged": true
+    }
   }
 }

--- a/packages/openneuro-components/package.json
+++ b/packages/openneuro-components/package.json
@@ -39,7 +39,7 @@
     "@storybook/preset-scss": "^1.0.3",
     "@storybook/react": "^6.2.8",
     "@storybook/theming": "^6.2.8",
-    "@testing-library/jest-dom": "^5.11.4",
+    "@testing-library/jest-dom": "^5.14.1",
     "@testing-library/react": "^11.1.0",
     "@types/bytes": "^3",
     "@types/jest": "^26.0.23",
@@ -49,7 +49,9 @@
     "@types/react-router-dom": "^5",
     "@types/react-slick": "^0",
     "@types/slick-carousel": "^1",
+    "@types/testing-library__jest-dom": "^5.14.0",
     "babel-jest": "^27.0.2",
+    "core-js": "^3.14.0",
     "css-loader": "^5.2.1",
     "jest": "^27.0.4",
     "sass": "^1.32.8",
@@ -77,7 +79,7 @@
       "dist"
     ],
     "moduleNameMapper": {
-      "^.+\\.(css|less|scss)$": "babel-jest"
+      "^.+\\.(css|less|scss|svg|png|jpg)$": "babel-jest"
     }
   },
   "gitHead": "dbbc1c2c6a8ffbf82ce814bce981ccf9fde116fb"

--- a/packages/openneuro-components/src/accordion/__tests__/AccordionTab.spec.tsx
+++ b/packages/openneuro-components/src/accordion/__tests__/AccordionTab.spec.tsx
@@ -1,0 +1,29 @@
+import React from 'react'
+import '@testing-library/jest-dom/extend-expect'
+import { render, screen } from '@testing-library/react'
+import { AccordionTab } from '../AccordionTab'
+
+describe('AccordionTab component', () => {
+  it('is open by default with startOpen prop', async () => {
+    render(
+      <AccordionTab id="test" className="" label="test" startOpen>
+        Child Element Text
+      </AccordionTab>,
+    )
+    expect(await screen.getByText(/Child Element Text/)).toBeVisible()
+  })
+  it('displays an icon when accordionStyle = "fileTree"', async () => {
+    render(
+      <AccordionTab
+        id="test"
+        className=""
+        label="test"
+        startOpen
+        accordionStyle="file-tree">
+        Child Element Text
+      </AccordionTab>,
+    )
+    expect(await screen.getByText(/Child Element Text/)).toBeInTheDocument()
+    expect(await screen.getByRole('img')).toBeInTheDocument()
+  })
+})

--- a/packages/openneuro-components/src/button/__tests__/Button.spec.tsx
+++ b/packages/openneuro-components/src/button/__tests__/Button.spec.tsx
@@ -1,0 +1,20 @@
+import React from 'react'
+import { render, fireEvent, screen } from '@testing-library/react'
+import { Button } from '../Button'
+
+describe('Button component', () => {
+  it('is clickable', () => {
+    const onClick = jest.fn()
+    render(<Button label="Primary" primary onClick={onClick} />)
+    expect(onClick).not.toBeCalled()
+    fireEvent.click(screen.getByText(/Primary/))
+    expect(onClick).toBeCalled()
+  })
+  it('is not clickable while disabled', () => {
+    const onClick = jest.fn()
+    render(<Button label="Primary" primary onClick={onClick} disabled />)
+    expect(onClick).not.toBeCalled()
+    fireEvent.click(screen.getByText(/Primary/))
+    expect(onClick).not.toBeCalled()
+  })
+})

--- a/packages/openneuro-components/src/count-toggle/__tests__/CountToggle.spec.tsx
+++ b/packages/openneuro-components/src/count-toggle/__tests__/CountToggle.spec.tsx
@@ -1,0 +1,33 @@
+import React from 'react'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { CountToggle } from '../CountToggle'
+import '@testing-library/jest-dom/extend-expect'
+
+export const datasetType_available = [
+  { label: 'All Public', value: 'All Public' },
+  { label: 'Following', value: 'Following' },
+  { label: 'My Datasets', value: 'My Datasets' },
+  { label: 'My Bookmarks', value: 'My Bookmarks' },
+]
+
+describe('CountToggle component', () => {
+  it('calls toggleClick on toggle', async () => {
+    const toggleClick = jest.fn()
+    const clicked = false
+    const showClicked = jest.fn()
+    const count = 3
+    render(
+      <CountToggle
+        label="count toggle test"
+        icon="fa-thumbtack"
+        toggleClick={toggleClick}
+        tooltip="test tip"
+        clicked={clicked}
+        showClicked={showClicked}
+        count={count}
+      />,
+    )
+    fireEvent.click(screen.getByText('count toggle test'))
+    expect(toggleClick).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/openneuro-components/src/icon/Icon.tsx
+++ b/packages/openneuro-components/src/icon/Icon.tsx
@@ -39,7 +39,8 @@ export const Icon: React.FC<IconProps> = ({
       className={[className, 'on-icon', iconWithText, wBackgroundColor].join(
         ' ',
       )}
-      style={{ backgroundColor, color }}>
+      style={{ backgroundColor, color }}
+      role="img">
       {imgIcon}
       {fontIcon}
       {label}

--- a/packages/openneuro-components/src/icon/__tests__/Icon.spec.tsx
+++ b/packages/openneuro-components/src/icon/__tests__/Icon.spec.tsx
@@ -1,0 +1,11 @@
+import React from 'react'
+import '@testing-library/jest-dom/extend-expect'
+import { render, screen } from '@testing-library/react'
+import { Icon } from '../Icon'
+
+describe('Icon component', () => {
+  it('provides "img" role', async () => {
+    render(<Icon />)
+    expect(await screen.getByRole('img')).toBeVisible()
+  })
+})

--- a/packages/openneuro-components/src/loading/Loading.tsx
+++ b/packages/openneuro-components/src/loading/Loading.tsx
@@ -5,16 +5,17 @@ import './loading.scss'
 export interface LoadingProps {}
 
 export const Loading: React.FC<LoadingProps> = ({}) => (
-  <>
-    <div className="cxq-spinner cxq-spinner--waveStretchDelay">
-      <div className="cxq-spinner-hexagon "></div>
-      <div className="rects">
-        <div className="rect rect1"></div>
-        <div className="rect rect2"></div>
-        <div className="rect rect3"></div>
-        <div className="rect rect4"></div>
-        <div className="rect rect5"></div>
-      </div>
+  <div
+    className="cxq-spinner cxq-spinner--waveStretchDelay"
+    role="alert"
+    aria-busy="true">
+    <div className="cxq-spinner-hexagon "></div>
+    <div className="rects">
+      <div className="rect rect1"></div>
+      <div className="rect rect2"></div>
+      <div className="rect rect3"></div>
+      <div className="rect rect4"></div>
+      <div className="rect rect5"></div>
     </div>
-  </>
+  </div>
 )

--- a/packages/openneuro-components/src/loading/__tests__/Loading.spec.tsx
+++ b/packages/openneuro-components/src/loading/__tests__/Loading.spec.tsx
@@ -1,0 +1,13 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { Loading } from '../Loading'
+import '@testing-library/jest-dom/extend-expect'
+
+describe('Loading component', () => {
+  it('loading animation is labeled alert and aria-busy', async () => {
+    render(<Loading />)
+    const loader = await screen.getByRole('alert')
+    expect(loader).toBeInTheDocument()
+    expect(loader.hasAttribute('aria-busy')).toBe(true)
+  })
+})

--- a/packages/openneuro-components/src/logo/__tests__/Logo.spec.tsx
+++ b/packages/openneuro-components/src/logo/__tests__/Logo.spec.tsx
@@ -1,0 +1,23 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { Logo } from '../Logo'
+import '@testing-library/jest-dom/extend-expect'
+
+describe('Logo component', () => {
+  it('renders dark/horizontal', async () => {
+    render(<Logo />)
+    expect(await screen.getByRole('img')).toBeInTheDocument()
+  })
+  it('renders light/horizontal', async () => {
+    render(<Logo dark={false} />)
+    expect(await screen.getByRole('img')).toBeInTheDocument()
+  })
+  it('renders dark/vertical', async () => {
+    render(<Logo horizontal={false} />)
+    expect(await screen.getByRole('img')).toBeInTheDocument()
+  })
+  it('renders light/vertical', async () => {
+    render(<Logo dark={false} horizontal={false} />)
+    expect(await screen.getByRole('img')).toBeInTheDocument()
+  })
+})

--- a/packages/openneuro-components/src/radio/__tests__/RadioGroup.spec.tsx
+++ b/packages/openneuro-components/src/radio/__tests__/RadioGroup.spec.tsx
@@ -1,0 +1,31 @@
+import React from 'react'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { RadioGroup } from '../RadioGroup'
+import '@testing-library/jest-dom/extend-expect'
+
+export const datasetType_available = [
+  { label: 'All Public', value: 'All Public' },
+  { label: 'Following', value: 'Following' },
+  { label: 'My Datasets', value: 'My Datasets' },
+  { label: 'My Bookmarks', value: 'My Bookmarks' },
+]
+
+describe('RadioGroup component', () => {
+  it('has selectable options', async () => {
+    const setSelected = jest.fn()
+    render(
+      <RadioGroup
+        setSelected={setSelected}
+        selected={'All Public'}
+        name={name}
+        radioArr={datasetType_available}
+        layout="row"
+      />,
+    )
+    // Check an option is rendered
+    expect(await screen.getByText(/Following/)).toBeInTheDocument()
+    const followingRadio = screen.getByText('Following')
+    fireEvent.click(followingRadio)
+    expect(setSelected).toHaveBeenCalledWith('Following')
+  })
+})

--- a/packages/openneuro-components/src/read-more/__tests__/ReadMore.spec.tsx
+++ b/packages/openneuro-components/src/read-more/__tests__/ReadMore.spec.tsx
@@ -1,0 +1,15 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { ReadMore } from '../ReadMore'
+import '@testing-library/jest-dom/extend-expect'
+
+describe('ReadMore component', () => {
+  it('renders children', async () => {
+    render(
+      <ReadMore id="readmoretest" expandLabel="expand" collapseabel="hide">
+        Hidden children
+      </ReadMore>,
+    )
+    expect(await screen.getByText(/Hidden children/)).toBeInTheDocument()
+  })
+})

--- a/packages/openneuro-components/src/select/SelectGroup.tsx
+++ b/packages/openneuro-components/src/select/SelectGroup.tsx
@@ -3,12 +3,10 @@ import React from 'react'
 import './select.scss'
 
 export interface SelectGroupProps {
-  options: [
-    {
-      label: string
-      value: string
-    },
-  ]
+  options: {
+    label: string
+    value: string
+  }[]
   value: string
   setValue: (string) => void
   label?: string

--- a/packages/openneuro-components/src/select/__tests__/SelectGroup.spec.tsx
+++ b/packages/openneuro-components/src/select/__tests__/SelectGroup.spec.tsx
@@ -1,0 +1,43 @@
+import React from 'react'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { SelectGroup } from '../SelectGroup'
+import '@testing-library/jest-dom/extend-expect'
+
+const SelectContent = [
+  { label: '--Select--', value: '' },
+  { label: 'Option-1', value: 'option1' },
+  { label: 'Option-2', value: 'option2' },
+  { label: 'Option-3', value: 'option3' },
+  { label: 'Option-4', value: 'option4' },
+]
+
+describe('SelectGroup component', () => {
+  it('renders options', async () => {
+    const setValue = jest.fn()
+    render(
+      <SelectGroup
+        id="test-select"
+        options={SelectContent}
+        value=""
+        layout="inline"
+        setValue={setValue}
+      />,
+    )
+    expect(await screen.queryAllByRole('option')).toHaveLength(5)
+  })
+  it('is selectable', async () => {
+    const setValue = jest.fn()
+    render(
+      <SelectGroup
+        id="test-select"
+        options={SelectContent}
+        value=""
+        setValue={setValue}
+        layout="inline"
+      />,
+    )
+    const select = await screen.getByRole('combobox')
+    fireEvent.change(select, { target: { value: 'option4' } })
+    expect(setValue).toHaveBeenCalledWith('option4')
+  })
+})

--- a/packages/openneuro-components/src/textarea/__tests__/Textarea.spec.tsx
+++ b/packages/openneuro-components/src/textarea/__tests__/Textarea.spec.tsx
@@ -1,0 +1,30 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { Textarea } from '../Textarea'
+import '@testing-library/jest-dom/extend-expect'
+
+describe('Textarea component', () => {
+  it('supports inline type', () => {
+    render(<Textarea type="inline" name="inline test" label="in-label" />)
+    const textbox = screen.getByRole('textbox')
+    expect(textbox).toBeInTheDocument()
+    expect(textbox.closest('div')).toHaveClass('inline')
+    expect(screen.getByText('in-label')).toBeInTheDocument()
+  })
+  it('supports float type', () => {
+    render(<Textarea type="float" name="float test" label="float-label" />)
+    const textbox = screen.getByRole('textbox')
+    expect(textbox).toBeInTheDocument()
+    expect(textbox.closest('div')).toHaveClass('float-form-style')
+    expect(screen.getByText('float-label')).toBeInTheDocument()
+  })
+  it('supports default type', () => {
+    render(<Textarea name="default test" label="default-label" />)
+    const textbox = screen.getByRole('textbox')
+    expect(textbox).toBeInTheDocument()
+    expect(textbox.closest('div')).toHaveClass('form-control')
+    expect(textbox.closest('div')).not.toHaveClass('inline')
+    expect(textbox.closest('div')).not.toHaveClass('float-form-style')
+    expect(screen.getByText('default-label')).toBeInTheDocument()
+  })
+})

--- a/packages/openneuro-components/src/tooltip/__tests__/Tooltip.spec.tsx
+++ b/packages/openneuro-components/src/tooltip/__tests__/Tooltip.spec.tsx
@@ -1,0 +1,15 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { Tooltip } from '../Tooltip'
+import '@testing-library/jest-dom/extend-expect'
+
+describe('Tooltip component', () => {
+  it('renders children', async () => {
+    render(
+      <Tooltip tooltip="tooltiptest" flow="up">
+        hover
+      </Tooltip>,
+    )
+    expect(await screen.getByText(/hover/)).toBeInTheDocument()
+  })
+})

--- a/packages/openneuro-components/src/user/Avatar.tsx
+++ b/packages/openneuro-components/src/user/Avatar.tsx
@@ -21,6 +21,7 @@ export function generateGravatarUrl(userProfile) {
 export interface AvatarProps {
   profile: {
     name: string
+    email?: string
   }
 }
 

--- a/packages/openneuro-components/src/user/__tests__/Avatar.spec.tsx
+++ b/packages/openneuro-components/src/user/__tests__/Avatar.spec.tsx
@@ -1,0 +1,40 @@
+import '@testing-library/jest-dom/extend-expect'
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { Avatar, generateGravatarUrl } from '../Avatar'
+
+describe('generateGravatarUrl', () => {
+  it('returns an image for a valid object', () => {
+    expect(generateGravatarUrl({ email: 'loremipsum@example.com' })).toMatch(
+      /https:\/\/www.gravatar.com\//,
+    )
+  })
+  it('returns null when no email is provided', () => {
+    expect(generateGravatarUrl({})).toBe(null)
+  })
+})
+
+describe('Avatar component', () => {
+  it('renders with image', () => {
+    render(
+      <Avatar
+        profile={{
+          name: 'Test User',
+          email: 'loreipsum@example.com',
+        }}
+      />,
+    )
+    expect(screen.getByRole('img')).toBeInTheDocument()
+  })
+  it('renders a default with no image', () => {
+    render(
+      <Avatar
+        profile={{
+          name: 'Test User',
+        }}
+      />,
+    )
+    expect(screen.queryByRole('img')).toBeNull()
+    expect(screen.getByText('T')).toBeInTheDocument()
+  })
+})

--- a/packages/openneuro-components/src/warn-button/WarnButton.tsx
+++ b/packages/openneuro-components/src/warn-button/WarnButton.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect } from 'react'
+import React from 'react'
 import './warn-button.scss'
 import { Tooltip } from '../tooltip/Tooltip'
 import { Button } from '../button/Button'

--- a/yarn.lock
+++ b/yarn.lock
@@ -5343,7 +5343,7 @@ __metadata:
     "@storybook/preset-scss": ^1.0.3
     "@storybook/react": ^6.2.8
     "@storybook/theming": ^6.2.8
-    "@testing-library/jest-dom": ^5.11.4
+    "@testing-library/jest-dom": ^5.14.1
     "@testing-library/react": ^11.1.0
     "@types/bytes": ^3
     "@types/jest": ^26.0.23
@@ -5353,10 +5353,12 @@ __metadata:
     "@types/react-router-dom": ^5
     "@types/react-slick": ^0
     "@types/slick-carousel": ^1
+    "@types/testing-library__jest-dom": ^5.14.0
     "@wojtekmaj/react-daterange-picker": ^3.2.0
     babel-jest: ^27.0.2
     bytes: ^3.1.0
     commafy: ^0.0.6
+    core-js: ^3.14.0
     css-loader: ^5.2.1
     date-fns: ^2.21.1
     jest: ^27.0.4
@@ -6862,6 +6864,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@testing-library/jest-dom@npm:^5.14.1":
+  version: 5.14.1
+  resolution: "@testing-library/jest-dom@npm:5.14.1"
+  dependencies:
+    "@babel/runtime": ^7.9.2
+    "@types/testing-library__jest-dom": ^5.9.1
+    aria-query: ^4.2.2
+    chalk: ^3.0.0
+    css: ^3.0.0
+    css.escape: ^1.5.1
+    dom-accessibility-api: ^0.5.6
+    lodash: ^4.17.15
+    redent: ^3.0.0
+  checksum: b0c4b4ffa1d58bdf22f1682eb973397e8044a3cdd8527de8d1c8169640b3c4585165abcbfc819dee7f4aa40204c6a63afb28dd74ad9bb4e1bfbdc680fd491e30
+  languageName: node
+  linkType: hard
+
 "@testing-library/react@npm:^11.1.0":
   version: 11.2.7
   resolution: "@testing-library/react@npm:11.2.7"
@@ -7960,7 +7979,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/testing-library__jest-dom@npm:^5.14.0":
+"@types/testing-library__jest-dom@npm:^5, @types/testing-library__jest-dom@npm:^5.14.0":
   version: 5.14.0
   resolution: "@types/testing-library__jest-dom@npm:5.14.0"
   dependencies:
@@ -12939,6 +12958,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"core-js@npm:^3.14.0":
+  version: 3.14.0
+  resolution: "core-js@npm:3.14.0"
+  checksum: fc830e61146f50241f431c711674a6af0a3633269a2a2afada3da1054f0c3b3a8b571fb4ca4c87d53193def47a4f56a18c32e832e6587b363ff0ff153508f300
+  languageName: node
+  linkType: hard
+
 "core-util-is@npm:1.0.2, core-util-is@npm:^1.0.2, core-util-is@npm:~1.0.0":
   version: 1.0.2
   resolution: "core-util-is@npm:1.0.2"
@@ -14400,6 +14426,13 @@ __metadata:
   version: 0.5.4
   resolution: "dom-accessibility-api@npm:0.5.4"
   checksum: 39351d26a3732312f14411effef698204bf6c79a7d5eb0664441897541243f2cdf2e508aca52684ccf3b10df6708a6c265d1fde323eebcb8363a1093f5927b10
+  languageName: node
+  linkType: hard
+
+"dom-accessibility-api@npm:^0.5.6":
+  version: 0.5.6
+  resolution: "dom-accessibility-api@npm:0.5.6"
+  checksum: b579681083e683291df022bdf094dae2c7e39db0ff28f70ed2c8368eda203fe4c45bcf92f1c623ce4b746cb245f9a5dc9d176f1781d600b9218728d3a1d1580f
   languageName: node
   linkType: hard
 
@@ -30932,10 +30965,12 @@ resolve@^2.0.0-next.3:
     "@babel/runtime-corejs3": ^7.13.10
     "@loadable/babel-plugin": ^5.13.2
     "@sentry/cli": 1.37.4
+    "@testing-library/jest-dom": ^5.14.1
     "@types/babel__core": ^7
     "@types/babel__plugin-transform-runtime": ^7
     "@types/babel__preset-env": ^7
     "@types/jest": ^26.0.23
+    "@types/testing-library__jest-dom": ^5
     "@typescript-eslint/eslint-plugin": ^4.19.0
     "@typescript-eslint/parser": ^4.19.0
     babel-eslint: 10.0.3
@@ -30959,6 +30994,9 @@ resolve@^2.0.0-next.3:
     react-dom: ^17.0.1
     tsc-watch: ^4.2.9
     typescript: 4.0.6
+  dependenciesMeta:
+    open@7.4.2:
+      unplugged: true
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Adds some test cases for the accordion tab component and extends Icon with role="img" and the clickable parts of the accordion with role="button" and aria-pressed states (to indicate it can be toggled).

Depends on #2166, mergable after that one.