### PR TITLE
fix(typescript): Use moduleNameMapper and ts-jest for test imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "lint-staged": "^10.5.4",
     "pinst": "^2.1.6",
     "prettier": "^2.2.1",
+    "ts-jest": "^27.0.3",
     "tsc-watch": "^4.2.9",
     "typescript": "4.0.6"
   },
@@ -61,6 +62,7 @@
     ]
   },
   "jest": {
+    "preset": "ts-jest",
     "projects": [
       "packages/*"
     ],
@@ -74,7 +76,10 @@
     ],
     "testPathIgnorePatterns": [
       "dist"
-    ]
+    ],
+    "moduleNameMapper": {
+      "@openneuro/(.+)": "<rootDir>../openneuro-$1/src"
+    }
   },
   "dependencies": {
     "docz": "^2.3.1",

--- a/packages/openneuro-app/package.json
+++ b/packages/openneuro-app/package.json
@@ -135,7 +135,8 @@
     "moduleNameMapper": {
       "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/__mocks__/fileMock.js",
       "\\.(css|less)$": "<rootDir>/__mocks__/styleMock.js",
-      "openneuro-content": "<rootDir>/__mocks__/contentMock.js"
+      "openneuro-content": "<rootDir>/__mocks__/contentMock.js",
+      "@openneuro/(.+)": "<rootDir>../openneuro-$1/src"
     },
     "transformIgnorePatterns": [
       "/node_modules/(?!bids-validator).+\\.js$"

--- a/packages/openneuro-cli/package.json
+++ b/packages/openneuro-cli/package.json
@@ -54,7 +54,10 @@
     ],
     "transformIgnorePatterns": [
       "/node_modules/(?!bids-validator).+\\.js$"
-    ]
+    ],
+    "moduleNameMapper": {
+      "@openneuro/(.+)": "<rootDir>../openneuro-$1/src"
+    }
   },
   "devDependencies": {
     "@babel/runtime-corejs3": "^7.13.10",

--- a/packages/openneuro-client/package.json
+++ b/packages/openneuro-client/package.json
@@ -2,7 +2,7 @@
   "name": "@openneuro/client",
   "version": "3.34.0-alpha.0",
   "description": "OpenNeuro shared client library.",
-  "main": "src/index.js",
+  "main": "dist/index.js",
   "browser": "src/index.js",
   "exports": {
     ".": "./src/index.js"
@@ -26,6 +26,7 @@
     "testEnvironment": "node"
   },
   "devDependencies": {
+    "@babel/preset-typescript": "^7.14.5",
     "@babel/runtime-corejs3": "^7.13.10",
     "@openneuro/server": "^3.34.0-alpha.0",
     "apollo-server": "^2.23.0",

--- a/packages/openneuro-components/package.json
+++ b/packages/openneuro-components/package.json
@@ -79,7 +79,8 @@
       "dist"
     ],
     "moduleNameMapper": {
-      "^.+\\.(css|less|scss|svg|png|jpg)$": "babel-jest"
+      "^.+\\.(css|less|scss|svg|png|jpg)$": "babel-jest",
+      "@openneuro/(.+)": "<rootDir>../openneuro-$1/src"
     }
   },
   "gitHead": "dbbc1c2c6a8ffbf82ce814bce981ccf9fde116fb"


### PR DESCRIPTION
Avoids depending on the typescript build in tests. Reverts #2168 since it led to the indexer not starting up.