### PR TITLE
fix(dev): Improve macOS dev experience by not mapping yarn cache

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,6 @@ services:
     volumes:
       - ./:/srv
       - node_deps:/srv/.yarn
-      - ./.yarn/cache:/srv/.yarn/cache
       - ./.yarn/releases:/srv/.yarn/releases
       - ./.yarn/plugins:/srv/.yarn/plugins
       - dist:/src/dist


### PR DESCRIPTION
This slows things down very slightly on Linux but major performance boost on macOS and no permission issues with lockfiles.