### PR TITLE
fix(components): Drop commafy for toLocaleString

### DIFF
--- a/.pnp.js
+++ b/.pnp.js
@@ -10330,7 +10330,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@wojtekmaj/react-daterange-picker", "virtual:bb4ed02b339ed801b02d2ec15b42a5aa7b1afdaf44119aefaab128a59d6e16cc6018880c169f24bf2107550e914562ee9e1780db01a12e1bc3c492ad0a049c36#npm:3.2.0"],
             ["babel-jest", "virtual:bb4ed02b339ed801b02d2ec15b42a5aa7b1afdaf44119aefaab128a59d6e16cc6018880c169f24bf2107550e914562ee9e1780db01a12e1bc3c492ad0a049c36#npm:27.0.2"],
             ["bytes", "npm:3.1.0"],
-            ["commafy", "npm:0.0.6"],
             ["core-js", "npm:3.14.0"],
             ["css-loader", "virtual:bb4ed02b339ed801b02d2ec15b42a5aa7b1afdaf44119aefaab128a59d6e16cc6018880c169f24bf2107550e914562ee9e1780db01a12e1bc3c492ad0a049c36#npm:5.2.4"],
             ["date-fns", "npm:2.21.3"],
@@ -19734,15 +19733,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "packageLocation": "./.yarn/cache/comma-separated-tokens-npm-1.0.8-00dbbf3418-31a5a2fa6e.zip/node_modules/comma-separated-tokens/",
           "packageDependencies": [
             ["comma-separated-tokens", "npm:1.0.8"]
-          ],
-          "linkType": "HARD",
-        }]
-      ]],
-      ["commafy", [
-        ["npm:0.0.6", {
-          "packageLocation": "./.yarn/cache/commafy-npm-0.0.6-128d8e915e-5b9e202b43.zip/node_modules/commafy/",
-          "packageDependencies": [
-            ["commafy", "npm:0.0.6"]
           ],
           "linkType": "HARD",
         }]

--- a/packages/openneuro-components/package.json
+++ b/packages/openneuro-components/package.json
@@ -15,7 +15,6 @@
     "@mdx-js/react": "^1.6.22",
     "@wojtekmaj/react-daterange-picker": "^3.2.0",
     "bytes": "^3.1.0",
-    "commafy": "^0.0.6",
     "date-fns": "^2.21.1",
     "markdown-to-jsx": "^7.1.3",
     "md5": "^2.3.0",

--- a/packages/openneuro-components/src/facets/FacetSelect.tsx
+++ b/packages/openneuro-components/src/facets/FacetSelect.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import commafy from 'commafy'
 import { AccordionTab } from '../accordion/AccordionTab'
 import { AccordionWrap } from '../accordion/AccordionWrap'
 import './facet.scss'
@@ -27,9 +26,9 @@ export interface FacetSelectProps {
 }
 
 const get = (obj, property) => (typeof obj === 'object' ? obj[property] : obj)
-const check = (obj, property) =>
+export const check = (obj, property) =>
   typeof obj === 'object' && typeof obj[property] === 'number'
-    ? commafy(obj[property])
+    ? obj[property].toLocaleString()
     : typeof obj === 'object'
     ? obj[property]
     : false

--- a/packages/openneuro-components/src/facets/__tests__/FacetSelect.spec.tsx
+++ b/packages/openneuro-components/src/facets/__tests__/FacetSelect.spec.tsx
@@ -1,0 +1,14 @@
+import { check } from '../FacetSelect'
+
+describe('FacetSelect component', () => {
+  describe('check()', () => {
+    it('adds commas to numeric properties', () => {
+      expect(check({ data: 1934810581 }, 'data')).toEqual('1,934,810,581')
+    })
+    it('nested objects to return child object', () => {
+      expect(check({ num: 18485, obj: { num: 810591 } }, 'obj')).toEqual({
+        num: 810591,
+      })
+    })
+  })
+})

--- a/packages/openneuro-components/src/search-page/SearchResultItem.tsx
+++ b/packages/openneuro-components/src/search-page/SearchResultItem.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import bytes from 'bytes'
-import commafy from 'commafy'
 import parseISO from 'date-fns/parseISO'
 import formatDistanceToNow from 'date-fns/formatDistanceToNow'
 import { Link } from 'react-router-dom'
@@ -115,13 +114,13 @@ export const SearchResultItem = ({ node, profile }: SearchResultItemProps) => {
   const sessions = (
     <span className="result-summary-meta">
       <strong>Sessions: </strong>
-      <span>{commafy(numSessions)}</span>
+      <span>{numSessions.toLocaleString()}</span>
     </span>
   )
   const subjects = (
     <span className="result-summary-meta">
       <strong> Participants: </strong>
-      <span>{commafy(numSubjects)}</span>
+      <span>{numSubjects.toLocaleString()}</span>
     </span>
   )
   const size = (
@@ -133,7 +132,7 @@ export const SearchResultItem = ({ node, profile }: SearchResultItemProps) => {
   const files = (
     <span className="result-summary-meta">
       <strong>Files: </strong>
-      <span>{commafy(summary.totalFiles)}</span>
+      <span>{summary.totalFiles.toLocaleString()}</span>
     </span>
   )
 
@@ -161,16 +160,16 @@ export const SearchResultItem = ({ node, profile }: SearchResultItemProps) => {
     </div>
   )
   const downloads = node.analytics.downloads
-    ? commafy(node.analytics.downloads) + ' Downloads \n'
+    ? node.analytics.downloads.toLocaleString() + ' Downloads \n'
     : ''
   const views = node.analytics.views
-    ? commafy(node.analytics.views) + ' Views \n'
+    ? node.analytics.views.toLocaleString() + ' Views \n'
     : ''
   const following = node.followers.length
-    ? commafy(node.followers.length) + ' Follower \n'
+    ? node.followers.length.toLocaleString() + ' Follower \n'
     : ''
   const stars = node.stars.length
-    ? commafy(node.stars.length) + ' Bookmarked'
+    ? node.stars.length.toLocaleString() + ' Bookmarked'
     : ''
 
   const activtyTooltip = downloads + views + following + stars

--- a/yarn.lock
+++ b/yarn.lock
@@ -5409,7 +5409,6 @@ __metadata:
     "@wojtekmaj/react-daterange-picker": ^3.2.0
     babel-jest: ^27.0.2
     bytes: ^3.1.0
-    commafy: ^0.0.6
     core-js: ^3.14.0
     css-loader: ^5.2.1
     date-fns: ^2.21.1
@@ -12355,13 +12354,6 @@ __metadata:
   version: 1.0.8
   resolution: "comma-separated-tokens@npm:1.0.8"
   checksum: 31a5a2fa6e0f02764b0634e0aa31913c9be0ef568f4e58b5c1ec85d0a6e4a6c367905eacf2c7e59b57d3d05f40cff166ea3c9b6ee8338625cad060ce43ede9fd
-  languageName: node
-  linkType: hard
-
-"commafy@npm:^0.0.6":
-  version: 0.0.6
-  resolution: "commafy@npm:0.0.6"
-  checksum: 5b9e202b43f7d1086aae4ab04325c679acd6a3e09d95de96e47d356fae30dc2798eb370a20e9d9d0bdb6a810c581f420ebf9f63ff74df7d8321249d592c8d68e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This library is causing SSR rendering to fail. I've replaced it with toLocaleString.

Adds a couple tests to FacetSelect to make sure this is functionally equivalent.

Fixes gitlab 244