### PR TITLE
Portal header content updates

### DIFF
--- a/.pnp.js
+++ b/.pnp.js
@@ -27080,7 +27080,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
       ]],
       ["git-win", [
         ["npm:2.3.0", {
-          "packageLocation": "./.yarn/cache/git-win-npm-2.3.0-b98f2b7122-a273c79c22.zip/node_modules/git-win/",
+          "packageLocation": "./.yarn/unplugged/git-win-npm-2.3.0-b98f2b7122/node_modules/git-win/",
           "packageDependencies": [
             ["git-win", "npm:2.3.0"],
             ["@babel/runtime", "npm:7.14.0"],

--- a/packages/openneuro-components/src/mock-content/front-page-content.jsx
+++ b/packages/openneuro-components/src/mock-content/front-page-content.jsx
@@ -141,12 +141,6 @@ export const frontPage = {
       link: 'https://braininitiative.nih.gov/',
     },
     {
-      title: 'The National Institute of Mental Health',
-      alt: 'The National Institute of Mental Health logo',
-      logo: nimh,
-      link: 'https://www.nimh.nih.gov/index.shtml',
-    },
-    {
       title: 'NSF',
       alt: 'National Science Foundation',
       logo: nsf,

--- a/packages/openneuro-components/src/mock-content/portal-content.jsx
+++ b/packages/openneuro-components/src/mock-content/portal-content.jsx
@@ -18,15 +18,9 @@ export const portalContent = {
     hexBackgroundImage: mriScan,
     swoopBackgroundColorLight: 'rgba(109,83,156,1)',
     swoopBackgroundColorDark: 'rgba(45,34,64,1)',
-    communityHeader:
-      'Join the OHBM virtual meeting the week of June 21st, 2021',
-    communityPrimary:
-      'Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deser unt mollit anim id est laborumror sit voluptatem accusantium doloremque.',
-    communitySecondary: (
-      <span>
-        Visit the <a href="#">Eventbright</a> for more information.
-      </span>
-    ),
+    communityHeader: null,
+    communityPrimary: null,
+    communitySecondary: null,
   },
   eeg: {
     modality: 'EEG', // corresponds to values in `modality_available` in (packages/openneuro-app/src/scripts/refactor_2021/search/initial-search-params.tsx)
@@ -44,14 +38,9 @@ export const portalContent = {
     hexBackgroundImage: mriScan,
     swoopBackgroundColorLight: 'rgba(109,83,156,1)',
     swoopBackgroundColorDark: 'rgba(45,34,64,1)',
-    communityHeader: 'Join the EEG hackathon on July 1st, 2021',
-    communityPrimary:
-      'Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deser unt mollit anim id est laborumror sit voluptatem accusantium doloremque.',
-    communitySecondary: (
-      <span>
-        Visit the <a href="#">Eventbright</a> for more information.
-      </span>
-    ),
+    communityHeader: null,
+    communityPrimary: null,
+    communitySecondary: null,
   },
   ieeg: {
     modality: 'iEEG', // corresponds to values in `modality_available` in (packages/openneuro-app/src/scripts/refactor_2021/search/initial-search-params.tsx)
@@ -69,14 +58,9 @@ export const portalContent = {
     hexBackgroundImage: mriScan,
     swoopBackgroundColorLight: 'rgba(109,83,156,1)',
     swoopBackgroundColorDark: 'rgba(45,34,64,1)',
-    communityHeader: 'Join the iEEG hackathon on July 1st, 2021',
-    communityPrimary:
-      'Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deser unt mollit anim id est laborumror sit voluptatem accusantium doloremque.',
-    communitySecondary: (
-      <span>
-        Visit the <a href="#">Eventbright</a> for more information.
-      </span>
-    ),
+    communityHeader: null,
+    communityPrimary: null,
+    communitySecondary: null,
   },
   meg: {
     modality: 'MEG', // corresponds to values in `modality_available` in (packages/openneuro-app/src/scripts/refactor_2021/search/initial-search-params.tsx)
@@ -94,14 +78,9 @@ export const portalContent = {
     hexBackgroundImage: mriScan,
     swoopBackgroundColorLight: 'rgba(109,83,156,1)',
     swoopBackgroundColorDark: 'rgba(45,34,64,1)',
-    communityHeader: 'Join the MEG hackathon on July 1st, 2021',
-    communityPrimary:
-      'Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deser unt mollit anim id est laborumror sit voluptatem accusantium doloremque.',
-    communitySecondary: (
-      <span>
-        Visit the <a href="#">Eventbright</a> for more information.
-      </span>
-    ),
+    communityHeader: null,
+    communityPrimary: null,
+    communitySecondary: null,
   },
   pet: {
     modality: 'PET', // corresponds to values in `modality_available` in (packages/openneuro-app/src/scripts/refactor_2021/search/initial-search-params.tsx)

--- a/packages/openneuro-components/src/mock-content/portal-content.jsx
+++ b/packages/openneuro-components/src/mock-content/portal-content.jsx
@@ -9,12 +9,8 @@ export const portalContent = {
     portalName: 'OpenNeuro MRI',
     portalPrimary: (
       <>
-        The OpenNeuro platform was developed by the Center for Reproducible
-        Neuroscience as a tool to encourage and enhance data sharing and
-        analysis of raw MRI data, using{' '}
-        <a href="https://bids.neuroimaging.io">BIDS</a> to organize and
-        standardize this data. Since its release in 2017 the site has seen the
-        upload of more than 200 public MRI-specific datasets.
+        The OpenNeuro platform was developed by the Center for Reproducible Neuroscience as a tool to encourage and enhance data sharing and analysis of raw MRI data, using{' '}
+        <a href="https://bids.neuroimaging.io">BIDS</a> to organize and standardize these data.
       </>
     ),
     publicDatasetStat: 100,
@@ -36,8 +32,12 @@ export const portalContent = {
     modality: 'EEG', // corresponds to values in `modality_available` in (packages/openneuro-app/src/scripts/refactor_2021/search/initial-search-params.tsx)
     className: 'search-page-eeg',
     portalName: 'OpenNeuro EEG',
-    portalPrimary:
-      'The OpenNeuro platform was developed by the Center for Reproducible Neuroscience as a tool to encourage and enhance data sharing and analysis of raw MRI data, using BIDS to organize and standardize this data. Since its release in 2017, the site has seen the upload of more than 200 public MRI-specific datasets.',
+    portalPrimary: (
+      <>
+        OpenNeuro added support for EEG datasets in 2019, when EEG was incorporated into the{' '}
+        <a href="https://bids.neuroimaging.io">BIDS</a> standard.
+      </>
+    ),
     publicDatasetStat: 100,
     participantsStat: 1100,
     hexBackgroundImage: mriScan,
@@ -56,8 +56,12 @@ export const portalContent = {
     modality: 'iEEG', // corresponds to values in `modality_available` in (packages/openneuro-app/src/scripts/refactor_2021/search/initial-search-params.tsx)
     className: 'search-page-ieeg',
     portalName: 'OpenNeuro iEEG',
-    portalPrimary:
-      'The OpenNeuro platform was developed by the Center for Reproducible Neuroscience as a tool to encourage and enhance data sharing and analysis of raw MRI data, using BIDS to organize and standardize this data. Since its release in 2017, the site has seen the upload of more than 200 public MRI-specific datasets.',
+    portalPrimary: (
+      <>
+        OpenNeuro added support for iEEG datasets in 2019, when iEEG was incorporated into the{' '}
+        <a href="https://bids.neuroimaging.io">BIDS</a> standard.
+      </>
+    ),
     publicDatasetStat: 100,
     participantsStat: 1100,
     hexBackgroundImage: mriScan,
@@ -76,8 +80,12 @@ export const portalContent = {
     modality: 'MEG', // corresponds to values in `modality_available` in (packages/openneuro-app/src/scripts/refactor_2021/search/initial-search-params.tsx)
     className: 'search-page-meg',
     portalName: 'OpenNeuro MEG',
-    portalPrimary:
-      'The OpenNeuro platform was developed by the Center for Reproducible Neuroscience as a tool to encourage and enhance data sharing and analysis of raw MRI data, using BIDS to organize and standardize this data. Since its release in 2017, the site has seen the upload of more than 200 public MRI-specific datasets.',
+    portalPrimary: (
+      <>
+        OpenNeuro added support for MEG datasets in 2018, when MEG was incorporated into the{' '}
+        <a href="https://bids.neuroimaging.io">BIDS</a> standard.
+      </>
+    ),
     publicDatasetStat: 100,
     participantsStat: 1100,
     hexBackgroundImage: mriScan,

--- a/packages/openneuro-components/src/mock-content/portal-content.jsx
+++ b/packages/openneuro-components/src/mock-content/portal-content.jsx
@@ -34,7 +34,8 @@ export const portalContent = {
     portalName: 'OpenNeuro EEG',
     portalPrimary: (
       <>
-        OpenNeuro added support for EEG datasets in 2019, when EEG was incorporated into the{' '}
+        OpenNeuro added support for EEG datasets in 2019, when{' '}
+        <a href="https://www.nature.com/articles/s41597-019-0104-8">EEG was incorporated</a> into the{' '}
         <a href="https://bids.neuroimaging.io">BIDS</a> standard.
       </>
     ),
@@ -58,7 +59,8 @@ export const portalContent = {
     portalName: 'OpenNeuro iEEG',
     portalPrimary: (
       <>
-        OpenNeuro added support for iEEG datasets in 2019, when iEEG was incorporated into the{' '}
+        OpenNeuro added support for iEEG datasets in 2019, when{' '}
+        <a href="https://www.nature.com/articles/s41597-019-0105-7">iEEG was incorporated</a> into the{' '}
         <a href="https://bids.neuroimaging.io">BIDS</a> standard.
       </>
     ),
@@ -82,7 +84,8 @@ export const portalContent = {
     portalName: 'OpenNeuro MEG',
     portalPrimary: (
       <>
-        OpenNeuro added support for MEG datasets in 2018, when MEG was incorporated into the{' '}
+        OpenNeuro added support for MEG datasets in 2018, when{' '}
+        <a href="https://www.nature.com/articles/sdata2018110">MEG was incorporated</a> into the{' '}
         <a href="https://bids.neuroimaging.io">BIDS</a> standard.
       </>
     ),


### PR DESCRIPTION
This will close Gitlab 219 once completed.  Currently, this includes portal header content for MRI, EEG, iEEG, and MEG.  No community bar/sweep content has been updated at this point.  PET portal content is also still pending.

This will also close Gitlab 267, the removal of NIMH and associated logo from the footer.