### PR TITLE
fix(api): Add new bids-validator summary data to summary model and API types

### DIFF
--- a/packages/openneuro-server/src/graphql/schema.js
+++ b/packages/openneuro-server/src/graphql/schema.js
@@ -189,10 +189,19 @@ export const typeDefs = `
     size: BigInt!
   }
 
+  input SummaryPetInput {
+    BodyPart: [String]
+    ScannerManufacturer: [String]
+    ScannerManufacturersModelName: [String]
+    TracerName: [String]
+    TracerRadionuclide: [String]
+  }
+
   input SummaryInput {
     id: ID! # Git reference for this summary
     datasetId: ID!
     modalities: [String]
+    secondaryModalities: [String]
     sessions: [String]
     subjects: [String]
     subjectMetadata: [SubjectMetadataInput]
@@ -200,6 +209,7 @@ export const typeDefs = `
     size: BigInt!
     totalFiles: Int!
     dataProcessed: Boolean
+    pet: SummaryPetInput
   }
 
   input SubjectMetadataInput {

--- a/packages/openneuro-server/src/models/summary.ts
+++ b/packages/openneuro-server/src/models/summary.ts
@@ -1,17 +1,27 @@
 import mongoose, { Document } from 'mongoose'
 const { Schema, model } = mongoose
 
+export interface SummaryPetField {
+  BodyPart: string[]
+  ScannerManufacturer: string[]
+  ScannerManufacturersModelName: string[]
+  TracerName: string[]
+  TracerRadionuclide: string[]
+}
+
 export interface SummaryDocument extends Document {
   id: string
   datasetId: string
   sessions: string[]
   subjects: string[]
-  subjectMetadata: object
+  subjectMetadata: Record<string, any>
   tasks: string[]
   modalities: string[]
+  secondaryModalities: string[]
   totalFiles: number
   size: number
   dataProcessed: boolean
+  pet: SummaryPetField
 }
 
 const summarySchema = new Schema({
@@ -22,9 +32,17 @@ const summarySchema = new Schema({
   subjectMetadata: Object,
   tasks: [String],
   modalities: [String],
+  secondaryModalities: [String],
   totalFiles: Number,
   size: Number,
   dataProcessed: Boolean,
+  pet: {
+    BodyPart: [String],
+    ScannerManufacturer: [String],
+    ScannerManufacturersModelName: [String],
+    TracerName: [String],
+    TracerRadionuclide: [String],
+  },
 })
 
 summarySchema.index({ id: 1 })


### PR DESCRIPTION
This adds the PET and secondary modality types to the API and MongoDB models.