### PR TITLE
Pet summary fields

### DIFF
--- a/.pnp.js
+++ b/.pnp.js
@@ -26274,7 +26274,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
       ]],
       ["git-win", [
         ["npm:2.3.0", {
-          "packageLocation": "./.yarn/unplugged/git-win-npm-2.3.0-b98f2b7122/node_modules/git-win/",
+          "packageLocation": "./.yarn/cache/git-win-npm-2.3.0-b98f2b7122-a273c79c22.zip/node_modules/git-win/",
           "packageDependencies": [
             ["git-win", "npm:2.3.0"],
             ["@babel/runtime", "npm:7.14.6"],

--- a/packages/openneuro-app/src/scripts/datalad/dataset/dataset-query-fragments.js
+++ b/packages/openneuro-app/src/scripts/datalad/dataset/dataset-query-fragments.js
@@ -33,6 +33,13 @@ export const DRAFT_FRAGMENT = gql`
         size
         totalFiles
         dataProcessed
+        pet {
+          BodyPart
+          ScannerManufacturer
+          ScannerManufacturersModelName
+          TracerName
+          TracerRadionuclide
+        }
       }
     }
   }
@@ -161,6 +168,13 @@ export const SNAPSHOT_FIELDS = gql`
       size
       totalFiles
       dataProcessed
+      pet {
+        BodyPart
+        ScannerManufacturer
+        ScannerManufacturersModelName
+        TracerName
+        TracerRadionuclide
+      }
     }
     analytics {
       downloads

--- a/packages/openneuro-app/src/scripts/datalad/fragments/dataset-summary.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/fragments/dataset-summary.jsx
@@ -53,6 +53,68 @@ class Summary extends React.PureComponent {
         </span>
       )
 
+      let bodyPart,
+        scannerManufacturer,
+        scannerManufacturersModelName,
+        tracerName,
+        tracerRadionuclide
+      if (summary.pet) {
+        bodyPart = (
+          <span>
+            <strong>
+              {' '}
+              {pluralize('Target', summary.pet.BodyPart.length)}:{' '}
+            </strong>
+            {summary.pet.BodyPart.join(', ')}
+          </span>
+        )
+        scannerManufacturer = (
+          <span>
+            <strong>
+              {' '}
+              {pluralize(
+                'Scanner Manufacturer',
+                summary.pet.ScannerManufacturer.length,
+              )}
+              :{' '}
+            </strong>
+            {summary.pet.ScannerManufacturer.join(', ')}
+          </span>
+        )
+        scannerManufacturersModelName = (
+          <span>
+            <strong>
+              {' '}
+              {pluralize(
+                'Scanner Model',
+                summary.pet.ScannerManufacturersModelName.length,
+              )}
+              :{' '}
+            </strong>
+            {summary.pet.ScannerManufacturersModelName.join(', ')}
+          </span>
+        )
+        tracerName = (
+          <span>
+            <strong>
+              {' '}
+              {pluralize('Tracer', summary.pet.TracerName.length)}:{' '}
+            </strong>
+            {summary.pet.TracerName.join(', ')}
+          </span>
+        )
+        tracerRadionuclide = (
+          <span>
+            <strong>
+              {' '}
+              {pluralize('Radionuclide', summary.pet.TracerRadionuclide.length)}
+              :{' '}
+            </strong>
+            {summary.pet.TracerRadionuclide.join(', ')}
+          </span>
+        )
+      }
+
       if (minimal) {
         return (
           <div className="minimal-summary">
@@ -66,6 +128,17 @@ class Summary extends React.PureComponent {
             <div className="summary-data modalities">
               {this._list(<b>Modalities</b>, summary.modalities)}
             </div>
+            {summary.pet && (
+              <>
+                <div className="summary-data">{bodyPart}</div>
+                <div className="summary-data">{scannerManufacturer}</div>
+                <div className="summary-data">
+                  {scannerManufacturersModelName}
+                </div>
+                <div className="summary-data">{tracerName}</div>
+                <div className="summary-data">{tracerRadionuclide}</div>
+              </>
+            )}
           </div>
         )
       } else {
@@ -78,6 +151,15 @@ class Summary extends React.PureComponent {
             </h5>
             <h5>{this._list(<b>Tasks</b>, summary.tasks)}</h5>
             <h5>{this._list(<b>Modalities</b>, summary.modalities)}</h5>
+            {summary.pet && (
+              <>
+                <h5>{bodyPart}</h5>
+                <h5>{scannerManufacturer}</h5>
+                <h5>{scannerManufacturersModelName}</h5>
+                <h5>{tracerName}</h5>
+                <h5>{tracerRadionuclide}</h5>
+              </>
+            )}
           </div>
         )
       }

--- a/packages/openneuro-app/src/scripts/refactor_2021/search/initial-search-params.tsx
+++ b/packages/openneuro-app/src/scripts/refactor_2021/search/initial-search-params.tsx
@@ -21,7 +21,7 @@ type ModalityOption = {
   children?: ModalityOption[]
 }
 
-const modality_available: ModalityOption[] = [
+export const modality_available: ModalityOption[] = [
   {
     label: 'MRI',
     value: 'MRI',
@@ -148,6 +148,11 @@ export interface SearchParams {
   section_selected: string | null
   studyDomain_available: string[]
   studyDomain_selected: string | null
+  bodyParts: string[]
+  scannerManufacturers: string[]
+  scannerManufacturersModelNames: string[]
+  tracerNames: string[]
+  tracerRadionuclides: string[]
   sortBy_available
   sortBy_selected
 }
@@ -179,6 +184,11 @@ const initialSearchParams: SearchParams = {
   section_selected: null,
   studyDomain_available: [],
   studyDomain_selected: null,
+  bodyParts: [],
+  scannerManufacturers: [],
+  scannerManufacturersModelNames: [],
+  tracerNames: [],
+  tracerRadionuclides: [],
   sortBy_available: sortBy,
   sortBy_selected: sortBy[0],
 }
@@ -220,6 +230,11 @@ const TEMPORARY_initialSearchParams: SearchParams = {
   section_selected: null,
   studyDomain_available: ['a', 'b', 'c'],
   studyDomain_selected: null,
+  bodyParts: [],
+  scannerManufacturers: [],
+  scannerManufacturersModelNames: [],
+  tracerNames: [],
+  tracerRadionuclides: [],
   sortBy_available: sortBy,
   sortBy_selected: sortBy[0],
 }

--- a/packages/openneuro-app/src/scripts/refactor_2021/search/inputs/index.ts
+++ b/packages/openneuro-app/src/scripts/refactor_2021/search/inputs/index.ts
@@ -11,6 +11,11 @@ import DateRadios from './date-radios'
 import SpeciesSelect from './species-select'
 import SectionSelect from './section-select'
 import StudyDomainSelect from './study-domain-select'
+import BodyPartsInput from './pet/bodyParts_input'
+import ScannerManufacturers from './pet/scannerManufacturers_input'
+import ScannerManufacturersModelNames from './pet/scannerManufacturersModelNames_input'
+import TracerNames from './pet/tracerNames_input'
+import TracerRadionuclides from './pet/tracerRadionuclides_input'
 import SortBySelect from './sort-by-select'
 
 export {
@@ -27,5 +32,10 @@ export {
   SpeciesSelect,
   SectionSelect,
   StudyDomainSelect,
+  BodyPartsInput,
+  ScannerManufacturers,
+  ScannerManufacturersModelNames,
+  TracerNames,
+  TracerRadionuclides,
   SortBySelect,
 }

--- a/packages/openneuro-app/src/scripts/refactor_2021/search/inputs/pet/bodyParts_input.tsx
+++ b/packages/openneuro-app/src/scripts/refactor_2021/search/inputs/pet/bodyParts_input.tsx
@@ -1,0 +1,56 @@
+import React, { FC, useContext } from 'react'
+import useState from 'react-usestateref'
+import { SearchParamsCtx, removeFilterItem } from '../../search-params-ctx'
+import { FacetSearch, Icon } from '@openneuro/components'
+
+const BodyPartsInput: FC = () => {
+  const { searchParams, setSearchParams } = useContext(SearchParamsCtx)
+  const bodyParts = searchParams.bodyParts
+
+  const [newInput, setNewInput, newInputRef] = useState('')
+
+  const addBodyPart = () => {
+    setSearchParams(prevState => ({
+      ...prevState,
+      bodyParts: [...bodyParts, newInputRef.current],
+    }))
+    setNewInput('')
+  }
+
+  return (
+    <FacetSearch
+      accordionStyle="plain"
+      label="Target"
+      startOpen={false}
+      className="search-authors"
+      type="text"
+      placeholder="Enter Target(s) to Search"
+      labelStyle="default"
+      name="bodyParts"
+      termValue={newInput}
+      setTermValue={setNewInput}
+      primary={true}
+      color="#fff"
+      icon="fas fa-plus"
+      iconSize="20px"
+      size="small"
+      pushTerm={addBodyPart}
+      allTerms={bodyParts}
+      removeFilterItem={removeFilterItem(setSearchParams)}
+      helpText={
+        <span>
+          Each time the <Icon icon="fas fa-plus" label="plus" iconOnly={true} />{' '}
+          button is clicked, it will add a search filter. Multiple words in a
+          filter will return results containing any or all words. For advanced
+          filters use the{' '}
+          <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-simple-query-string-query.html#simple-query-string-syntax">
+            simple query string syntax
+          </a>
+          .
+        </span>
+      }
+    />
+  )
+}
+
+export default BodyPartsInput

--- a/packages/openneuro-app/src/scripts/refactor_2021/search/inputs/pet/scannerManufacturersModelNames_input.tsx
+++ b/packages/openneuro-app/src/scripts/refactor_2021/search/inputs/pet/scannerManufacturersModelNames_input.tsx
@@ -1,0 +1,60 @@
+import React, { FC, useContext } from 'react'
+import useState from 'react-usestateref'
+import { SearchParamsCtx, removeFilterItem } from '../../search-params-ctx'
+import { FacetSearch, Icon } from '@openneuro/components'
+
+const ScannerManufacturersModelNamesInput: FC = () => {
+  const { searchParams, setSearchParams } = useContext(SearchParamsCtx)
+  const scannerManufacturersModelNames =
+    searchParams.scannerManufacturersModelNames
+
+  const [newInput, setNewInput, newInputRef] = useState('')
+
+  const addScannerManufacturersModelName = () => {
+    setSearchParams(prevState => ({
+      ...prevState,
+      scannerManufacturersModelNames: [
+        ...scannerManufacturersModelNames,
+        newInputRef.current,
+      ],
+    }))
+    setNewInput('')
+  }
+
+  return (
+    <FacetSearch
+      accordionStyle="plain"
+      label="Scanner Model"
+      startOpen={false}
+      className="search-authors"
+      type="text"
+      placeholder="Enter Scanner Model(s) to Search"
+      labelStyle="default"
+      name="scannerManufacturersModelNames"
+      termValue={newInput}
+      setTermValue={setNewInput}
+      primary={true}
+      color="#fff"
+      icon="fas fa-plus"
+      iconSize="20px"
+      size="small"
+      pushTerm={addScannerManufacturersModelName}
+      allTerms={scannerManufacturersModelNames}
+      removeFilterItem={removeFilterItem(setSearchParams)}
+      helpText={
+        <span>
+          Each time the <Icon icon="fas fa-plus" label="plus" iconOnly={true} />{' '}
+          button is clicked, it will add a search filter. Multiple words in a
+          filter will return results containing any or all words. For advanced
+          filters use the{' '}
+          <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-simple-query-string-query.html#simple-query-string-syntax">
+            simple query string syntax
+          </a>
+          .
+        </span>
+      }
+    />
+  )
+}
+
+export default ScannerManufacturersModelNamesInput

--- a/packages/openneuro-app/src/scripts/refactor_2021/search/inputs/pet/scannerManufacturers_input.tsx
+++ b/packages/openneuro-app/src/scripts/refactor_2021/search/inputs/pet/scannerManufacturers_input.tsx
@@ -1,0 +1,56 @@
+import React, { FC, useContext } from 'react'
+import useState from 'react-usestateref'
+import { SearchParamsCtx, removeFilterItem } from '../../search-params-ctx'
+import { FacetSearch, Icon } from '@openneuro/components'
+
+const ScannerManufacturersInput: FC = () => {
+  const { searchParams, setSearchParams } = useContext(SearchParamsCtx)
+  const scannerManufacturers = searchParams.scannerManufacturers
+
+  const [newInput, setNewInput, newInputRef] = useState('')
+
+  const addScannerManufacturer = () => {
+    setSearchParams(prevState => ({
+      ...prevState,
+      scannerManufacturers: [...scannerManufacturers, newInputRef.current],
+    }))
+    setNewInput('')
+  }
+
+  return (
+    <FacetSearch
+      accordionStyle="plain"
+      label="Scanner Manufacturer"
+      startOpen={false}
+      className="search-authors"
+      type="text"
+      placeholder="Enter Scanner Manufacturer(s) to Search"
+      labelStyle="default"
+      name="scannerManufacturers"
+      termValue={newInput}
+      setTermValue={setNewInput}
+      primary={true}
+      color="#fff"
+      icon="fas fa-plus"
+      iconSize="20px"
+      size="small"
+      pushTerm={addScannerManufacturer}
+      allTerms={scannerManufacturers}
+      removeFilterItem={removeFilterItem(setSearchParams)}
+      helpText={
+        <span>
+          Each time the <Icon icon="fas fa-plus" label="plus" iconOnly={true} />{' '}
+          button is clicked, it will add a search filter. Multiple words in a
+          filter will return results containing any or all words. For advanced
+          filters use the{' '}
+          <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-simple-query-string-query.html#simple-query-string-syntax">
+            simple query string syntax
+          </a>
+          .
+        </span>
+      }
+    />
+  )
+}
+
+export default ScannerManufacturersInput

--- a/packages/openneuro-app/src/scripts/refactor_2021/search/inputs/pet/tracerNames_input.tsx
+++ b/packages/openneuro-app/src/scripts/refactor_2021/search/inputs/pet/tracerNames_input.tsx
@@ -1,0 +1,56 @@
+import React, { FC, useContext } from 'react'
+import useState from 'react-usestateref'
+import { SearchParamsCtx, removeFilterItem } from '../../search-params-ctx'
+import { FacetSearch, Icon } from '@openneuro/components'
+
+const TracerNamesInput: FC = () => {
+  const { searchParams, setSearchParams } = useContext(SearchParamsCtx)
+  const tracerNames = searchParams.tracerNames
+
+  const [newInput, setNewInput, newInputRef] = useState('')
+
+  const addtracerName = () => {
+    setSearchParams(prevState => ({
+      ...prevState,
+      tracerNames: [...tracerNames, newInputRef.current],
+    }))
+    setNewInput('')
+  }
+
+  return (
+    <FacetSearch
+      accordionStyle="plain"
+      label="Tracer"
+      startOpen={false}
+      className="search-authors"
+      type="text"
+      placeholder="Enter Tracer(s) to Search"
+      labelStyle="default"
+      name="tracerNames"
+      termValue={newInput}
+      setTermValue={setNewInput}
+      primary={true}
+      color="#fff"
+      icon="fas fa-plus"
+      iconSize="20px"
+      size="small"
+      pushTerm={addtracerName}
+      allTerms={tracerNames}
+      removeFilterItem={removeFilterItem(setSearchParams)}
+      helpText={
+        <span>
+          Each time the <Icon icon="fas fa-plus" label="plus" iconOnly={true} />{' '}
+          button is clicked, it will add a search filter. Multiple words in a
+          filter will return results containing any or all words. For advanced
+          filters use the{' '}
+          <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-simple-query-string-query.html#simple-query-string-syntax">
+            simple query string syntax
+          </a>
+          .
+        </span>
+      }
+    />
+  )
+}
+
+export default TracerNamesInput

--- a/packages/openneuro-app/src/scripts/refactor_2021/search/inputs/pet/tracerRadionuclides_input.tsx
+++ b/packages/openneuro-app/src/scripts/refactor_2021/search/inputs/pet/tracerRadionuclides_input.tsx
@@ -1,0 +1,56 @@
+import React, { FC, useContext } from 'react'
+import useState from 'react-usestateref'
+import { SearchParamsCtx, removeFilterItem } from '../../search-params-ctx'
+import { FacetSearch, Icon } from '@openneuro/components'
+
+const TracerRadionuclidesInput: FC = () => {
+  const { searchParams, setSearchParams } = useContext(SearchParamsCtx)
+  const tracerRadionuclides = searchParams.tracerRadionuclides
+
+  const [newInput, setNewInput, newInputRef] = useState('')
+
+  const addTracerRadionuclide = () => {
+    setSearchParams(prevState => ({
+      ...prevState,
+      tracerRadionuclides: [...tracerRadionuclides, newInputRef.current],
+    }))
+    setNewInput('')
+  }
+
+  return (
+    <FacetSearch
+      accordionStyle="plain"
+      label="Radionuclide"
+      startOpen={false}
+      className="search-authors"
+      type="text"
+      placeholder="Enter Radionuclide(s) to Search"
+      labelStyle="default"
+      name="tracerRadionuclides"
+      termValue={newInput}
+      setTermValue={setNewInput}
+      primary={true}
+      color="#fff"
+      icon="fas fa-plus"
+      iconSize="20px"
+      size="small"
+      pushTerm={addTracerRadionuclide}
+      allTerms={tracerRadionuclides}
+      removeFilterItem={removeFilterItem(setSearchParams)}
+      helpText={
+        <span>
+          Each time the <Icon icon="fas fa-plus" label="plus" iconOnly={true} />{' '}
+          button is clicked, it will add a search filter. Multiple words in a
+          filter will return results containing any or all words. For advanced
+          filters use the{' '}
+          <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-simple-query-string-query.html#simple-query-string-syntax">
+            simple query string syntax
+          </a>
+          .
+        </span>
+      }
+    />
+  )
+}
+
+export default TracerRadionuclidesInput

--- a/packages/openneuro-app/src/scripts/refactor_2021/search/search-container.tsx
+++ b/packages/openneuro-app/src/scripts/refactor_2021/search/search-container.tsx
@@ -20,6 +20,11 @@ import {
   SpeciesSelect,
   SectionSelect,
   StudyDomainSelect,
+  BodyPartsInput,
+  ScannerManufacturers,
+  ScannerManufacturersModelNames,
+  TracerNames,
+  TracerRadionuclides,
   SortBySelect,
 } from './inputs'
 import FiltersBlockContainer from './filters-block-container'
@@ -103,6 +108,16 @@ const SearchContainer: FC<SearchContainerProps> = ({ portalContent }) => {
           <SpeciesSelect />
           <SectionSelect />
           <StudyDomainSelect />
+          {(portalContent === undefined ||
+            portalContent.modality === 'PET') && (
+            <>
+              <BodyPartsInput />
+              <ScannerManufacturers />
+              <ScannerManufacturersModelNames />
+              <TracerNames />
+              <TracerRadionuclides />
+            </>
+          )}
         </>
       )}
       renderLoading={() =>

--- a/packages/openneuro-app/src/scripts/refactor_2021/search/search-container.tsx
+++ b/packages/openneuro-app/src/scripts/refactor_2021/search/search-container.tsx
@@ -59,9 +59,15 @@ const SearchContainer: FC<SearchContainerProps> = ({ portalContent }) => {
   const { loading, data, fetchMore, refetch, variables, error } =
     useSearchResults()
 
-  const numResultsShown = data?.datasets?.edges.length || 0
-  const numTotalResults = data?.datasets?.pageInfo.count || 0
-  const resultsList = data?.datasets?.edges || []
+  let numResultsShown = 0
+  let numTotalResults = 0
+  let resultsList = []
+  if (data?.datasets) {
+    const edges = data.datasets.edges.filter(edge => edge)
+    numResultsShown = edges.length
+    numTotalResults = data.datasets.pageInfo.count
+    resultsList = edges
+  }
   return (
     <SearchPage
       portalContent={portalContent}

--- a/packages/openneuro-app/src/scripts/refactor_2021/search/search-params-ctx.tsx
+++ b/packages/openneuro-app/src/scripts/refactor_2021/search/search-params-ctx.tsx
@@ -53,6 +53,11 @@ export const removeFilterItem = setSearchParams => (param, value) => {
     case 'keywords':
     case 'authors':
     case 'tasks':
+    case 'bodyParts':
+    case 'scannerManufacturers':
+    case 'scannerManufacturersModelNames':
+    case 'tracerNames':
+    case 'tracerRadionuclides':
       setSearchParams(prevState => {
         const list = prevState[param]
         const i = list.indexOf(value)
@@ -86,6 +91,11 @@ export const getSelectParams = ({
   section_selected,
   species_selected,
   studyDomain_selected,
+  bodyParts,
+  scannerManufacturers,
+  scannerManufacturersModelNames,
+  tracerNames,
+  tracerRadionuclides,
 }) => ({
   keywords,
   modality_selected,
@@ -101,6 +111,11 @@ export const getSelectParams = ({
   section_selected,
   species_selected,
   studyDomain_selected,
+  bodyParts,
+  scannerManufacturers,
+  scannerManufacturersModelNames,
+  tracerNames,
+  tracerRadionuclides,
 })
 
 /**

--- a/packages/openneuro-app/src/scripts/refactor_2021/search/use-search-results.tsx
+++ b/packages/openneuro-app/src/scripts/refactor_2021/search/use-search-results.tsx
@@ -69,6 +69,13 @@ const searchQuery = gql`
               size
               totalFiles
               dataProcessed
+              pet {
+                BodyPart
+                ScannerManufacturer
+                ScannerManufacturersModelName
+                TracerName
+                TracerRadionuclide
+              }
             }
             issues {
               severity

--- a/packages/openneuro-app/src/scripts/refactor_2021/search/use-search-results.tsx
+++ b/packages/openneuro-app/src/scripts/refactor_2021/search/use-search-results.tsx
@@ -1,6 +1,7 @@
 import React, { useContext } from 'react'
 import { gql, useQuery } from '@apollo/client'
 import { SearchParamsCtx } from './search-params-ctx'
+import { modality_available } from './initial-search-params'
 import {
   BoolQuery,
   simpleQueryString,
@@ -139,6 +140,11 @@ export const useSearchResults = () => {
     species_selected,
     section_selected,
     studyDomain_selected,
+    bodyParts,
+    scannerManufacturers,
+    scannerManufacturersModelNames,
+    tracerNames,
+    tracerRadionuclides,
     sortBy_selected,
   } = searchParams
 
@@ -209,6 +215,43 @@ export const useSearchResults = () => {
       'filter',
       matchQuery('metadata.studyDomain', studyDomain_selected, 'AUTO'),
     )
+  if (modality_selected === 'PET' || modality_selected === null) {
+    if (bodyParts.length)
+      boolQuery.addClause(
+        'must',
+        simpleQueryString(sqsJoinWithAND(bodyParts), [
+          'latestSnapshot.summary.pet.BodyPart',
+        ]),
+      )
+    if (scannerManufacturers.length)
+      boolQuery.addClause(
+        'must',
+        simpleQueryString(sqsJoinWithAND(scannerManufacturers), [
+          'latestSnapshot.summary.pet.ScannerManufacturer',
+        ]),
+      )
+    if (scannerManufacturersModelNames.length)
+      boolQuery.addClause(
+        'must',
+        simpleQueryString(sqsJoinWithAND(scannerManufacturersModelNames), [
+          'latestSnapshot.summary.pet.ScannerManufacturersModelName',
+        ]),
+      )
+    if (tracerNames.length)
+      boolQuery.addClause(
+        'must',
+        simpleQueryString(sqsJoinWithAND(tracerNames), [
+          'latestSnapshot.summary.pet.TracerName',
+        ]),
+      )
+    if (tracerRadionuclides.length)
+      boolQuery.addClause(
+        'must',
+        simpleQueryString(sqsJoinWithAND(tracerRadionuclides), [
+          'latestSnapshot.summary.pet.TracerRadionuclide',
+        ]),
+      )
+  }
 
   let sortField = 'created',
     order = 'desc'

--- a/packages/openneuro-app/src/scripts/search/search-results.tsx
+++ b/packages/openneuro-app/src/scripts/search/search-results.tsx
@@ -46,6 +46,13 @@ const searchQuery = gql`
               size
               totalFiles
               dataProcessed
+              pet {
+                BodyPart
+                ScannerManufacturer
+                ScannerManufacturersModelName
+                TracerName
+                TracerRadionuclide
+              }
             }
             issues {
               severity

--- a/packages/openneuro-client/src/datasets.js
+++ b/packages/openneuro-client/src/datasets.js
@@ -38,6 +38,13 @@ export const getDataset = gql`
           size
           totalFiles
           dataProcessed
+          pet {
+            BodyPart
+            ScannerManufacturer
+            ScannerManufacturersModelName
+            TracerName
+            TracerRadionuclide
+          }
         }
         issues {
           key
@@ -143,6 +150,13 @@ export const getDatasets = gql`
               size
               totalFiles
               dataProcessed
+              pet {
+                BodyPart
+                ScannerManufacturer
+                ScannerManufacturersModelName
+                TracerName
+                TracerRadionuclide
+              }
             }
             issues {
               severity
@@ -241,13 +255,13 @@ export const deleteSnapshot = gql`
 `
 
 export const updatePublic = gql`
-  mutation($id: ID!, $publicFlag: Boolean!) {
+  mutation ($id: ID!, $publicFlag: Boolean!) {
     updatePublic(datasetId: $id, publicFlag: $publicFlag)
   }
 `
 
 export const updatePermissions = gql`
-  mutation($datasetId: ID!, $userEmail: String!, $level: String) {
+  mutation ($datasetId: ID!, $userEmail: String!, $level: String) {
     updatePermissions(
       datasetId: $datasetId
       userEmail: $userEmail
@@ -257,13 +271,13 @@ export const updatePermissions = gql`
 `
 
 export const removePermissions = gql`
-  mutation($datasetId: ID!, $userId: String!) {
+  mutation ($datasetId: ID!, $userId: String!) {
     removePermissions(datasetId: $datasetId, userId: $userId)
   }
 `
 
 export const trackAnalytics = gql`
-  mutation($datasetId: ID!, $tag: String, $type: AnalyticTypes!) {
+  mutation ($datasetId: ID!, $tag: String, $type: AnalyticTypes!) {
     trackAnalytics(datasetId: $datasetId, tag: $tag, type: $type)
   }
 `

--- a/packages/openneuro-components/src/search-page/FiltersBlock.tsx
+++ b/packages/openneuro-components/src/search-page/FiltersBlock.tsx
@@ -21,6 +21,11 @@ export interface FiltersBlockProps {
   section_selected?: FacetSelectValueType
   species_selected?: FacetSelectValueType
   studyDomain_selected?: FacetSelectValueType
+  bodyParts?: string[]
+  scannerManufacturers?: string[]
+  scannerManufacturersModelNames?: string[]
+  tracerNames?: string[]
+  tracerRadionuclides?: string[]
   noFilters: boolean
   removeFilterItem?(isModality?: boolean): (key: string, value) => void
   removeAllFilters?(): void
@@ -42,6 +47,11 @@ export const FiltersBlock = ({
   species_selected,
   studyDomain_selected,
   date_selected,
+  bodyParts,
+  scannerManufacturers,
+  scannerManufacturersModelNames,
+  tracerNames,
+  tracerRadionuclides,
   noFilters,
   removeFilterItem,
   removeAllFilters,
@@ -169,6 +179,48 @@ export const FiltersBlock = ({
           <FilterListItem
             type="Publication Date "
             item={{ param: 'date_selected', value: date_selected }}
+            removeFilterItem={removeFilterItem()}
+          />
+        )}
+
+        {bodyParts && (
+          <TermListItem
+            type="Target"
+            item={{ param: 'bodyParts', values: bodyParts }}
+            removeFilterItem={removeFilterItem()}
+          />
+        )}
+        {scannerManufacturers && (
+          <TermListItem
+            type="Scanner Manufacturers"
+            item={{
+              param: 'scannerManufacturers',
+              values: scannerManufacturers,
+            }}
+            removeFilterItem={removeFilterItem()}
+          />
+        )}
+        {scannerManufacturersModelNames && (
+          <TermListItem
+            type="Scanner Model"
+            item={{
+              param: 'scannerManufacturersModelNames',
+              values: scannerManufacturersModelNames,
+            }}
+            removeFilterItem={removeFilterItem()}
+          />
+        )}
+        {tracerNames && (
+          <TermListItem
+            type="Tracer"
+            item={{ param: 'tracerNames', values: tracerNames }}
+            removeFilterItem={removeFilterItem()}
+          />
+        )}
+        {tracerRadionuclides && (
+          <TermListItem
+            type="Radionuclide"
+            item={{ param: 'tracerRadionuclides', values: tracerRadionuclides }}
             removeFilterItem={removeFilterItem()}
           />
         )}

--- a/packages/openneuro-components/src/search-page/SearchResultItem.tsx
+++ b/packages/openneuro-components/src/search-page/SearchResultItem.tsx
@@ -107,6 +107,7 @@ export const SearchResultItem = ({ node, profile }: SearchResultItemProps) => {
   const datasetId = node.draft.id
   const numSessions = summary?.sessions.length > 0 ? summary.sessions.length : 1
   const numSubjects = summary?.subjects.length > 0 ? summary.subjects.length : 1
+  const noSnapshots = !!node.snapshots
 
   const accessionNumber = (
     <span className="result-summary-meta">
@@ -150,24 +151,19 @@ export const SearchResultItem = ({ node, profile }: SearchResultItemProps) => {
 
   const dateAdded = formatDate(node.created)
   const dateAddedDifference = formatDistanceToNow(parseISO(node.created))
+  const date = noSnapshots
+    ? node.created
+    : node.snapshots[node.snapshots.length - 1].created
+  const dateUpdated = formatDate(date)
+  const dateUpdatedDifference = formatDistanceToNow(parseISO(date))
 
-  let lastUpdatedDate
-  if (node.snapshots.length) {
-    const dateUpdated = formatDate(
-      node.snapshots[node.snapshots.length - 1].created,
-    )
-    const dateUpdatedDifference = formatDistanceToNow(
-      parseISO(node.snapshots[node.snapshots.length - 1].created),
-    )
-
-    lastUpdatedDate = (
-      <div className="updated-date">
-        <span className="divider">|</span>
-        <span>Updated: </span>
-        {dateUpdated} - {dateUpdatedDifference} ago
-      </div>
-    )
-  }
+  const lastUpdatedDate = node.snapshots?.length ? (
+    <div className="updated-date">
+      <span className="divider">|</span>
+      <span>Updated: </span>
+      {dateUpdated} - {dateUpdatedDifference} ago
+    </div>
+  ) : null
 
   const uploader = (
     <div className="uploader">

--- a/packages/openneuro-components/src/search-page/SearchResultItem.tsx
+++ b/packages/openneuro-components/src/search-page/SearchResultItem.tsx
@@ -151,19 +151,23 @@ export const SearchResultItem = ({ node, profile }: SearchResultItemProps) => {
 
   const dateAdded = formatDate(node.created)
   const dateAddedDifference = formatDistanceToNow(parseISO(node.created))
-  const date = noSnapshots
-    ? node.created
-    : node.snapshots[node.snapshots.length - 1].created
-  const dateUpdated = formatDate(date)
-  const dateUpdatedDifference = formatDistanceToNow(parseISO(date))
+  let lastUpdatedDate
+  if (node.snapshots.length) {
+    const dateUpdated = formatDate(
+      node.snapshots[node.snapshots.length - 1].created,
+    )
+    const dateUpdatedDifference = formatDistanceToNow(
+      parseISO(node.snapshots[node.snapshots.length - 1].created),
+    )
 
-  const lastUpdatedDate = node.snapshots?.length ? (
-    <div className="updated-date">
-      <span className="divider">|</span>
-      <span>Updated: </span>
-      {dateUpdated} - {dateUpdatedDifference} ago
-    </div>
-  ) : null
+    lastUpdatedDate = (
+      <div className="updated-date">
+        <span className="divider">|</span>
+        <span>Updated: </span>
+        {dateUpdated} - {dateUpdatedDifference} ago
+      </div>
+    )
+  }
 
   const uploader = (
     <div className="uploader">

--- a/packages/openneuro-indexer/src/indexQuery.ts
+++ b/packages/openneuro-indexer/src/indexQuery.ts
@@ -52,6 +52,13 @@ export const indexQuery = gql`
                 age
               }
               subjects
+              pet {
+                BodyPart
+                ScannerManufacturer
+                ScannerManufacturersModelName
+                TracerName
+                TracerRadionuclide
+              }
             }
             readme
           }

--- a/packages/openneuro-indexer/src/mappings/datasets-mapping.json
+++ b/packages/openneuro-indexer/src/mappings/datasets-mapping.json
@@ -43,6 +43,15 @@
                 "sex": { "type": "keyword" },
                 "age": { "type": "integer" }
               }
+            },
+            "pet": {
+              "properties": {
+                "BodyPart": { "type": "keyword" },
+                "ScannerManufacturer": { "type": "keyword" },
+                "ScannerManufacturersModelName": { "type": "keyword" },
+                "TracerName": { "type": "keyword" },
+                "TracerRadionuclide": { "type": "keyword" }
+              }
             }
           }
         },

--- a/packages/openneuro-server/src/graphql/resolvers/__tests__/dataset-search.spec.js
+++ b/packages/openneuro-server/src/graphql/resolvers/__tests__/dataset-search.spec.js
@@ -24,7 +24,7 @@ describe('dataset search resolvers', () => {
     })
   })
   describe('elasticRelayConnection()', () => {
-    it('returns a relay cursor for empty ApiResponse', () => {
+    it('returns a relay cursor for empty ApiResponse', async () => {
       const emptyApiResponse = {
         body: {
           hits: {
@@ -45,13 +45,13 @@ describe('dataset search resolvers', () => {
           hasPreviousPage: false,
         },
       }
-      const connection = elasticRelayConnection(emptyApiResponse, {
+      const connection = await elasticRelayConnection(emptyApiResponse, {
         dataset: jest.fn(),
       })
       expect(connection).toMatchObject(nullRelayConnection)
     })
 
-    it('returns a relay cursor for ApiResponse with results', () => {
+    it('returns a relay cursor for ApiResponse with results', async () => {
       const mockResolvers = {
         dataset: jest.fn(),
       }
@@ -83,10 +83,11 @@ describe('dataset search resolvers', () => {
           hasPreviousPage: false,
         },
       }
-      const connection = elasticRelayConnection(
+      const connection = await elasticRelayConnection(
         expectedApiResponse,
         mockResolvers,
       )
+      connection.edges = await Promise.all(connection.edges)
       expect(connection).toMatchObject(resultsRelayConnection)
     })
   })

--- a/packages/openneuro-server/src/graphql/resolvers/dataset-search.js
+++ b/packages/openneuro-server/src/graphql/resolvers/dataset-search.js
@@ -45,18 +45,13 @@ export const elasticRelayConnection = async (
   const count = body.hits.total.value
   const lastMatch = body.hits.hits[body.hits.hits.length - 1]
   return {
-    edges: body.hits.hits.map(async hit => {
-      try {
-        const node = await childResolvers.dataset(
-          null,
-          { id: hit._source.id },
-          { user, userInfo },
-        )
-        return { node }
-      } catch (err) {
-        if (err.message === states.READ.errorMessage) return null
-        else throw err
-      }
+    edges: body.hits.hits.map(hit => {
+      const node = childResolvers.dataset(
+        null,
+        { id: hit._source.id },
+        { user, userInfo },
+      )
+      return { node }
     }),
     pageInfo: {
       count,

--- a/packages/openneuro-server/src/graphql/resolvers/dataset-search.js
+++ b/packages/openneuro-server/src/graphql/resolvers/dataset-search.js
@@ -44,8 +44,8 @@ export const elasticRelayConnection = async (
 ) => {
   const count = body.hits.total.value
   const lastMatch = body.hits.hits[body.hits.hits.length - 1]
-  const edges = await Promise.all(
-    body.hits.hits.map(async hit => {
+  return {
+    edges: body.hits.hits.map(async hit => {
       try {
         const node = await childResolvers.dataset(
           null,
@@ -58,10 +58,6 @@ export const elasticRelayConnection = async (
         else throw err
       }
     }),
-  )
-  const allowedEdges = edges.filter(edge => edge !== null) // remove datasets that user does not have permissions for
-  return {
-    edges: allowedEdges,
     pageInfo: {
       count,
       endCursor: lastMatch

--- a/packages/openneuro-server/src/graphql/resolvers/dataset.js
+++ b/packages/openneuro-server/src/graphql/resolvers/dataset.js
@@ -10,7 +10,6 @@ import {
 } from '../permissions.js'
 import { user } from './user.js'
 import { permissions } from './permissions.js'
-import { states } from '../permissions.js'
 import { datasetComments } from './comment.js'
 import { metadata } from './metadata.js'
 import { history } from './history.js'
@@ -24,22 +23,10 @@ import { getDatasetWorker } from '../../libs/datalad-service.js'
 import { getDraftHead } from '../../datalad/dataset.js'
 import { getFileName } from '../../datalad/files.js'
 
-export const dataset = async (
-  obj,
-  { id },
-  { user, userInfo },
-  ignoreInaccessibleDatasets = false,
-) => {
-  try {
-    return await checkDatasetRead(id, user, userInfo).then(() => {
-      return datalad.getDataset(id)
-    })
-  } catch (err) {
-    // Don't throw the error if this is for a dataset search.
-    if (ignoreInaccessibleDatasets && err.message === states.READ.errorMessage)
-      return null
-    else throw err
-  }
+export const dataset = async (obj, { id }, { user, userInfo }) => {
+  return await checkDatasetRead(id, user, userInfo).then(() => {
+    return datalad.getDataset(id)
+  })
 }
 
 export const datasets = (parent, args, { user, userInfo }) => {

--- a/packages/openneuro-server/src/graphql/resolvers/dataset.js
+++ b/packages/openneuro-server/src/graphql/resolvers/dataset.js
@@ -10,6 +10,7 @@ import {
 } from '../permissions.js'
 import { user } from './user.js'
 import { permissions } from './permissions.js'
+import { states } from '../permissions.js'
 import { datasetComments } from './comment.js'
 import { metadata } from './metadata.js'
 import { history } from './history.js'
@@ -23,10 +24,22 @@ import { getDatasetWorker } from '../../libs/datalad-service.js'
 import { getDraftHead } from '../../datalad/dataset.js'
 import { getFileName } from '../../datalad/files.js'
 
-export const dataset = (obj, { id }, { user, userInfo }) => {
-  return checkDatasetRead(id, user, userInfo).then(() => {
-    return datalad.getDataset(id)
-  })
+export const dataset = async (
+  obj,
+  { id },
+  { user, userInfo },
+  ignoreInaccessibleDatasets = false,
+) => {
+  try {
+    return await checkDatasetRead(id, user, userInfo).then(() => {
+      return datalad.getDataset(id)
+    })
+  } catch (err) {
+    // Don't throw the error if this is for a dataset search.
+    if (ignoreInaccessibleDatasets && err.message === states.READ.errorMessage)
+      return null
+    else throw err
+  }
 }
 
 export const datasets = (parent, args, { user, userInfo }) => {

--- a/packages/openneuro-server/src/graphql/resolvers/dataset.js
+++ b/packages/openneuro-server/src/graphql/resolvers/dataset.js
@@ -24,9 +24,8 @@ import { getDraftHead } from '../../datalad/dataset.js'
 import { getFileName } from '../../datalad/files.js'
 
 export const dataset = async (obj, { id }, { user, userInfo }) => {
-  return await checkDatasetRead(id, user, userInfo).then(() => {
-    return datalad.getDataset(id)
-  })
+  await checkDatasetRead(id, user, userInfo)
+  return datalad.getDataset(id)
 }
 
 export const datasets = (parent, args, { user, userInfo }) => {

--- a/packages/openneuro-server/src/graphql/schema.js
+++ b/packages/openneuro-server/src/graphql/schema.js
@@ -499,10 +499,10 @@ export const typeDefs = `
     size: BigInt!
     totalFiles: Int!
     dataProcessed: Boolean
-    pet: PetSpecificFields
+    pet: SummaryPetFields
   }
 
-  type PetSpecificFields {
+  type SummaryPetFields {
     BodyPart: [String]
     ScannerManufacturer: [String]
     ScannerManufacturersModelName: [String]

--- a/packages/openneuro-server/src/graphql/schema.js
+++ b/packages/openneuro-server/src/graphql/schema.js
@@ -499,6 +499,15 @@ export const typeDefs = `
     size: BigInt!
     totalFiles: Int!
     dataProcessed: Boolean
+    pet: PetSpecificFields
+  }
+
+  type PetSpecificFields {
+    BodyPart: [String]
+    ScannerManufacturer: [String]
+    ScannerManufacturersModelName: [String]
+    TracerName: [String]
+    TracerRadionuclide: [String]
   }
 
   type SubjectMetadata {


### PR DESCRIPTION
## Major Changes
- Add pet specific fields from validator to Summary in mongo.
- Display pet fields in in summary section of dataset page (draft & snapshot).
- Make pet fields filterable on global and PET search pages.

## Minor Changes
- Fix no-snapshot datasets in search results.