### PR TITLE
272 range slider updates

### DIFF
--- a/.pnp.js
+++ b/.pnp.js
@@ -26274,7 +26274,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
       ]],
       ["git-win", [
         ["npm:2.3.0", {
-          "packageLocation": "./.yarn/unplugged/git-win-npm-2.3.0-b98f2b7122/node_modules/git-win/",
+          "packageLocation": "./.yarn/cache/git-win-npm-2.3.0-b98f2b7122-a273c79c22.zip/node_modules/git-win/",
           "packageDependencies": [
             ["git-win", "npm:2.3.0"],
             ["@babel/runtime", "npm:7.14.6"],

--- a/packages/openneuro-app/src/scripts/refactor_2021/search/initial-search-params.tsx
+++ b/packages/openneuro-app/src/scripts/refactor_2021/search/initial-search-params.tsx
@@ -183,7 +183,7 @@ const initialSearchParams: SearchParams = {
   sortBy_selected: sortBy[0],
 }
 
-// TODO: delete and move to dynamically loaded initialSearchParams
+// TODO: (stretch) delete and move to dynamically loaded initialSearchParams
 const TEMPORARY_initialSearchParams: SearchParams = {
   keywords: [],
   datasetType_available,

--- a/packages/openneuro-app/src/scripts/refactor_2021/search/inputs/age-range-input.tsx
+++ b/packages/openneuro-app/src/scripts/refactor_2021/search/inputs/age-range-input.tsx
@@ -15,7 +15,7 @@ const AgeRangeInput: FC = () => {
 
   const min = 0
   const max = 100
-  const defaultValue =
+  const value =
     JSON.stringify(ageRange) === JSON.stringify(initialSearchParams.ageRange)
       ? [min, max]
       : ageRange
@@ -28,7 +28,7 @@ const AgeRangeInput: FC = () => {
       min={min}
       max={max}
       step={10}
-      defaultValue={defaultValue}
+      value={value}
       onChange={setAgeRange}
     />
   )

--- a/packages/openneuro-app/src/scripts/refactor_2021/search/inputs/age-range-input.tsx
+++ b/packages/openneuro-app/src/scripts/refactor_2021/search/inputs/age-range-input.tsx
@@ -1,5 +1,6 @@
 import React, { FC, useContext } from 'react'
 import { SearchParamsCtx } from '../search-params-ctx'
+import initialSearchParams from '../initial-search-params'
 import { FacetRange } from '@openneuro/components'
 
 const AgeRangeInput: FC = () => {
@@ -12,15 +13,22 @@ const AgeRangeInput: FC = () => {
       ageRange,
     }))
 
+  const min = 0
+  const max = 100
+  const defaultValue =
+    JSON.stringify(ageRange) === JSON.stringify(initialSearchParams.ageRange)
+      ? [min, max]
+      : ageRange
+
   return (
     <FacetRange
       startOpen={false}
       label="Age of Participants"
       accordionStyle="plain"
-      min={0}
-      max={100}
+      min={min}
+      max={max}
       step={10}
-      defaultValue={[0, 20]}
+      defaultValue={defaultValue}
       onChange={setAgeRange}
     />
   )

--- a/packages/openneuro-app/src/scripts/refactor_2021/search/inputs/subject-count-range-input.tsx
+++ b/packages/openneuro-app/src/scripts/refactor_2021/search/inputs/subject-count-range-input.tsx
@@ -16,10 +16,11 @@ const SubjectCountRangeInput: FC = () => {
 
   const min = 0
   const max = 100
-  const defaultValue =
-    JSON.stringify(ageRange) === JSON.stringify(initialSearchParams.ageRange)
+  const value =
+    JSON.stringify(subjectCountRange) ===
+    JSON.stringify(initialSearchParams.subjectCountRange)
       ? [min, max]
-      : ageRange
+      : subjectCountRange
 
   return (
     <FacetRange
@@ -29,7 +30,7 @@ const SubjectCountRangeInput: FC = () => {
       min={min}
       max={max}
       step={10}
-      defaultValue={defaultValue}
+      value={value}
       onChange={setSubjectRange}
     />
   )

--- a/packages/openneuro-app/src/scripts/refactor_2021/search/inputs/subject-count-range-input.tsx
+++ b/packages/openneuro-app/src/scripts/refactor_2021/search/inputs/subject-count-range-input.tsx
@@ -1,5 +1,6 @@
 import React, { FC, useContext } from 'react'
 import { SearchParamsCtx } from '../search-params-ctx'
+import initialSearchParams from '../initial-search-params'
 import { FacetRange } from '@openneuro/components'
 
 const SubjectCountRangeInput: FC = () => {
@@ -13,15 +14,22 @@ const SubjectCountRangeInput: FC = () => {
     }))
   }
 
+  const min = 0
+  const max = 100
+  const defaultValue =
+    JSON.stringify(ageRange) === JSON.stringify(initialSearchParams.ageRange)
+      ? [min, max]
+      : ageRange
+
   return (
     <FacetRange
       startOpen={false}
       label="Number of Participants"
       accordionStyle="plain"
-      min={0}
-      max={100}
+      min={min}
+      max={max}
       step={10}
-      defaultValue={[0, 20]}
+      defaultValue={defaultValue}
       onChange={setSubjectRange}
     />
   )

--- a/packages/openneuro-components/src/facets/FacetRange.tsx
+++ b/packages/openneuro-components/src/facets/FacetRange.tsx
@@ -12,7 +12,7 @@ export interface FacetRangeProps {
   min: number
   max: number
   step: number
-  defaultValue: [number | null, number | null]
+  value: [number | null, number | null]
   onChange: (newvalue) => void
 }
 
@@ -24,7 +24,7 @@ export const FacetRange = ({
   min,
   max,
   step,
-  defaultValue,
+  value,
   onChange,
 }: FacetRangeProps) => {
   return (
@@ -39,7 +39,7 @@ export const FacetRange = ({
             min={min}
             max={max}
             step={step}
-            defaultValue={defaultValue}
+            value={value}
             onChange={onChange}
           />
         </div>

--- a/packages/openneuro-components/src/range/TwoHandleRange.stories.tsx
+++ b/packages/openneuro-components/src/range/TwoHandleRange.stories.tsx
@@ -12,7 +12,7 @@ const RangeTemplate: Story<TwoHandleRangeProps> = ({
   min,
   max,
   step,
-  defaultValue,
+  value,
 }) => {
   const setNewValue = (value: [number, number]) => {}
   return (
@@ -20,7 +20,7 @@ const RangeTemplate: Story<TwoHandleRangeProps> = ({
       min={min}
       max={max}
       step={step}
-      defaultValue={defaultValue}
+      value={value}
       onChange={setNewValue}
     />
   )
@@ -31,7 +31,7 @@ DefaultRange.args = {
   min: 0,
   max: 100,
   step: 10,
-  defaultValue: [0, 20],
+  value: [0, 20],
   marks: { 0: '0', 50: '50', 100: '100' },
 }
 DefaultRange.parameters = {

--- a/packages/openneuro-components/src/range/TwoHandleRange.tsx
+++ b/packages/openneuro-components/src/range/TwoHandleRange.tsx
@@ -13,7 +13,7 @@ export interface TwoHandleRangeProps {
   // Integer step for range values
   step: number
   // [min, max] starting values
-  defaultValue: [number, number]
+  value: [number, number]
   // Change event handler for either value changing, returns [minVal, maxVal]
   onChange: (value: [number, number]) => void
 }
@@ -22,11 +22,9 @@ export const TwoHandleRange: React.FC<TwoHandleRangeProps> = ({
   min,
   max,
   step,
-  defaultValue,
+  value,
   onChange,
 }) => {
-  const [minVal, setMinVal] = useState(defaultValue ? defaultValue[0] : min)
-  const [maxVal, setMaxVal] = useState(defaultValue ? defaultValue[1] : max)
   const minValRef = useRef(min)
   const maxValRef = useRef(max)
   const range = useRef<HTMLDivElement>(null)
@@ -39,24 +37,24 @@ export const TwoHandleRange: React.FC<TwoHandleRangeProps> = ({
 
   // Set width of the range to decrease from the left side
   useEffect(() => {
-    const minPercent = getPercent(minVal)
+    const minPercent = getPercent(value[0])
     const maxPercent = getPercent(maxValRef.current)
 
     if (range.current) {
       range.current.style.left = `${minPercent}%`
       range.current.style.width = `${maxPercent - minPercent}%`
     }
-  }, [minVal, getPercent])
+  }, [value[0], getPercent])
 
   // Set width of the range to decrease from the right side
   useEffect(() => {
     const minPercent = getPercent(minValRef.current)
-    const maxPercent = getPercent(maxVal)
+    const maxPercent = getPercent(value[1])
 
     if (range.current) {
       range.current.style.width = `${maxPercent - minPercent}%`
     }
-  }, [maxVal, getPercent])
+  }, [value[1], getPercent])
 
   const minChangeHandler = (
     event:
@@ -64,13 +62,12 @@ export const TwoHandleRange: React.FC<TwoHandleRangeProps> = ({
       | React.KeyboardEvent<HTMLInputElement>,
   ) => {
     const changeEvent = event as React.ChangeEvent<HTMLInputElement>
-    const value = stepping(
-      Math.min(Number(changeEvent.target.value), maxVal - 1),
+    const discreteValue = stepping(
+      Math.min(Number(changeEvent.target.value), value[1] - 1),
       step,
     )
-    setMinVal(value)
-    minValRef.current = value
-    onChange([value, maxVal])
+    minValRef.current = discreteValue
+    onChange([discreteValue, value[1]])
   }
   const maxChangeHandler = (
     event:
@@ -78,50 +75,48 @@ export const TwoHandleRange: React.FC<TwoHandleRangeProps> = ({
       | React.KeyboardEvent<HTMLInputElement>,
   ) => {
     const changeEvent = event as React.ChangeEvent<HTMLInputElement>
-    const value = stepping(
-      Math.max(Number(changeEvent.target.value), minVal + 1),
+    const discreteValue = stepping(
+      Math.max(Number(changeEvent.target.value), value[0] + 1),
       step,
     )
-    setMaxVal(value)
-    maxValRef.current = value
-    onChange([minVal, value])
+    maxValRef.current = discreteValue
+    onChange([value[0], discreteValue])
   }
-
   return (
     <div className="formRange-inner">
       <input
         type="range"
         min={min}
         max={max}
-        value={minVal}
+        value={value[0]}
         step={step}
         onChange={minChangeHandler}
         onKeyDown={minChangeHandler}
         aria-valuemin={min}
         aria-valuemax={max}
-        aria-valuenow={minVal}
+        aria-valuenow={value[0]}
         className="thumb thumb--left"
-        style={{ zIndex: minVal > max - 100 && 5 }}
+        style={{ zIndex: value[0] > max - 100 && 5 }}
       />
       <input
         type="range"
         min={min}
         max={max}
-        value={maxVal}
+        value={value[1]}
         step={step}
         onChange={maxChangeHandler}
         onKeyDown={maxChangeHandler}
         aria-valuemin={min}
         aria-valuemax={max}
-        aria-valuenow={maxVal}
+        aria-valuenow={value[1]}
         className="thumb thumb--right"
       />
 
       <div className="slider">
         <div className="slider__track"></div>
         <div ref={range} className="slider__range"></div>
-        <div className="slider__left-value">{minVal}</div>
-        <div className="slider__right-value">{maxVal}</div>
+        <div className="slider__left-value">{value[0]}</div>
+        <div className="slider__right-value">{value[1]}</div>
       </div>
     </div>
   )

--- a/packages/openneuro-components/src/range/TwoHandleRange.tsx
+++ b/packages/openneuro-components/src/range/TwoHandleRange.tsx
@@ -25,8 +25,6 @@ export const TwoHandleRange: React.FC<TwoHandleRangeProps> = ({
   value,
   onChange,
 }) => {
-  const minValRef = useRef(min)
-  const maxValRef = useRef(max)
   const range = useRef<HTMLDivElement>(null)
 
   // Convert to percentage
@@ -38,7 +36,7 @@ export const TwoHandleRange: React.FC<TwoHandleRangeProps> = ({
   // Set width of the range to decrease from the left side
   useEffect(() => {
     const minPercent = getPercent(value[0])
-    const maxPercent = getPercent(maxValRef.current)
+    const maxPercent = getPercent(value[1])
 
     if (range.current) {
       range.current.style.left = `${minPercent}%`
@@ -48,7 +46,7 @@ export const TwoHandleRange: React.FC<TwoHandleRangeProps> = ({
 
   // Set width of the range to decrease from the right side
   useEffect(() => {
-    const minPercent = getPercent(minValRef.current)
+    const minPercent = getPercent(value[0])
     const maxPercent = getPercent(value[1])
 
     if (range.current) {
@@ -66,7 +64,7 @@ export const TwoHandleRange: React.FC<TwoHandleRangeProps> = ({
       Math.min(Number(changeEvent.target.value), value[1] - 1),
       step,
     )
-    minValRef.current = discreteValue
+    value[0] = discreteValue
     onChange([discreteValue, value[1]])
   }
   const maxChangeHandler = (
@@ -79,7 +77,7 @@ export const TwoHandleRange: React.FC<TwoHandleRangeProps> = ({
       Math.max(Number(changeEvent.target.value), value[0] + 1),
       step,
     )
-    maxValRef.current = discreteValue
+    value[1] = discreteValue
     onChange([value[0], discreteValue])
   }
   return (

--- a/packages/openneuro-components/src/range/__tests__/TwoHandleRange.spec.tsx
+++ b/packages/openneuro-components/src/range/__tests__/TwoHandleRange.spec.tsx
@@ -20,7 +20,7 @@ describe('TwoHandleRange component', () => {
         min={0}
         max={100}
         step={10}
-        defaultValue={[0, 20]}
+        value={[0, 20]}
         onChange={onChange}
       />,
     )

--- a/packages/openneuro-components/src/search-page/SearchPageContainerExample.tsx
+++ b/packages/openneuro-components/src/search-page/SearchPageContainerExample.tsx
@@ -223,7 +223,7 @@ export const SearchPageContainerExample = ({
                 min={0}
                 max={100}
                 step={10}
-                defaultValue={[0, 20]}
+                value={[0, 20]}
                 onChange={setAgeRange}
               />
               <FacetRange
@@ -233,7 +233,7 @@ export const SearchPageContainerExample = ({
                 min={0}
                 max={100}
                 step={10}
-                defaultValue={[0, 20]}
+                value={[0, 20]}
                 onChange={setSubjectRange}
               />
               <FacetSelect

--- a/yarn.lock
+++ b/yarn.lock
@@ -5110,11 +5110,7 @@ __metadata:
     "@apollo/client": 3.3.14
     "@babel/runtime-corejs3": ^7.13.10
     "@openneuro/client": ^3.34.0-alpha.4
-    "@types/mkdirp": ^1.0.1
     "@types/node": ^14.14.41
-    bids-validator: 1.7.3
-    cli-progress: ^3.8.2
-    commander: 7.2.0
     core-js: ^3.10.1
     cross-fetch: ^3.0.5
     elastic-apm-node: 3.12.1


### PR DESCRIPTION
## Major Changes
- Have RangeSlider inputs default to max and min values when not set by user.

## Minor Changes
- Convert `TwoHandleRange` to controlled input.