### PR TITLE
fix(app): Add redirects to new design for existing dashboard URLs

### DIFF
--- a/packages/openneuro-app/package.json
+++ b/packages/openneuro-app/package.json
@@ -114,6 +114,7 @@
     "moduleNameMapper": {
       "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/__mocks__/fileMock.js",
       "\\.(css|less)$": "<rootDir>/__mocks__/styleMock.js",
+      "^.+\\.(scss)$": "babel-jest",
       "openneuro-content": "<rootDir>/__mocks__/contentMock.js",
       "@openneuro/(.+)": "<rootDir>../openneuro-$1/src"
     },

--- a/packages/openneuro-app/src/scripts/refactor_2021/routes.tsx
+++ b/packages/openneuro-app/src/scripts/refactor_2021/routes.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Route, Switch } from 'react-router-dom'
+import { Route, Switch, Redirect } from 'react-router-dom'
 
 // TODO - Re-enable code splitting these when we can
 //import Dataset from './dataset/draft-snapshot-routes'
@@ -29,6 +29,9 @@ const Routes = () => (
     <Route name="error" path="/error" component={ErrorRoute} />
     <Route name="pet-landing" path="/pet" component={PETDummy} />
     <Route name="citation" path="/cite" component={Citation} />
+    <Redirect from="/public" to="/search" />
+    <Redirect from="/saved" to="/search?bookmarks" />
+    <Redirect from="/dashboard" to="/search?mydatasets" />
   </Switch>
 )
 

--- a/packages/openneuro-app/src/scripts/refactor_2021/search/__tests__/search-container.spec.tsx
+++ b/packages/openneuro-app/src/scripts/refactor_2021/search/__tests__/search-container.spec.tsx
@@ -1,0 +1,56 @@
+import { setDefaultSearch } from '../search-container'
+
+describe('SearchContainer component', () => {
+  describe('setDefaultSearch', () => {
+    it('updates default state when a modality is provided differing from the default', () => {
+      const context = { modality_selected: 'MRI' }
+      const setContext = jest.fn()
+      setDefaultSearch(
+        'MRI',
+        context,
+        setContext,
+        new URLSearchParams('/search'),
+      )
+      expect(setContext).not.toHaveBeenCalled()
+      setDefaultSearch(
+        'PET',
+        context,
+        setContext,
+        new URLSearchParams('/search'),
+      )
+      expect(setContext).toHaveBeenCalled()
+    })
+    it('sets datasetType_select to my datasets with "mydatasets" parameter', () => {
+      let context = {
+        modality_selected: 'MRI',
+        datasetType_selected: 'All Public',
+      }
+      const setContext = jest.fn().mockImplementation(arg => {
+        context = arg(context)
+      })
+      setDefaultSearch(
+        'MRI',
+        context,
+        setContext,
+        new URLSearchParams('mydatasets'),
+      )
+      expect(context.datasetType_selected).toEqual('My Datasets')
+    })
+    it('sets datasetType_select to my datasets with "bookmarks" parameter', () => {
+      let context = {
+        modality_selected: 'PET',
+        datasetType_selected: 'All Public',
+      }
+      const setContext = jest.fn().mockImplementation(arg => {
+        context = arg(context)
+      })
+      setDefaultSearch(
+        'MRI',
+        context,
+        setContext,
+        new URLSearchParams('bookmarks'),
+      )
+      expect(context.datasetType_selected).toEqual('My Bookmarks')
+    })
+  })
+})

--- a/packages/openneuro-app/src/scripts/refactor_2021/search/search-container.tsx
+++ b/packages/openneuro-app/src/scripts/refactor_2021/search/search-container.tsx
@@ -1,4 +1,5 @@
 import React, { FC, useContext, useEffect } from 'react'
+import { useLocation } from 'react-router-dom'
 import {
   SearchPage,
   SearchResultsList,
@@ -38,22 +39,56 @@ export interface SearchContainerProps {
   portalContent?: Record<string, any>
 }
 
+/**
+ * Setup default search parameters based on URL and other state
+ */
+export const setDefaultSearch = (
+  modality: string,
+  searchParams: Record<string, any>,
+  setSearchParams: (newParams: Record<string, any>) => void,
+  query: URLSearchParams,
+): void => {
+  if (query.has('mydatasets')) {
+    setSearchParams(
+      (prevState: SearchParams): SearchParams => ({
+        ...prevState,
+        datasetType_selected: 'My Datasets',
+      }),
+    )
+  }
+  if (query.has('bookmarks')) {
+    setSearchParams(
+      (prevState: SearchParams): SearchParams => ({
+        ...prevState,
+        datasetType_selected: 'My Bookmarks',
+      }),
+    )
+  }
+  if (searchParams.modality_selected !== modality) {
+    setSearchParams(
+      (prevState: SearchParams): SearchParams => ({
+        ...prevState,
+        modality_selected: modality,
+      }),
+    )
+  }
+}
+
 const SearchContainer: FC<SearchContainerProps> = ({ portalContent }) => {
   const [cookies] = useCookies()
   const profile = getUnexpiredProfile(cookies)
+  const location = useLocation()
 
   const { searchParams, setSearchParams } = useContext(SearchParamsCtx)
   const modality = portalContent?.modality || null
   useEffect(() => {
-    if (searchParams.modality_selected !== modality) {
-      setSearchParams(
-        (prevState: SearchParams): SearchParams => ({
-          ...prevState,
-          modality_selected: modality,
-        }),
-      )
-    }
-  }, [modality, searchParams.modality_selected, setSearchParams])
+    setDefaultSearch(
+      modality,
+      searchParams,
+      setSearchParams,
+      new URLSearchParams(location.search),
+    )
+  }, [modality, searchParams.modality_selected, setSearchParams, location])
 
   const { loading, data, fetchMore, refetch, variables, error } =
     useSearchResults()


### PR DESCRIPTION
This adds redirects for the new design from /public, /saved, and /dashboard to the appropriately configured search pages.