### PR TITLE
fix(datalad): Improve snapshot exception handling

### DIFF
--- a/services/datalad/datalad_service/tasks/dataset.py
+++ b/services/datalad/datalad_service/tasks/dataset.py
@@ -9,9 +9,6 @@ import stat
 import pygit2
 
 from datalad_service.common.annex import CommitInfo
-from datalad_service.tasks.description import update_description
-from datalad_service.tasks.snapshots import get_snapshot, update_changes
-
 
 # A list of patterns to avoid annexing in BIDS datasets
 BIDS_NO_ANNEX = [
@@ -58,30 +55,3 @@ def delete_dataset(store, dataset):
     """Fully delete a given dataset. Removes all snapshots!"""
     ds = store.get_dataset(dataset)
     force_rmtree(ds.path)
-
-
-def validate_snapshot_name(store, dataset, snapshot):
-    ds = store.get_dataset(dataset)
-    # Search for any existing tags
-    tagged = [tag for tag in ds.repo.get_tags() if tag['name'] == snapshot]
-    if tagged:
-        raise Exception(
-            'Tag "{}" already exists, name conflict'.format(snapshot))
-
-
-def save_snapshot(store, dataset, snapshot):
-    ds = store.get_dataset(dataset)
-    ds.save(version_tag=snapshot)
-
-
-def create_snapshot(store, dataset, snapshot, description_fields, snapshot_changes):
-    """
-    Create a new snapshot (git tag).
-
-    Raises an exception if the tag already exists.
-    """
-    validate_snapshot_name(store, dataset, snapshot)
-    update_description(store, dataset, description_fields)
-    update_changes(store, dataset, snapshot, snapshot_changes)
-    save_snapshot(store, dataset, snapshot)
-    return get_snapshot(store, dataset, snapshot)


### PR DESCRIPTION
This prevents the create snapshot datalad_service call from returning incorrect HTTP Conflict errors on any exception.