### PR TITLE
Fix silent nested file object delete failure

### DIFF
--- a/packages/openneuro-server/src/graphql/resolvers/dataset.js
+++ b/packages/openneuro-server/src/graphql/resolvers/dataset.js
@@ -145,9 +145,7 @@ export const deleteFiles = async (
     await checkDatasetWrite(datasetId, user, userInfo)
     const deletedFiles = await datalad
       .deleteFiles(datasetId, files, userInfo)
-      .then(filenames =>
-        Promise.all(filenames.map(filename => new UpdatedFile(filename))),
-      )
+      .then(filenames => filenames.map(filename => new UpdatedFile(filename)))
 
     await datalad.commitFiles(datasetId, userInfo)
     pubsub.publish('filesUpdated', {

--- a/services/datalad/datalad_service/handlers/files.py
+++ b/services/datalad/datalad_service/handlers/files.py
@@ -113,7 +113,8 @@ class FilesResource(object):
             files_to_delete = []
             dirs_to_delete = []
             paths_not_found = []
-            filenames = req.media['filenames']
+            filenames = [filename.replace(':', '/')
+                         for filename in req.media['filenames']]
             for filename in filenames:
                 file_path = os.path.join(ds_path, filename)
                 if os.path.exists(file_path):


### PR DESCRIPTION
Anytime the consolidated delete resolver is used, it would use encoded filenames but this case where they are passed as a request body instead of a URL parameter isn't correctly decoded on the datalad-service side. This adds a test for this case as well.