### PR TITLE
fix: Fix extra rstrip of dataset_description leading to failed initial snapshot

### DIFF
--- a/services/datalad/datalad_service/tasks/description.py
+++ b/services/datalad/datalad_service/tasks/description.py
@@ -14,7 +14,7 @@ def edit_description(description, new_fields):
 def update_description(store, dataset, description_fields, name=None, email=None):
     ds = store.get_dataset(dataset)
     description = git_show(
-        ds.path, 'HEAD', 'dataset_description.json').rstrip()
+        ds.path, 'HEAD', 'dataset_description.json')
     description_json = json.loads(description)
     if description_json.get('License') != 'CC0':
         description_fields = edit_description(
@@ -23,10 +23,11 @@ def update_description(store, dataset, description_fields, name=None, email=None
         updated = edit_description(description_json, description_fields)
         path = os.path.join(store.get_dataset_path(
             dataset), 'dataset_description.json')
-        with open(path, 'r+', encoding='utf-8') as description_file:
-            description_file_contents = description_file.read().rstrip()
+        with open(path, 'r+', encoding='utf-8', newline='') as description_file:
+            description_file_contents = description_file.read()
             if description != description_file_contents:
-                raise Exception('unexpected dataset_description.json contents')
+                raise Exception('unexpected dataset_description.json contents',
+                                description, description_file_contents)
             description_file.seek(0)
             description_file.truncate(0)
             description_file.write(json.dumps(updated, indent=4))


### PR DESCRIPTION
This fixes an incorrect case for this error:
```
  File "/datalad_service/tasks/description.py", line 29, in update_description
    raise Exception('unexpected dataset_description.json contents')
```
Where Python reading the dataset_description would modify it with universal newlines and rstrip didn't remove it because it was elsewhere in the file (but otherwise valid). Instead, we read the raw newlines on the Python side and avoid rstrip on both.