### PR TITLE
feat: Allow unbound maximum for participants count searches

### DIFF
--- a/packages/openneuro-app/src/scripts/refactor_2021/search/inputs/subject-count-range-input.tsx
+++ b/packages/openneuro-app/src/scripts/refactor_2021/search/inputs/subject-count-range-input.tsx
@@ -4,23 +4,24 @@ import initialSearchParams from '../initial-search-params'
 import { FacetRange } from '@openneuro/components/facets'
 
 const SubjectCountRangeInput: FC = () => {
+  const min = 0
+  const max = 200
   const { searchParams, setSearchParams } = useContext(SearchParamsCtx)
-
-  const subjectCountRange = searchParams.subjectCountRange
   const setSubjectRange = subjectCountRange => {
     setSearchParams(prevState => ({
       ...prevState,
-      subjectCountRange,
+      subjectCountRange: [
+        (subjectCountRange[0] !== min && subjectCountRange[0]) || null,
+        (subjectCountRange[1] !== max && subjectCountRange[1]) || null,
+      ],
     }))
   }
 
-  const min = 0
-  const max = 100
-  const value =
-    JSON.stringify(subjectCountRange) ===
-    JSON.stringify(initialSearchParams.subjectCountRange)
-      ? [min, max]
-      : subjectCountRange
+  // Convert nulls to numeric values for TwoHandleRange
+  const value = [
+    searchParams.subjectCountRange[0] || min,
+    searchParams.subjectCountRange[1] || max,
+  ]
 
   return (
     <FacetRange
@@ -32,6 +33,7 @@ const SubjectCountRangeInput: FC = () => {
       step={10}
       value={value}
       onChange={setSubjectRange}
+      uncappedMax
     />
   )
 }

--- a/packages/openneuro-app/src/scripts/refactor_2021/search/inputs/subject-count-range-input.tsx
+++ b/packages/openneuro-app/src/scripts/refactor_2021/search/inputs/subject-count-range-input.tsx
@@ -1,6 +1,5 @@
 import React, { FC, useContext } from 'react'
 import { SearchParamsCtx } from '../search-params-ctx'
-import initialSearchParams from '../initial-search-params'
 import { FacetRange } from '@openneuro/components/facets'
 
 const SubjectCountRangeInput: FC = () => {
@@ -18,7 +17,7 @@ const SubjectCountRangeInput: FC = () => {
   }
 
   // Convert nulls to numeric values for TwoHandleRange
-  const value = [
+  const value: [number, number] = [
     searchParams.subjectCountRange[0] || min,
     searchParams.subjectCountRange[1] || max,
   ]

--- a/packages/openneuro-app/src/scripts/refactor_2021/search/use-search-results.tsx
+++ b/packages/openneuro-app/src/scripts/refactor_2021/search/use-search-results.tsx
@@ -197,9 +197,9 @@ export const useSearchResults = () => {
     boolQuery.addClause(
       'filter',
       rangeListLengthQuery(
-        'latestSnapshot.summary.subjects.keyword',
-        subjectCountRange[0],
-        subjectCountRange[1],
+        'latestSnapshot.summary.subjects',
+        subjectCountRange[0] || 0,
+        subjectCountRange[1] || Infinity,
       ),
     )
   if (diagnosis_selected)

--- a/packages/openneuro-components/src/facets/FacetRange.tsx
+++ b/packages/openneuro-components/src/facets/FacetRange.tsx
@@ -13,6 +13,7 @@ export interface FacetRangeProps {
   step: number
   value: [number | null, number | null]
   onChange: (newvalue) => void
+  uncappedMax?: boolean
 }
 
 export const FacetRange = ({
@@ -25,6 +26,7 @@ export const FacetRange = ({
   step,
   value,
   onChange,
+  uncappedMax,
 }: FacetRangeProps) => {
   return (
     <AccordionWrap className="facet-accordion">
@@ -40,6 +42,7 @@ export const FacetRange = ({
             step={step}
             value={value}
             onChange={onChange}
+            uncappedMax={uncappedMax}
           />
         </div>
       </AccordionTab>

--- a/packages/openneuro-components/src/range/TwoHandleRange.tsx
+++ b/packages/openneuro-components/src/range/TwoHandleRange.tsx
@@ -15,6 +15,8 @@ export interface TwoHandleRangeProps {
   value: [number, number]
   // Change event handler for either value changing, returns [minVal, maxVal]
   onChange: (value: [number, number]) => void
+  // At max value interpret this as any value greater than min
+  uncappedMax?: boolean
 }
 
 export const TwoHandleRange: React.FC<TwoHandleRangeProps> = ({
@@ -23,6 +25,7 @@ export const TwoHandleRange: React.FC<TwoHandleRangeProps> = ({
   step,
   value,
   onChange,
+  uncappedMax = false,
 }) => {
   const range = useRef<HTMLDivElement>(null)
 
@@ -79,6 +82,12 @@ export const TwoHandleRange: React.FC<TwoHandleRangeProps> = ({
     value[1] = discreteValue
     onChange([value[0], discreteValue])
   }
+
+  const leftValue = value[0]
+  const rightValue = uncappedMax
+    ? (value[1] === max && `${value[1]}+`) || value[1]
+    : value[1]
+
   return (
     <div className="formRange-inner">
       <input
@@ -112,8 +121,8 @@ export const TwoHandleRange: React.FC<TwoHandleRangeProps> = ({
       <div className="slider">
         <div className="slider__track"></div>
         <div ref={range} className="slider__range"></div>
-        <div className="slider__left-value">{value[0]}</div>
-        <div className="slider__right-value">{value[1]}</div>
+        <div className="slider__left-value">{leftValue}</div>
+        <div className="slider__right-value">{rightValue}</div>
       </div>
     </div>
   )

--- a/packages/openneuro-components/src/range/__tests__/TwoHandleRange.spec.tsx
+++ b/packages/openneuro-components/src/range/__tests__/TwoHandleRange.spec.tsx
@@ -31,42 +31,4 @@ describe('TwoHandleRange component', () => {
     fireEvent.keyDown(ranges[1], { key: 'ArrowRight', code: 'ArrowRight' })
     expect(onChange).toHaveBeenCalledTimes(2)
   })
-  it('returns Infinity when max range is uncapped', () => {
-    const onChange = jest.fn()
-    render(
-      <TwoHandleRange
-        min={0}
-        max={20}
-        step={10}
-        value={[0, 20]}
-        onChange={onChange}
-        uncappedMax
-      />,
-    )
-    const ranges = screen.queryAllByRole('slider')
-    fireEvent.focus(ranges[0])
-    fireEvent.keyDown(ranges[0], { key: 'ArrowRight', code: 'ArrowRight' })
-    fireEvent.focus(ranges[1])
-    fireEvent.keyDown(ranges[1], { key: 'ArrowRight', code: 'ArrowRight' })
-    expect(onChange).toHaveBeenCalledTimes(2)
-    expect(onChange).toHaveBeenLastCalledWith([0, Infinity])
-  })
-  it('sets a correct max value when value is set to [0, Infinity]', () => {
-    const onChange = jest.fn()
-    render(
-      <TwoHandleRange
-        min={0}
-        max={20}
-        step={10}
-        value={[0, Infinity]}
-        onChange={onChange}
-        uncappedMax
-      />,
-    )
-    const ranges = screen.queryAllByRole('slider')
-    fireEvent.focus(ranges[1])
-    fireEvent.keyDown(ranges[1], { key: 'ArrowLeft', code: 'ArrowLeft' })
-    expect(onChange).toHaveBeenCalledTimes(1)
-    expect(onChange).toHaveBeenLastCalledWith([0, 10])
-  })
 })

--- a/packages/openneuro-components/src/range/__tests__/TwoHandleRange.spec.tsx
+++ b/packages/openneuro-components/src/range/__tests__/TwoHandleRange.spec.tsx
@@ -31,4 +31,42 @@ describe('TwoHandleRange component', () => {
     fireEvent.keyDown(ranges[1], { key: 'ArrowRight', code: 'ArrowRight' })
     expect(onChange).toHaveBeenCalledTimes(2)
   })
+  it('returns Infinity when max range is uncapped', () => {
+    const onChange = jest.fn()
+    render(
+      <TwoHandleRange
+        min={0}
+        max={20}
+        step={10}
+        value={[0, 20]}
+        onChange={onChange}
+        uncappedMax
+      />,
+    )
+    const ranges = screen.queryAllByRole('slider')
+    fireEvent.focus(ranges[0])
+    fireEvent.keyDown(ranges[0], { key: 'ArrowRight', code: 'ArrowRight' })
+    fireEvent.focus(ranges[1])
+    fireEvent.keyDown(ranges[1], { key: 'ArrowRight', code: 'ArrowRight' })
+    expect(onChange).toHaveBeenCalledTimes(2)
+    expect(onChange).toHaveBeenLastCalledWith([0, Infinity])
+  })
+  it('sets a correct max value when value is set to [0, Infinity]', () => {
+    const onChange = jest.fn()
+    render(
+      <TwoHandleRange
+        min={0}
+        max={20}
+        step={10}
+        value={[0, Infinity]}
+        onChange={onChange}
+        uncappedMax
+      />,
+    )
+    const ranges = screen.queryAllByRole('slider')
+    fireEvent.focus(ranges[1])
+    fireEvent.keyDown(ranges[1], { key: 'ArrowLeft', code: 'ArrowLeft' })
+    expect(onChange).toHaveBeenCalledTimes(1)
+    expect(onChange).toHaveBeenLastCalledWith([0, 10])
+  })
 })

--- a/packages/openneuro-components/src/search-page/FilterListItem.tsx
+++ b/packages/openneuro-components/src/search-page/FilterListItem.tsx
@@ -9,6 +9,16 @@ type Item = {
   value: TextList | Text | OptionObject | NumberCouple
 }
 
+const rangeDisplay = range => {
+  if (range[0] === null) {
+    return `<= ${range[1]}`
+  } else if (range[1] === null) {
+    return `>= ${range[0]}`
+  } else {
+    return `${range[0]} - ${range[1]}`
+  }
+}
+
 export interface FilterListItemProps {
   item: Item
   type?: string
@@ -33,7 +43,7 @@ export const FilterListItem = ({
           <strong>{type}:</strong>
           <span>
             {type === 'Age' || type === 'Participants'
-              ? item.value[0] + ' - ' + item.value[1]
+              ? rangeDisplay(item.value)
               : item.value}
             <span onClick={() => removeFilterItem(item.param, item.value)}>
               &times;


### PR DESCRIPTION
Major changes:
* Allows you search for a minimum number of participants without specifying a max
* TwoHandleRange supports a unboundMax display option to show the max value as "value+" when at the max

Minor changes:
* Fixes the search query to use the correct field name for this search as well