### PR TITLE
fix(search): Allow for partial matches of author names and some mistakes

### DIFF
--- a/packages/openneuro-app/src/scripts/refactor_2021/search/es-query-builders.ts
+++ b/packages/openneuro-app/src/scripts/refactor_2021/search/es-query-builders.ts
@@ -88,4 +88,4 @@ export const rangeListLengthQuery = (field, gte: number, lte: number) => {
 export const sqsJoinWithAND = (list: string[]) =>
   list.map(str => `${str}`).join(' + ')
 export const joinWithOR = (list: string[]) =>
-  list.map(str => `${str}`).join(' | ')
+  list.map(str => `${str}~`).join(' | ')

--- a/packages/openneuro-app/src/scripts/refactor_2021/search/use-search-results.tsx
+++ b/packages/openneuro-app/src/scripts/refactor_2021/search/use-search-results.tsx
@@ -238,6 +238,7 @@ export const useSearchResults = () => {
       matchQuery(
         'latestSnapshot.description.SeniorAuthor',
         joinWithOR(authors),
+        '3',
       ),
     )
   if (gender_selected !== 'All')


### PR DESCRIPTION
This avoids the need to type exactly the right senior author name when searching (aligns it with the global keywords field).