### PR TITLE
fix(search): Convert SeniorAuthor field to text mapping

### DIFF
--- a/packages/openneuro-app/src/scripts/refactor_2021/search/es-query-builders.ts
+++ b/packages/openneuro-app/src/scripts/refactor_2021/search/es-query-builders.ts
@@ -88,4 +88,4 @@ export const rangeListLengthQuery = (field, gte: number, lte: number) => {
 export const sqsJoinWithAND = (list: string[]) =>
   list.map(str => `${str}`).join(' + ')
 export const joinWithOR = (list: string[]) =>
-  list.map(str => `${str}~`).join(' | ')
+  list.map(str => `${str}`).join(' | ')

--- a/packages/openneuro-indexer/src/mappings/datasets-mapping.json
+++ b/packages/openneuro-indexer/src/mappings/datasets-mapping.json
@@ -60,7 +60,7 @@
           "properties": {
             "Name": { "type": "keyword" },
             "Authors": { "type": "keyword" },
-            "SeniorAuthor": { "type": "keyword" }
+            "SeniorAuthor": { "type": "text" }
           }
         },
         "readme": {


### PR DESCRIPTION
This allows for infix search results (part of an author's name) without much performance cost.