### PR TITLE
fix: Allow for partial matches within dataset title keyword searches

### DIFF
--- a/packages/openneuro-indexer/src/mappings/datasets-mapping.json
+++ b/packages/openneuro-indexer/src/mappings/datasets-mapping.json
@@ -58,7 +58,7 @@
         },
         "description": {
           "properties": {
-            "Name": { "type": "keyword" },
+            "Name": { "type": "text" },
             "Authors": { "type": "keyword" },
             "SeniorAuthor": { "type": "text" }
           }


### PR DESCRIPTION
This allows you match a partial string within a title.