### PR TITLE
chore(publish): Cleanup of arguments for publish tasks to avoid unused dataset object

### DIFF
--- a/services/datalad/datalad_service/handlers/publish.py
+++ b/services/datalad/datalad_service/handlers/publish.py
@@ -12,9 +12,8 @@ class PublishResource(object):
         self.store = store
 
     def on_post(self, req, resp, dataset):
-        datalad = self.store.get_dataset(dataset)
+        dataset_path = self.store.get_dataset_path(dataset)
 
-        gevent.spawn(publish_dataset, self.store,
-                     dataset, cookies=req.cookies)
+        gevent.spawn(publish_dataset, dataset_path, cookies=req.cookies)
         resp.media = {}
         resp.status = falcon.HTTP_OK

--- a/services/datalad/datalad_service/handlers/reexporter.py
+++ b/services/datalad/datalad_service/handlers/reexporter.py
@@ -4,12 +4,13 @@ import gevent
 
 from datalad_service.tasks.publish import reexport_dataset
 
+
 class ReexporterResource(object):
     def __init__(self, store):
         self.store = store
         self.logger = logging.getLogger('datalad_service.' + __name__)
 
     def on_post(self, req, resp, dataset):
-        gevent.spawn(reexport_dataset, self.store,
-                        dataset, req.cookies)
+        dataset_path = self.store.get_dataset_path(dataset)
+        gevent.spawn(reexport_dataset, dataset_path, req.cookies)
         resp.status = falcon.HTTP_OK

--- a/services/datalad/tests/test_publish.py
+++ b/services/datalad/tests/test_publish.py
@@ -5,23 +5,21 @@ from .dataset_fixtures import *
 from datalad_service.tasks.publish import publish_snapshot, create_github_repo
 
 
-
 def test_publish(s3_creds, datalad_store, new_dataset):
     ds_id = os.path.basename(new_dataset.path)
     publish_snapshot(
-        datalad_store, ds_id, snapshot='test-version')
+        new_dataset.path, snapshot='test-version')
 
 
 def test_publish_private(s3_creds, datalad_store, new_dataset):
     ds_id = os.path.basename(new_dataset.path)
     publish_snapshot(
-        datalad_store, ds_id, snapshot='test-version', cookies=None, realm='PRIVATE')
+        new_dataset.path, snapshot='test-version', cookies=None, realm='PRIVATE')
 
 
 def test_publish_public(s3_creds, monkeypatch, github_dryrun, datalad_store, new_dataset):
     monkeypatch.setenv('DATALAD_GITHUB_ORG', 'test')
     monkeypatch.setenv('DATALAD_GITHUB_LOGIN', 'user')
     monkeypatch.setenv('DATALAD_GITHUB_PASS', 'password')
-    ds_id = os.path.basename(new_dataset.path)
     publish_snapshot(
-        datalad_store, ds_id, snapshot='test-version', cookies=None, realm='PUBLIC')
+        new_dataset.path, snapshot='test-version', cookies=None, realm='PUBLIC')


### PR DESCRIPTION
This cleans up some remaining structure held over from the days of the Celery backend in publishing.