### PR TITLE
dep: Update to MongoDB 4.4

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -99,7 +99,7 @@ services:
 
   # mongodb
   mongo:
-    image: mongo:4.0
+    image: mongo:4.4
     volumes:
       - ${PERSISTENT_DIR}/mongo:/data/db:delegated
 


### PR DESCRIPTION
Update to MongoDB 4.4. I tested 5.0 but there's a number of issues, rolling back to 4.4 I didn't find any issues. No manual upgrade steps are required, just stop and start the mongo container to test this.