### PR TITLE
feat: Add API for anonymous reviewer users

### DIFF
--- a/packages/openneuro-server/src/graphql/permissions.js
+++ b/packages/openneuro-server/src/graphql/permissions.js
@@ -57,6 +57,12 @@ export const checkDatasetExists = async datasetId => {
 export const checkDatasetRead = async (datasetId, userId, userInfo) => {
   // indexer has universal read access
   if (userInfo?.indexer) return true
+  // Reviewers are anonymous users with single dataset read access
+  if (userInfo?.reviewer) {
+    if (userInfo.datasetId === datasetId) {
+      return true
+    }
+  }
   // Check that dataset exists.
   await checkDatasetExists(datasetId)
   // Look for any matching datasets

--- a/packages/openneuro-server/src/graphql/resolvers/mutation.js
+++ b/packages/openneuro-server/src/graphql/resolvers/mutation.js
@@ -33,6 +33,7 @@ import { prepareRepoAccess } from './git'
 import { cacheClear } from './cache'
 import { reexportRemotes } from './reexporter'
 import { resetDraft } from './reset'
+import { createReviewer } from './reviewer'
 
 const Mutation = {
   createDataset,
@@ -71,6 +72,7 @@ const Mutation = {
   prepareRepoAccess,
   reexportRemotes,
   resetDraft,
+  createReviewer,
 }
 
 export default Mutation

--- a/packages/openneuro-server/src/graphql/resolvers/reviewer.ts
+++ b/packages/openneuro-server/src/graphql/resolvers/reviewer.ts
@@ -1,0 +1,25 @@
+import config from '../../config'
+import Reviewer from '../../models/reviewer'
+import { checkDatasetAdmin } from '../permissions.js'
+import { generateReviewerToken } from '../../libs/authentication/jwt.js'
+
+/**
+ * Create an anonymous read-only access key
+ * @param {object} obj Parent object or null
+ * @param {object} arguments Resolver arguments
+ * @param {string} arguments.datasetId Accession number string
+ * @param {object} context Resolver context
+ * @param {string} context.user User id
+ * @param {object} context.userInfo Decoded userInfo from token
+ */
+export async function createReviewer(obj, { datasetId }, { user, userInfo }) {
+  await checkDatasetAdmin(datasetId, user, userInfo)
+  const reviewer = new Reviewer({ datasetId })
+  await reviewer.save()
+  const token = generateReviewerToken(reviewer.id, datasetId)
+  return {
+    id: reviewer.id,
+    datasetId: datasetId,
+    url: `${config.url}/crn/reviewer/${token}`,
+  }
+}

--- a/packages/openneuro-server/src/graphql/schema.js
+++ b/packages/openneuro-server/src/graphql/schema.js
@@ -177,6 +177,17 @@ export const typeDefs = `
     resetDraft(datasetId: ID!, ref: String!): Boolean
     # Flag snapshot as deprecated
     deprecateSnapshot(datasetId: ID!, tag: String!, reason: String!): Boolean
+    # Create anonymous read only reviewer
+    createReviewer(datasetId: ID!): DatasetReviewer
+  }
+
+  # Anonymous dataset reviewer
+  type DatasetReviewer {
+    id: ID!
+    # Dataset accession number
+    datasetId: ID!
+    # Login URL generated
+    url: String!
   }
 
   input DeleteFile {

--- a/packages/openneuro-server/src/handlers/reviewer.ts
+++ b/packages/openneuro-server/src/handlers/reviewer.ts
@@ -1,0 +1,27 @@
+import Reviewer from '../models/reviewer'
+import { decodeJWT } from '../libs/authentication/jwt'
+
+export const reviewerHandler = async (req, res, next) => {
+  try {
+    const token = req.params.token
+    const decodedToken = decodeJWT(token)
+    if (decodedToken?.scopes.includes('dataset:reviewer')) {
+      const reviewer = await Reviewer.exists({
+        id: decodedToken.sub,
+        datasetId: decodedToken.dataset,
+      })
+      if (reviewer) {
+        res
+          .cookie('accessToken', token)
+          .redirect(`/datasets/${decodedToken.dataset}`)
+      } else {
+        throw Error('Review token not valid')
+      }
+    } else {
+      throw Error('Invalid token scope for reviewer')
+    }
+  } catch (err) {
+    res.status(401)
+    next(err)
+  }
+}

--- a/packages/openneuro-server/src/libs/authentication/jwt.js
+++ b/packages/openneuro-server/src/libs/authentication/jwt.js
@@ -28,10 +28,12 @@ export const buildToken = (config, user, expiresIn, options) => {
 }
 
 // Helper to generate a JWT containing user info
-export const addJWT = config => (user, expiration = 60 * 60 * 24 * 7) => {
-  const token = buildToken(config, user, expiration)
-  return Object.assign({}, user, { token })
-}
+export const addJWT =
+  config =>
+  (user, expiration = 60 * 60 * 24 * 7) => {
+    const token = buildToken(config, user, expiration)
+    return Object.assign({}, user, { token })
+  }
 
 /**
  * Generate an upload specific token
@@ -48,6 +50,28 @@ export function generateUploadToken(
     dataset: datasetId,
   }
   return buildToken(config, user, expiresIn, options)
+}
+
+/**
+ * Create a token that allows read only access to one dataset
+ */
+export function generateReviewerToken(
+  id,
+  datasetId,
+  expiresIn = 60 * 60 * 24 * 365,
+) {
+  const options = {
+    scopes: ['dataset:reviewer'],
+    dataset: datasetId,
+  }
+  const reviewer = {
+    id,
+    email: 'reviewer@openneuro.org',
+    provider: 'OpenNeuro',
+    name: 'Anonymous Reviewer',
+    admin: false,
+  }
+  return buildToken(config, reviewer, expiresIn, options)
 }
 
 /**

--- a/packages/openneuro-server/src/models/reviewer.ts
+++ b/packages/openneuro-server/src/models/reviewer.ts
@@ -1,0 +1,17 @@
+import uuid from 'uuid'
+import mongoose, { Document } from 'mongoose'
+const { Schema, model } = mongoose
+
+export interface ReviewerDocument extends Document {
+  id: string
+  datasetId: string
+}
+
+const reviewerSchema = new Schema({
+  id: { type: String, required: true, default: uuid.v4 },
+  datasetId: { type: String, required: true },
+})
+
+const Reviewer = model<ReviewerDocument>('Reviewer', reviewerSchema)
+
+export default Reviewer

--- a/packages/openneuro-server/src/routes.js
+++ b/packages/openneuro-server/src/routes.js
@@ -13,11 +13,11 @@ import {
 import verifyUser from './libs/authentication/verifyUser.js'
 import * as google from './libs/authentication/google.js'
 import * as orcid from './libs/authentication/orcid.js'
-import * as globus from './libs/authentication/globus.js'
 import * as jwt from './libs/authentication/jwt.js'
 import * as auth from './libs/authentication/states.js'
 import * as doi from './handlers/doi'
 import { sitemapHandler } from './handlers/sitemap.js'
+import { reviewerHandler } from './handlers/reviewer'
 
 const noCache = (req, res, next) => {
   res.setHeader('Surrogate-Control', 'no-store')
@@ -155,6 +155,13 @@ const routes = [
     url: '/auth/orcid/callback',
     middleware: [noCache, orcid.authCallback],
     handler: jwt.authSuccessHandler,
+  },
+  // Anonymous reviewer access
+  {
+    method: 'get',
+    url: '/reviewer/:token',
+    middleware: [noCache],
+    handler: reviewerHandler,
   },
   // sitemap
   {


### PR DESCRIPTION
This adds support for a new type of user, anonymous reviewers that have revocable read only access to private datasets. The token is valid for one year. Currently this is only available at the API level but I think we should work on a design to include this information on the new datasets pages.

Example usage, a dataset admin can run this mutation:
```graphql
mutation {
  createReviewer(datasetId: "ds001001") {
    id
    datasetId
    url
  }
}
```

It returns a result like this:

```json
  "data": {
    "createReviewer": {
      "id": "280d6cb5-a401-4452-b1a9-2b657b6ac872",
      "datasetId": "ds001001",
      "url": "https://openneuro.org/crn/reviewer/token.string.here"
    }
  },
```

Visiting this URL will redirect to this dataset and allow any read access functionality.

Fixes #565