### PR TITLE
fix: Prevent serialization error of Infinity in subject count range searches

### DIFF
--- a/packages/openneuro-app/src/scripts/refactor_2021/search/use-search-results.tsx
+++ b/packages/openneuro-app/src/scripts/refactor_2021/search/use-search-results.tsx
@@ -217,7 +217,7 @@ export const useSearchResults = () => {
       rangeListLengthQuery(
         'latestSnapshot.summary.subjects',
         subjectCountRange[0] || 0,
-        subjectCountRange[1] || Infinity,
+        subjectCountRange[1] || 1000000,
       ),
     )
   if (diagnosis_selected)


### PR DESCRIPTION
Fixes a crash when changing the number of participants search constraint minimum slider without adjusting the maximum value.