### PR TITLE
fix: Change author field from keyword to text to allow partial match

### DIFF
--- a/packages/openneuro-indexer/src/mappings/datasets-mapping.json
+++ b/packages/openneuro-indexer/src/mappings/datasets-mapping.json
@@ -59,7 +59,7 @@
         "description": {
           "properties": {
             "Name": { "type": "text" },
-            "Authors": { "type": "keyword" },
+            "Authors": { "type": "text" },
             "SeniorAuthor": { "type": "text" }
           }
         },


### PR DESCRIPTION
Additional fix for #2305 to allow substring matches for authors.