### PR TITLE
feat: Add primaryModality field to Summary type

### DIFF
--- a/packages/openneuro-server/src/graphql/resolvers/summary.js
+++ b/packages/openneuro-server/src/graphql/resolvers/summary.js
@@ -3,11 +3,17 @@ import Summary from '../../models/summary'
 /**
  * Summary resolver
  */
-export const summary = dataset => {
-  return Summary.findOne({
-    id: dataset.revision,
-    datasetId: dataset.id,
-  }).exec()
+export const summary = async dataset => {
+  const datasetSummary = (
+    await Summary.findOne({
+      id: dataset.revision,
+      datasetId: dataset.id,
+    }).exec()
+  ).toObject()
+  return {
+    ...datasetSummary,
+    primaryModality: datasetSummary?.modalities[0],
+  }
 }
 
 /**

--- a/packages/openneuro-server/src/graphql/schema.js
+++ b/packages/openneuro-server/src/graphql/schema.js
@@ -507,6 +507,7 @@ export const typeDefs = `
   type Summary {
     id: ID!
     modalities: [String]
+    primaryModality: String
     secondaryModalities: [String]
     sessions: [String]
     subjects: [String]


### PR DESCRIPTION
This encapsulates the primary modality logic in a server side resolver, to keep the (currently extremely simple) logic in one location.

```graphql
query {
  dataset(id: "ds001001") {
    id
    draft {
      summary {
        modalities
        primaryModality
      }
    }
  }
}
```

```json
{
  "data": {
    "dataset": {
      "id": "ds001001",
      "draft": {
        "summary": {
          "modalities": [
            "MRI"
          ],
          "primaryModality": "MRI"
        }
      }
    }
  },
}
```