### PR TITLE
fix(search): Use a more robust empty field check for rangeListLengthQuery

### DIFF
--- a/packages/openneuro-app/src/scripts/refactor_2021/search/es-query-builders.ts
+++ b/packages/openneuro-app/src/scripts/refactor_2021/search/es-query-builders.ts
@@ -71,7 +71,7 @@ export const rangeListLengthQuery = (field, gte: number, lte: number) => {
       script: {
         lang: 'painless',
         source: `
-          if (doc.containsKey(params.field)) {
+          if (doc[params.field].size() != 0) {
             return ( doc[params.field].value.length() >= params.gte && doc[params.field].value.length() <= params.lte )
           } else return false`,
         params: {


### PR DESCRIPTION
This is the [recommended way to filter missing field values](https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking-changes-7.0.html#_accessing_missing_document_values_will_throw_an_error).

To reproduce, manipulate the number of participants search slider on with no other filters. The existing check here will throw:

```
"org.elasticsearch.index.fielddata.ScriptDocValues$Strings.get(ScriptDocValues.java:494)", "org.elasticsearch.index.fielddata.ScriptDocValues$Strings.getValue(ScriptDocValues.java:508)", "return ( doc[params.field].value.length() >= params.gte && doc[params.field].value.length() <= params.lte )\n } else ", " ^---- HERE"
```

This is because the document does contain the key but it has no elements. This is expected behavior because occasionally the dataset is indexable otherwise but extraction of the participant summary data was not possible.