### PR TITLE
fix: Prevent race condition accidentally readding deleted files

### DIFF
--- a/packages/openneuro-server/src/graphql/resolvers/dataset.js
+++ b/packages/openneuro-server/src/graphql/resolvers/dataset.js
@@ -147,8 +147,6 @@ export const deleteFiles = async (
     const deletedFiles = await datalad
       .deleteFiles(datasetId, files, userInfo)
       .then(filenames => filenames.map(filename => new UpdatedFile(filename)))
-
-    await datalad.commitFiles(datasetId, userInfo)
     pubsub.publish('filesUpdated', {
       datasetId,
       filesUpdated: {


### PR DESCRIPTION
This commitFiles call has been redundant for a while but the refactor in #2286 meant the duplicate commit (which was silently skipped) is now harmful, sometimes managing to commit the deleted files after they are removed. The delete call now always makes a commit, so it's safe to remove this.