### PR TITLE
fix: Increase dataset title and authors search priority and order score

### DIFF
--- a/packages/openneuro-app/src/scripts/refactor_2021/search/use-search-results.tsx
+++ b/packages/openneuro-app/src/scripts/refactor_2021/search/use-search-results.tsx
@@ -160,8 +160,8 @@ export const useSearchResults = () => {
       'must',
       simpleQueryString(sqsJoinWithAND(keywords), [
         'latestSnapshot.readme',
-        'latestSnapshot.description.Name',
-        'latestSnapshot.description.Authors',
+        'latestSnapshot.description.Name^6',
+        'latestSnapshot.description.Authors^3',
       ]),
     )
   if (modality_selected) {

--- a/packages/openneuro-server/src/graphql/resolvers/dataset-search.js
+++ b/packages/openneuro-server/src/graphql/resolvers/dataset-search.js
@@ -4,7 +4,6 @@ import Star from '../../models/stars'
 import Subscription from '../../models/subscription'
 import Permission from '../../models/permission'
 import { hashObject } from '../../libs/authentication/crypto'
-import { states } from '../permissions.js'
 
 const elasticIndex = 'datasets'
 
@@ -70,8 +69,7 @@ export const elasticRelayConnection = (
       },
     }
   } catch (err) {
-    console.log('((((((()))))))')
-    console.log(err)
+    console.error(err)
   }
 }
 
@@ -214,7 +212,7 @@ export const advancedDatasetSearchConnection = async (
     sortBy,
     user,
   })
-  const sort = [{ _score: 'asc' }, { id: 'desc' }]
+  const sort = [{ _score: 'desc' }, { id: 'desc' }]
   if (sortBy) sort.unshift(sortBy)
   const requestBody = {
     sort,


### PR DESCRIPTION
This raises the importance of title and authors fields on keyword matches and fixes the inverted score ordering that was giving some strange results when using the default sort.