### PR TITLE
fix: Avoid first load css issues when enable/disable feature flags

### DIFF
--- a/packages/openneuro-app/src/ssr.ts
+++ b/packages/openneuro-app/src/ssr.ts
@@ -120,7 +120,7 @@ async function createServer(): Promise<void> {
         let template = fs.readFileSync(path.resolve(__dirname, index), 'utf-8')
 
         // Allow proxies to cache anonymous requests
-        let cacheControl = 'public, max-age=86400'
+        let cacheControl = url === '/' ? 'no-cache' : 'public, max-age=86400'
 
         try {
           // 2. Apply vite HTML transforms. This injects the vite HMR client, and


### PR DESCRIPTION
This avoids the first load served from cache issue that occurs when enabling or disabling the redesign pages.