### PR TITLE
Reset search params on route changes.

### DIFF
--- a/packages/openneuro-app/src/scripts/refactor_2021/search/search-params-ctx.tsx
+++ b/packages/openneuro-app/src/scripts/refactor_2021/search/search-params-ctx.tsx
@@ -2,9 +2,11 @@ import React, {
   createContext,
   useState,
   useContext,
+  useEffect,
   FC,
   ReactNode,
 } from 'react'
+import { useHistory } from 'react-router-dom'
 import initialSearchParams from './initial-search-params'
 
 export const SearchParamsCtx = createContext(null)
@@ -17,6 +19,16 @@ export const SearchParamsProvider: FC<SearchParamsProviderProps> = ({
   children,
 }) => {
   const [searchParams, setSearchParams] = useState(initialSearchParams)
+  const history = useHistory()
+  useEffect(() => {
+    const unlisten = history.listen((location, action) => {
+      console.log({location, action})
+      if (action === 'PUSH') {
+        setSearchParams(initialSearchParams)
+      }
+    })
+    return unlisten
+  }, [])
   return (
     <SearchParamsCtx.Provider value={{ searchParams, setSearchParams }}>
       {children}


### PR DESCRIPTION
resolves 347

## Major Changes
- search params reset on any route change in redesign layout.