### PR TITLE
fix: Reduce websocket layer chatter by sending server keepalive message every 30 seconds

### DIFF
--- a/packages/openneuro-server/src/libs/subscription-server.js
+++ b/packages/openneuro-server/src/libs/subscription-server.js
@@ -8,6 +8,7 @@ const subscriptionServerFactory = httpserver =>
       execute,
       subscribe,
       schema,
+      keepAlive: 30000,
     },
     {
       server: httpserver,


### PR DESCRIPTION
This was causing some slow performance on pages testing locally when dev mode + debuggers introduced latency. Could happen in some cases in production, I don't think there's a downside to keeping this relatively small number of socket connections open rather than re-establishing them every minute or so.