### PR TITLE
fix: Include dataset worker id in snapshot page query

### DIFF
--- a/packages/openneuro-app/src/scripts/refactor_2021/dataset/dataset-query.jsx
+++ b/packages/openneuro-app/src/scripts/refactor_2021/dataset/dataset-query.jsx
@@ -41,6 +41,7 @@ export const getDatasetPage = gql`
       stars {
         userId
       }
+      worker
       ...DatasetDraft
       ...DatasetPermissions
       ...DatasetSnapshots


### PR DESCRIPTION
This makes the worker id available on snapshots.