### PR TITLE
fix(ssr): Serve most pages with user specific data and cache-control

### DIFF
--- a/packages/openneuro-app/src/client.jsx
+++ b/packages/openneuro-app/src/client.jsx
@@ -18,7 +18,7 @@ import { relayStylePagination } from '@apollo/client/utilities'
 
 gtag.initialize(config.analytics.trackingIds)
 
-ReactDOM.render(
+ReactDOM.hydrate(
   <App>
     <ApolloProvider
       client={createClient(`${config.url}/crn/graphql`, {


### PR DESCRIPTION
Hydrate is still throwing some warnings but it looks like this is generally working now.