### PR TITLE
fix(analytics): Prevent over-reporting of views for front page datasets

### DIFF
--- a/packages/openneuro-app/src/scripts/refactor_2021/dataset/dataset-query.jsx
+++ b/packages/openneuro-app/src/scripts/refactor_2021/dataset/dataset-query.jsx
@@ -21,6 +21,7 @@ import ErrorBoundary, {
   ErrorBoundaryAssertionFailureException,
 } from '../../errors/errorBoundary.jsx'
 import DatasetRedirect from '../../datalad/routes/dataset-redirect'
+import datalad from '../../utils/datalad'
 
 //TODO imports
 
@@ -190,18 +191,28 @@ DatasetQueryHook.propTypes = {
  * @param {Object} props.draft Is this the draft page?
  * @param {Object} props.history React router history
  */
-const DatasetQuery = ({ match, history }) => (
-  <>
-    <DatasetRedirect />
-    <ErrorBoundaryAssertionFailureException subject={'error in dataset query'}>
-      <DatasetQueryHook
-        datasetId={match.params.datasetId}
-        draft={!match.params.snapshotId}
-        history={history}
-      />
-    </ErrorBoundaryAssertionFailureException>
-  </>
-)
+const DatasetQuery = ({ match, history }) => {
+  const datasetId = match.params.datasetId
+  const snapshotId = match.params.snapshotId
+  datalad.trackAnalytics(datasetId, {
+    snapshot: true,
+    tag: snapshotId,
+    type: 'views',
+  })
+  return (
+    <>
+      <DatasetRedirect />
+      <ErrorBoundaryAssertionFailureException
+        subject={'error in dataset query'}>
+        <DatasetQueryHook
+          datasetId={datasetId}
+          draft={!snapshotId}
+          history={history}
+        />
+      </ErrorBoundaryAssertionFailureException>
+    </>
+  )
+}
 
 DatasetQuery.propTypes = {
   match: PropTypes.object,

--- a/packages/openneuro-server/src/datalad/analytics.js
+++ b/packages/openneuro-server/src/datalad/analytics.js
@@ -1,10 +1,16 @@
 import Analytics from '../models/analytics'
+import Dataset from '../models/dataset'
 
-export const trackAnalytics = (datasetId, tag, type) => {
-  return Analytics.updateOne(
+/**
+ * Update a dataset's analytics count
+ * @param {string} datasetId
+ * @param {string} tag Deprecated
+ * @param {'views'|'downloads'} type
+ */
+export const trackAnalytics = async (datasetId, tag, type) => {
+  return Dataset.updateOne(
     {
-      datasetId: datasetId,
-      tag: tag,
+      id: datasetId,
     },
     {
       $inc: {

--- a/packages/openneuro-server/src/datalad/snapshots.js
+++ b/packages/openneuro-server/src/datalad/snapshots.js
@@ -213,8 +213,6 @@ export const getSnapshot = (datasetId, commitRef) => {
   const url = `${getDatasetWorker(
     datasetId,
   )}/datasets/${datasetId}/snapshots/${commitRef}`
-  // Track a view for each snapshot query
-  trackAnalytics(datasetId, commitRef, 'views')
   const cache = new CacheItem(redis, CacheType.snapshot, [datasetId, commitRef])
   return cache.get(() =>
     request

--- a/packages/openneuro-server/src/models/dataset.ts
+++ b/packages/openneuro-server/src/models/dataset.ts
@@ -10,6 +10,8 @@ export interface DatasetDocument extends Document {
   publishDate: Date
   uploader: string
   name: string
+  downloads: number
+  views: number
   _conditions: any
 }
 


### PR DESCRIPTION
This simplifies tracking of views/downloads to a dataset global value on the dataset model and returns views to reporting via an API call instead of implicit with every server API call (which was over reporting for things on the front page). Fixes #2073 

For production the data will be migrated over to the new fields before deployment and corrected for some of the most affected datasets.