### PR TITLE
fix(api): Include any modality match in public dataset count

### DIFF
--- a/packages/openneuro-server/src/datalad/dataset.js
+++ b/packages/openneuro-server/src/datalad/dataset.js
@@ -154,7 +154,7 @@ export const datasetsFilter = options => match => {
         },
         {
           $match: {
-            'summaries.0.modalities.0': options.modality,
+            $in: [options.modality, 'summaries.0.modalities'],
           },
         },
       ],


### PR DESCRIPTION
This filters datasets to match any modality present instead of the first. This does not fix GitLab 349 as expected because the component does not re-render when this data is updated but this fixes the issue at the API level.