### PR TITLE
refactor: Redirect createSnapshot only after the snapshot is done

### DIFF
--- a/packages/openneuro-app/src/scripts/datalad/subscriptions/useSnapshotsUpdatedSubscriptions.js
+++ b/packages/openneuro-app/src/scripts/datalad/subscriptions/useSnapshotsUpdatedSubscriptions.js
@@ -2,7 +2,7 @@ import { useSubscription, gql } from '@apollo/client'
 
 import { DATASET_SNAPSHOTS } from '../dataset/dataset-query-fragments.js'
 
-const SNAPSHOTS_UPDATED_SUBSCRIPTION = gql`
+export const SNAPSHOTS_UPDATED_SUBSCRIPTION = gql`
   subscription snapshotsUpdated($datasetId: ID!) {
     snapshotsUpdated(datasetId: $datasetId) {
       id


### PR DESCRIPTION
This breaks the snapshot creation mutation up into one more stage:

1. Request snapshot
2. Snapshot in progress
3. Snapshot done -> trigger redirect

Previously it was:
1. Request snapshot
2. Snapshot in progress -> trigger redirect

This would throw an error because the redirect would sometimes load before the snapshot was ready. There's a small delay inserted after the snapshot update event because it was still possible to get the error, this might need the subscription tweaked so the notification goes out a little later to prevent this but leaving that for another change.