### PR TITLE
Drop unused analytics collection aggregate from sorting

### DIFF
--- a/packages/openneuro-server/src/datalad/__tests__/pagination.spec.js
+++ b/packages/openneuro-server/src/datalad/__tests__/pagination.spec.js
@@ -114,8 +114,6 @@ describe('pagination model operations', () => {
       const agg = pagination.sortAggregate({
         orderBy: { downloads: 'ascending' },
       })
-      expect(agg[0]).toHaveProperty('$lookup')
-      expect(agg[1]).not.toHaveProperty('$addFields')
       // Ends with count sort
       expect(agg.slice(-1)).toEqual([{ $sort: { downloads: 1 } }])
     })
@@ -123,8 +121,6 @@ describe('pagination model operations', () => {
       const agg = pagination.sortAggregate({
         orderBy: { views: 'ascending' },
       })
-      expect(agg[0]).toHaveProperty('$lookup')
-      expect(agg[1]).not.toHaveProperty('$addFields')
       // Ends with count sort
       expect(agg.slice(-1)).toEqual([{ $sort: { views: 1 } }])
     })
@@ -139,7 +135,7 @@ describe('pagination model operations', () => {
           subscriptions: 'ascending',
         },
       })
-      expect(agg).toHaveLength(9)
+      expect(agg).toHaveLength(6)
       // Final stage should always be a sort
       expect(agg.slice(-1)[0]).toHaveProperty('$sort')
     })

--- a/packages/openneuro-server/src/datalad/pagination.js
+++ b/packages/openneuro-server/src/datalad/pagination.js
@@ -56,37 +56,6 @@ export const getOffsetFromCursor = options => {
 }
 
 /**
- * Modify sortingStages with aggregates required for dataset analytics field
- */
-export const sortByAnalytics = (aggregateType, sortingStages) => {
-  sortingStages.push({
-    $lookup: {
-      from: 'analytics',
-      localField: 'id',
-      foreignField: 'datasetId',
-      as: 'analytics',
-    },
-  })
-  sortingStages.push({ $unwind: '$analytics' })
-  // TODO - fields are repeated here and they will become stale if Datasets model changes
-  const groupOperation = {
-    $group: {
-      _id: '$_id',
-      id: { $first: '$id' },
-      created: { $first: '$created' },
-      modified: { $first: '$modified' },
-      uploader: { $first: '$uploader' },
-      revision: { $first: '$revision' },
-      name: { $first: '$name' },
-    },
-  }
-  groupOperation['$group'][aggregateType] = {
-    $sum: `$analytics.${aggregateType}`,
-  }
-  sortingStages.push(groupOperation)
-}
-
-/**
  * Apply any needed sorts to an aggregation pipeline
  * @param {object} options Query parameters
  * @returns {array} Steps required to sort any specified fields
@@ -131,11 +100,9 @@ export const sortAggregate = options => {
       finalSort['starsCount'] = sortEnumToInt(options.orderBy.stars)
     }
     if ('downloads' in options.orderBy && options.orderBy.downloads) {
-      sortByAnalytics('downloads', sortingStages)
       finalSort['downloads'] = sortEnumToInt(options.orderBy.downloads)
     }
     if ('views' in options.orderBy && options.orderBy.views) {
-      sortByAnalytics('views', sortingStages)
       finalSort['views'] = sortEnumToInt(options.orderBy.views)
     }
     if ('subscriptions' in options.orderBy && options.orderBy.subscriptions) {

--- a/packages/openneuro-server/src/models/dataset.ts
+++ b/packages/openneuro-server/src/models/dataset.ts
@@ -49,12 +49,6 @@ datasetSchema.virtual('stars', {
   justOne: true,
 })
 
-datasetSchema.virtual('analytics', {
-  ref: 'Analytics',
-  localField: 'id',
-  foreignField: 'datasetId',
-})
-
 datasetSchema.virtual('subscriptions', {
   ref: 'Subscription',
   localField: 'id',


### PR DESCRIPTION
This uses the datasets collection instead, avoiding the expensive lookup part of this sort.