### PR TITLE
fix: Summary is not required, make toObject() call optional when undefined

### DIFF
--- a/packages/openneuro-server/src/graphql/resolvers/summary.js
+++ b/packages/openneuro-server/src/graphql/resolvers/summary.js
@@ -9,7 +9,7 @@ export const summary = async dataset => {
       id: dataset.revision,
       datasetId: dataset.id,
     }).exec()
-  ).toObject()
+  )?.toObject()
   return {
     ...datasetSummary,
     primaryModality: datasetSummary?.modalities[0],


### PR DESCRIPTION
Fixes #2359 