### PR TITLE
Fix git-annex-remote-openneuro CLI entrypoint regression

### DIFF
--- a/packages/openneuro-cli/src/__tests__/gitAnnexRemote.spec.js
+++ b/packages/openneuro-cli/src/__tests__/gitAnnexRemote.spec.js
@@ -1,4 +1,5 @@
-import { handleGitAnnexMessage } from '../gitAnnexRemote.js'
+import event from 'events'
+import { gitAnnexRemote, handleGitAnnexMessage } from '../gitAnnexRemote.js'
 import { storeKey, retrieveKey, checkKey } from '../transferKey.js'
 
 jest.mock('../transferKey.js', () => {
@@ -16,6 +17,26 @@ const mockState = {
 }
 
 describe('gitAnnexRemote protocol implementation', () => {
+  describe('gitAnnexRemote() entrypoint', () => {
+    it('exits after readline.close()', () => {
+      const mockConsoleLog = jest
+        .spyOn(console, 'log')
+        .mockImplementation(() => {})
+      const mockOnce = jest
+        .spyOn(event, 'once')
+        .mockImplementation(() => Promise.resolve())
+      const mockExit = jest
+        .spyOn(process, 'exit')
+        .mockImplementationOnce(() => {})
+      // Test if the entrypoint function succeeds
+      gitAnnexRemote()
+      expect(mockOnce).toHaveBeenCalled()
+      expect(mockConsoleLog).toHaveBeenCalledWith('VERSION 1')
+      // Teardown mocks
+      mockOnce.mockReset()
+      mockExit.mockReset()
+    })
+  })
   describe('gitAnnexRemote handler', () => {
     it('accepts EXTENSIONS message', async () => {
       expect(await handleGitAnnexMessage('EXTENSIONS INFO ASYNC')).toEqual(

--- a/packages/openneuro-cli/src/cli.js
+++ b/packages/openneuro-cli/src/cli.js
@@ -68,12 +68,17 @@ commander
     create()
   })
 
-commander.parse(process.argv)
+const processName = process.argv[1].endsWith('index.js')
+  ? process.env.npm_lifecycle_event
+  : process.argv[1]
 
-if (process.argv[1].endsWith('git-credential-openneuro')) {
+if (processName.endsWith('git-credential-openneuro')) {
   gitCredential()
-} else if (process.argv[1].endsWith('git-annex-remote-openneuro')) {
+} else if (processName.endsWith('git-annex-remote-openneuro')) {
   gitAnnexRemote()
-} else if (!process.argv.slice(2).length) {
-  commander.help()
+} else {
+  commander.parse(process.argv)
+  if (!process.argv.slice(2).length) {
+    commander.help()
+  }
 }

--- a/packages/openneuro-cli/src/gitAnnexRemote.js
+++ b/packages/openneuro-cli/src/gitAnnexRemote.js
@@ -58,6 +58,7 @@ export async function handleGitAnnexMessage(line, state) {
 
 /**
  * Stateful response handling for git annex protocol
+ * @returns {() => void}
  */
 export const response = () => {
   const state = {}
@@ -84,7 +85,7 @@ export async function gitAnnexRemote() {
       input: process.stdin,
     })
     console.log(GIT_ANNEX_VERSION)
-    rl.on('line', void response())
+    rl.on('line', response())
     await once(rl, 'close')
     process.exit(0)
   } catch (err) {


### PR DESCRIPTION
The bug here is caused by the type definition on `rl.on('line', void response())` when it's actually the return type of the function returned by the response() call. Adds a test to that mocks out the I/O and runs the entry point function to catch this regression in the future.

Fixes #2322 