### PR TITLE
fix(publish): Ignore versioning can't be enabled error on update remote

### DIFF
--- a/services/datalad/datalad_service/common/s3.py
+++ b/services/datalad/datalad_service/common/s3.py
@@ -84,7 +84,7 @@ def update_s3_sibling(dataset_path, realm):
     annex_options = generate_s3_annex_options(dataset_path, realm)
     # note: enableremote command will only upsert config options, none are deleted
     subprocess.run(['git-annex', 'enableremote', realm.s3_remote] +
-                   annex_options, check=True, cwd=dataset_path)
+                   annex_options, cwd=dataset_path)
 
 
 def validate_s3_config(dataset_path, realm):


### PR DESCRIPTION
This restores the behavior before #2286 to workaround git-annex throwing an error that it could not enable versioning on this bucket. Related #2370