### PR TITLE
fix(publish): Fix git-annex remote test regression

### DIFF
--- a/services/datalad/datalad_service/common/annex.py
+++ b/services/datalad/datalad_service/common/annex.py
@@ -13,7 +13,8 @@ SERVICE_USER = 'Git Worker'
 
 def init_annex(dataset_path):
     """Setup git-annex within an existing git repo"""
-    subprocess.run(['git-annex', 'init', 'OpenNeuro'], check=True, cwd=dataset_path)
+    subprocess.run(['git-annex', 'init', 'OpenNeuro'],
+                   check=True, cwd=dataset_path)
 
 
 def compute_git_hash(path, size):
@@ -206,3 +207,18 @@ def get_tag_info(dataset_path, tag):
     git_process = subprocess.run(['git-annex', 'info', '--json', tag],
                                  cwd=dataset_path, capture_output=True)
     return json.loads(git_process.stdout)
+
+
+def test_git_annex_remote(dataset_path, remote):
+    """Test if a remote is a git-annex remote and active."""
+    remote_info = get_tag_info(dataset_path, remote)
+    if remote_info['success']:
+        # Exists and is a remote
+        if remote_info['remote'] == remote:
+            return True
+        else:
+            # Some other object likely matched
+            return False
+    else:
+        # Nothing like this exists
+        return False

--- a/services/datalad/datalad_service/handlers/snapshots.py
+++ b/services/datalad/datalad_service/handlers/snapshots.py
@@ -43,8 +43,8 @@ class SnapshotResource(object):
             snapshot_changes = media.get('snapshot_changes')
             skip_publishing = media.get('skip_publishing')
 
-        monitor_remote_configs(
-            self.store, dataset, snapshot)
+        ds_path = self.store.get_dataset_path(dataset)
+        monitor_remote_configs(ds_path)
 
         try:
             created = create_snapshot(


### PR DESCRIPTION
Fixes an issue where git-annex remotes were not being detected correctly, enableremote would run but try to enable the wrong remote since it did not detect the s3-PUBLIC remote. This calls git-annex to do this check instead to avoid missing git-annex configured remotes.

#2370 is an example with an affected dataset.