### PR TITLE
fix(api): Don't return partial object when summary is unavailable

### DIFF
--- a/packages/openneuro-server/src/graphql/resolvers/summary.js
+++ b/packages/openneuro-server/src/graphql/resolvers/summary.js
@@ -10,9 +10,13 @@ export const summary = async dataset => {
       datasetId: dataset.id,
     }).exec()
   )?.toObject()
-  return {
-    ...datasetSummary,
-    primaryModality: datasetSummary?.modalities[0],
+  if (datasetSummary) {
+    return {
+      ...datasetSummary,
+      primaryModality: datasetSummary?.modalities[0],
+    }
+  } else {
+    return null
   }
 }
 


### PR DESCRIPTION
This fixes a partial summary object being returned when none matched, avoiding the query error for datasets while validation is pending.

Fixes #2375.