### PR TITLE
fix: Delay cache-and-network refetch until after most SSR renders

### DIFF
--- a/packages/openneuro-client/src/client.js
+++ b/packages/openneuro-client/src/client.js
@@ -158,6 +158,7 @@ export const createClient = (
     cache: cache || new InMemoryCache(),
     connectToDevTools: true,
     ssrMode,
+    ssrForceFetchDelay: 1000,
   }
 
   // TODO: Figure this out?


### PR DESCRIPTION
This fixes the duplicate re-render that leads to this loading screen after hydrating the SSR version of the redesign datasets page:

![image](https://user-images.githubusercontent.com/11369795/135500825-9b29ee0a-a3ae-4fe9-ab39-ef6a807700e9.png)

Requires dropping the TypeScript build-cache to see the change because @openneuro/client isn't expiring the cache for some reason. Should only affect the SSR render, avoiding an extra query for any cache-and-network fetchPolicy queries that run.