### PR TITLE
refactor: Use automated persisted queries to enable CDN query cache

### DIFF
--- a/.pnp.js
+++ b/.pnp.js
@@ -10076,6 +10076,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["connect-history-api-fallback", "npm:1.6.0"],
             ["core-js", "npm:3.18.0"],
             ["cross-fetch", "npm:3.1.4"],
+            ["crypto-hash", "npm:1.3.0"],
             ["date-fns", "npm:2.24.0"],
             ["draft-js", "virtual:4112afb9dad10978c159910bf10db9840b981b1333117623c8a4a8cf77481344a0a24735a5506e2920c18e3cfa2cc179489824b6a56c988bb070f4f60da40974#npm:0.11.7"],
             ["email-validator", "npm:2.0.4"],
@@ -10167,6 +10168,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["apollo-server", "virtual:86720daff6fa91ef488bb305b0b2c8253fb3fabde470b409f92b17f3b1d6203e3f6631585a5dc2cd5ccefab01339e6676f430f53e0206b9354f687fcc9c70489#npm:2.25.2"],
             ["core-js", "npm:3.18.0"],
             ["cross-fetch", "npm:3.1.4"],
+            ["crypto-hash", "npm:1.3.0"],
             ["graphql", "npm:14.7.0"],
             ["semver", "npm:5.7.1"],
             ["subscriptions-transport-ws", "virtual:97dccaff73165508c12f2d40feea1ff8717e10423a567c2ece21e61362bdf9f610ba446599f6020c727df6997ab189a775bc307c0a84173a7ff8b1f77a3b2979#npm:0.9.19"]
@@ -20440,6 +20442,15 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["public-encrypt", "npm:4.0.3"],
             ["randombytes", "npm:2.1.0"],
             ["randomfill", "npm:1.0.4"]
+          ],
+          "linkType": "HARD",
+        }]
+      ]],
+      ["crypto-hash", [
+        ["npm:1.3.0", {
+          "packageLocation": "./.yarn/cache/crypto-hash-npm-1.3.0-8ec42184ed-3d0817091b.zip/node_modules/crypto-hash/",
+          "packageDependencies": [
+            ["crypto-hash", "npm:1.3.0"]
           ],
           "linkType": "HARD",
         }]
@@ -34276,6 +34287,13 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["nanocolors", "npm:0.1.12"]
           ],
           "linkType": "HARD",
+        }],
+        ["npm:0.2.12", {
+          "packageLocation": "./.yarn/cache/nanocolors-npm-0.2.12-f605aa543e-6f66a8cccb.zip/node_modules/nanocolors/",
+          "packageDependencies": [
+            ["nanocolors", "npm:0.2.12"]
+          ],
+          "linkType": "HARD",
         }]
       ]],
       ["nanoid", [
@@ -36665,6 +36683,16 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "packageDependencies": [
             ["postcss", "npm:8.3.7"],
             ["nanocolors", "npm:0.1.12"],
+            ["nanoid", "npm:3.1.25"],
+            ["source-map-js", "npm:0.6.2"]
+          ],
+          "linkType": "HARD",
+        }],
+        ["npm:8.3.8", {
+          "packageLocation": "./.yarn/cache/postcss-npm-8.3.8-adce56afd5-bea4f2f367.zip/node_modules/postcss/",
+          "packageDependencies": [
+            ["postcss", "npm:8.3.8"],
+            ["nanocolors", "npm:0.2.12"],
             ["nanoid", "npm:3.1.25"],
             ["source-map-js", "npm:0.6.2"]
           ],
@@ -45981,7 +46009,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["vite", "npm:2.3.1"],
             ["esbuild", "npm:0.11.23"],
             ["fsevents", "patch:fsevents@npm%3A2.3.2#builtin<compat/fsevents>::version=2.3.2&hash=11e9ea"],
-            ["postcss", "npm:8.3.7"],
+            ["postcss", "npm:8.3.8"],
             ["resolve", "patch:resolve@npm%3A1.20.0#builtin<compat/resolve>::version=1.20.0&hash=3388aa"],
             ["rollup", "npm:2.57.0"]
           ],

--- a/packages/openneuro-app/package.json
+++ b/packages/openneuro-app/package.json
@@ -29,6 +29,7 @@
     "comlink": "^4.0.5",
     "core-js": "^3.3.2",
     "cross-fetch": "^3.1.4",
+    "crypto-hash": "^1.3.0",
     "date-fns": "^2.16.1",
     "draft-js": "^0.11.7",
     "email-validator": "^2.0.4",

--- a/packages/openneuro-app/src/client.jsx
+++ b/packages/openneuro-app/src/client.jsx
@@ -23,6 +23,7 @@ ReactDOM.hydrate(
     <ApolloProvider
       client={createClient(`${config.url}/crn/graphql`, {
         clientVersion: version,
+        enableWebsocket: true,
         cache: new InMemoryCache({
           typePolicies: {
             Query: {
@@ -33,7 +34,8 @@ ReactDOM.hydrate(
           },
           // @ts-expect-error
         }).restore(JSON.parse(window.__APOLLO_STATE__)),
-      })}>
+      })}
+    >
       <BrowserRouter>
         <Route component={analyticsWrapper(Index)} />
       </BrowserRouter>

--- a/packages/openneuro-client/package.json
+++ b/packages/openneuro-client/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@apollo/client": "3.3.14",
     "cross-fetch": "^3.1.2",
+    "crypto-hash": "^1.3.0",
     "graphql": "14.7.0",
     "semver": "^5.5.0",
     "subscriptions-transport-ws": "^0.9.18"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5138,8 +5138,8 @@ __metadata:
     "@jest/globals": ^26.6.2
     "@loadable/babel-plugin": ^5.10.3
     "@loadable/component": ^5.7.0
-    "@openneuro/client": ^3.36.6-alpha.1
-    "@openneuro/components": ^3.36.6-alpha.1
+    "@openneuro/client": ^3.36.6-alpha.2
+    "@openneuro/components": ^3.36.6-alpha.2
     "@testing-library/jest-dom": ^5.11.4
     "@testing-library/react": ^11.1.0
     "@types/jest": ^26.0.22
@@ -5159,6 +5159,7 @@ __metadata:
     connect-history-api-fallback: ^1.5.0
     core-js: ^3.3.2
     cross-fetch: ^3.1.4
+    crypto-hash: ^1.3.0
     date-fns: ^2.16.1
     draft-js: ^0.11.7
     email-validator: ^2.0.4
@@ -5214,7 +5215,7 @@ __metadata:
   dependencies:
     "@apollo/client": 3.3.14
     "@babel/runtime-corejs3": ^7.13.10
-    "@openneuro/client": ^3.36.6-alpha.1
+    "@openneuro/client": ^3.36.6-alpha.2
     "@types/mkdirp": ^1.0.1
     "@types/node": ^14.14.41
     bids-validator: 1.8.4
@@ -5239,24 +5240,25 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@openneuro/client@^3.36.6-alpha.1, @openneuro/client@workspace:packages/openneuro-client":
+"@openneuro/client@^3.36.6-alpha.2, @openneuro/client@workspace:packages/openneuro-client":
   version: 0.0.0-use.local
   resolution: "@openneuro/client@workspace:packages/openneuro-client"
   dependencies:
     "@apollo/client": 3.3.14
     "@babel/preset-typescript": ^7.14.5
     "@babel/runtime-corejs3": ^7.13.10
-    "@openneuro/server": ^3.36.6-alpha.1
+    "@openneuro/server": ^3.36.6-alpha.2
     apollo-server: ^2.23.0
     core-js: ^3.10.1
     cross-fetch: ^3.1.2
+    crypto-hash: ^1.3.0
     graphql: 14.7.0
     semver: ^5.5.0
     subscriptions-transport-ws: ^0.9.18
   languageName: unknown
   linkType: soft
 
-"@openneuro/components@^3.36.6-alpha.1, @openneuro/components@workspace:packages/openneuro-components":
+"@openneuro/components@^3.36.6-alpha.2, @openneuro/components@workspace:packages/openneuro-components":
   version: 0.0.0-use.local
   resolution: "@openneuro/components@workspace:packages/openneuro-components"
   dependencies:
@@ -5315,7 +5317,7 @@ __metadata:
     "@apollo/client": 3.3.14
     "@babel/runtime-corejs3": ^7.13.10
     "@elastic/elasticsearch": ^7.5.0
-    "@openneuro/client": ^3.36.6-alpha.1
+    "@openneuro/client": ^3.36.6-alpha.2
     "@types/jsonwebtoken": ^8
     "@types/node": ^14.14.41
     "@types/tsc-watch": ^4
@@ -5329,7 +5331,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@openneuro/server@^3.36.6-alpha.1, @openneuro/server@workspace:packages/openneuro-server":
+"@openneuro/server@^3.36.6-alpha.2, @openneuro/server@workspace:packages/openneuro-server":
   version: 0.0.0-use.local
   resolution: "@openneuro/server@workspace:packages/openneuro-server"
   dependencies:
@@ -12980,6 +12982,13 @@ __metadata:
     randombytes: ^2.0.0
     randomfill: ^1.0.3
   checksum: 8b558367b3759652b7c8dfd8fa0dc55a69362ae3efe039ac44d4b010bc63143708f4748ef8efc079945bf61dbc53c829cda968cd2abc1f34fcf43f669a414f73
+  languageName: node
+  linkType: hard
+
+"crypto-hash@npm:^1.3.0":
+  version: 1.3.0
+  resolution: "crypto-hash@npm:1.3.0"
+  checksum: 3d0817091b1fa37dfd47680186439dc752ad224d7da55ae21923be3242c1315c1ac953841a026966fc251d5022e4c534192d1cd4591e1c1cc427ce5498a857c4
   languageName: node
   linkType: hard
 
@@ -24732,6 +24741,13 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"nanocolors@npm:^0.2.2":
+  version: 0.2.12
+  resolution: "nanocolors@npm:0.2.12"
+  checksum: 6f66a8cccb3bf419aacc9ec416dc948d4cea10681f6cf19ecfebdf707b593ea53f6dd6d675128c41e0a4164e734e54497beb20ddd00dacd859c4b5cad2a8c60f
+  languageName: node
+  linkType: hard
+
 "nanoid@npm:^3.1.25":
   version: 3.1.25
   resolution: "nanoid@npm:3.1.25"
@@ -27399,7 +27415,18 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"postcss@npm:^8.2.10, postcss@npm:^8.2.15":
+"postcss@npm:^8.2.10":
+  version: 8.3.8
+  resolution: "postcss@npm:8.3.8"
+  dependencies:
+    nanocolors: ^0.2.2
+    nanoid: ^3.1.25
+    source-map-js: ^0.6.2
+  checksum: bea4f2f367c803739ca89c6773aa80ecad6480171db7e1ebb211fabe7eaf7ff68b3b4d007e41f84d561344a588d62d1b50b3e46e1f5c368712100df553fc09ca
+  languageName: node
+  linkType: hard
+
+"postcss@npm:^8.2.15":
   version: 8.3.7
   resolution: "postcss@npm:8.3.7"
   dependencies:


### PR DESCRIPTION
1. Disables the websocket connection in SSR renders (it is just wasting resources there)
2. Enable [automatic persisted queries for all non-subscription queries](https://www.apollographql.com/docs/apollo-server/performance/apq/) - this will let us cache queries at the CDN level