### PR TITLE
Safari cache fixes

### DIFF
--- a/packages/openneuro-client/src/client.js
+++ b/packages/openneuro-client/src/client.js
@@ -102,7 +102,6 @@ const createLink = (uri, getAuthorization, fetch, enableWebsocket) => {
   const persistedQueryLink = createPersistedQueryLink({
     sha256,
     useGETForHashedQueries: true,
-    disable: () => true,
   })
 
   return split(


### PR DESCRIPTION
This just avoids caching SSR renders and enables APQ instead (avoiding the conflicts with cached SSR renders).