### PR TITLE
fix(redesign): Hide upload button on phone sized screens

### DIFF
--- a/packages/openneuro-app/src/scripts/refactor_2021/uploader/upload-button.jsx
+++ b/packages/openneuro-app/src/scripts/refactor_2021/uploader/upload-button.jsx
@@ -1,10 +1,17 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import styled from '@emotion/styled'
+
+const UploadAnchor = styled.a`
+  @media (max-width: 450px) {
+    display: none;
+  }
+`
 
 const UploadButton = ({ onClick }) => (
-  <a className="nav-link nl-upload" onClick={onClick}>
+  <UploadAnchor className="nav-link nl-upload" onClick={onClick}>
     Upload
-  </a>
+  </UploadAnchor>
 )
 
 UploadButton.propTypes = {


### PR DESCRIPTION
Hide this button for portrait orientation on phone sized screens.