### PR TITLE
fit and finish work

### DIFF
--- a/packages/openneuro-components/src/dataset/dataset-page.scss
+++ b/packages/openneuro-components/src/dataset/dataset-page.scss
@@ -62,8 +62,7 @@
     > span {
       display: flex;
       margin: 0 auto 20px;
-      padding: 0 5px;
-      width: 100px;
+      min-width: 160px;
       justify-content: center;
       .dataset-tool {
         color: var(--current-theme-primary);

--- a/packages/openneuro-components/src/dataset/dataset-page.scss
+++ b/packages/openneuro-components/src/dataset/dataset-page.scss
@@ -158,6 +158,9 @@
             > div {
               flex-grow: 1;
               padding: 5px;
+              text-overflow: ellipsis;
+              max-width: 100%;
+              overflow: hidden;
             }
           }
         }

--- a/packages/openneuro-components/src/dataset/dataset-page.scss
+++ b/packages/openneuro-components/src/dataset/dataset-page.scss
@@ -62,7 +62,8 @@
     > span {
       display: flex;
       margin: 0 auto 20px;
-      min-width: 160px;
+      flex-basis: auto;
+      padding: 0 15px;
       justify-content: center;
       .dataset-tool {
         color: var(--current-theme-primary);

--- a/packages/openneuro-components/src/input/input.scss
+++ b/packages/openneuro-components/src/input/input.scss
@@ -4,7 +4,7 @@ fieldset {
   padding: 0;
   border-style: none;
 }
-
+input,
 input[type='text'],
 input[type='tel'],
 input[type='email'],
@@ -15,7 +15,7 @@ textarea {
   appearance: none;
   box-sizing: border-box;
   border-radius: 0;
-  border: 0.1rem solid $newspaper;
+  border: 1px solid $newspaper;
   padding: 10px 12px;
   max-width: 100%;
   line-height: 12px;
@@ -40,7 +40,9 @@ input[type='search'] {
 }
 
 select {
-  border-radius: 0;
+  border-radius: 4px;
+  -webkit-appearance: none;
+  border: 1px solid $newspaper;
 }
 
 textarea {


### PR DESCRIPTION
updates the inputs
adds ellipsis to overflow git url on mobile in clone dropdown
tool icons should adjust and fit or wrap in a fluid way 