### PR TITLE
fix: Use redesign upload context for UpdateFile

### DIFF
--- a/packages/openneuro-app/src/scripts/refactor_2021/dataset/mutations/update-file.jsx
+++ b/packages/openneuro-app/src/scripts/refactor_2021/dataset/mutations/update-file.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import UploaderContext from '../../../uploader/uploader-context.js'
+import UploaderContext from '../../uploader/uploader-context.js'
 import Tooltip from '../../../common/partials/tooltip.jsx'
 
 const UpdateFile = ({


### PR DESCRIPTION
Fixes an error where the redesign datasets page UpdateFile component would throw an undefined property exception.