### PR TITLE
fix: Prevent delete file producing uncommitted working tree

### DIFF
--- a/services/datalad/datalad_service/tasks/files.py
+++ b/services/datalad/datalad_service/tasks/files.py
@@ -67,6 +67,7 @@ def remove_files(store, dataset, paths, name=None, email=None, cookies=None):
         author = None
     repo.index.remove_all(paths)
     repo.index.write()
+    repo.checkout_index()
     hexsha = git_commit_index(repo, author,
                               message="[OpenNeuro] Files removed").hex
     update_head(dataset, dataset_path, hexsha, cookies)


### PR DESCRIPTION
This fixes an issue where the index would remove a file but the file persisted in the working tree unless certain other operations ran after the delete.