### PR TITLE
fix: Redirect /pet to new portal page and link to OpenNeuro PET site

### DIFF
--- a/packages/openneuro-app/src/scripts/pet/redirect.tsx
+++ b/packages/openneuro-app/src/scripts/pet/redirect.tsx
@@ -1,0 +1,4 @@
+import React from 'react'
+import { Redirect } from 'react-router-dom'
+
+export const PETRedirect = () => <Redirect to="/search/modality/pet" />

--- a/packages/openneuro-app/src/scripts/refactor_2021/routes.tsx
+++ b/packages/openneuro-app/src/scripts/refactor_2021/routes.tsx
@@ -11,7 +11,7 @@ import Admin from './admin/admin'
 import SearchRoutes from './search/search-routes'
 import APIKey from './user/api'
 import ErrorRoute from '../errors/errorRoute'
-import PETDummy from '../pet/dummy'
+import { PETRedirect } from '../pet/redirect'
 import Citation from '../pages/citation-page'
 import FourOFourPage from '../errors/404page'
 
@@ -24,7 +24,7 @@ const Routes = () => (
     <Route name="search" path="/search" component={SearchRoutes} />
     <Route name="admin" path="/admin" component={Admin} />
     <Route name="error" path="/error" component={ErrorRoute} />
-    <Route name="pet-landing" path="/pet" component={PETDummy} />
+    <Route name="pet-landing" path="/pet" component={PETRedirect} />
     <Route name="citation" path="/cite" component={Citation} />
     <Redirect from="/public" to="/search" />
     <Redirect from="/saved" to="/search?bookmarks" />

--- a/packages/openneuro-components/src/mock-content/portal-content.jsx
+++ b/packages/openneuro-components/src/mock-content/portal-content.jsx
@@ -101,8 +101,19 @@ export const portalContent = {
     modality: 'PET', // corresponds to values in `modality_available` in (packages/openneuro-app/src/scripts/refactor_2021/search/initial-search-params.tsx)
     className: 'search-page-pet',
     portalName: 'OpenNeuro PET',
-    portalPrimary:
-      'The PET portal of OpenNeuro is supported by a collaboration between Stanford University, NIH, MGH and the Neurobiology Research Unit (NRU) at Copenhagen University Hospital through the OpenNeuroPET project. The project is funded through the BRAIN Initiative and the Novo Nordisk Foundation. Besides developing data sharing, the OpenNeuroPET project also aims at developing user friendly tools for the BIDS based data curation of PET data as well as tools for automated QC and template building.',
+    portalPrimary: (
+      <>
+        The PET portal of OpenNeuro is supported by a collaboration between
+        Stanford University, NIH, MGH and the Neurobiology Research Unit (NRU)
+        at Copenhagen University Hospital through the{' '}
+        <a href="https://openneuropet.github.io/">OpenNeuroPET project</a>. The
+        project is funded through the BRAIN Initiative and the Novo Nordisk
+        Foundation. Besides developing data sharing, the OpenNeuroPET project
+        also aims at developing user friendly tools for the BIDS based data
+        curation of PET data as well as tools for automated QC and template
+        building.
+      </>
+    ),
     publicDatasetStat: 100,
     participantsStat: 1100,
     hexBackgroundImage: pet,


### PR DESCRIPTION
* Redirects /pet to /search/modality/pet where the portal header is.
* Adds a link to the OpenNeuro PET project site