### PR TITLE
fix: Add test for git_tag common utility and fix tag name in publish

### DIFF
--- a/services/datalad/datalad_service/tasks/publish.py
+++ b/services/datalad/datalad_service/tasks/publish.py
@@ -105,7 +105,7 @@ def publish_dataset(dataset_path, cookies=None, realm='PUBLIC'):
 
 def reexport_dataset(dataset_path, cookies=None, realm=None):
     def should_export(dataset_path, tags):
-        latest_tag = tags[-1:][0]
+        latest_tag = tags[-1:][0].name
         # If remote has latest snapshot, do not reexport.
         # Reexporting all snapshots could make a previous snapshot latest in s3.
         return not check_remote_has_version(dataset_path, DatasetRealm.PUBLIC.s3_remote, latest_tag)
@@ -134,13 +134,13 @@ def export_all_tags(dataset_path, cookies, realm, check_should_export, esLogger=
             github_export_successful = False
             error = None
             try:
-                publish_target(dataset_path, realm.s3_remote, tag)
+                publish_target(dataset_path, realm.s3_remote, tag.name)
                 gevent.sleep()
                 s3_export_successful = True
                 # Public publishes to GitHub
                 if realm == DatasetRealm.PUBLIC and DATALAD_GITHUB_EXPORTS_ENABLED:
                     github_sibling(dataset_path, dataset)
-                    publish_target(dataset_path, realm.github_remote, tag)
+                    publish_target(dataset_path, realm.github_remote, tag.name)
                     gevent.sleep()
                     github_export_successful = True
             except Exception as err:

--- a/services/datalad/tests/test_common_git.py
+++ b/services/datalad/tests/test_common_git.py
@@ -1,0 +1,13 @@
+import pygit2
+from datalad_service.common.git import git_tag
+
+from .dataset_fixtures import *
+
+
+def test_git_tag(new_dataset):
+    repo = pygit2.Repository(new_dataset.path)
+    author = pygit2.Signature('Tagger', 'test@example.com')
+    commit = repo.revparse_single('HEAD')
+    repo.create_tag('1.0.0', commit.oid.hex,
+                    pygit2.GIT_OBJ_COMMIT, author, 'test tag')
+    assert git_tag(repo)[0].name == 'refs/tags/1.0.0'


### PR DESCRIPTION
Tests that git_tag returns the expected object with the name property and fixes one misuse of it.