### PR TITLE
fix: Cache participantCount query for one hour

### DIFF
--- a/packages/openneuro-server/src/cache/types.ts
+++ b/packages/openneuro-server/src/cache/types.ts
@@ -10,4 +10,5 @@ export enum CacheType {
   readme = 'readme',
   snapshot = 'snapshot',
   snapshotIndex = 'snapshotIndex',
+  participantCount = 'participantCount',
 }

--- a/packages/openneuro-server/src/graphql/resolvers/snapshots.js
+++ b/packages/openneuro-server/src/graphql/resolvers/snapshots.js
@@ -68,7 +68,6 @@ export const deprecateSnapshot = async (
 }
 
 export const participantCount = (obj, { modality }) => {
-  console.log(participantCount)
   const cache = new CacheItem(
     redis,
     CacheType.participantCount,

--- a/packages/openneuro-server/src/graphql/resolvers/snapshots.js
+++ b/packages/openneuro-server/src/graphql/resolvers/snapshots.js
@@ -13,6 +13,8 @@ import { checkDatasetAdmin } from '../permissions.js'
 import SnapshotModel from '../../models/snapshot'
 import User from '../../models/user'
 import * as Sentry from '@sentry/node'
+import { redis } from '../../libs/redis'
+import CacheItem, { CacheType } from '../../cache/item'
 
 export const snapshots = obj => {
   return datalad.getSnapshots(obj.id)
@@ -65,66 +67,73 @@ export const deprecateSnapshot = async (
   }
 }
 
-export const participantCount = async (obj, { modality }) => {
-  const queryHasSubjects = {
-    'summary.subjects': {
-      $exists: true,
-    },
-  }
-  const matchQuery = modality
-    ? {
-        $and: [
-          queryHasSubjects,
-          {
-            'summary.modalities.0': modality,
-          },
-        ],
-      }
-    : queryHasSubjects
-  const aggregateResult = await DatasetModel.aggregate([
-    {
-      $match: {
-        public: true,
+export const participantCount = (obj, { modality }) => {
+  console.log(participantCount)
+  const cache = new CacheItem(
+    redis,
+    CacheType.participantCount,
+    [modality || 'all'],
+    3600,
+  )
+  return cache.get(async () => {
+    const queryHasSubjects = {
+      'summary.subjects': {
+        $exists: true,
       },
-    },
-    {
-      $lookup: {
-        from: 'snapshots',
-        localField: 'id',
-        foreignField: 'datasetId',
-        as: 'snapshots',
-      },
-    },
-    {
-      $project: {
-        id: '$id',
-        hexsha: { $arrayElemAt: ['$snapshots.hexsha', -1] },
-      },
-    },
-    {
-      $lookup: {
-        from: 'summaries',
-        localField: 'hexsha',
-        foreignField: 'id',
-        as: 'summary',
-      },
-    },
-    {
-      $match: matchQuery,
-    },
-    {
-      $group: {
-        _id: null,
-        participantCount: {
-          $sum: { $size: { $arrayElemAt: ['$summary.subjects', 0] } },
+    }
+    const matchQuery = modality
+      ? {
+          $and: [
+            queryHasSubjects,
+            {
+              'summary.modalities.0': modality,
+            },
+          ],
+        }
+      : queryHasSubjects
+    const aggregateResult = await DatasetModel.aggregate([
+      {
+        $match: {
+          public: true,
         },
       },
-    },
-  ]).exec()
-  if (Array.isArray(aggregateResult)) {
+      {
+        $lookup: {
+          from: 'snapshots',
+          localField: 'id',
+          foreignField: 'datasetId',
+          as: 'snapshots',
+        },
+      },
+      {
+        $project: {
+          id: '$id',
+          hexsha: { $arrayElemAt: ['$snapshots.hexsha', -1] },
+        },
+      },
+      {
+        $lookup: {
+          from: 'summaries',
+          localField: 'hexsha',
+          foreignField: 'id',
+          as: 'summary',
+        },
+      },
+      {
+        $match: matchQuery,
+      },
+      {
+        $group: {
+          _id: null,
+          participantCount: {
+            $sum: { $size: { $arrayElemAt: ['$summary.subjects', 0] } },
+          },
+        },
+      },
+    ]).exec()
     if (aggregateResult.length) return aggregateResult[0].participantCount
     else return 0
-  } else return null
+  })
 }
 
 const sortSnapshots = (a, b) =>


### PR DESCRIPTION
Don't run this query as often, this is causing some latency blocking other queries from running.