### PR TITLE
Snapshot sort refinements

### DIFF
--- a/packages/openneuro-server/src/graphql/resolvers/__tests__/dataset.spec.js
+++ b/packages/openneuro-server/src/graphql/resolvers/__tests__/dataset.spec.js
@@ -36,8 +36,8 @@ describe('dataset resolvers', () => {
         { id: 4, created: new Date('2018-11-23T00:05:43.473Z'), tag: '1.0.3' },
       ]
       const sorted = testArray.sort(ds.snapshotCreationComparison)
-      expect(sorted[0].id).toBe(1)
-      expect(sorted[1].id).toBe(2)
+      expect(sorted[0].id).toBe(2)
+      expect(sorted[1].id).toBe(1)
       expect(sorted[2].id).toBe(3)
       expect(sorted[3].id).toBe(4)
       expect(sorted[4].id).toBe(5)

--- a/packages/openneuro-server/src/graphql/resolvers/__tests__/dataset.spec.js
+++ b/packages/openneuro-server/src/graphql/resolvers/__tests__/dataset.spec.js
@@ -91,6 +91,29 @@ describe('dataset resolvers', () => {
       expect(sorted[1].id).toBe(1)
       expect(sorted[2].id).toBe(3)
     })
+    it('sorts very similar creation times by semver order', () => {
+      const testSnapshots = [
+        {
+          id: 'ds002680:1.0.0',
+          created: '2020-04-03T23:19:56.000Z',
+          tag: '1.0.0',
+        },
+        {
+          id: 'ds002680:1.2.0',
+          created: '2021-10-19T16:26:43.000Z',
+          tag: '1.2.0',
+        },
+        {
+          id: 'ds002680:1.1.0',
+          created: '2021-10-19T16:26:44.000Z',
+          tag: '1.1.0',
+        },
+      ]
+      const sorted = testSnapshots.sort(ds.snapshotCreationComparison)
+      expect(sorted[0].id).toBe('ds002680:1.0.0')
+      expect(sorted[1].id).toBe('ds002680:1.1.0')
+      expect(sorted[2].id).toBe('ds002680:1.2.0')
+    })
   })
   describe('deleteFiles', () => {
     beforeEach(() => {

--- a/packages/openneuro-server/src/graphql/resolvers/dataset.js
+++ b/packages/openneuro-server/src/graphql/resolvers/dataset.js
@@ -46,10 +46,11 @@ export const snapshotCreationComparison = (
   { created: a, tag: a_tag },
   { created: b, tag: b_tag },
 ) => {
-  return (
-    new Date(a).getTime() - new Date(b).getTime() ||
-    (semver.valid(a_tag) && semver.valid(b_tag) && semver.compare(a_tag, b_tag))
-  )
+  if (semver.valid(a_tag) && semver.valid(b_tag)) {
+    return semver.compare(a_tag, b_tag)
+  } else {
+    return new Date(a).getTime() - new Date(b).getTime()
+  }
 }
 
 /**

--- a/packages/openneuro-server/src/graphql/resolvers/snapshots.js
+++ b/packages/openneuro-server/src/graphql/resolvers/snapshots.js
@@ -1,5 +1,5 @@
 import * as datalad from '../../datalad/snapshots.js'
-import { dataset, analytics } from './dataset.js'
+import { dataset, analytics, snapshotCreationComparison } from './dataset.js'
 import { checkDatasetRead, checkDatasetWrite } from '../permissions.js'
 import { readme } from './readme.js'
 import { description } from './description.js'
@@ -135,15 +135,12 @@ export const participantCount = (obj, { modality }) => {
   })
 }
 
-const sortSnapshots = (a, b) =>
-  new Date(b.created).getTime() - new Date(a.created).getTime()
-
 export const latestSnapshot = (obj, _, context) => {
   return datalad.getSnapshots(obj.id).then(snapshots => {
     if (snapshots.length) {
       const sortedSnapshots = Array.prototype.sort.call(
         snapshots,
-        sortSnapshots,
+        snapshotCreationComparison,
       )
       return snapshot(
         obj,


### PR DESCRIPTION
Adds test coverage for using the real snapshot objects from #2450

This inverts the sort to sort on semantic versioning order ahead of creation time and only fall back to creation time if there is no semantic versioning order for snapshots.