### PR TITLE
Render snapshot DOIs as links and normalize display to BIDS recommendation

### DIFF
--- a/packages/openneuro-app/src/scripts/refactor_2021/dataset/draft-container.tsx
+++ b/packages/openneuro-app/src/scripts/refactor_2021/dataset/draft-container.tsx
@@ -36,6 +36,7 @@ import { StarDataset } from './mutations/star'
 
 import EditDescriptionField from './fragments/edit-description-field.jsx'
 import EditDescriptionList from './fragments/edit-description-list.jsx'
+import DOILink from './fragments/doi-link'
 
 export interface DraftContainerProps {
   dataset
@@ -111,8 +112,7 @@ const DraftContainer: React.FC<DraftContainerProps> = ({ dataset }) => {
                   field="Name"
                   rows={2}
                   description={description.Name}
-                  editMode={hasEdit}
-                >
+                  editMode={hasEdit}>
                   {description.Name}
                 </EditDescriptionField>
               )}
@@ -196,8 +196,7 @@ const DraftContainer: React.FC<DraftContainerProps> = ({ dataset }) => {
             fileTree={true}
             id="collapse-tree"
             expandLabel="Expand File Tree"
-            collapseabel="Collapse File Tree"
-          >
+            collapseabel="Collapse File Tree">
             <Files
               datasetId={datasetId}
               snapshotTag={null}
@@ -219,13 +218,11 @@ const DraftContainer: React.FC<DraftContainerProps> = ({ dataset }) => {
                 field="readme"
                 rows={12}
                 description={dataset.draft.readme}
-                editMode={hasEdit}
-              >
+                editMode={hasEdit}>
                 <ReadMore
                   id="readme"
                   expandLabel="Read More"
-                  collapseabel="Collapse"
-                >
+                  collapseabel="Collapse">
                   <Markdown>{dataset.draft.readme || 'N/A'}</Markdown>
                 </ReadMore>
               </EditDescriptionField>
@@ -240,8 +237,7 @@ const DraftContainer: React.FC<DraftContainerProps> = ({ dataset }) => {
               field="Authors"
               heading="Authors"
               description={description.Authors}
-              editMode={hasEdit}
-            >
+              editMode={hasEdit}>
               {description.Authors?.length ? description.Authors : ['N/A']}
             </EditDescriptionList>
 
@@ -360,10 +356,7 @@ const DraftContainer: React.FC<DraftContainerProps> = ({ dataset }) => {
 
             <MetaDataBlock
               heading="Dataset DOI"
-              item={
-                description.DatasetDOI ||
-                'Create a new snapshot to obtain a DOI for the snapshot.'
-              }
+              item={<DOILink DOI={description.DatasetDOI} />}
             />
             <MetaDataBlock heading="License" item={description.License} />
 
@@ -376,8 +369,7 @@ const DraftContainer: React.FC<DraftContainerProps> = ({ dataset }) => {
                   field="Acknowledgements"
                   rows={2}
                   description={description.Acknowledgements}
-                  editMode={hasEdit}
-                >
+                  editMode={hasEdit}>
                   <Markdown>{description.Acknowledgements || 'N/A'}</Markdown>
                 </EditDescriptionField>
               )}
@@ -392,8 +384,7 @@ const DraftContainer: React.FC<DraftContainerProps> = ({ dataset }) => {
                   field="HowToAcknowledge"
                   rows={2}
                   description={description.HowToAcknowledge}
-                  editMode={hasEdit}
-                >
+                  editMode={hasEdit}>
                   <Markdown>{description.HowToAcknowledge || 'N/A'}</Markdown>
                 </EditDescriptionField>
               )}
@@ -405,8 +396,7 @@ const DraftContainer: React.FC<DraftContainerProps> = ({ dataset }) => {
               field="Funding"
               heading="Funding"
               description={description.Funding}
-              editMode={hasEdit}
-            >
+              editMode={hasEdit}>
               {description.Funding?.length ? description.Funding : ['N/A']}
             </EditDescriptionList>
 
@@ -416,8 +406,7 @@ const DraftContainer: React.FC<DraftContainerProps> = ({ dataset }) => {
               field="ReferencesAndLinks"
               heading="References and Links"
               description={description.ReferencesAndLinks}
-              editMode={hasEdit}
-            >
+              editMode={hasEdit}>
               {description.ReferencesAndLinks?.length
                 ? description.ReferencesAndLinks
                 : ['N/A']}
@@ -429,8 +418,7 @@ const DraftContainer: React.FC<DraftContainerProps> = ({ dataset }) => {
               field="EthicsApprovals"
               heading="Ethics Approvals"
               description={description.EthicsApprovals}
-              editMode={hasEdit}
-            >
+              editMode={hasEdit}>
               {description.EthicsApprovals?.length
                 ? description.EthicsApprovals
                 : ['N/A']}
@@ -442,8 +430,7 @@ const DraftContainer: React.FC<DraftContainerProps> = ({ dataset }) => {
             isOpen={deprecatedmodalIsOpen}
             toggle={() => setDeprecatedModalIsOpen(prevIsOpen => !prevIsOpen)}
             closeText={'close'}
-            className="deprecated-modal"
-          >
+            className="deprecated-modal">
             <p>
               You have selected a deprecated version. The author of the dataset
               does not recommend this specific version.

--- a/packages/openneuro-app/src/scripts/refactor_2021/dataset/draft-container.tsx
+++ b/packages/openneuro-app/src/scripts/refactor_2021/dataset/draft-container.tsx
@@ -36,7 +36,7 @@ import { StarDataset } from './mutations/star'
 
 import EditDescriptionField from './fragments/edit-description-field.jsx'
 import EditDescriptionList from './fragments/edit-description-list.jsx'
-import DOILink from './fragments/doi-link'
+import { DOILink } from './fragments/doi-link'
 
 export interface DraftContainerProps {
   dataset
@@ -112,7 +112,8 @@ const DraftContainer: React.FC<DraftContainerProps> = ({ dataset }) => {
                   field="Name"
                   rows={2}
                   description={description.Name}
-                  editMode={hasEdit}>
+                  editMode={hasEdit}
+                >
                   {description.Name}
                 </EditDescriptionField>
               )}
@@ -196,7 +197,8 @@ const DraftContainer: React.FC<DraftContainerProps> = ({ dataset }) => {
             fileTree={true}
             id="collapse-tree"
             expandLabel="Expand File Tree"
-            collapseabel="Collapse File Tree">
+            collapseabel="Collapse File Tree"
+          >
             <Files
               datasetId={datasetId}
               snapshotTag={null}
@@ -218,11 +220,13 @@ const DraftContainer: React.FC<DraftContainerProps> = ({ dataset }) => {
                 field="readme"
                 rows={12}
                 description={dataset.draft.readme}
-                editMode={hasEdit}>
+                editMode={hasEdit}
+              >
                 <ReadMore
                   id="readme"
                   expandLabel="Read More"
-                  collapseabel="Collapse">
+                  collapseabel="Collapse"
+                >
                   <Markdown>{dataset.draft.readme || 'N/A'}</Markdown>
                 </ReadMore>
               </EditDescriptionField>
@@ -237,7 +241,8 @@ const DraftContainer: React.FC<DraftContainerProps> = ({ dataset }) => {
               field="Authors"
               heading="Authors"
               description={description.Authors}
-              editMode={hasEdit}>
+              editMode={hasEdit}
+            >
               {description.Authors?.length ? description.Authors : ['N/A']}
             </EditDescriptionList>
 
@@ -369,7 +374,8 @@ const DraftContainer: React.FC<DraftContainerProps> = ({ dataset }) => {
                   field="Acknowledgements"
                   rows={2}
                   description={description.Acknowledgements}
-                  editMode={hasEdit}>
+                  editMode={hasEdit}
+                >
                   <Markdown>{description.Acknowledgements || 'N/A'}</Markdown>
                 </EditDescriptionField>
               )}
@@ -384,7 +390,8 @@ const DraftContainer: React.FC<DraftContainerProps> = ({ dataset }) => {
                   field="HowToAcknowledge"
                   rows={2}
                   description={description.HowToAcknowledge}
-                  editMode={hasEdit}>
+                  editMode={hasEdit}
+                >
                   <Markdown>{description.HowToAcknowledge || 'N/A'}</Markdown>
                 </EditDescriptionField>
               )}
@@ -396,7 +403,8 @@ const DraftContainer: React.FC<DraftContainerProps> = ({ dataset }) => {
               field="Funding"
               heading="Funding"
               description={description.Funding}
-              editMode={hasEdit}>
+              editMode={hasEdit}
+            >
               {description.Funding?.length ? description.Funding : ['N/A']}
             </EditDescriptionList>
 
@@ -406,7 +414,8 @@ const DraftContainer: React.FC<DraftContainerProps> = ({ dataset }) => {
               field="ReferencesAndLinks"
               heading="References and Links"
               description={description.ReferencesAndLinks}
-              editMode={hasEdit}>
+              editMode={hasEdit}
+            >
               {description.ReferencesAndLinks?.length
                 ? description.ReferencesAndLinks
                 : ['N/A']}
@@ -418,7 +427,8 @@ const DraftContainer: React.FC<DraftContainerProps> = ({ dataset }) => {
               field="EthicsApprovals"
               heading="Ethics Approvals"
               description={description.EthicsApprovals}
-              editMode={hasEdit}>
+              editMode={hasEdit}
+            >
               {description.EthicsApprovals?.length
                 ? description.EthicsApprovals
                 : ['N/A']}
@@ -430,7 +440,8 @@ const DraftContainer: React.FC<DraftContainerProps> = ({ dataset }) => {
             isOpen={deprecatedmodalIsOpen}
             toggle={() => setDeprecatedModalIsOpen(prevIsOpen => !prevIsOpen)}
             closeText={'close'}
-            className="deprecated-modal">
+            className="deprecated-modal"
+          >
             <p>
               You have selected a deprecated version. The author of the dataset
               does not recommend this specific version.

--- a/packages/openneuro-app/src/scripts/refactor_2021/dataset/fragments/__tests__/doi-link.spec.tsx
+++ b/packages/openneuro-app/src/scripts/refactor_2021/dataset/fragments/__tests__/doi-link.spec.tsx
@@ -1,0 +1,42 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { DOILink } from '../doi-link'
+import { MemoryRouter } from 'react-router-dom'
+
+describe('DoiLink component', () => {
+  it('Renders usable link with raw DOI value', () => {
+    render(<DOILink DOI="10.18112/openneuro.ds000001.v1.0.0" />, {
+      wrapper: MemoryRouter,
+    })
+    expect(screen.getByRole('link')).toHaveTextContent(
+      'doi:10.18112/openneuro.ds000001.v1.0.0',
+    )
+    expect(screen.getByRole('link')).toHaveAttribute(
+      'href',
+      'https://doi.org/10.18112/openneuro.ds000001.v1.0.0',
+    )
+  })
+  it('Renders usable link with URI DOI value', () => {
+    render(<DOILink DOI="doi:10.18112/openneuro.ds000001.v1.0.0" />, {
+      wrapper: MemoryRouter,
+    })
+    expect(screen.getByRole('link')).toHaveTextContent(
+      'doi:10.18112/openneuro.ds000001.v1.0.0',
+    )
+  })
+  it('Renders usage link with URL DOI value', () => {
+    render(
+      <DOILink DOI="https://doi.org/10.18112/openneuro.ds000001.v1.0.0" />,
+      { wrapper: MemoryRouter },
+    )
+    expect(screen.getByRole('link')).toHaveTextContent(
+      'doi:10.18112/openneuro.ds000001.v1.0.0',
+    )
+  })
+  it('Renders fallback text if no valid DOI string is found', () => {
+    render(<DOILink />, { wrapper: MemoryRouter })
+    expect(screen.getByRole('link')).toHaveTextContent(
+      'Create a new snapshot to obtain a DOI for the snapshot.',
+    )
+  })
+})

--- a/packages/openneuro-app/src/scripts/refactor_2021/dataset/fragments/__tests__/doi-link.spec.tsx
+++ b/packages/openneuro-app/src/scripts/refactor_2021/dataset/fragments/__tests__/doi-link.spec.tsx
@@ -34,7 +34,7 @@ describe('DoiLink component', () => {
     )
   })
   it('Renders fallback text if no valid DOI string is found', () => {
-    render(<DOILink />, { wrapper: MemoryRouter })
+    render(<DOILink DOI={null} />, { wrapper: MemoryRouter })
     expect(screen.getByRole('link')).toHaveTextContent(
       'Create a new snapshot to obtain a DOI for the snapshot.',
     )

--- a/packages/openneuro-app/src/scripts/refactor_2021/dataset/fragments/doi-link.tsx
+++ b/packages/openneuro-app/src/scripts/refactor_2021/dataset/fragments/doi-link.tsx
@@ -1,0 +1,30 @@
+import React from 'react'
+import { Link } from 'react-router-dom'
+
+// See https://www.crossref.org/blog/dois-and-matching-regular-expressions/
+const DOIPattern = /^10.\d{4,9}\/[-._;()/:A-Z0-9]+$/i
+
+export const DOILink = ({ DOI }) => {
+  if (
+    DOI &&
+    (DOI.match(DOIPattern) ||
+      DOI.startsWith('doi:') ||
+      DOI.startsWith('https://doi.org'))
+  ) {
+    if (DOI.match(DOIPattern)) {
+      return <a href={`https://doi.org/${DOI}`}>{`doi:${DOI}`}</a>
+    }
+    if (DOI.startsWith('doi:') && DOI.slice(4).match(DOIPattern)) {
+      return <a href={`https://doi.org/${DOI.slice(4)}`}>{DOI}</a>
+    }
+    if (DOI.startsWith('https://doi.org/')) {
+      return <a href={DOI}>{`doi:${DOI.slice(16)}`}</a>
+    }
+  } else {
+    return (
+      <Link to="snapshot">
+        Create a new snapshot to obtain a DOI for the snapshot.
+      </Link>
+    )
+  }
+}

--- a/packages/openneuro-app/src/scripts/refactor_2021/dataset/snapshot-container.tsx
+++ b/packages/openneuro-app/src/scripts/refactor_2021/dataset/snapshot-container.tsx
@@ -41,6 +41,7 @@ import { FollowDataset } from './mutations/follow'
 import { StarDataset } from './mutations/star'
 
 import { SNAPSHOT_FIELDS } from './queries/dataset-query-fragments.js'
+import { DOILink } from './fragments/doi-link'
 
 const formatDate = dateObject =>
   new Date(dateObject).toISOString().split('T')[0]
@@ -170,8 +171,7 @@ const SnapshotContainer: React.FC<SnapshotContainerProps> = ({
             fileTree={true}
             id="collapse-tree"
             expandLabel="Read More"
-            collapseabel="Collapse"
-          >
+            collapseabel="Collapse">
             <Files
               datasetId={datasetId}
               snapshotTag={snapshot.tag}
@@ -189,8 +189,7 @@ const SnapshotContainer: React.FC<SnapshotContainerProps> = ({
               <ReadMore
                 id="readme"
                 expandLabel="Read More"
-                collapseabel="Collapse"
-              >
+                collapseabel="Collapse">
                 <Markdown>
                   {snapshot.readme == null ? 'N/A' : snapshot.readme}
                 </Markdown>
@@ -327,10 +326,7 @@ const SnapshotContainer: React.FC<SnapshotContainerProps> = ({
 
             <MetaDataBlock
               heading="Dataset DOI"
-              item={
-                description.DatasetDOI ||
-                'Create a new snapshot to obtain a DOI for the snapshot.'
-              }
+              item={<DOILink DOI={description.DatasetDOI} />}
             />
             <MetaDataBlock heading="License" item={description.License} />
 
@@ -378,8 +374,7 @@ const SnapshotContainer: React.FC<SnapshotContainerProps> = ({
             isOpen={deprecatedmodalIsOpen}
             toggle={() => setDeprecatedModalIsOpen(prevIsOpen => !prevIsOpen)}
             closeText={'close'}
-            className="deprecated-modal"
-          >
+            className="deprecated-modal">
             <p>
               You have selected a deprecated version. The author of the dataset
               does not recommend this specific version.
@@ -437,8 +432,7 @@ const SnapshotLoader: React.FC<SnapshotLoaderProps> = ({ dataset, tag }) => {
           datasetId: dataset.id,
           fetchMore,
           error: null,
-        }}
-      >
+        }}>
         <SnapshotContainer
           dataset={dataset}
           tag={tag}

--- a/packages/openneuro-server/src/datalad/snapshots.js
+++ b/packages/openneuro-server/src/datalad/snapshots.js
@@ -58,7 +58,8 @@ const createIfNotExistsDoi = async (
         tag,
         oldDesc,
       )
-      if (snapshotDoi) descriptionFieldUpdates['DatasetDOI'] = snapshotDoi
+      if (snapshotDoi)
+        descriptionFieldUpdates['DatasetDOI'] = `doi:${snapshotDoi}`
     } catch (err) {
       Sentry.captureException(err)
       console.error(err)


### PR DESCRIPTION
Displays snapshot DOIs in the `doi:...` format and links to a `https://doi.org/` value.