### PR TITLE
feat: Add snapshot.relatedObjects field to match for known DOI references

### DIFF
--- a/packages/openneuro-server/src/graphql/resolvers/__tests__/snapshots.spec.js
+++ b/packages/openneuro-server/src/graphql/resolvers/__tests__/snapshots.spec.js
@@ -1,0 +1,26 @@
+jest.mock('../../../config')
+import { matchKnownObjects } from '../snapshots.js'
+
+describe('snapshot resolvers', () => {
+  describe('matchKnownObjects()', () => {
+    it('should return NDA as a source when given a description containing 10.15154 DOIs', () => {
+      expect(
+        matchKnownObjects({
+          ReferencesAndLinks: [
+            '10.18112/openneuro.ds000001.v1.0.0',
+            '10.15154/1503209',
+          ],
+        }).sort(),
+      ).toEqual([
+        {
+          id: '10.18112/openneuro.ds000001.v1.0.0',
+        },
+        {
+          id: '10.15154/1503209',
+          source: 'NDA',
+          type: 'dataset',
+        },
+      ])
+    })
+  })
+})

--- a/packages/openneuro-server/src/graphql/schema.js
+++ b/packages/openneuro-server/src/graphql/schema.js
@@ -447,6 +447,18 @@ export const typeDefs = `
     hexsha: String
     # Whether or not this snapshot has been deprecated (returns null if false)
     deprecated: DeprecatedSnapshot
+    # Related DOI references extracted from ReferencesAndLinks
+    relatedObjects: [ExternalDOI]
+  }
+
+  # DOI for an external object with the source if available
+  type ExternalDOI {
+    # DOI string in uri format
+    id: ID!
+    # Source if known
+    source: String
+    # Type if known
+    type: String
   }
 
   # Set on snapshots that have been deprecated

--- a/packages/openneuro-server/src/libs/doi/__tests__/normalize.spec.ts
+++ b/packages/openneuro-server/src/libs/doi/__tests__/normalize.spec.ts
@@ -1,0 +1,28 @@
+import { normalizeDOI } from '../normalize'
+
+describe('DOI normalize utility', () => {
+  it('returns null for non-DOI input', () => {
+    expect(normalizeDOI('Sphinx of black quartz, judge my vow.')).toBe(null)
+  })
+  it('returns the raw DOI value from a raw input', () => {
+    expect(normalizeDOI('10.18112/openneuro.ds000001.v1.0.0')).toBe(
+      '10.18112/openneuro.ds000001.v1.0.0',
+    )
+  })
+  it('returns the raw DOI value from a URI input', () => {
+    expect(normalizeDOI('doi:10.18112/openneuro.ds000001.v1.0.0')).toBe(
+      '10.18112/openneuro.ds000001.v1.0.0',
+    )
+    expect(normalizeDOI('DOI:10.18112/openneuro.ds000001.v1.0.0')).toBe(
+      '10.18112/openneuro.ds000001.v1.0.0',
+    )
+  })
+  it('returns the raw DOI value from a URI input', () => {
+    expect(
+      normalizeDOI('https://doi.org/10.18112/openneuro.ds000001.v1.0.0'),
+    ).toBe('10.18112/openneuro.ds000001.v1.0.0')
+    expect(
+      normalizeDOI('HTTPS://DOI.ORG/10.18112/openneuro.ds000001.v1.0.0'),
+    ).toBe('10.18112/openneuro.ds000001.v1.0.0')
+  })
+})

--- a/packages/openneuro-server/src/libs/doi/normalize.ts
+++ b/packages/openneuro-server/src/libs/doi/normalize.ts
@@ -1,0 +1,20 @@
+// See https://www.crossref.org/blog/dois-and-matching-regular-expressions/
+const DOIPattern = /^10.\d{4,9}\/[-._;()/:A-Z0-9]+$/i
+
+export const normalizeDOI = (doi: string): string | null => {
+  // Raw DOI
+  if (doi.match(DOIPattern)) {
+    return doi
+  }
+  if (doi.toLowerCase().startsWith('doi:') && doi.slice(4).match(DOIPattern)) {
+    return doi.slice(4)
+  }
+  if (
+    doi.toLowerCase().startsWith('https://doi.org/') &&
+    doi.slice(16).match(DOIPattern)
+  ) {
+    return doi.slice(16)
+  }
+
+  return null
+}


### PR DESCRIPTION
The finds some known DOI types in ReferencesAndLinks to allow those to be indexed in search. The intent here is to leave room to use extend the sources searched here to include things like crossref and other data repositories in the future.