### PR TITLE
fix: Use absolute routes for documentation links

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1,6 +1,6 @@
 ---
 name: GraphQL API
-route: api
+route: /api
 ---
 
 # API Examples

--- a/docs/git.md
+++ b/docs/git.md
@@ -1,6 +1,6 @@
 ---
 name: Git Access
-route: git
+route: /git
 ---
 
 # Git access to OpenNeuro datasets

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -1,6 +1,6 @@
 ---
 name: Site Maintenance
-route: maintenance
+route: /maintenance
 ---
 
 ## Unpublishing a dataset

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -1,6 +1,6 @@
 ---
 name: Kubernetes Monitoring
-route: monitoring
+route: /monitoring
 ---
 
 # Infrastructure Monitoring

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -1,6 +1,6 @@
 ---
 name: User Guide
-route: user-guide
+route: /user-guide
 ---
 
 # User Guide

--- a/packages/openneuro-cli/README.md
+++ b/packages/openneuro-cli/README.md
@@ -1,5 +1,6 @@
 ---
 name: Command Line Interface
+route: /cli
 ---
 
 # OpenNeuro command line interface


### PR DESCRIPTION
Fixes an issue with navigation between pages on the documentation site. Adds docs.openneuro.org/cli for a short path to the command line tool documentation.