### PR TITLE
feat(api): Support adding related DOI metadata to datasets

### DIFF
--- a/packages/openneuro-server/src/graphql/resolvers/mutation.js
+++ b/packages/openneuro-server/src/graphql/resolvers/mutation.js
@@ -34,6 +34,7 @@ import { cacheClear } from './cache'
 import { reexportRemotes } from './reexporter'
 import { resetDraft } from './reset'
 import { createReviewer, deleteReviewer } from './reviewer'
+import { createRelation, deleteRelation } from './relation'
 
 const Mutation = {
   createDataset,
@@ -74,6 +75,8 @@ const Mutation = {
   resetDraft,
   createReviewer,
   deleteReviewer,
+  createRelation,
+  deleteRelation,
 }
 
 export default Mutation

--- a/packages/openneuro-server/src/graphql/resolvers/relation.ts
+++ b/packages/openneuro-server/src/graphql/resolvers/relation.ts
@@ -1,0 +1,40 @@
+import Dataset from '../../models/dataset'
+import { checkDatasetAdmin } from '../permissions'
+import { DOIPattern } from '../../libs/doi/normalize'
+
+export const createRelation = async (
+  obj,
+  { datasetId, doi, relation, kind, description },
+  { user, userInfo },
+) => {
+  await checkDatasetAdmin(datasetId, user, userInfo)
+  // Validate the right DOI format
+  if (!doi.startsWith('doi:') || !doi.slice(4).match(DOIPattern)) {
+    throw new Error(
+      'DOI format must follow BIDS recommended format (see https://bids-specification.readthedocs.io/en/stable/02-common-principles.html#uniform-resource-indicator)',
+    )
+  }
+  const dataset = await Dataset.findOneAndUpdate(
+    { id: datasetId },
+    { $push: { related: { id: doi, relation, kind, description } } },
+    { new: true },
+  )
+    .lean()
+    .exec()
+  return dataset
+}
+
+export const deleteRelation = async (
+  obj,
+  { datasetId, doi },
+  { user, userInfo },
+) => {
+  await checkDatasetAdmin(datasetId, user, userInfo)
+  return await Dataset.findOneAndUpdate(
+    { id: datasetId },
+    { $pull: { related: { id: doi } } },
+    { new: true },
+  )
+    .lean()
+    .exec()
+}

--- a/packages/openneuro-server/src/graphql/resolvers/snapshots.js
+++ b/packages/openneuro-server/src/graphql/resolvers/snapshots.js
@@ -35,7 +35,7 @@ export const snapshot = (obj, { datasetId, tag }, context) => {
             .then(filterFiles(prefix))
             .then(filterRemovedAnnexObjects(datasetId, context.userInfo)),
         deprecated: () => deprecated(snapshot),
-        relatedObjects: () => relatedObjects(snapshot),
+        related: () => related(datasetId),
       }))
     },
   )
@@ -46,11 +46,12 @@ export const deprecated = snapshot => {
 }
 
 /**
- * Search snapshot data for related objects and return an array
- * @param {*} snapshot
+ * Search dataset metadeta for related objects and return an array
+ * @param {string} datasetId
  */
-export const relatedObjects = async snapshot => {
-  return matchKnownObjects(await description(snapshot))
+export const related = async datasetId => {
+  const dataset = await DatasetModel.findOne({ id: datasetId }).lean().exec()
+  return dataset.related
 }
 
 export const matchKnownObjects = desc => {

--- a/packages/openneuro-server/src/graphql/schema.js
+++ b/packages/openneuro-server/src/graphql/schema.js
@@ -181,6 +181,10 @@ export const typeDefs = `
     createReviewer(datasetId: ID!): DatasetReviewer
     # Remove reviewer
     deleteReviewer(datasetId: ID!, id: ID!): DatasetReviewer
+    # Add a relationship to an external DOI
+    createRelation(datasetId: ID!, doi: String!, relation: RelatedObjectRelation!, kind: RelatedObjectKind!, description: String): Dataset
+    # Remove a relationship to an external DOI
+    deleteRelation(datasetId: ID!, doi: String!): Dataset
   }
 
   # Anonymous dataset reviewer
@@ -447,18 +451,30 @@ export const typeDefs = `
     hexsha: String
     # Whether or not this snapshot has been deprecated (returns null if false)
     deprecated: DeprecatedSnapshot
-    # Related DOI references extracted from ReferencesAndLinks
-    relatedObjects: [ExternalDOI]
+    # Related DOI references
+    related: [RelatedObject]
   }
 
-  # DOI for an external object with the source if available
-  type ExternalDOI {
+  # RelatedObject nature of relationship
+  enum RelatedObjectRelation {
+    sameAs
+  }
+
+  # RelatedObject kind of target object
+  enum RelatedObjectKind {
+    Dataset
+  }
+
+  # DOI for an external object
+  type RelatedObject {
     # DOI string in uri format
     id: ID!
-    # Source if known
-    source: String
-    # Type if known
-    type: String
+    # The nature of the relationship
+    relation: RelatedObjectRelation!
+    # What kind of target object is it?
+    kind: RelatedObjectKind!
+    # Optional description
+    description: String
   }
 
   # Set on snapshots that have been deprecated

--- a/packages/openneuro-server/src/libs/doi/normalize.ts
+++ b/packages/openneuro-server/src/libs/doi/normalize.ts
@@ -1,5 +1,5 @@
 // See https://www.crossref.org/blog/dois-and-matching-regular-expressions/
-const DOIPattern = /^10.\d{4,9}\/[-._;()/:A-Z0-9]+$/i
+export const DOIPattern = /^10.\d{4,9}\/[-._;()/:A-Z0-9]+$/i
 
 export const normalizeDOI = (doi: string): string | null => {
   // Raw DOI

--- a/packages/openneuro-server/src/models/dataset.ts
+++ b/packages/openneuro-server/src/models/dataset.ts
@@ -2,6 +2,21 @@ import mongoose, { Document } from 'mongoose'
 const { Schema, model } = mongoose
 import DatasetChange from './datasetChange'
 
+// External relations annotating the whole dataset
+export interface DatasetRelationDocument extends Document {
+  id: string // DOI
+  relation: 'sameAs'
+  kind: 'Dataset'
+  description: string
+}
+
+const RelationSchema = new Schema<DatasetRelationDocument>({
+  id: { type: String, required: true },
+  relation: { type: String, required: true },
+  kind: { type: String, required: true },
+  description: String,
+})
+
 export interface DatasetDocument extends Document {
   id: string
   created: Date
@@ -12,6 +27,7 @@ export interface DatasetDocument extends Document {
   name: string
   downloads: number
   views: number
+  related: [DatasetRelationDocument]
   _conditions: any
 }
 
@@ -26,6 +42,7 @@ const datasetSchema = new Schema<DatasetDocument>(
     name: String,
     downloads: Number,
     views: Number,
+    related: [RelationSchema],
   },
   { toJSON: { virtuals: true }, toObject: { virtuals: true } },
 )


### PR DESCRIPTION
This lets a dataset admin annotate a dataset with a related DOI object (currently just sameAs relations with Datasets)