### PR TITLE
fix(app): Handle undefined data error when adding files to dataset

### DIFF
--- a/packages/openneuro-app/src/scripts/refactor_2021/dataset/dataset-query.jsx
+++ b/packages/openneuro-app/src/scripts/refactor_2021/dataset/dataset-query.jsx
@@ -144,7 +144,7 @@ export const DatasetQueryHook = ({ datasetId, draft, history }) => {
   })
   useDraftSubscription(datasetId)
 
-  if (loading)
+  if (loading || !data)
     return (
       <div className="loading-dataset">
         <Loading />
@@ -172,7 +172,8 @@ export const DatasetQueryHook = ({ datasetId, draft, history }) => {
             datasetId,
             fetchMore,
             error,
-          }}>
+          }}
+        >
           <DatasetRoutes dataset={data.dataset} />
           <FilesSubscription datasetId={datasetId} />
         </DatasetQueryContext.Provider>
@@ -207,7 +208,8 @@ const DatasetQuery = ({ match, history }) => {
     <>
       <DatasetRedirect />
       <ErrorBoundaryAssertionFailureException
-        subject={'error in dataset query'}>
+        subject={'error in dataset query'}
+      >
         <DatasetQueryHook
           datasetId={datasetId}
           draft={!snapshotId}


### PR DESCRIPTION
A subscription update can return null once while adding files, this prevents a crash and renders the component loading state instead.