### PR TITLE
breaking link if it expands past the block

### DIFF
--- a/packages/openneuro-components/src/activity-slider/slider.scss
+++ b/packages/openneuro-components/src/activity-slider/slider.scss
@@ -21,6 +21,9 @@
       font-weight: 600;
       margin-bottom: 0;
       text-decoration: underline;
+      a {
+        word-break: break-word;
+      }
     }
     .ds-pub-views,
     .ds-pub-date {


### PR DESCRIPTION
if the link has no spaces and expands past the block this will break it and wrap to a new line. 

fixes 
https://gitlab.com/squishymedia/nimh/openneuropet/-/issues/410