### PR TITLE
Test git history API formats and fix extra commas returned in references format

### DIFF
--- a/services/datalad/datalad_service/handlers/history.py
+++ b/services/datalad/datalad_service/handlers/history.py
@@ -22,7 +22,7 @@ class HistoryResource(object):
                 references = []
                 for tag in tags:
                     if tag.target.hex == commit.hex:
-                        references += tag.name
+                        references.append(tag.name)
                 log.append({
                     "id": commit.hex, "date": commit.commit_time,
                     "authorName": commit.author.name, "authorEmail": commit.author.email,

--- a/services/datalad/tests/test_history.py
+++ b/services/datalad/tests/test_history.py
@@ -1,5 +1,6 @@
 import falcon
 import json
+import pygit2
 
 from .dataset_fixtures import *
 from datalad_service.handlers.history import HistoryResource
@@ -13,3 +14,18 @@ def test_history(client):
         response.content) if response.content else None
     assert history is not None
     assert len(history["log"]) == 4
+    for entry in history["log"]:
+        assert isinstance(entry["authorEmail"], str)
+        assert '@' in entry["authorEmail"]
+        assert isinstance(entry["authorName"], str)
+        assert isinstance(entry["date"], int)
+        assert isinstance(entry["message"], str)
+        assert isinstance(entry["id"], str)
+        assert len(entry["id"]) == 40
+        assert isinstance(entry["references"], str)
+        # If there is any references content, check the format
+        if (len(entry["references"]) > 0):
+            for ref in entry["references"].split(','):
+                # Full references will always have at least "refs" prefixed
+                assert len(ref) > 4
+                pygit2.reference_is_valid_name(ref)


### PR DESCRIPTION
Fixes a string concatenation issue in the git history API for datasets. Adds test coverage for the format this API returns beyond just checking the correct number of git log entries.

GitLab #396