### PR TITLE
Update prettier to use new bracketSameLine option for JSX end of line

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,6 @@
 singleQuote: true
 jsxBracketSameLine: true
+bracketSameLine: true
 semi: false
 trailingComma: all
 arrowParens: avoid


### PR DESCRIPTION
Fixes this inconsistent JSX bracket closing issue between different tools in many recent merge requests.