### PR TITLE
fix(search): Prioritize accession number matches ahead of most other matches

### DIFF
--- a/packages/openneuro-app/src/scripts/refactor_2021/search/use-search-results.tsx
+++ b/packages/openneuro-app/src/scripts/refactor_2021/search/use-search-results.tsx
@@ -154,6 +154,7 @@ export const useSearchResults = () => {
     boolQuery.addClause(
       'must',
       simpleQueryString(sqsJoinWithAND(keywords), [
+        'id^6',
         'latestSnapshot.readme',
         'latestSnapshot.description.Name^6',
         'latestSnapshot.description.Authors^3',


### PR DESCRIPTION
This allows you to search for accession numbers and prioritizes an exact match ahead of other matches if you specify multiple keywords.