### PR TITLE
fix(search): Disable "relevance" sort when no query is set

### DIFF
--- a/packages/openneuro-app/src/scripts/refactor_2021/search/__tests__/search-params-ctx.spec.tsx
+++ b/packages/openneuro-app/src/scripts/refactor_2021/search/__tests__/search-params-ctx.spec.tsx
@@ -1,0 +1,20 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+import { SearchParamsCtx } from '../search-params-ctx'
+import '@testing-library/jest-dom'
+
+/**
+ * Render with SearchParamsCtx state
+ */
+export const searchRender = (ui, { providerProps, ...renderOptions }) => {
+  return render(
+    <SearchParamsCtx.Provider {...providerProps}>
+      {ui}
+    </SearchParamsCtx.Provider>,
+    renderOptions,
+  )
+}
+
+describe('SearchParamsCtx', () => {
+  it('initializes with expected defaults', () => {})
+})

--- a/packages/openneuro-app/src/scripts/refactor_2021/search/inputs/__tests__/sort-by-select.spec.tsx
+++ b/packages/openneuro-app/src/scripts/refactor_2021/search/inputs/__tests__/sort-by-select.spec.tsx
@@ -1,0 +1,56 @@
+import React from 'react'
+import { screen } from '@testing-library/react'
+import { searchRender } from '../../__tests__/search-params-ctx.spec'
+import SortBySelect from '../sort-by-select'
+import initialSearchParams from '../../initial-search-params'
+
+const providerProps = {
+  value: { searchParams: { ...initialSearchParams } },
+}
+
+describe('SortBySelect component', () => {
+  it('displays Newest when parameters are set to default', () => {
+    searchRender(<SortBySelect variables={{ query: { bool: {} } }} />, {
+      providerProps,
+    })
+    expect(screen.getByText('SORT BY:').closest('div')).toHaveTextContent(
+      'SORT BY: Newest',
+    )
+  })
+  it('displays Newest when parameters are set to default and modality has changed', () => {
+    searchRender(
+      <SortBySelect
+        variables={{
+          query: {
+            bool: {
+              filter: [
+                {
+                  match: {
+                    'latestSnapshot.summary.modalities': {
+                      query: 'MRI',
+                    },
+                  },
+                },
+              ],
+            },
+          },
+        }}
+      />,
+      {
+        providerProps,
+      },
+    )
+    expect(screen.getByText('SORT BY:').closest('div')).toHaveTextContent(
+      'SORT BY: Newest',
+    )
+  })
+  it('displays Relevance when any non-modality parameters are set away from default', () => {
+    searchRender(
+      <SortBySelect variables={{ query: { bool: { species: 'Human' } } }} />,
+      { providerProps },
+    )
+    expect(screen.getByText('SORT BY:').closest('div')).toHaveTextContent(
+      'SORT BY: Relevance',
+    )
+  })
+})

--- a/packages/openneuro-app/src/scripts/refactor_2021/search/inputs/__tests__/sort-by-select.spec.tsx
+++ b/packages/openneuro-app/src/scripts/refactor_2021/search/inputs/__tests__/sort-by-select.spec.tsx
@@ -53,4 +53,31 @@ describe('SortBySelect component', () => {
       'SORT BY: Relevance',
     )
   })
+  it('displays Relevance with age of participants set', () => {
+    searchRender(
+      <SortBySelect
+        variables={{
+          query: {
+            bool: {
+              filter: [
+                {
+                  range: {
+                    'latestSnapshot.summary.subjectMetadata.age': {
+                      gte: 10,
+                      lte: 100,
+                      relation: 'INTERSECTS',
+                    },
+                  },
+                },
+              ],
+            },
+          },
+        }}
+      />,
+      { providerProps },
+    )
+    expect(screen.getByText('SORT BY:').closest('div')).toHaveTextContent(
+      'SORT BY: Relevance',
+    )
+  })
 })

--- a/packages/openneuro-app/src/scripts/refactor_2021/search/inputs/sort-by-select.tsx
+++ b/packages/openneuro-app/src/scripts/refactor_2021/search/inputs/sort-by-select.tsx
@@ -2,7 +2,13 @@ import React, { FC, useContext } from 'react'
 import { SearchParamsCtx } from '../search-params-ctx'
 import { SearchSort } from '@openneuro/components/search-page'
 
-const SortBySelect: FC = () => {
+interface SortBySelectProps {
+  variables: any
+}
+
+const SortBySelect: FC<SortBySelectProps> = ({
+  variables,
+}: SortBySelectProps) => {
   const { searchParams, setSearchParams } = useContext(SearchParamsCtx)
 
   const { sortBy_available, sortBy_selected } = searchParams
@@ -12,13 +18,37 @@ const SortBySelect: FC = () => {
       sortBy_selected,
     }))
 
-  return (
-    <SearchSort
-      items={sortBy_available}
-      selected={sortBy_selected}
-      setSelected={setSortBy}
-    />
-  )
+  // If no query or only modality is set, ignore "relevance" option
+  if (
+    Object.keys(variables.query.bool).length === 0 ||
+    (Object.keys(variables.query.bool).length === 1 &&
+      variables.query.bool?.filter?.every(
+        f => f?.match['latestSnapshot.summary.modalities'],
+      ))
+  ) {
+    const available = sortBy_available.filter(
+      item => item.value !== 'relevance',
+    )
+    const selected =
+      sortBy_selected.value === 'relevance'
+        ? { label: 'Newest', value: 'newest' }
+        : sortBy_selected
+    return (
+      <SearchSort
+        items={available}
+        selected={selected}
+        setSelected={setSortBy}
+      />
+    )
+  } else {
+    return (
+      <SearchSort
+        items={sortBy_available}
+        selected={sortBy_selected}
+        setSelected={setSortBy}
+      />
+    )
+  }
 }
 
 export default SortBySelect

--- a/packages/openneuro-app/src/scripts/refactor_2021/search/inputs/sort-by-select.tsx
+++ b/packages/openneuro-app/src/scripts/refactor_2021/search/inputs/sort-by-select.tsx
@@ -23,7 +23,7 @@ const SortBySelect: FC<SortBySelectProps> = ({
     Object.keys(variables.query.bool).length === 0 ||
     (Object.keys(variables.query.bool).length === 1 &&
       variables.query.bool?.filter?.every(
-        f => f?.match['latestSnapshot.summary.modalities'],
+        f => f?.match?.['latestSnapshot.summary.modalities'],
       ))
   ) {
     const available = sortBy_available.filter(

--- a/packages/openneuro-app/src/scripts/refactor_2021/search/search-container.tsx
+++ b/packages/openneuro-app/src/scripts/refactor_2021/search/search-container.tsx
@@ -148,7 +148,7 @@ const SearchContainer: FC<SearchContainerProps> = ({ portalContent }) => {
             numTotalResults={numTotalResults}
           />
         )}
-        renderSortBy={() => <SortBySelect />}
+        renderSortBy={() => <SortBySelect variables={variables} />}
         renderSearchHeader={() => (
           <>
             {portalContent


### PR DESCRIPTION
If no search filters have been set, disable the relevance sort and show "Newest" instead.

Adds test coverage for this behavior and some test utils for testing search parameters generally.