### PR TITLE
feat(cli): Validate API key to catch extra characters and similar errors

### DIFF
--- a/packages/openneuro-cli/src/__tests__/validateApiKey.spec.js
+++ b/packages/openneuro-cli/src/__tests__/validateApiKey.spec.js
@@ -1,0 +1,14 @@
+import { validateApiKey } from '../validateApiKey'
+
+describe('validateApiKey()', () => {
+  it('succeeds silently with valid API key', () => {
+    expect(
+      validateApiKey(
+        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJlNmY2YWZlOC02MWZhLTRjYmUtOWNkYi1hMzkyN2U3MGJlMjciLCJlbWFpbCI6Im5lbGxAc3F1aXNoeW1lZGlhLmNvbSIsInByb3ZpZGVyIjoiZ29vZ2xlIiwibmFtZSI6Ik5lbGwgSGFyZGNhc3RsZSIsImFkbWluIjp0cnVlLCJpYXQiOjE2MzgzOTE1MDMsImV4cCI6MTY2OTkyNzUwM30.ijz_SSHXP03qtIr6Wm4QjtoI-9UGGPBxsEqFV4H-zCc',
+      ),
+    ).toBe(true)
+  })
+  it('raises exception on invalid API key formats', () => {
+    expect(typeof validateApiKey('joadfoij')).toBe('string')
+  })
+})

--- a/packages/openneuro-cli/src/actions.js
+++ b/packages/openneuro-cli/src/actions.js
@@ -8,6 +8,7 @@ import { getDatasetFiles, createDataset } from './datasets'
 import { getSnapshots } from './snapshots.js'
 import { getDownload } from './download.js'
 import { configuredClient } from './configuredClient.js'
+import { validateApiKey } from './validateApiKey'
 
 /**
  * Login action to save an auth key locally
@@ -35,6 +36,7 @@ export const login = () => {
           type: 'password',
           name: 'apikey',
           message: `Enter your API key for OpenNeuro (get an API key from ${answers.url}keygen)`,
+          validate: validateApiKey,
         }),
       ),
     )
@@ -259,7 +261,13 @@ export const download = (datasetId, destination, cmd) => {
       if (data.dataset && data.dataset.snapshots) {
         const tags = data.dataset.snapshots.map(snap => snap.tag)
         return promptTags(tags).then(choices =>
-          getDownload(destination, datasetId, choices.tag, apmTransaction, client),
+          getDownload(
+            destination,
+            datasetId,
+            choices.tag,
+            apmTransaction,
+            client,
+          ),
         )
       }
     })

--- a/packages/openneuro-cli/src/validateApiKey.js
+++ b/packages/openneuro-cli/src/validateApiKey.js
@@ -1,0 +1,14 @@
+import jwtDecode, { InvalidTokenError } from 'jwt-decode'
+
+export const validateApiKey = key => {
+  try {
+    jwtDecode(key)
+    return true
+  } catch (err) {
+    if (err instanceof InvalidTokenError) {
+      return "API key format is invalid, please make sure you've copied the correct key and try again."
+    } else {
+      throw err
+    }
+  }
+}


### PR DESCRIPTION
Provides user feedback when an invalid API key is added during `openneuro login`.

![image](https://user-images.githubusercontent.com/11369795/144314565-a4f01e34-3f97-4194-9057-ebc2ceb4db3f.png)

Fixes #2461 