### PR TITLE
fix(api): Return correct encoded URLs for S3 objects

### DIFF
--- a/services/datalad/datalad_service/common/annex.py
+++ b/services/datalad/datalad_service/common/annex.py
@@ -3,6 +3,7 @@ import io
 import json
 from mmap import mmap
 import subprocess
+import urllib.parse
 
 from sentry_sdk import capture_exception
 
@@ -116,6 +117,11 @@ def read_rmet_file(remote, catFile):
     return url
 
 
+def encode_remote_url(url):
+    """S3 requires some characters to be encoded"""
+    return urllib.parse.quote_plus(url, safe="/:?")
+
+
 def get_repo_urls(path, files):
     """For each file provided, obtain the rmet data and append URLs if possible."""
     # First obtain the git-annex branch objects
@@ -165,7 +171,8 @@ def get_repo_urls(path, files):
         for path in rmetPaths:
             url = read_rmet_file(remote, catFile)
             if url:
-                rmetFiles[path]['urls'].append(url)
+                encoded_url = encode_remote_url(url)
+                rmetFiles[path]['urls'].append(encoded_url)
     return files
 
 

--- a/services/datalad/tests/test_annex.py
+++ b/services/datalad/tests/test_annex.py
@@ -1,7 +1,7 @@
 import io
 
 from .dataset_fixtures import *
-from datalad_service.common.annex import parse_ls_tree_line, read_ls_tree_line, compute_rmet, parse_remote_line, parse_rmet_line, read_rmet_file
+from datalad_service.common.annex import parse_ls_tree_line, read_ls_tree_line, compute_rmet, parse_remote_line, parse_rmet_line, read_rmet_file, encode_remote_url
 
 expected_file_object = {
     'filename': 'dataset_description.json',
@@ -122,3 +122,8 @@ def test_read_rmet_file():
     1590213748.042921433s 57894849-d0c8-4c62-8418-3627be18a196:V +iVcEk18e3J2WQys4zr_ANaTPfpUufW4Y#ds002778/dataset_description.json""")
     url = read_rmet_file(remote, catFile)
     assert url == 'http://openneuro.org.s3.amazonaws.com/ds002778/dataset_description.json?versionId=iVcEk18e3J2WQys4zr_ANaTPfpUufW4Y'
+
+
+def test_remote_url_encoding():
+    assert encode_remote_url(
+        "https://s3.amazonaws.com/openneuro.org/ds000248/derivatives/freesurfer/subjects/sub-01/mri/aparc+aseg.mgz?versionId=2Wx7w.fCYeGzGWLnW9sxWsPdztl.2HL0") == "https://s3.amazonaws.com/openneuro.org/ds000248/derivatives/freesurfer/subjects/sub-01/mri/aparc%2Baseg.mgz?versionId%3D2Wx7w.fCYeGzGWLnW9sxWsPdztl.2HL0"


### PR DESCRIPTION
The actual S3 path for these files is the urlencoded form, so the unencoded URL is accurate but does not actually work.

Fixes #2400 