### PR TITLE
fix(app): Correct clickable area for add files / add directories to file tree

### DIFF
--- a/packages/openneuro-app/src/scripts/refactor_2021/dataset/files/file-tree.jsx
+++ b/packages/openneuro-app/src/scripts/refactor_2021/dataset/files/file-tree.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React from 'react'
 import PropTypes from 'prop-types'
 import File from './file.jsx'
 import UpdateFile from '../mutations/update-file.jsx'
@@ -41,13 +41,14 @@ const FileTree = ({
             <UpdateFile
               datasetId={datasetId}
               path={unescapePath(path)}
+              tooltip={`Choose one or more files to be added to ${name}.`}
               multiple>
               <i className="fa fa-plus" /> Add Files
             </UpdateFile>
             <UpdateFile
               datasetId={datasetId}
               path={unescapePath(path)}
-              tooltip={`Choose a folder to be added to /${name}. Adding a folder with an existing name will overwrite that folder.`}
+              tooltip={`Choose a folder to be added to ${name}. Adding a folder with an existing name will overwrite that folder.`}
               directory>
               <i className="fa fa-plus" /> Add Directory
             </UpdateFile>

--- a/packages/openneuro-app/src/scripts/refactor_2021/dataset/mutations/update-file.jsx
+++ b/packages/openneuro-app/src/scripts/refactor_2021/dataset/mutations/update-file.jsx
@@ -30,8 +30,8 @@ const UpdateFile = ({
               webkitdirectory={directory && 'true'}
               multiple={multiple && true}
             />
+            {children}
           </Tooltip>
-          {children}
         </div>
       )}
     </UploaderContext.Consumer>


### PR DESCRIPTION
This fixes a bug where sometimes in larger file trees, the add files button would become unclickable because the active area was hidden by the tooltip component.