### PR TITLE
fix: Add = character to excluded encodings in S3 URLs

### DIFF
--- a/services/datalad/datalad_service/common/annex.py
+++ b/services/datalad/datalad_service/common/annex.py
@@ -119,7 +119,7 @@ def read_rmet_file(remote, catFile):
 
 def encode_remote_url(url):
     """S3 requires some characters to be encoded"""
-    return urllib.parse.quote_plus(url, safe="/:?")
+    return urllib.parse.quote_plus(url, safe="/:?=")
 
 
 def get_repo_urls(path, files):

--- a/services/datalad/tests/test_annex.py
+++ b/services/datalad/tests/test_annex.py
@@ -126,4 +126,7 @@ def test_read_rmet_file():
 
 def test_remote_url_encoding():
     assert encode_remote_url(
-        "https://s3.amazonaws.com/openneuro.org/ds000248/derivatives/freesurfer/subjects/sub-01/mri/aparc+aseg.mgz?versionId=2Wx7w.fCYeGzGWLnW9sxWsPdztl.2HL0") == "https://s3.amazonaws.com/openneuro.org/ds000248/derivatives/freesurfer/subjects/sub-01/mri/aparc%2Baseg.mgz?versionId%3D2Wx7w.fCYeGzGWLnW9sxWsPdztl.2HL0"
+        "https://s3.amazonaws.com/openneuro.org/ds000248/derivatives/freesurfer/subjects/sub-01/mri/aparc+aseg.mgz?versionId=2Wx7w.fCYeGzGWLnW9sxWsPdztl.2HL0") == "https://s3.amazonaws.com/openneuro.org/ds000248/derivatives/freesurfer/subjects/sub-01/mri/aparc%2Baseg.mgz?versionId=2Wx7w.fCYeGzGWLnW9sxWsPdztl.2HL0"
+    assert encode_remote_url(
+        "https://s3.amazonaws.com/openneuro.org/ds000248/sub-01/anat/sub-01_T1w.nii.gz?versionId=8uTXIQ10Blcp2GeAVJJCHL5PimkSaQZL") == "https://s3.amazonaws.com/openneuro.org/ds000248/sub-01/anat/sub-01_T1w.nii.gz?versionId=8uTXIQ10Blcp2GeAVJJCHL5PimkSaQZL"
+    assert encode_remote_url("=") == '='


### PR DESCRIPTION
Fix for #2521 