### PR TITLE
fix: Correct @openneuro/client entrypoint for CJS uses

### DIFF
--- a/packages/openneuro-client/package.json
+++ b/packages/openneuro-client/package.json
@@ -5,7 +5,8 @@
   "main": "dist/index.js",
   "browser": "src/index.js",
   "exports": {
-    ".": "./src/index.js"
+    "import": "./src/index.js",
+    "require": "./dist/index.js"
   },
   "repository": "git@github.com:OpenNeuroOrg/openneuro.git",
   "author": "Squishymedia",


### PR DESCRIPTION
Looks like this behavior changed when the indexer was updated to Node 16.