### PR TITLE
fix(upload): Avoid uploading ._ prefixed files created by macOS

### DIFF
--- a/packages/openneuro-server/src/datalad/__tests__/dataset.spec.js
+++ b/packages/openneuro-server/src/datalad/__tests__/dataset.spec.js
@@ -95,10 +95,16 @@ describe('dataset model operations', () => {
         expect(testBlacklist('.git', 'HEAD')).toBe(true)
       })
       it('returns true for root level .DS_Store files', () => {
-        expect(testBlacklist('', '.DS_Store'))
+        expect(testBlacklist('', '.DS_Store')).toBe(true)
       })
       it('returns true for nested .DS_Store files', () => {
-        expect(testBlacklist('sub-01/anat/', '.DS_Store'))
+        expect(testBlacklist('sub-01/anat/', '.DS_Store')).toBe(true)
+      })
+      // https://github.com/OpenNeuroOrg/openneuro/issues/2519
+      it('skips ._ prefixed files created by macOS', () => {
+        expect(testBlacklist('', '._.DS_Store')).toBe(true)
+        expect(testBlacklist('stimuli/', '._1002.png')).toBe(true)
+        expect(testBlacklist('stimuli/', 'test._1002.png')).toBe(false)
       })
     })
   })

--- a/packages/openneuro-server/src/datalad/dataset.js
+++ b/packages/openneuro-server/src/datalad/dataset.js
@@ -298,7 +298,7 @@ export const getDatasets = options => {
 }
 
 // Files to skip in uploads
-const filenameBlacklist = new RegExp(/.DS_Store|Icon\r/)
+const filenameBlacklist = new RegExp(/.DS_Store|Icon\r|^\._/)
 const pathBlacklist = new RegExp(/^.git|^.gitattributes|^.datalad|^.heudiconv/)
 export const testBlacklist = (path, filename) =>
   filenameBlacklist.test(filename) || pathBlacklist.test(path)


### PR DESCRIPTION
Adds test coverage and filtering for the files reported in #2519