### PR TITLE
fix(app): Prevent component crash when rendering dataset missing authors

### DIFF
--- a/packages/openneuro-app/src/scripts/refactor_2021/dataset/draft-container.tsx
+++ b/packages/openneuro-app/src/scripts/refactor_2021/dataset/draft-container.tsx
@@ -235,7 +235,7 @@ const DraftContainer: React.FC<DraftContainerProps> = ({ dataset }) => {
               heading="Authors"
               description={description.Authors}
               editMode={hasEdit}>
-              {description.Authors?.length ? description.Authors : ['N/A']}
+              {description?.Authors?.length ? description.Authors : ['N/A']}
             </EditDescriptionList>
 
             {summary && (

--- a/packages/openneuro-app/src/scripts/refactor_2021/dataset/snapshot-container.tsx
+++ b/packages/openneuro-app/src/scripts/refactor_2021/dataset/snapshot-container.tsx
@@ -214,7 +214,7 @@ const SnapshotContainer: React.FC<SnapshotContainerProps> = ({
             <MetaDataBlock
               heading="Authors"
               item={
-                description.Authors.length
+                description?.Authors?.length
                   ? description.Authors.join(', ')
                   : 'N/A'
               }


### PR DESCRIPTION
Handles the case where no authors value is present in dataset_description.json.