### PR TITLE
feat: Use versioned URLs for Brainlife links

### DIFF
--- a/packages/openneuro-app/src/scripts/datalad/dataset/dataset-query-fragments.js
+++ b/packages/openneuro-app/src/scripts/datalad/dataset/dataset-query-fragments.js
@@ -190,6 +190,7 @@ export const SNAPSHOT_FIELDS = gql`
     }
     ...SnapshotIssues
     hexsha
+    onBrainlife
   }
   ${SNAPSHOT_ISSUES}
 `

--- a/packages/openneuro-app/src/scripts/refactor_2021/dataset/dataset-query.jsx
+++ b/packages/openneuro-app/src/scripts/refactor_2021/dataset/dataset-query.jsx
@@ -106,7 +106,6 @@ export const getDraftPage = gql`
         downloads
         views
       }
-      onBrainlife
     }
   }
   ${DatasetQueryFragments.DRAFT_FRAGMENT}

--- a/packages/openneuro-app/src/scripts/refactor_2021/dataset/snapshot-container.tsx
+++ b/packages/openneuro-app/src/scripts/refactor_2021/dataset/snapshot-container.tsx
@@ -145,7 +145,8 @@ const SnapshotContainer: React.FC<SnapshotContainerProps> = ({
         renderBrainLifeButton={() => (
           <BrainLifeButton
             datasetId={datasetId}
-            onBrainlife={dataset.onBrainlife}
+            onBrainlife={snapshot.onBrainlife}
+            snapshotVersion={snapshot.tag}
           />
         )}
         renderValidationBlock={() => (

--- a/packages/openneuro-components/src/dataset/BrainLifeButton.tsx
+++ b/packages/openneuro-components/src/dataset/BrainLifeButton.tsx
@@ -4,16 +4,18 @@ import { Button } from '../button/Button'
 
 export interface BrainLifeButtonProps {
   datasetId: string
+  snapshotVersion?: string
   onBrainlife: boolean
 }
 
 export const BrainLifeButton: React.FC<BrainLifeButtonProps> = ({
   datasetId,
+  snapshotVersion,
   onBrainlife,
 }) => {
-  const goToBrainlife = datasetId => {
-    window.open(`https://brainlife.io/openneuro/${datasetId}`, '_blank')
-  }
+  const url = snapshotVersion
+    ? `https://brainlife.io/openneuro/${datasetId}/${snapshotVersion}`
+    : `https://brainlife.io/openneuro/${datasetId}`
   return (
     <>
       {onBrainlife && (
@@ -23,7 +25,9 @@ export const BrainLifeButton: React.FC<BrainLifeButtonProps> = ({
               className="brainlife-link"
               primary={true}
               size="small"
-              onClick={() => goToBrainlife(datasetId)}
+              onClick={() => {
+                window.open(url, '_blank')
+              }}
               label="brainlife.io"
             />
           </Tooltip>

--- a/packages/openneuro-server/src/graphql/resolvers/dataset.js
+++ b/packages/openneuro-server/src/graphql/resolvers/dataset.js
@@ -287,13 +287,24 @@ export const starred = (obj, _, { user }) =>
 /**
  * Is this dataset available on brainlife?
  */
-export const onBrainlife = async dataset => {
+export const onBrainlife = async datasetOrSnapshot => {
   try {
-    const url = `https://brainlife.io/api/warehouse/datalad/datasets?find={"path":{"$regex":"${dataset.id}$"}}`
+    const find = {
+      removed: false,
+    }
+    if (datasetOrSnapshot.tag) {
+      find.path = { $regex: '^OpenNeuro/' + datasetOrSnapshot.id.split(':')[0] }
+      find.version = datasetOrSnapshot.tag
+    } else {
+      find.path = { $regex: '^OpenNeuro/' + datasetOrSnapshot.id }
+    }
+    const url = `https://brainlife.io/api/warehouse/datalad/datasets?find=${JSON.stringify(
+      find,
+    )}`
     const res = await fetch(url)
     const body = await res.json()
     if (Array.isArray(body) && body.length) {
-      return body[0].path === `OpenNeuroDatasets/${dataset.id}`
+      return true
     } else {
       return false
     }

--- a/packages/openneuro-server/src/graphql/resolvers/snapshots.js
+++ b/packages/openneuro-server/src/graphql/resolvers/snapshots.js
@@ -1,5 +1,10 @@
 import * as datalad from '../../datalad/snapshots.js'
-import { dataset, analytics, snapshotCreationComparison } from './dataset.js'
+import {
+  dataset,
+  analytics,
+  snapshotCreationComparison,
+  onBrainlife,
+} from './dataset.js'
 import { checkDatasetRead, checkDatasetWrite } from '../permissions.js'
 import { readme } from './readme.js'
 import { description } from './description.js'
@@ -32,6 +37,7 @@ export const snapshot = (obj, { datasetId, tag }, context) => {
             .then(filterRemovedAnnexObjects(datasetId, context.userInfo)),
         deprecated: () => deprecated({ datasetId, tag }),
         related: () => related(datasetId),
+        onBrainlife,
       }))
     },
   )

--- a/packages/openneuro-server/src/graphql/schema.js
+++ b/packages/openneuro-server/src/graphql/schema.js
@@ -459,6 +459,8 @@ export const typeDefs = `
     deprecated: DeprecatedSnapshot
     # Related DOI references
     related: [RelatedObject]
+    # Is the snapshot available for analysis on Brainlife?
+    onBrainlife: Boolean @cacheControl(maxAge: 10080, scope: PUBLIC)
   }
 
   # RelatedObject nature of relationship


### PR DESCRIPTION
* Adds the onBrainlife field to snapshots.
* Updates the snapshot pages to link to the versioned Brainlife URL.

Fixes #2539