### PR TITLE
refactor(server): Add better type coverage and tests for Brainlife resolver

### DIFF
--- a/packages/openneuro-server/src/datalad/description.js
+++ b/packages/openneuro-server/src/datalad/description.js
@@ -9,7 +9,7 @@ import { fileUrl, getFiles } from './files.js'
 import { generateDataladCookie } from '../libs/authentication/jwt'
 import { getDatasetWorker } from '../libs/datalad-service'
 import CacheItem, { CacheType } from '../cache/item'
-import { datasetOrSnapshot } from './utils.js'
+import { datasetOrSnapshot } from '../utils/datasetOrSnapshot'
 
 export const defaultDescription = {
   Name: 'Unnamed Dataset',

--- a/packages/openneuro-server/src/datalad/readme.js
+++ b/packages/openneuro-server/src/datalad/readme.js
@@ -3,7 +3,7 @@ import { addFileString, commitFiles } from './dataset'
 import { redis } from '../libs/redis'
 import CacheItem, { CacheType } from '../cache/item'
 import { getDatasetWorker } from '../libs/datalad-service'
-import { datasetOrSnapshot } from './utils.js'
+import { datasetOrSnapshot } from '../utils/datasetOrSnapshot'
 
 export const readmeUrl = (datasetId, revision) => {
   return `http://${getDatasetWorker(

--- a/packages/openneuro-server/src/datalad/utils.js
+++ b/packages/openneuro-server/src/datalad/utils.js
@@ -23,15 +23,3 @@ export const addFileUrl = (datasetId, tag) => file => {
     }
   }
 }
-
-/**
- * Helper for resolvers with dataset and snapshot parents
- * @param {object} obj A snapshot or dataset parent object
- */
-export function datasetOrSnapshot(obj) {
-  if ('tag' in obj) {
-    return { datasetId: obj.id.split(':')[0], revision: obj.hexsha || obj.tag }
-  } else {
-    return { datasetId: obj.id, revision: obj.revision }
-  }
-}

--- a/packages/openneuro-server/src/graphql/resolvers/__tests__/brainlife.spec.ts
+++ b/packages/openneuro-server/src/graphql/resolvers/__tests__/brainlife.spec.ts
@@ -1,0 +1,17 @@
+import { HasId } from '../../../utils/datasetOrSnapshot'
+import { brainlifeQuery } from '../brainlife'
+
+describe('brainlife resolvers', () => {
+  it('correctly queries drafts', () => {
+    expect(brainlifeQuery({ id: 'ds000001' } as HasId).toString()).toEqual(
+      'https://brainlife.io/api/warehouse/datalad/datasets?find=%7B%22removed%22%3Afalse%2C%22path%22%3A%7B%22%24regex%22%3A%22%5EOpenNeuro%2Fds000001%22%7D%7D',
+    )
+  })
+  it('correctly queries versioned datasets', () => {
+    expect(
+      brainlifeQuery({ id: 'ds000001:1.0.0', tag: '1.0.0' }).toString(),
+    ).toEqual(
+      'https://brainlife.io/api/warehouse/datalad/datasets?find=%7B%22removed%22%3Afalse%2C%22path%22%3A%7B%22%24regex%22%3A%22%5EOpenNeuro%2Fds000001%22%7D%2C%22version%22%3A%221.0.0%22%7D',
+    )
+  })
+})

--- a/packages/openneuro-server/src/graphql/resolvers/__tests__/dataset.spec.js
+++ b/packages/openneuro-server/src/graphql/resolvers/__tests__/dataset.spec.js
@@ -179,5 +179,4 @@ describe('dataset resolvers', () => {
       ).then(() => done())
     })
   })
-  describe('onBrainlife', () => {})
 })

--- a/packages/openneuro-server/src/graphql/resolvers/__tests__/dataset.spec.js
+++ b/packages/openneuro-server/src/graphql/resolvers/__tests__/dataset.spec.js
@@ -179,4 +179,5 @@ describe('dataset resolvers', () => {
       ).then(() => done())
     })
   })
+  describe('onBrainlife', () => {})
 })

--- a/packages/openneuro-server/src/graphql/resolvers/dataset.js
+++ b/packages/openneuro-server/src/graphql/resolvers/dataset.js
@@ -22,6 +22,7 @@ import { UpdatedFile } from '../utils/file.js'
 import { getDatasetWorker } from '../../libs/datalad-service.js'
 import { getDraftHead } from '../../datalad/dataset.js'
 import { getFileName } from '../../datalad/files.js'
+import { onBrainlife } from './brainlife'
 import semver from 'semver'
 
 export const dataset = async (obj, { id }, { user, userInfo }) => {
@@ -283,35 +284,6 @@ export const starred = (obj, _, { user }) =>
   user
     ? datalad.getUserStarred(obj.id, user).then(res => (res ? true : false))
     : null
-
-/**
- * Is this dataset available on brainlife?
- */
-export const onBrainlife = async datasetOrSnapshot => {
-  try {
-    const find = {
-      removed: false,
-    }
-    if (datasetOrSnapshot.tag) {
-      find.path = { $regex: '^OpenNeuro/' + datasetOrSnapshot.id.split(':')[0] }
-      find.version = datasetOrSnapshot.tag
-    } else {
-      find.path = { $regex: '^OpenNeuro/' + datasetOrSnapshot.id }
-    }
-    const url = `https://brainlife.io/api/warehouse/datalad/datasets?find=${JSON.stringify(
-      find,
-    )}`
-    const res = await fetch(url)
-    const body = await res.json()
-    if (Array.isArray(body) && body.length) {
-      return true
-    } else {
-      return false
-    }
-  } catch (err) {
-    return false
-  }
-}
 
 const worker = obj => getDatasetWorker(obj.id)
 

--- a/packages/openneuro-server/src/graphql/resolvers/snapshots.js
+++ b/packages/openneuro-server/src/graphql/resolvers/snapshots.js
@@ -1,10 +1,6 @@
 import * as datalad from '../../datalad/snapshots.js'
-import {
-  dataset,
-  analytics,
-  snapshotCreationComparison,
-  onBrainlife,
-} from './dataset.js'
+import { dataset, analytics, snapshotCreationComparison } from './dataset.js'
+import { onBrainlife } from './brainlife'
 import { checkDatasetRead, checkDatasetWrite } from '../permissions.js'
 import { readme } from './readme.js'
 import { description } from './description.js'
@@ -37,7 +33,7 @@ export const snapshot = (obj, { datasetId, tag }, context) => {
             .then(filterRemovedAnnexObjects(datasetId, context.userInfo)),
         deprecated: () => deprecated({ datasetId, tag }),
         related: () => related(datasetId),
-        onBrainlife,
+        onBrainlife: () => onBrainlife(snapshot),
       }))
     },
   )

--- a/packages/openneuro-server/src/models/snapshot.ts
+++ b/packages/openneuro-server/src/models/snapshot.ts
@@ -2,6 +2,7 @@ import mongoose, { Document } from 'mongoose'
 const { Schema, model } = mongoose
 
 export interface SnapshotDocument extends Document {
+  id: string
   datasetId: string
   tag: string
   created: Date

--- a/packages/openneuro-server/src/utils/__tests__/datasetOrSnapshot.spec.ts
+++ b/packages/openneuro-server/src/utils/__tests__/datasetOrSnapshot.spec.ts
@@ -1,4 +1,7 @@
-import { datasetOrSnapshot } from '../utils.js'
+import {
+  datasetOrSnapshot,
+  getDatasetFromSnapshotId,
+} from '../datasetOrSnapshot'
 
 describe('datasetOrSnapshot()', () => {
   it('resolves a dataset object correctly', () => {
@@ -37,6 +40,11 @@ describe('datasetOrSnapshot()', () => {
     expect(datasetOrSnapshot(snapshot)).toEqual({
       datasetId: 'ds000002',
       revision: '1.0.1',
+    })
+  })
+  describe('getDatasetFromSnapshotId', () => {
+    it('extracts the datasetId correctly', () => {
+      expect(getDatasetFromSnapshotId('ds000001:1.0.0')).toBe('ds000001')
     })
   })
 })

--- a/packages/openneuro-server/src/utils/datasetOrSnapshot.ts
+++ b/packages/openneuro-server/src/utils/datasetOrSnapshot.ts
@@ -1,0 +1,42 @@
+export interface HasId {
+  id: string
+  revision: string
+}
+
+export interface HasSnapshotId {
+  id: string
+  tag: string
+  hexsha?: string
+}
+
+export interface DatasetRevisionReference {
+  datasetId: string
+  revision: string
+}
+
+export type DatasetOrSnapshot = HasId | HasSnapshotId
+
+/**
+ * Helper for resolvers with dataset and snapshot parents
+ * @param {object} obj A snapshot or dataset parent object
+ */
+export function datasetOrSnapshot(
+  obj: DatasetOrSnapshot,
+): DatasetRevisionReference {
+  if ('tag' in obj) {
+    return {
+      datasetId: getDatasetFromSnapshotId(obj.id),
+      revision: obj.hexsha || obj.tag,
+    }
+  } else {
+    return { datasetId: obj.id, revision: obj.revision }
+  }
+}
+
+/**
+ * @param snapshotId 'ds000001:1.0.0' style snapshot ID
+ * @returns {string} Dataset id portion 'ds000001'
+ */
+export function getDatasetFromSnapshotId(snapshotId: string): string {
+  return snapshotId.split(':')[0]
+}


### PR DESCRIPTION
* Creates types for DatasetOrSnapshot and DatasetRevisionReference which are used in various places in the server implementation but had not been defined as types.
* Converts the Brainlife resolver to use these and moves it to its own module.
* Fixes a bug (pointed out by typechecking) with the resolver used on the GraphQL Snapshot type.