### PR TITLE
ENH: Show orientation markers on NIfTI images

### DIFF
--- a/packages/openneuro-app/src/scripts/common/partials/papaya.jsx
+++ b/packages/openneuro-app/src/scripts/common/partials/papaya.jsx
@@ -25,6 +25,7 @@ class Papaya extends React.Component {
       allowScroll: false,
       fullScreenPadding: false,
       showControlBar: true,
+      showOrientation: true,
       images: [this.props.image],
       kioskMode: true,
     }


### PR DESCRIPTION
From my reading of https://github.com/rii-mango/Papaya/wiki/Configuration#display-parameters, this should show L/R, P/A, and I/S markers on the images, to help users determine whether they are viewing as radiological vs neurological, and detect orientation errors.