### PR TITLE
fix(server): Prevent undefined fetch reference error in brainlife resolver

### DIFF
--- a/packages/openneuro-server/src/graphql/resolvers/brainlife.ts
+++ b/packages/openneuro-server/src/graphql/resolvers/brainlife.ts
@@ -1,3 +1,4 @@
+import fetch from 'node-fetch'
 import {
   DatasetOrSnapshot,
   getDatasetFromSnapshotId,


### PR DESCRIPTION
Fixes a missing import in the Brainlife snapshot resolver.