### PR TITLE
fix(cli): Remove obsolete win32 restriction and bump required Node to 16

### DIFF
--- a/packages/openneuro-cli/package.json
+++ b/packages/openneuro-cli/package.json
@@ -5,11 +5,8 @@
   "main": "index.js",
   "repository": "git@github.com:OpenNeuroOrg/openneuro.git",
   "engines": {
-    "node": ">=12.9.0"
+    "node": ">=16.0.0"
   },
-  "os": [
-    "!win32"
-  ],
   "author": "Squishymedia",
   "license": "MIT",
   "bin": {


### PR DESCRIPTION
Updates the CLI package requirements to reflect the current minimum requirements correctly.