### PR TITLE
Show file size in dataset file tree

### DIFF
--- a/packages/openneuro-app/src/scripts/dataset/files/__tests__/__snapshots__/file.spec.jsx.snap
+++ b/packages/openneuro-app/src/scripts/dataset/files/__tests__/__snapshots__/file.spec.jsx.snap
@@ -22,7 +22,7 @@ exports[`File component renders for dataset snapshots 1`] = `
       <span
         class=" "
         data-flow="up"
-        data-tooltip="Download"
+        data-tooltip="Download: 500B"
       >
         <span
           class="edit-file download-file"
@@ -83,7 +83,7 @@ exports[`File component renders with common props 1`] = `
       <span
         class=" "
         data-flow="up"
-        data-tooltip="Download"
+        data-tooltip="Download: 500B"
       >
         <span
           class="edit-file download-file"

--- a/packages/openneuro-app/src/scripts/dataset/files/__tests__/file.spec.jsx
+++ b/packages/openneuro-app/src/scripts/dataset/files/__tests__/file.spec.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { render, screen } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
-import File from '../file.jsx'
+import File from '../file'
 
 describe('File component', () => {
   it('renders with common props', () => {

--- a/packages/openneuro-app/src/scripts/dataset/files/__tests__/file.spec.jsx
+++ b/packages/openneuro-app/src/scripts/dataset/files/__tests__/file.spec.jsx
@@ -6,20 +6,26 @@ import File from '../file'
 describe('File component', () => {
   it('renders with common props', () => {
     const { asFragment } = render(
-      <File datasetId="ds001" path="" filename="README" />,
+      <File datasetId="ds001" path="" filename="README" size={500} />,
       { wrapper: MemoryRouter },
     )
     expect(asFragment()).toMatchSnapshot()
   })
   it('renders for dataset snapshots', () => {
     const { asFragment } = render(
-      <File datasetId="ds001" snapshotTag="1.0.0" path="" filename="README" />,
+      <File
+        datasetId="ds001"
+        snapshotTag="1.0.0"
+        path=""
+        filename="README"
+        size={500}
+      />,
       { wrapper: MemoryRouter },
     )
     expect(asFragment()).toMatchSnapshot()
   })
   it('generates correct download links for top level files', () => {
-    render(<File datasetId="ds001" path="" filename="README" />, {
+    render(<File datasetId="ds001" path="" filename="README" size={500} />, {
       wrapper: MemoryRouter,
     })
     expect(screen.getByRole('link', { name: 'download file' })).toHaveAttribute(
@@ -33,6 +39,7 @@ describe('File component', () => {
         datasetId="ds001"
         path="sub-01:anat"
         filename="sub-01_T1w.nii.gz"
+        size={2000000}
       />,
       { wrapper: MemoryRouter },
     )

--- a/packages/openneuro-app/src/scripts/dataset/files/file-display.jsx
+++ b/packages/openneuro-app/src/scripts/dataset/files/file-display.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { Link } from 'react-router-dom'
 import FileView from './file-view.jsx'
-import { apiPath } from './file.jsx'
+import { apiPath } from './file'
 import styled from '@emotion/styled'
 import { Media } from '../../styles/media'
 

--- a/packages/openneuro-app/src/scripts/dataset/files/file-tree.jsx
+++ b/packages/openneuro-app/src/scripts/dataset/files/file-tree.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import File from './file.jsx'
+import File from './file'
 import UpdateFile from '../mutations/update-file.jsx'
 import DeleteDir from '../mutations/delete-dir.jsx'
 import FileTreeUnloadedDirectory from './file-tree-unloaded-directory.jsx'
@@ -66,6 +66,7 @@ const FileTree = ({
               datasetId={datasetId}
               snapshotTag={snapshotTag}
               path={path}
+              size={file.size}
               editMode={editMode}
               toggleFileToDelete={toggleFileToDelete}
               isFileToBeDeleted={isFileToBeDeleted}

--- a/packages/openneuro-app/src/scripts/dataset/files/file-view.jsx
+++ b/packages/openneuro-app/src/scripts/dataset/files/file-view.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react'
 import { Loading } from '@openneuro/components/loading'
-import { apiPath } from './file.jsx'
+import { apiPath } from './file'
 import FileViewerType from './file-viewer-type.jsx'
 
 const FileView = ({ datasetId, snapshotTag, path }) => {

--- a/packages/openneuro-app/src/scripts/dataset/files/file.tsx
+++ b/packages/openneuro-app/src/scripts/dataset/files/file.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import PropTypes from 'prop-types'
+import bytes from 'bytes'
 import { Link } from 'react-router-dom'
 import UpdateFile from '../mutations/update-file.jsx'
 import DeleteFile from '../mutations/delete-file.jsx'
@@ -79,8 +79,33 @@ export const apiPath = (datasetId, snapshotTag, filePath) => {
   return `/crn/datasets/${datasetId}${snapshotPath}/files/${filePath}`
 }
 
+interface FileProps {
+  id: string
+  size: number
+  datasetId: string
+  path: string
+  filename: string
+  snapshotTag: string
+  editMode: boolean
+  isMobile: boolean
+  annexed: boolean
+  annexKey: string
+  datasetPermissions: string[]
+  toggleFileToDelete: ({
+    id,
+    path,
+    filename,
+  }: {
+    id: string
+    path: string
+    filename: string
+  }) => boolean
+  isFileToBeDeleted: (id: string) => boolean
+}
+
 const File = ({
   id,
+  size,
   datasetId,
   path,
   filename,
@@ -92,7 +117,7 @@ const File = ({
   datasetPermissions,
   toggleFileToDelete,
   isFileToBeDeleted,
-}) => {
+}: FileProps) => {
   const { icon, color } = getFileIcon(filename)
   const snapshotVersionPath = snapshotTag ? `/versions/${snapshotTag}` : ''
   // React route to display the file
@@ -109,7 +134,7 @@ const File = ({
       {filename}
       <span className="filetree-editfile">
         <Media greaterThanOrEqual="medium">
-          <Tooltip tooltip="Download">
+          <Tooltip tooltip={`Download: ${bytes.format(size) as string}`}>
             <span className="edit-file download-file">
               <a
                 href={apiPath(datasetId, snapshotTag, filePath(path, filename))}
@@ -131,7 +156,7 @@ const File = ({
           <Media greaterThanOrEqual="medium">
             <Tooltip tooltip="Update">
               <UpdateFile datasetId={datasetId} path={path}>
-                <i className="fa fa-file-o" />
+                <i className="fa fa-cloud-upload" />
               </UpdateFile>
             </Tooltip>
           </Media>
@@ -203,14 +228,6 @@ const File = ({
       </span>
     </>
   )
-}
-
-File.propTypes = {
-  datasetId: PropTypes.string,
-  path: PropTypes.string,
-  filename: PropTypes.string,
-  snapshotTag: PropTypes.string,
-  editMode: PropTypes.bool,
 }
 
 export default File


### PR DESCRIPTION
Adds the file size in human readable sizes as part of the download link tooltip.

Fixes #2510