### PR TITLE
feat(api): Add size field to drafts and snapshots

### DIFF
--- a/packages/openneuro-server/src/datalad/__tests__/files.spec.js
+++ b/packages/openneuro-server/src/datalad/__tests__/files.spec.js
@@ -3,6 +3,7 @@ import {
   decodeFilePath,
   fileUrl,
   filterFiles,
+  computeTotalSize,
 } from '../files.js'
 
 jest.mock('../../config.js')
@@ -103,5 +104,17 @@ describe('datalad files', () => {
     it('works correctly for deeply nested files', () => {
       expect(filterFiles('sub-01/func')(mockFiles)).toEqual([mockSub01[1]])
     })
+  })
+  describe('computeTotalSize()', () => {
+    const mockFileSizes = [
+      { filename: 'README', size: 234 },
+      { filename: 'dataset_description.json', size: 432 },
+      { filename: 'sub-01/anat/sub-01_T1w.nii.gz', size: 10858 },
+      {
+        filename: 'sub-01/func/sub-01_task-onebacktask_run-01_bold.nii.gz',
+        size: 1945682,
+      },
+    ]
+    expect(computeTotalSize(mockFileSizes)).toBe(1957206)
   })
 })

--- a/packages/openneuro-server/src/datalad/description.js
+++ b/packages/openneuro-server/src/datalad/description.js
@@ -127,6 +127,7 @@ export const description = obj => {
   return cache
     .get(() => {
       return getFiles(datasetId, revision)
+        .then(response => response.files)
         .then(getDescriptionObject(datasetId))
         .then(uncachedDescription => ({ id: revision, ...uncachedDescription }))
     })

--- a/packages/openneuro-server/src/datalad/files.js
+++ b/packages/openneuro-server/src/datalad/files.js
@@ -52,6 +52,12 @@ export const filesUrl = datasetId =>
   `http://${getDatasetWorker(datasetId)}/datasets/${datasetId}/files`
 
 /**
+ * Sum all file sizes for total dataset size
+ */
+export const computeTotalSize = files =>
+  files.reduce((size, f) => size + f.size, 0)
+
+/**
  * Get files for a specific revision
  * Similar to getDraftFiles but different cache key and fixed revisions
  * @param {string} datasetId - Dataset accession number
@@ -75,7 +81,11 @@ export const getFiles = (datasetId, hexsha) => {
           const {
             body: { files },
           } = response
-          return files.map(addFileUrl(datasetId, hexsha))
+          const size = computeTotalSize(files)
+          return {
+            files: files.map(addFileUrl(datasetId, hexsha)),
+            size,
+          }
         }
       }),
   )

--- a/packages/openneuro-server/src/datalad/snapshots.js
+++ b/packages/openneuro-server/src/datalad/snapshots.js
@@ -154,7 +154,9 @@ export const createSnapshot = async (
       snapshotChanges,
     )
     snapshot.created = new Date()
-    snapshot.files = await getFiles(datasetId, tag)
+    const { files, size } = await getFiles(datasetId, tag)
+    snapshot.files = files
+    snapshot.size = size
 
     await Promise.all([
       // Update the draft status in datasets collection in case any changes were made (DOI, License)

--- a/packages/openneuro-server/src/graphql/resolvers/draft.js
+++ b/packages/openneuro-server/src/graphql/resolvers/draft.js
@@ -10,9 +10,15 @@ import { filterRemovedAnnexObjects } from '../utils/file.js'
 // A draft must have a dataset parent
 const draftFiles = async (dataset, args, { userInfo }) => {
   const hexsha = await getDraftRevision(dataset.id)
-  const files = await getFiles(dataset.id, hexsha)
+  const { files } = await getFiles(dataset.id, hexsha)
   const prefixFiltered = filterFiles('prefix' in args && args.prefix)(files)
   return filterRemovedAnnexObjects(dataset.id, userInfo)(prefixFiltered)
+}
+
+const draftSize = async (dataset, args, { userInfo }) => {
+  const hexsha = await getDraftRevision(dataset.id)
+  const { size } = await getFiles(dataset.id, hexsha)
+  return size
 }
 
 /**
@@ -39,6 +45,7 @@ export const revalidate = async (obj, { datasetId }, { user, userInfo }) => {
 const draft = {
   id: obj => obj.id,
   files: draftFiles,
+  size: draftSize,
   summary,
   issues,
   modified: obj => obj.modified,

--- a/packages/openneuro-server/src/graphql/resolvers/snapshots.js
+++ b/packages/openneuro-server/src/graphql/resolvers/snapshots.js
@@ -29,8 +29,11 @@ export const snapshot = (obj, { datasetId, tag }, context) => {
         summary: () => summary({ id: datasetId, revision: snapshot.hexsha }),
         files: ({ prefix }) =>
           getFiles(datasetId, snapshot.hexsha)
+            .then(response => response.files)
             .then(filterFiles(prefix))
             .then(filterRemovedAnnexObjects(datasetId, context.userInfo)),
+        size: () =>
+          getFiles(datasetId, snapshot.hexsha).then(response => response.size),
         deprecated: () => deprecated({ datasetId, tag }),
         related: () => related(datasetId),
         onBrainlife: () => onBrainlife(snapshot),

--- a/packages/openneuro-server/src/graphql/schema.js
+++ b/packages/openneuro-server/src/graphql/schema.js
@@ -430,6 +430,8 @@ export const typeDefs = `
     uploads: [UploadMetadata]
     # Git commit hash
     head: String
+    # Total size in bytes of this draft
+    size: Int
   }
 
   # Tagged snapshot of a draft
@@ -461,6 +463,8 @@ export const typeDefs = `
     related: [RelatedObject]
     # Is the snapshot available for analysis on Brainlife?
     onBrainlife: Boolean @cacheControl(maxAge: 10080, scope: PUBLIC)
+    # Total size in bytes of this snapshot
+    size: Int
   }
 
   # RelatedObject nature of relationship


### PR DESCRIPTION
Reports total dataset size in bytes based on the git content size, not on disk size for the repository. See #2572

Examples: 
```graphql
query {
  snapshot(datasetId: "ds001003", tag: "1.0.0") {
    size
  }
}
```

```json
{
  "data": {
    "snapshot": {
      "size": 311027405
    }
  },
}
```

Note: Requires a Redis cache clear to drop existing commit indexing caches as the total size is cached along with the file entries.