### PR TITLE
dep: Update to bids-validator@1.9.3

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -9253,7 +9253,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["babel-core", "virtual:4112afb9dad10978c159910bf10db9840b981b1333117623c8a4a8cf77481344a0a24735a5506e2920c18e3cfa2cc179489824b6a56c988bb070f4f60da40974#npm:7.0.0-bridge.0"],
             ["babel-jest", "virtual:4112afb9dad10978c159910bf10db9840b981b1333117623c8a4a8cf77481344a0a24735a5506e2920c18e3cfa2cc179489824b6a56c988bb070f4f60da40974#npm:24.9.0"],
             ["babel-runtime", "npm:6.26.0"],
-            ["bids-validator", "npm:1.9.2"],
+            ["bids-validator", "npm:1.9.3"],
             ["bytes", "npm:3.1.0"],
             ["comlink", "npm:4.3.1"],
             ["core-js", "npm:3.18.0"],
@@ -9312,7 +9312,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@openneuro/client", "workspace:packages/openneuro-client"],
             ["@types/mkdirp", "npm:1.0.2"],
             ["@types/node", "npm:16.11.13"],
-            ["bids-validator", "npm:1.9.2"],
+            ["bids-validator", "npm:1.9.3"],
             ["cli-progress", "npm:3.9.1"],
             ["commander", "npm:7.2.0"],
             ["core-js", "npm:3.18.0"],
@@ -16198,10 +16198,10 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
         }]
       ]],
       ["bids-validator", [
-        ["npm:1.9.2", {
-          "packageLocation": "./.yarn/cache/bids-validator-npm-1.9.2-5cf9cf5cd6-2376ad5b27.zip/node_modules/bids-validator/",
+        ["npm:1.9.3", {
+          "packageLocation": "./.yarn/cache/bids-validator-npm-1.9.3-02a034ed19-f0e6713fe2.zip/node_modules/bids-validator/",
           "packageDependencies": [
-            ["bids-validator", "npm:1.9.2"],
+            ["bids-validator", "npm:1.9.3"],
             ["@aws-sdk/client-s3", "npm:3.33.0"],
             ["ajv", "npm:6.12.6"],
             ["bytes", "npm:3.1.0"],

--- a/packages/openneuro-app/package.json
+++ b/packages/openneuro-app/package.json
@@ -22,7 +22,7 @@
     "@openneuro/client": "^4.5.0",
     "@openneuro/components": "^4.5.0",
     "babel-runtime": "^6.26.0",
-    "bids-validator": "1.9.2",
+    "bids-validator": "1.9.3",
     "bytes": "^3.0.0",
     "comlink": "^4.0.5",
     "core-js": "^3.3.2",

--- a/packages/openneuro-cli/package.json
+++ b/packages/openneuro-cli/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@apollo/client": "3.4.17",
     "@openneuro/client": "^4.5.0",
-    "bids-validator": "1.9.2",
+    "bids-validator": "1.9.3",
     "cli-progress": "^3.8.2",
     "commander": "7.2.0",
     "cross-fetch": "^3.0.5",

--- a/services/datalad/package.json
+++ b/services/datalad/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "bids-validator": "1.9.2"
+    "bids-validator": "1.9.3"
   }
 }

--- a/services/datalad/yarn.lock
+++ b/services/datalad/yarn.lock
@@ -1069,9 +1069,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bids-validator@npm:1.9.2":
-  version: 1.9.2
-  resolution: "bids-validator@npm:1.9.2"
+"bids-validator@npm:1.9.3":
+  version: 1.9.3
+  resolution: "bids-validator@npm:1.9.3"
   dependencies:
     "@aws-sdk/client-s3": ^3.9.0
     ajv: ^6.5.2
@@ -1100,7 +1100,7 @@ __metadata:
     yargs: ^16.2.0
   bin:
     bids-validator: bin/bids-validator
-  checksum: 2376ad5b27a2cec63b32889be2cd962eb35682f165f4e5aee6b31b7c49e7f58c5829049fb5709c63486d562465ce9f06ed74267f49e54d260995fac06cf67657
+  checksum: f0e6713fe26f8ab8d539fed910a18d36cd051eca26bf84768ff664d95ae040653d5cbf8a5d33ccc3cd5721c7861eed10ecd2a879402482d366b4e6a428e1ce5a
   languageName: node
   linkType: hard
 
@@ -2411,7 +2411,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "root-workspace-0b6124@workspace:."
   dependencies:
-    bids-validator: 1.9.2
+    bids-validator: 1.9.3
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4674,7 +4674,7 @@ __metadata:
     babel-core: ^7.0.0-bridge.0
     babel-jest: ^24.9.0
     babel-runtime: ^6.26.0
-    bids-validator: 1.9.2
+    bids-validator: 1.9.3
     bytes: ^3.0.0
     comlink: ^4.0.5
     core-js: ^3.3.2
@@ -4731,7 +4731,7 @@ __metadata:
     "@openneuro/client": ^4.5.0
     "@types/mkdirp": ^1.0.1
     "@types/node": 16.11.13
-    bids-validator: 1.9.2
+    bids-validator: 1.9.3
     cli-progress: ^3.8.2
     commander: 7.2.0
     core-js: ^3.10.1
@@ -9600,9 +9600,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bids-validator@npm:1.9.2":
-  version: 1.9.2
-  resolution: "bids-validator@npm:1.9.2"
+"bids-validator@npm:1.9.3":
+  version: 1.9.3
+  resolution: "bids-validator@npm:1.9.3"
   dependencies:
     "@aws-sdk/client-s3": ^3.9.0
     ajv: ^6.5.2
@@ -9631,7 +9631,7 @@ __metadata:
     yargs: ^16.2.0
   bin:
     bids-validator: bin/bids-validator
-  checksum: 2376ad5b27a2cec63b32889be2cd962eb35682f165f4e5aee6b31b7c49e7f58c5829049fb5709c63486d562465ce9f06ed74267f49e54d260995fac06cf67657
+  checksum: f0e6713fe26f8ab8d539fed910a18d36cd051eca26bf84768ff664d95ae040653d5cbf8a5d33ccc3cd5721c7861eed10ecd2a879402482d366b4e6a428e1ce5a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes an issue with certain datasets missing validation due to too many files per directory level.