### PR TITLE
feat(app): Display content size instead of validator summary size for datasets

### DIFF
--- a/packages/openneuro-app/src/scripts/datalad/dataset/dataset-query-fragments.js
+++ b/packages/openneuro-app/src/scripts/datalad/dataset/dataset-query-fragments.js
@@ -8,6 +8,7 @@ export const DRAFT_FRAGMENT = gql`
       modified
       readme
       head
+      size
       description {
         Name
         Authors
@@ -136,6 +137,7 @@ export const SNAPSHOT_FIELDS = gql`
     tag
     created
     readme
+    size
     deprecated {
       id
       user

--- a/packages/openneuro-app/src/scripts/dataset/draft-container.tsx
+++ b/packages/openneuro-app/src/scripts/dataset/draft-container.tsx
@@ -120,7 +120,7 @@ const DraftContainer: React.FC<DraftContainerProps> = ({ dataset }) => {
             <div className="col col-8 col-lg">
               {summary && (
                 <DatasetHeaderMeta
-                  size={summary.size}
+                  size={dataset.draft.size}
                   totalFiles={summary.totalFiles}
                   datasetId={datasetId}
                 />

--- a/packages/openneuro-app/src/scripts/dataset/snapshot-container.tsx
+++ b/packages/openneuro-app/src/scripts/dataset/snapshot-container.tsx
@@ -111,7 +111,7 @@ const SnapshotContainer: React.FC<SnapshotContainerProps> = ({
           <div className="col col-8 col-lg">
             {summary && (
               <DatasetHeaderMeta
-                size={summary.size}
+                size={snapshot.size}
                 totalFiles={summary.totalFiles}
                 datasetId={datasetId}
               />

--- a/packages/openneuro-app/src/scripts/search/use-search-results.tsx
+++ b/packages/openneuro-app/src/scripts/search/use-search-results.tsx
@@ -59,6 +59,7 @@ const searchQuery = gql`
             ages
           }
           latestSnapshot {
+            size
             summary {
               modalities
               secondaryModalities

--- a/packages/openneuro-components/src/search-page/SearchResultItem.tsx
+++ b/packages/openneuro-components/src/search-page/SearchResultItem.tsx
@@ -165,7 +165,7 @@ export const SearchResultItem = ({
   const size = (
     <span className="result-summary-meta">
       <strong>Size: </strong>
-      <span>{bytes(node?.latestSnapshot?.size)}</span>
+      <span>{bytes(node?.latestSnapshot?.size) || "unknown" }</span>
     </span>
   )
   const files = (

--- a/packages/openneuro-components/src/search-page/SearchResultItem.tsx
+++ b/packages/openneuro-components/src/search-page/SearchResultItem.tsx
@@ -46,6 +46,7 @@ export interface SearchResultItemProps {
     }
     latestSnapshot: {
       id: string
+      size: number
       summary: {
         pet: {
           BodyPart: string
@@ -164,7 +165,7 @@ export const SearchResultItem = ({
   const size = (
     <span className="result-summary-meta">
       <strong>Size: </strong>
-      <span>{bytes(summary?.size)}</span>
+      <span>{bytes(node?.latestSnapshot?.size)}</span>
     </span>
   )
   const files = (
@@ -221,8 +222,7 @@ export const SearchResultItem = ({
     <Tooltip
       tooltip={activtyTooltip}
       flow="up"
-      className="result-icon result-activity-icon"
-    >
+      className="result-icon result-activity-icon">
       <Icon
         imgSrc={activityPulseIcon}
         iconSize="22px"
@@ -236,8 +236,7 @@ export const SearchResultItem = ({
     <Tooltip
       tooltip="Shared with me"
       flow="up"
-      className="result-icon result-shared-icon"
-    >
+      className="result-icon result-shared-icon">
       <Icon
         icon="fas fa-user"
         color="rgb(119,191,217)"
@@ -251,8 +250,7 @@ export const SearchResultItem = ({
     <Tooltip
       tooltip="Visable to all viewers"
       flow="up"
-      className="result-icon result-publlic-icon"
-    >
+      className="result-icon result-publlic-icon">
       <Icon
         icon="fas fa-globe"
         color="rgb(116,181,105)"
@@ -267,8 +265,7 @@ export const SearchResultItem = ({
     <Tooltip
       tooltip="Invalid"
       flow="up"
-      className="result-icon result-errors-icon"
-    >
+      className="result-icon result-errors-icon">
       <Icon
         icon="fas fa-exclamation-circle"
         color="rgb(202,97,86)"


### PR DESCRIPTION
Uses the new API implemented in #2578 to show a better estimate of dataset size in bytes.