### PR TITLE
FIX: Drop second tooltip on purge button

### DIFF
--- a/packages/openneuro-app/src/scripts/dataset/mutations/remove-annex-object.jsx
+++ b/packages/openneuro-app/src/scripts/dataset/mutations/remove-annex-object.jsx
@@ -41,7 +41,6 @@ const RemoveAnnexObject = ({
           iconOnly={true}
           icon="fa-frown-o"
           className="edit-file"
-          tooltip={'Delete ' + name}
           onConfirmedClick={() => {
             removeAnnexObject({
               variables: {


### PR DESCRIPTION
Currently hovering over the purge button shows a "Delete " tooltip on top of the regular tooltip. Grepping for the tooltip text, it looks like a simple thing to fix.