### PR TITLE
fix(app): Fix publish incorrectly underlined when tab is redirecting to versioning

### DIFF
--- a/packages/openneuro-components/src/dataset/DatasetTools.tsx
+++ b/packages/openneuro-components/src/dataset/DatasetTools.tsx
@@ -52,7 +52,7 @@ export const DatasetTools = ({
           ) : (
             <DatasetToolButton
               tooltip="Create a version to publish"
-              path={`/datasets/${datasetId}/snapshot`}
+              path={`/datasets/${datasetId}/snapshot?publish`}
               icon="fa-globe"
               label="Publish"
             />


### PR DESCRIPTION
This avoids the publish link getting the active state when redirected to the version tab.

![image](https://user-images.githubusercontent.com/11369795/164105243-c144d01d-8ba1-4ec3-b2c3-f6e3615f9f69.png)