### PR TITLE
fix(app): Fix extraneous 0 rendering in version tab

### DIFF
--- a/packages/openneuro-app/src/scripts/dataset/routes/snapshot.jsx
+++ b/packages/openneuro-app/src/scripts/dataset/routes/snapshot.jsx
@@ -100,7 +100,7 @@ const SnapshotRoute = ({ datasetId, snapshots, issues, description }) => {
               />
             </div>
           </FormRow>
-          {latestSnapshot && (
+          {latestSnapshot ? (
             <FormRow>
               <HeaderRow4>Current Changelog</HeaderRow4>
               <FileView
@@ -109,7 +109,7 @@ const SnapshotRoute = ({ datasetId, snapshots, issues, description }) => {
                 path="CHANGES"
               />
             </FormRow>
-          )}
+          ) : null}
           <HeaderRow4>New Changelog</HeaderRow4>
           <p>Add CHANGES file lines describing the new version.</p>
           <EditList


### PR DESCRIPTION
This tab will render 0 when a dataset version does not yet exist. Instead, render nothing in this case by returning null.