### PR TITLE
fix(server): Use BigInt GraphQL type for total size fields

### DIFF
--- a/packages/openneuro-server/src/graphql/schema.js
+++ b/packages/openneuro-server/src/graphql/schema.js
@@ -431,7 +431,7 @@ export const typeDefs = `
     # Git commit hash
     head: String
     # Total size in bytes of this draft
-    size: Int
+    size: BigInt
   }
 
   # Tagged snapshot of a draft
@@ -464,7 +464,7 @@ export const typeDefs = `
     # Is the snapshot available for analysis on Brainlife?
     onBrainlife: Boolean @cacheControl(maxAge: 10080, scope: PUBLIC)
     # Total size in bytes of this snapshot
-    size: Int
+    size: BigInt
   }
 
   # RelatedObject nature of relationship


### PR DESCRIPTION
Fixes an issue where datasets over the size limit for the GraphQL int type would throw an error.