### PR TITLE
Dataset page 404 error handling fixes

### DIFF
--- a/packages/openneuro-app/src/scripts/dataset/dataset-query.jsx
+++ b/packages/openneuro-app/src/scripts/dataset/dataset-query.jsx
@@ -143,13 +143,6 @@ export const DatasetQueryHook = ({ datasetId, draft, history }) => {
   })
   useDraftSubscription(datasetId)
 
-  if (loading || !data)
-    return (
-      <div className="loading-dataset">
-        <Loading />
-        Loading Dataset
-      </div>
-    )
   if (error) {
     if (error.message === 'You do not have access to read this dataset.') {
       return <FourOThreePage />
@@ -161,6 +154,35 @@ export const DatasetQueryHook = ({ datasetId, draft, history }) => {
       }
       return <FourOFourPage />
     }
+  } else {
+    if (loading || !data)
+      return (
+        <div className="loading-dataset">
+          <Loading />
+          Loading Dataset
+        </div>
+      )
+  }
+
+  if (error) {
+    if (error.message === 'You do not have access to read this dataset.') {
+      return <FourOThreePage />
+    } else {
+      try {
+        apm.captureError(error)
+      } catch (err) {
+        // Ignore failure to write to APM
+      }
+      return <FourOFourPage />
+    }
+  } else {
+    if (loading || !data)
+      return (
+        <div className="loading-dataset">
+          <Loading />
+          Loading Dataset
+        </div>
+      )
   }
 
   return (

--- a/packages/openneuro-app/src/scripts/dataset/dataset-query.jsx
+++ b/packages/openneuro-app/src/scripts/dataset/dataset-query.jsx
@@ -146,27 +146,8 @@ export const DatasetQueryHook = ({ datasetId, draft, history }) => {
   if (error) {
     if (error.message === 'You do not have access to read this dataset.') {
       return <FourOThreePage />
-    } else {
-      try {
-        apm.captureError(error)
-      } catch (err) {
-        // Ignore failure to write to APM
-      }
-      return <FourOFourPage />
-    }
-  } else {
-    if (loading || !data)
-      return (
-        <div className="loading-dataset">
-          <Loading />
-          Loading Dataset
-        </div>
-      )
-  }
-
-  if (error) {
-    if (error.message === 'You do not have access to read this dataset.') {
-      return <FourOThreePage />
+    } else if (error.message.includes('has been deleted')) {
+      return <FourOFourPage message={error.message} />
     } else {
       try {
         apm.captureError(error)

--- a/packages/openneuro-app/src/scripts/errors/404page.tsx
+++ b/packages/openneuro-app/src/scripts/errors/404page.tsx
@@ -22,16 +22,19 @@ interface FourOFourPageProps {
   redirectRoute?: string
   redirectRouteName?: string
   theme?: string
+  message?: string
 }
 
 const FourOFourPage: FC<FourOFourPageProps> = ({
   redirectRoute = '/',
   redirectRouteName = 'the home page',
   theme = 'topLevel',
+  message = '',
 }) => {
   return (
     <Container styleContext={theme}>
       <h3>404: The page you are looking for does not exist.</h3>
+      {message && <p>{message}</p>}
       <p>
         Click <Link to={redirectRoute}>here</Link> to go to
         {' ' + redirectRouteName}.

--- a/packages/openneuro-server/src/graphql/permissions.js
+++ b/packages/openneuro-server/src/graphql/permissions.js
@@ -1,5 +1,6 @@
 import Permission from '../models/permission'
 import Dataset from '../models/dataset'
+import Deletion from '../models/deletion'
 
 // Definitions for permission levels allowed
 // Admin is write + manage user permissions
@@ -50,6 +51,12 @@ export const checkPermissionLevel = (permission, state) => {
 }
 
 export const checkDatasetExists = async datasetId => {
+  const deleted = await Deletion.findOne({ datasetId }).exec()
+  if (deleted) {
+    throw new Error(
+      `Dataset ${datasetId} has been deleted. Reason: ${deleted.reason}.`,
+    )
+  }
   const found = await Dataset.countDocuments({ id: datasetId }).exec()
   if (!found) throw new Error(`Dataset ${datasetId} does not exist.`)
 }


### PR DESCRIPTION
Fixes the issues reported in #2579

Includes information about the deleted dataset in the API error message. Also shows the reason for deletion if a redirect doesn't exist.