### PR TITLE
Add API and frontend support for displaying related dataset derivatives

### DIFF
--- a/packages/openneuro-app/src/scripts/dataset/dataset-query.jsx
+++ b/packages/openneuro-app/src/scripts/dataset/dataset-query.jsx
@@ -57,6 +57,12 @@ export const getDatasetPage = gql`
         downloads
         views
       }
+      derivatives {
+        name
+        s3Url
+        dataladUrl
+        local
+      }
       onBrainlife
     }
   }

--- a/packages/openneuro-app/src/scripts/dataset/dataset-query.jsx
+++ b/packages/openneuro-app/src/scripts/dataset/dataset-query.jsx
@@ -112,6 +112,12 @@ export const getDraftPage = gql`
         downloads
         views
       }
+      derivatives {
+        name
+        s3Url
+        dataladUrl
+        local
+      }
     }
   }
   ${DatasetQueryFragments.DRAFT_FRAGMENT}

--- a/packages/openneuro-app/src/scripts/dataset/download/download-derivative-datalad.tsx
+++ b/packages/openneuro-app/src/scripts/dataset/download/download-derivative-datalad.tsx
@@ -1,0 +1,19 @@
+import React from 'react'
+import ShellExample from './shell-example.jsx'
+
+interface DownloadDataLadDerivativesProps {
+  url: string
+}
+
+const DownloadDataLadDerivative = ({
+  url,
+}: DownloadDataLadDerivativesProps): JSX.Element => (
+  <div>
+    <h4>
+      Download with <a href="https://www.datalad.org">DataLad</a>
+    </h4>
+    <ShellExample>datalad install {url}</ShellExample>
+  </div>
+)
+
+export default DownloadDataLadDerivative

--- a/packages/openneuro-app/src/scripts/dataset/download/download-derivative-s3.tsx
+++ b/packages/openneuro-app/src/scripts/dataset/download/download-derivative-s3.tsx
@@ -1,0 +1,23 @@
+import React from 'react'
+import ShellExample from './shell-example.jsx'
+
+interface DownloadS3DerivativesProps {
+  name: string
+  url: string
+}
+
+const DownloadS3Derivatives = ({
+  name,
+  url,
+}: DownloadS3DerivativesProps): JSX.Element => (
+  <div>
+    <h4>
+      Download from <a href="https://aws.amazon.com/cli/">S3</a>
+    </h4>
+    <ShellExample>
+      aws s3 sync --no-sign-request {url} {name}
+    </ShellExample>
+  </div>
+)
+
+export default DownloadS3Derivatives

--- a/packages/openneuro-app/src/scripts/dataset/draft-container.tsx
+++ b/packages/openneuro-app/src/scripts/dataset/draft-container.tsx
@@ -84,6 +84,7 @@ const DraftContainer: React.FC<DraftContainerProps> = ({ dataset }) => {
   const isDatasetAdmin =
     hasDatasetAdminPermissions(dataset.permissions, profile?.sub) || isAdmin
   const modality: string = summary?.modalities[0] || ''
+  const hasDerivatives = dataset?.derivatives.length > 0
 
   return (
     <>
@@ -183,6 +184,7 @@ const DraftContainer: React.FC<DraftContainerProps> = ({ dataset }) => {
                 isAdmin={isAdmin}
                 hasSnapshot={dataset.snapshots.length !== 0}
                 isDatasetAdmin={isDatasetAdmin}
+                hasDerivatives={hasDerivatives}
               />
               <DatasetPageTabContainer>
                 <TabRoutesDraft dataset={dataset} hasEdit={hasEdit} />

--- a/packages/openneuro-app/src/scripts/dataset/routes/derivatives.tsx
+++ b/packages/openneuro-app/src/scripts/dataset/routes/derivatives.tsx
@@ -1,0 +1,77 @@
+import React from 'react'
+import DownloadS3Derivative from '../download/download-derivative-s3'
+import DownloadDataLadDerivative from '../download/download-derivative-datalad'
+import { DatasetPageBorder } from './styles/dataset-page-border'
+import { HeaderRow3 } from './styles/header-row'
+
+interface DerivativeElementProps {
+  name: string
+  s3Url: string
+  dataladUrl: string
+  local: boolean
+}
+
+const DerivativeElement = ({
+  name,
+  s3Url,
+  dataladUrl,
+  local,
+}: DerivativeElementProps): JSX.Element => {
+  if (local) {
+    return null
+  } else {
+    return (
+      <>
+        <hr />
+        <h3>
+          <a href={dataladUrl}>{name}</a>
+        </h3>
+        {s3Url && <DownloadS3Derivative url={s3Url} name={name} />}
+        {dataladUrl && <DownloadDataLadDerivative url={dataladUrl} />}
+      </>
+    )
+  }
+}
+
+interface DerivativesProps {
+  derivatives: DerivativeElementProps[]
+}
+
+const Derivatives = ({ derivatives }: DerivativesProps): JSX.Element => {
+  return (
+    <DatasetPageBorder>
+      <HeaderRow3>Available Derivatives</HeaderRow3>
+      <h5>Acknowledgements</h5>
+      <p>
+        These derivatives were generated on the{' '}
+        <a href="https://www.tacc.utexas.edu/">
+          Texas Advanced Computing Center
+        </a>{' '}
+        Frontera computing system [1] through their{' '}
+        <a href="https://frontera-portal.tacc.utexas.edu/allocations/">
+          Pathways allocation
+        </a>
+        . This work was also funded by the{' '}
+        <a href="https://grantome.com/grant/NIH/R24-MH117179-03">
+          NIH BRAIN Initiative
+        </a>
+        .
+      </p>
+      <p>
+        [1]: Dan Stanzione, John West, R. Todd Evans, Tommy Minyard, Omar
+        Ghattas, and Dhabaleswar K. Panda. 2020. Frontera: The Evolution of
+        Leadership Computing at the National Science Foundation. In Practice and
+        Experience in Advanced Research Computing (PEARC ’20), July 26–30, 2020,
+        Portland, OR, USA. ACM, New York, NY, USA, 11 pages.
+        <a href="https://doi.org/10.1145/3311790.3396656">
+          https://doi.org/10.1145/3311790.3396656
+        </a>
+      </p>
+      {derivatives.map(derivative => (
+        <DerivativeElement key={derivative.name} {...derivative} />
+      ))}
+    </DatasetPageBorder>
+  )
+}
+
+export default Derivatives

--- a/packages/openneuro-app/src/scripts/dataset/routes/tab-routes-draft.tsx
+++ b/packages/openneuro-app/src/scripts/dataset/routes/tab-routes-draft.tsx
@@ -8,6 +8,7 @@ import Publish from './publish'
 import Share from './manage-permissions'
 import Snapshot from './snapshot'
 import AddMetadata from './add-metadata'
+import Derivatives from './derivatives'
 import FileDisplay from '../files/file-display'
 
 export const TabRoutesDraft = ({ dataset, hasEdit }) => {
@@ -27,6 +28,11 @@ export const TabRoutesDraft = ({ dataset, hasEdit }) => {
             datasetPermissions={dataset.permissions}
           />
         )}
+      />
+      <Route
+        exact
+        path="/datasets/:datasetId/derivatives"
+        component={() => <Derivatives derivatives={dataset.derivatives} />}
       />
       <Route
         exact

--- a/packages/openneuro-app/src/scripts/dataset/routes/tab-routes-snapshot.tsx
+++ b/packages/openneuro-app/src/scripts/dataset/routes/tab-routes-snapshot.tsx
@@ -5,6 +5,7 @@ import DownloadDataset from './download-dataset'
 import { DeprecateSnapshotPage } from './deprecate-snapshot-page'
 import FileDisplay from '../files/file-display'
 import AddMetadata from './add-metadata'
+import Derivatives from './derivatives'
 
 export const TabRoutesSnapshot = ({ dataset, snapshot }) => {
   return (
@@ -25,6 +26,11 @@ export const TabRoutesSnapshot = ({ dataset, snapshot }) => {
             datasetPermissions={dataset.permissions}
           />
         )}
+      />
+      <Route
+        exact
+        path="/datasets/:datasetId/versions/:snapshotId/derivatives"
+        component={() => <Derivatives derivatives={dataset.derivatives} />}
       />
       <Route
         exact

--- a/packages/openneuro-app/src/scripts/dataset/snapshot-container.tsx
+++ b/packages/openneuro-app/src/scripts/dataset/snapshot-container.tsx
@@ -86,6 +86,7 @@ const SnapshotContainer: React.FC<SnapshotContainerProps> = ({
   const isDatasetAdmin =
     hasDatasetAdminPermissions(dataset.permissions, profile?.sub) || isAdmin
   const modality: string = summary?.modalities[0] || ''
+  const hasDerivatives = dataset?.derivatives.length > 0
 
   return (
     <>
@@ -170,6 +171,7 @@ const SnapshotContainer: React.FC<SnapshotContainerProps> = ({
                   snapshotId={snapshot.tag}
                   isAdmin={isAdmin}
                   isDatasetAdmin={isDatasetAdmin}
+                  hasDerivatives={hasDerivatives}
                 />
               </div>
               <DatasetPageTabContainer>

--- a/packages/openneuro-components/src/dataset/DatasetTools.tsx
+++ b/packages/openneuro-components/src/dataset/DatasetTools.tsx
@@ -16,6 +16,7 @@ export interface DatasetToolsProps {
   isAdmin: boolean
   isDatasetAdmin: boolean
   hasSnapshot?: boolean
+  hasDerivatives?: boolean
 }
 
 export const DatasetTools = ({
@@ -26,6 +27,7 @@ export const DatasetTools = ({
   isAdmin,
   hasSnapshot,
   isDatasetAdmin,
+  hasDerivatives,
 }: DatasetToolsProps) => {
   const isSnapshot = snapshotId
   return (
@@ -101,6 +103,18 @@ export const DatasetTools = ({
         icon="fa-download"
         label="Download"
       />
+      {hasDerivatives && (
+        <DatasetToolButton
+          tooltip="Available Derivatives"
+          path={
+            snapshotId
+              ? `/datasets/${datasetId}/versions/${snapshotId}/derivatives`
+              : `/datasets/${datasetId}/derivatives`
+          }
+          icon="fa-cubes"
+          label="Derivatives"
+        />
+      )}
       <DatasetToolButton
         tooltip={
           hasEdit

--- a/packages/openneuro-server/src/config.js
+++ b/packages/openneuro-server/src/config.js
@@ -64,6 +64,9 @@ const config = {
   elasticsearch: {
     connection: process.env.ELASTICSEARCH_CONNECTION,
   },
+  github: {
+    token: process.env.DATALAD_GITHUB_TOKEN,
+  },
 }
 
 export default config

--- a/packages/openneuro-server/src/graphql/resolvers/__tests__/derivatives.spec.ts
+++ b/packages/openneuro-server/src/graphql/resolvers/__tests__/derivatives.spec.ts
@@ -1,0 +1,33 @@
+import { githubDerivativeQuery, derivativeObject } from '../derivatives'
+
+describe('GraphQL derivatives', () => {
+  describe('githubDerivativeQuery()', () => {
+    it('constructs a correct URL', () => {
+      expect(githubDerivativeQuery('ds000102', 'mriqc').toString()).toEqual(
+        'https://api.github.com/repos/OpenNeuroDerivatives/ds000102-mriqc',
+      )
+    })
+  })
+  describe('derivativeObject()', () => {
+    it('returns expected values for mriqc', () => {
+      expect(derivativeObject('ds000102', 'mriqc')).toEqual({
+        dataladUrl: new URL(
+          'https://github.com/OpenNeuroDerivatives/ds000102-mriqc.git',
+        ),
+        local: false,
+        name: 'ds000102-mriqc',
+        s3Url: new URL('s3://openneuro-derivatives/mriqc/ds000102-mriqc'),
+      })
+    })
+    it('returns expected values for fmriprep', () => {
+      expect(derivativeObject('ds000102', 'fmriprep')).toEqual({
+        dataladUrl: new URL(
+          'https://github.com/OpenNeuroDerivatives/ds000102-fmriprep.git',
+        ),
+        local: false,
+        name: 'ds000102-fmriprep',
+        s3Url: new URL('s3://openneuro-derivatives/fmriprep/ds000102-fmriprep'),
+      })
+    })
+  })
+})

--- a/packages/openneuro-server/src/graphql/resolvers/dataset.js
+++ b/packages/openneuro-server/src/graphql/resolvers/dataset.js
@@ -21,6 +21,7 @@ import { getDatasetWorker } from '../../libs/datalad-service.js'
 import { getDraftHead } from '../../datalad/dataset.js'
 import { getFileName } from '../../datalad/files.js'
 import { onBrainlife } from './brainlife'
+import { derivatives } from './derivatives'
 import semver from 'semver'
 
 export const dataset = async (obj, { id }, { user, userInfo }) => {
@@ -304,6 +305,7 @@ const Dataset = {
   following,
   starred,
   onBrainlife,
+  derivatives,
   metadata,
   history,
   worker,

--- a/packages/openneuro-server/src/graphql/resolvers/derivatives.ts
+++ b/packages/openneuro-server/src/graphql/resolvers/derivatives.ts
@@ -1,0 +1,92 @@
+import fetch from 'node-fetch'
+import {
+  DatasetOrSnapshot,
+  getDatasetFromSnapshotId,
+} from '../../utils/datasetOrSnapshot'
+
+const S3_BUCKET = 'openneuro-derivatives'
+const GITHUB_ORGANIZATION = 'OpenNeuroDerivatives'
+
+// Available derivatives at this time
+type GitHubDerivative = 'mriqc' | 'fmriprep'
+
+/**
+ * Test for a derivative on GitHub via API
+ * @param datasetId
+ * @param derivative String identifying the kind of derivative
+ */
+export const githubDerivativeQuery = (
+  datasetId: string,
+  derivative: GitHubDerivative,
+): URL => {
+  const url = new URL(
+    `https://api.github.com/repos/${GITHUB_ORGANIZATION}/${datasetId}-${derivative}`,
+  )
+  return url
+}
+
+export const githubDerivative = async (
+  datasetId: string,
+  derivative: GitHubDerivative,
+): Promise<boolean> => {
+  try {
+    const url = githubDerivativeQuery(datasetId, derivative)
+    const res = await fetch(url.toString())
+    if (res.status === 200) {
+      const body = await res.json()
+      // Verify we aren't displaying a hidden repo
+      if (!body.private) {
+        return true
+      }
+    }
+    return false
+  } catch (err) {
+    return false
+  }
+}
+
+interface DatasetDerivatives {
+  name: string
+  local: boolean
+  s3Url: URL
+  dataladUrl: URL
+}
+
+export const derivativeObject = (
+  datasetId: string,
+  derivative: GitHubDerivative,
+): DatasetDerivatives => {
+  const name = `${datasetId}-${derivative}`
+  return {
+    name,
+    // Always false to identify OpenNeuro hosted derivatives later
+    local: false,
+    s3Url: new URL(name, `s3://${S3_BUCKET}/${derivative}/`),
+    dataladUrl: new URL(
+      `${name}.git`,
+      `https://github.com/${GITHUB_ORGANIZATION}/`,
+    ),
+  }
+}
+
+/**
+ * Derivative resolver, returns an array of the available derivative dataset sources
+ */
+export const derivatives = async (
+  dataset: DatasetOrSnapshot,
+): Promise<Array<DatasetDerivatives>> => {
+  let datasetId
+  if ('tag' in dataset) {
+    datasetId = getDatasetFromSnapshotId(dataset.id)
+  } else {
+    datasetId = dataset.id
+  }
+  const available: Array<DatasetDerivatives> = []
+  if (await githubDerivative(datasetId, 'mriqc')) {
+    available.push(derivativeObject(datasetId, 'mriqc'))
+  }
+  if (await githubDerivative(datasetId, 'fmriprep')) {
+    available.push(derivativeObject(datasetId, 'fmriprep'))
+  }
+  return available
+}

--- a/packages/openneuro-server/src/graphql/resolvers/derivatives.ts
+++ b/packages/openneuro-server/src/graphql/resolvers/derivatives.ts
@@ -3,6 +3,7 @@ import {
   DatasetOrSnapshot,
   getDatasetFromSnapshotId,
 } from '../../utils/datasetOrSnapshot'
+import config from '../../config'
 
 const S3_BUCKET = 'openneuro-derivatives'
 const GITHUB_ORGANIZATION = 'OpenNeuroDerivatives'
@@ -31,7 +32,11 @@ export const githubDerivative = async (
 ): Promise<boolean> => {
   try {
     const url = githubDerivativeQuery(datasetId, derivative)
-    const res = await fetch(url.toString())
+    const res = await fetch(url.toString(), {
+      headers: {
+        Authorization: `token ${config.github.token}`,
+      },
+    })
     if (res.status === 200) {
       const body = await res.json()
       // Verify we aren't displaying a hidden repo

--- a/packages/openneuro-server/src/graphql/schema.js
+++ b/packages/openneuro-server/src/graphql/schema.js
@@ -384,6 +384,8 @@ export const typeDefs = `
     publishDate: DateTime
     # Is the dataset available for analysis on Brainlife?
     onBrainlife: Boolean @cacheControl(maxAge: 10080, scope: PUBLIC)
+    # Available derivatives of this dataset
+    derivatives: [DatasetDerivatives]
     # Dataset Metadata
     metadata: Metadata
     # Return the version history for a dataset (git log)
@@ -392,6 +394,17 @@ export const typeDefs = `
     worker: String
     # Anonymous reviewers for this dataset
     reviewers: [DatasetReviewer]
+  }
+
+  type DatasetDerivatives {
+    # Remote reference to display
+    name: String
+    # Is this an OpenNeuro derivative?
+    local: Boolean
+    # S3-like URL if available
+    s3Url: String
+    # DataLad GitHub URL if available
+    dataladUrl: String
   }
 
   type DatasetCommit {

--- a/packages/openneuro-server/src/graphql/schema.js
+++ b/packages/openneuro-server/src/graphql/schema.js
@@ -385,7 +385,7 @@ export const typeDefs = `
     # Is the dataset available for analysis on Brainlife?
     onBrainlife: Boolean @cacheControl(maxAge: 10080, scope: PUBLIC)
     # Available derivatives of this dataset
-    derivatives: [DatasetDerivatives]
+    derivatives: [DatasetDerivatives] @cacheControl(maxAge: 3600, scope: PUBLIC)
     # Dataset Metadata
     metadata: Metadata
     # Return the version history for a dataset (git log)


### PR DESCRIPTION
This is only currently populated by available derivatives in the OpenNeuroDerivatives organization but should generalize for most other DataLad derivatives. A tab is shown on the draft and snapshot pages, right now containing identical content.