### PR TITLE
Annex configuration fixes and switch to SHA256E for new datasets

### DIFF
--- a/services/datalad/datalad_service/tasks/dataset.py
+++ b/services/datalad/datalad_service/tasks/dataset.py
@@ -12,15 +12,17 @@ from datalad_service.common.annex import init_annex
 from datalad_service.common.git import git_commit, COMMITTER_EMAIL, COMMITTER_NAME
 
 # A list of patterns to avoid annexing in BIDS datasets
-GIT_ATTRIBUTES = """* annex.backend=MD5E
+GIT_ATTRIBUTES = """* annex.backend=SHA256E
 **/.git* annex.largefiles=nothing
 *.bval annex.largefiles=nothing
 *.bvec annex.largefiles=nothing
-*.json annex.largefiles=nothing
-*.tsv annex.largefiles=nothing
+*.json annex.largefiles=largerthan=1mb
+*.tsv annex.largefiles=largerthan=1mb
+dataset_description.json annex.largefiles=nothing
 .bidsignore annex.largefiles=nothing
 CHANGES annex.largefiles=nothing
 README annex.largefiles=nothing
+LICENSE annex.largefiles=nothing
 """
 
 

--- a/services/datalad/datalad_service/tasks/dataset.py
+++ b/services/datalad/datalad_service/tasks/dataset.py
@@ -21,7 +21,7 @@ GIT_ATTRIBUTES = """* annex.backend=SHA256E
 dataset_description.json annex.largefiles=nothing
 .bidsignore annex.largefiles=nothing
 CHANGES annex.largefiles=nothing
-README annex.largefiles=nothing
+README* annex.largefiles=nothing
 LICENSE annex.largefiles=nothing
 """
 

--- a/services/datalad/hooks/pre-receive
+++ b/services/datalad/hooks/pre-receive
@@ -24,7 +24,7 @@ readonly GIT_ATTRIBUTES="* annex.backend=SHA256E
 dataset_description.json annex.largefiles=nothing
 .bidsignore annex.largefiles=nothing
 CHANGES annex.largefiles=nothing
-README annex.largefiles=nothing
+README* annex.largefiles=nothing
 LICENSE annex.largefiles=nothing
 "
 

--- a/services/datalad/hooks/pre-receive
+++ b/services/datalad/hooks/pre-receive
@@ -13,40 +13,36 @@ readonly MAXSIZE="10485760" # 10MB
 readonly NULLSHA="0000000000000000000000000000000000000000"
 readonly EXIT_SUCCESS="0"
 readonly EXIT_FAILURE="1"
+readonly OUTPUT_HR="------------------------------------------------------------------------"
 
-readonly requiredGitAttributes=(
-  "* annex.largefiles=largerthan=1mb"
-  "*.bval annex.largefiles=nothing"
-  "*.bvec annex.largefiles=nothing"
-  "*.json annex.largefiles=nothing"
-  "*.tsv annex.largefiles=nothing"
-  ".bidsignore annex.largefiles=nothing"
-  "CHANGES annex.largefiles=nothing"
-  "README annex.largefiles=nothing"
-)
+readonly GIT_ATTRIBUTES="* annex.backend=SHA256E
+**/.git* annex.largefiles=nothing
+*.bval annex.largefiles=nothing
+*.bvec annex.largefiles=nothing
+*.json annex.largefiles=largerthan=1mb
+*.tsv annex.largefiles=largerthan=1mb
+dataset_description.json annex.largefiles=nothing
+.bidsignore annex.largefiles=nothing
+CHANGES annex.largefiles=nothing
+README annex.largefiles=nothing
+LICENSE annex.largefiles=nothing
+"
 
 function validateGitAttributes() {
-  local missingLines=()
-
   # Find .gitattributes file
   local gitAttributes=$(git show "${newref}:.gitattributes")
-  if [[ "$?" = 0 ]]; then
-    for line in "${requiredGitAttributes[@]}"; do
-      if [[ ! "$gitAttributes" == *"$line"* ]]; then 
-        missingLines+=( "$line" ) 
-      fi
-    done
-  fi
-
-  if [ ${#missingLines[@]} -gt 0 ]; then
+  if [[ "$?" -ne 0 ]]; then
     echo ""
-    echo "---------------------------------------------------------------------------------------"
-    echo "Your push was rejected because your .gitattributes file is missing the following lines:"
-    echo "---------------------------------------------------------------------------------------"
-    for missingLine in "${missingLines[@]}"; do
-      echo "  $missingLine"
-    done
-    exit 1
+    echo $OUTPUT_HR
+    echo "Your push was rejected because a .gitattributes file was not found."
+    echo ""
+    echo ".gitattributes is required to set git-annex defaults for DataLad or git-annex repos."
+    echo "See https://handbook.datalad.org/en/latest/basics/101-123-config2.html#gitattributes"
+    echo ""
+    echo "A suggested default .gitattributes file:"
+    echo $OUTPUT_HR
+    echo $GIT_ATTRIBUTES
+    exit $EXIT_FAILURE
   fi
 }
 
@@ -59,10 +55,10 @@ function filterDotFiles() {
     fi
     if [[ "$filename" =~ ^\..*|\/\..* ]]; then
       echo ""
-      echo "-------------------------------------------------------------------------"
+      echo $OUTPUT_HR
       echo "Filenames beginning with . except for .bidsignore or DataLad repo settings are not allowed"
-      echo "-------------------------------------------------------------------------"
-      exit 1
+      echo $OUTPUT_HR
+      exit $EXIT_FAILURE
     fi
   done
 }
@@ -86,21 +82,21 @@ function main() {
         branch=$(expr "$refname" : "refs/heads/\(.*\)")
         if ! [[ "$branch" == "master" || "$branch" == "git-annex" || "$branch" == "main" || "$branch" =~ "^synced\/.*$" ]]; then
           echo ""
-          echo "-------------------------------------------------------------------------"
+          echo $OUTPUT_HR
           echo "Only 'master', 'main', or 'git-annex' branches are accepted."
-          echo "-------------------------------------------------------------------------"
+          echo $OUTPUT_HR
           exit $EXIT_FAILURE
         fi
         ;;
       refs/tags/*)
         echo ""
-        echo "-------------------------------------------------------------------------"
+        echo $OUTPUT_HR
         echo "Git tags cannot be pushed to OpenNeuro."
         echo ""
         echo "To tag your dataset, please create a snapshot via the dataset's"
         echo "page at https://openneuro.org (recommended) or the GraphQL API"
         echo "(https://docs.openneuro.org/api#snapshot-creation)."
-        echo "-------------------------------------------------------------------------"
+        echo $OUTPUT_HR
         exit $EXIT_FAILURE
         ;;
     esac

--- a/services/datalad/tests/test_annex.py
+++ b/services/datalad/tests/test_annex.py
@@ -93,6 +93,12 @@ def test_compute_rmet_annex():
         'MD5E-s12102144--d614929593bf2a7cccea90bea67255f4.bdf') == '9ce/c07/MD5E-s12102144--d614929593bf2a7cccea90bea67255f4.bdf.log.rmet'
 
 
+def test_compute_rmet_sha256_annex():
+    # Test a git annex MD5E key
+    assert compute_rmet(
+        'SHA256E-s311112--c3527d7944a9619afb57863a34e6af7ec3fe4f108e56c860d9e700699ff806fb.nii.gz') == '2ed/6ea/SHA256E-s311112--c3527d7944a9619afb57863a34e6af7ec3fe4f108e56c860d9e700699ff806fb.nii.gz.log.rmet'
+
+
 def test_parse_remote_line():
     remote = parse_remote_line("""57894849-d0c8-4c62-8418-3627be18a196 autoenable=true bucket=openneuro.org datacenter=US encryption=none exporttree=yes fileprefix=ds002778/ host=s3.amazonaws.com name=s3-PUBLIC partsize=1GiB port=80 public=yes publicurl=http://openneuro.org.s3.amazonaws.com/ storageclass=STANDARD type=S3 versioning=yes timestamp=1588743361.538097946s""")
     assert remote == {'url': 'http://openneuro.org.s3.amazonaws.com/',


### PR DESCRIPTION
This updates the default annex configuration for new datasets to place a smaller limit on JSON and TSV files. dataset_description.json and LICENSE are now also always committed to the repo.

With several variants of .gitattributes being valid and with slightly different requirements, I simplified the push test to allow any .gitattributes configuration. Instead we just make sure the file exists and display a recommended example if it does not. The ultimate limit for pushing large objects still exists in the receive hook, so I don't think this really opens up any potential for abuse but it does make it much more flexible for datasets with special requirements or evolving the configuration like this in the future.