### PR TITLE
fix(ssr): Prevent Apollo state from corrupting UTF-8 objects

### DIFF
--- a/packages/openneuro-app/src/index.html
+++ b/packages/openneuro-app/src/index.html
@@ -21,7 +21,7 @@
 <body>
     <div id="main">${react}</div>
     <script src="/client.jsx" type="module"></script>
-    <script>window.__APOLLO_STATE__=atob("${apolloState}");</script>
+    <script>window.__APOLLO_STATE__=decodeURIComponent(atob("${apolloState}"));</script>
 </body>
 
 </html>

--- a/packages/openneuro-app/src/server.jsx
+++ b/packages/openneuro-app/src/server.jsx
@@ -57,9 +57,9 @@ export async function render(url, cookies) {
   const head = `${helmet.title.toString()}${helmet.meta.toString()}${helmet.style.toString()}`
 
   // Prevent <script> tags from strings
-  const apolloState = Buffer.from(JSON.stringify(client.extract())).toString(
-    'base64',
-  )
+  const apolloState = Buffer.from(
+    encodeURIComponent(JSON.stringify(client.extract())),
+  ).toString('base64')
 
   return { react, apolloState, head, css: redesignStyles }
 }


### PR DESCRIPTION
atob can only return ASCII, so this would corrupt UTF-8 characters when loaded from the client cache after a correct SSR render. encodeURIComponent/decodeURIComponent will safely use URL encoding to avoid this limitation of the atob function.

Fixes #2622