### PR TITLE
fix(app): Allow copy and paste of comments

### DIFF
--- a/packages/openneuro-app/src/scripts/dataset/comments/comment.jsx
+++ b/packages/openneuro-app/src/scripts/dataset/comments/comment.jsx
@@ -37,6 +37,7 @@ const Comment = ({ datasetId, data, children }) => {
             <Editor
               editorKey={data.id}
               editorState={editorState}
+              readOnly={true}
               onChange={() => {
                 /* Not editable, this shouldn't fire */
               }}


### PR DESCRIPTION
Oddly, setting readOnly={false} also works but these comments are actually read only when rendered here.

Fixes #2621