### PR TITLE
fix: Add a datalad id while creating a snapshot if one does not exist

### DIFF
--- a/services/datalad/datalad_service/tasks/snapshots.py
+++ b/services/datalad/datalad_service/tasks/snapshots.py
@@ -138,7 +138,7 @@ def validate_datalad_config(store, dataset):
     dataset_path = store.get_dataset_path(dataset)
     try:
         git_show(dataset_path, 'HEAD', '.datalad/config')
-    except:
+    except KeyError:
         create_datalad_config(dataset_path)
         commit_files(store, dataset, ['.datalad/config'])
 

--- a/services/datalad/tests/dataset_fixtures.py
+++ b/services/datalad/tests/dataset_fixtures.py
@@ -98,6 +98,7 @@ def new_dataset(datalad_store):
     with open(changes_path, 'w') as f:
         f.write(CHANGES)
     ds.save(changes_path)
+    ds.close()
     return ds
 
 

--- a/services/datalad/tests/test_snapshots.py
+++ b/services/datalad/tests/test_snapshots.py
@@ -1,5 +1,6 @@
 import os
 import json
+import uuid
 
 import falcon
 import pytest
@@ -37,6 +38,29 @@ def test_create_snapshot(client, new_dataset):
     response = client.simulate_post(
         '/datasets/{}/snapshots/{}'.format(ds_id, snapshot_id), body="")
     assert response.status == falcon.HTTP_OK
+
+
+def test_create_snapshot_no_config(datalad_store, client, new_dataset):
+    """Validate adding a datalad config if one is missing during snapshot creation"""
+    ds_id = os.path.basename(new_dataset.path)
+    snapshot_id = '1'
+    # Delete the default config first
+    response = client.simulate_delete('/datasets/{}/files'.format(
+        ds_id), body='{ "filenames": [".datalad/config"] }')
+    assert response.status == falcon.HTTP_OK
+    assert json.loads(response.content)['deleted'] == [
+        '.datalad/config']
+    # Try to snapshot now
+    response = client.simulate_post(
+        '/datasets/{}/snapshots/{}'.format(ds_id, snapshot_id), body="")
+    assert response.status == falcon.HTTP_OK
+    # Verify the dataset now has an ID
+    ds = Dataset(os.path.join(datalad_store.annex_path, ds_id))
+    assert ds.id is not None
+    try:
+        uuid.UUID(ds.id, version=4)
+    except ValueError:
+        assert False, "datalad id is not a valid uuid4"
 
 
 def test_pre_snapshot_edit(client, new_dataset):

--- a/services/datalad/tests/test_snapshots.py
+++ b/services/datalad/tests/test_snapshots.py
@@ -50,6 +50,9 @@ def test_create_snapshot_no_config(datalad_store, client, new_dataset):
     assert response.status == falcon.HTTP_OK
     assert json.loads(response.content)['deleted'] == [
         '.datalad/config']
+    ds = Dataset(os.path.join(datalad_store.annex_path, ds_id))
+    assert ds.id is None
+    ds.close()
     # Try to snapshot now
     response = client.simulate_post(
         '/datasets/{}/snapshots/{}'.format(ds_id, snapshot_id), body="")


### PR DESCRIPTION
This is the second fix for #2625. When a snapshot is created, check if the .datalad/config file exists and if it does not, add one with an id.

I had tried validating the .datalad/config contents but that leads to needing to merge them safely. I think we should stick with just assuming it exists and is as expected, or it doesn't exist and we should add our minimum version that provides dataset identity, other cases can still be handled by the uploader with git access or via the API (OpenNeuro currently hides any .datalad files from the UI).