### PR TITLE
fix(app): Disable ReadMore component for FileTree

### DIFF
--- a/packages/openneuro-app/src/scripts/dataset/routes/dataset-default.tsx
+++ b/packages/openneuro-app/src/scripts/dataset/routes/dataset-default.tsx
@@ -11,20 +11,14 @@ import EditDescriptionField from '../fragments/edit-description-field'
  */
 export const DatasetDefault = ({ dataset, hasEdit }) => (
   <>
-    <ReadMore
-      fileTree={true}
-      id="collapse-tree"
-      expandLabel="Expand File Tree"
-      collapseLabel="Collapse File Tree">
-      <Files
-        datasetId={dataset.id}
-        snapshotTag={null}
-        datasetName={dataset.draft.description.Name}
-        files={dataset.draft.files}
-        editMode={hasEdit}
-        datasetPermissions={dataset.permissions}
-      />
-    </ReadMore>
+    <Files
+      datasetId={dataset.id}
+      snapshotTag={null}
+      datasetName={dataset.draft.description.Name}
+      files={dataset.draft.files}
+      editMode={hasEdit}
+      datasetPermissions={dataset.permissions}
+    />
     <MetaDataBlock
       heading="README"
       className="dataset-readme markdown-body"

--- a/packages/openneuro-app/src/scripts/dataset/routes/snapshot-default.tsx
+++ b/packages/openneuro-app/src/scripts/dataset/routes/snapshot-default.tsx
@@ -10,20 +10,14 @@ import Comments from '../comments/comments'
  */
 export const SnapshotDefault = ({ dataset, snapshot }) => (
   <>
-    <ReadMore
-      fileTree={true}
-      id="collapse-tree"
-      expandLabel="Read More"
-      collapseLabel="Collapse">
-      <Files
-        datasetId={dataset.id}
-        snapshotTag={snapshot.tag}
-        datasetName={snapshot.description.Name}
-        files={snapshot.files}
-        editMode={false}
-        datasetPermissions={dataset.permissions}
-      />
-    </ReadMore>
+    <Files
+      datasetId={dataset.id}
+      snapshotTag={snapshot.tag}
+      datasetName={snapshot.description.Name}
+      files={snapshot.files}
+      editMode={false}
+      datasetPermissions={dataset.permissions}
+    />
     <MetaDataBlock
       heading="README"
       item={

--- a/packages/openneuro-components/src/read-more/ReadMore.tsx
+++ b/packages/openneuro-components/src/read-more/ReadMore.tsx
@@ -5,7 +5,6 @@ export interface ReadMoreProps {
   id: string
   collapseLabel: string
   expandLabel: string
-  fileTree?: boolean
 }
 
 export const ReadMore = ({
@@ -13,7 +12,6 @@ export const ReadMore = ({
   id,
   expandLabel,
   collapseLabel,
-  fileTree,
 }: ReadMoreProps) => {
   const readmoreRef = useRef<HTMLDivElement>()
   const [dimensions, setDimensions] = useState({ height: 0 })
@@ -27,19 +25,7 @@ export const ReadMore = ({
 
   return (
     <div ref={readmoreRef}>
-      {fileTree && dimensions.height > 990 ? (
-        <article className="has-read-more readmore-file-tree">
-          <input type="checkbox" className="show-more" id={id} />
-
-          <section>
-            {children}
-            <label htmlFor={id} className="expand-collapse">
-              <span>{expandLabel}</span>
-              <span>{collapseLabel}</span>
-            </label>
-          </section>
-        </article>
-      ) : !fileTree && dimensions.height > 400 ? (
+      {dimensions.height > 400 ? (
         <article className="has-read-more file-tree">
           <input type="checkbox" className="show-more" id={id} />
 


### PR DESCRIPTION
Fixes issues with the FileTree component getting truncated by the ReadMore wrapper component. This will always show the full file listing now and tooltips are no longer cut off.

I gave scrolling within the file tree a try but this complicated navigation (especially on small screens) more than I think it helps with the few datasets that have a very large top level listings. Since we collapse directories anyways, it's rare enough to have a huge top level page that I think we should just leave the top level visible.