### PR TITLE
Dataset page layout height optimization

### DIFF
--- a/packages/openneuro-app/src/scripts/dataset/__tests__/__snapshots__/snapshot-container.spec.tsx.snap
+++ b/packages/openneuro-app/src/scripts/dataset/__tests__/__snapshots__/snapshot-container.spec.tsx.snap
@@ -62,105 +62,79 @@ exports[`SnapshotContainer component renders successfully 1`] = `
                 </div>
               </a>
               DS003-downsampled (only T1)
+              <div
+                class="css-1dyyc64"
+              >
+                <div
+                  class="toggle-counter-wrap"
+                >
+                  <span
+                    class=" "
+                    data-flow="up"
+                    data-tooltip="Get notified on new versions/comments"
+                  >
+                    <span
+                      class="toggle-counter disabled"
+                    >
+                      <button
+                        aria-label="Following"
+                        class="on-button on-button--medium on-button--default icon-text toggle-btn active"
+                        role="button"
+                        type="button"
+                      >
+                        <i
+                          aria-hidden="true"
+                          class="fa fa-star css-1qxtz39"
+                        />
+                        Following
+                        <span
+                          class="count-span"
+                        >
+                          1
+                        </span>
+                      </button>
+                    </span>
+                  </span>
+                </div>
+                <div
+                  class="toggle-counter-wrap"
+                >
+                  <span
+                    class=" "
+                    data-flow="up"
+                    data-tooltip="Save to your bookmarked datasets"
+                  >
+                    <span
+                      class="toggle-counter disabled"
+                    >
+                      <button
+                        aria-label="Bookmark"
+                        class="on-button on-button--medium on-button--default icon-text toggle-btn"
+                        role="button"
+                        type="button"
+                      >
+                        <i
+                          aria-hidden="true"
+                          class="fa fa-bookmark css-1qxtz39"
+                        />
+                        Bookmark
+                        <span
+                          class="count-span"
+                        >
+                          0
+                        </span>
+                      </button>
+                    </span>
+                  </span>
+                </div>
+              </div>
             </h1>
           </div>
         </div>
       </div>
     </div>
     <div
-      class="container"
-    >
-      <div
-        class="grid grid-between dataset-header-meta"
-      >
-        <div
-          class="col col-8 col-lg"
-        >
-          <div>
-            <span>
-              OpenNeuro Accession Number:
-            </span>
-             ds001032
-            <span>
-              Files:
-            </span>
-             7
-            <span>
-              Size:
-            </span>
-             608.78KB
-          </div>
-        </div>
-        <div
-          class="col follow-bookmark"
-        >
-          <div
-            class="toggle-counter-wrap"
-          >
-            <span
-              class=" "
-              data-flow="up"
-              data-tooltip="Get notified on new versions/comments"
-            >
-              <span
-                class="toggle-counter disabled"
-              >
-                <button
-                  aria-label="Following"
-                  class="on-button on-button--medium on-button--default icon-text toggle-btn active"
-                  role="button"
-                  type="button"
-                >
-                  <i
-                    aria-hidden="true"
-                    class="fa fa-star css-1qxtz39"
-                  />
-                  Following
-                  <span
-                    class="count-span"
-                  >
-                    1
-                  </span>
-                </button>
-              </span>
-            </span>
-          </div>
-          <div
-            class="toggle-counter-wrap"
-          >
-            <span
-              class=" "
-              data-flow="up"
-              data-tooltip="Save to your bookmarked datasets"
-            >
-              <span
-                class="toggle-counter disabled"
-              >
-                <button
-                  aria-label="Bookmark"
-                  class="on-button on-button--medium on-button--default icon-text toggle-btn"
-                  role="button"
-                  type="button"
-                >
-                  <i
-                    aria-hidden="true"
-                    class="fa fa-bookmark css-1qxtz39"
-                  />
-                  Bookmark
-                  <span
-                    class="count-span"
-                  >
-                    0
-                  </span>
-                </button>
-              </span>
-            </span>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      class="container"
+      class="dataset-content container"
     >
       <div
         class="grid grid-between"
@@ -434,7 +408,7 @@ exports[`SnapshotContainer component renders successfully 1`] = `
               class="css-1dvuowd"
             >
               <span
-                class="css-iux6yt"
+                class="css-1an2ojl"
               >
                 <span
                   class=" "
@@ -458,7 +432,7 @@ exports[`SnapshotContainer component renders successfully 1`] = `
                 </span>
               </span>
               <span
-                class="css-iux6yt"
+                class="css-1an2ojl"
               >
                 <span
                   class=" "
@@ -482,7 +456,7 @@ exports[`SnapshotContainer component renders successfully 1`] = `
                 </span>
               </span>
               <span
-                class="css-iux6yt"
+                class="css-1an2ojl"
               >
                 <span
                   class=" "
@@ -514,6 +488,16 @@ exports[`SnapshotContainer component renders successfully 1`] = `
         <div
           class="col sidebar"
         >
+          <div
+            class="dataset-meta-block undefined"
+          >
+            <h2
+              class="dmb-heading"
+            >
+              OpenNeuro Accession Number
+            </h2>
+            ds001032
+          </div>
           <div
             class="dataset-meta-block dmb-inline-list"
           >

--- a/packages/openneuro-app/src/scripts/dataset/common/follow-toggles.tsx
+++ b/packages/openneuro-app/src/scripts/dataset/common/follow-toggles.tsx
@@ -1,0 +1,12 @@
+import styled from '@emotion/styled'
+
+export const FollowToggles = styled.div`
+  display: flex;
+  font-size: 14px;
+  margin-left: auto;
+
+  .toggle-counter-wrap {
+    display: inline-flex;
+    margin-left: 1ch;
+  }
+`

--- a/packages/openneuro-app/src/scripts/dataset/draft-container.tsx
+++ b/packages/openneuro-app/src/scripts/dataset/draft-container.tsx
@@ -24,7 +24,6 @@ import {
   ValidationBlock,
   CloneDropdown,
   DatasetHeader,
-  DatasetHeaderMeta,
   DatasetGitAccess,
   VersionList,
   DatasetTools,
@@ -38,6 +37,7 @@ import EditDescriptionList from './fragments/edit-description-list.jsx'
 import { DOILink } from './fragments/doi-link'
 
 import { TabRoutesDraft } from './routes/tab-routes-draft'
+import { FollowToggles } from './common/follow-toggles'
 
 export interface DraftContainerProps {
   dataset
@@ -107,14 +107,30 @@ const DraftContainer: React.FC<DraftContainerProps> = ({ dataset }) => {
           pageHeading={description.Name}
           modality={modality}
           renderEditor={() => (
-            <EditDescriptionField
-              datasetId={datasetId}
-              field="Name"
-              rows={2}
-              description={description.Name}
-              editMode={hasEdit}>
-              {description.Name}
-            </EditDescriptionField>
+            <>
+              <EditDescriptionField
+                datasetId={datasetId}
+                field="Name"
+                rows={2}
+                description={description.Name}
+                editMode={hasEdit}>
+                {description.Name}
+              </EditDescriptionField>
+              <FollowToggles>
+                <FollowDataset
+                  profile={profile}
+                  datasetId={dataset.id}
+                  following={dataset.following}
+                  followers={dataset.followers.length}
+                />
+                <StarDataset
+                  profile={profile}
+                  datasetId={dataset.id}
+                  starred={dataset.starred}
+                  stars={dataset.stars.length}
+                />
+              </FollowToggles>
+            </>
           )}
         />
         <DatasetAlertDraft

--- a/packages/openneuro-app/src/scripts/dataset/draft-container.tsx
+++ b/packages/openneuro-app/src/scripts/dataset/draft-container.tsx
@@ -124,33 +124,6 @@ const DraftContainer: React.FC<DraftContainerProps> = ({ dataset }) => {
           hasSnapshot={dataset.snapshots.length !== 0}
         />
         <div className="container">
-          <div className="grid grid-between dataset-header-meta">
-            <div className="col col-8 col-lg">
-              {summary && (
-                <DatasetHeaderMeta
-                  size={dataset.draft.size}
-                  totalFiles={summary.totalFiles}
-                  datasetId={datasetId}
-                />
-              )}
-            </div>
-            <div className="col follow-bookmark">
-              <FollowDataset
-                profile={profile}
-                datasetId={dataset.id}
-                following={dataset.following}
-                followers={dataset.followers.length}
-              />
-              <StarDataset
-                profile={profile}
-                datasetId={dataset.id}
-                starred={dataset.starred}
-                stars={dataset.stars.length}
-              />
-            </div>
-          </div>
-        </div>
-        <div className="container">
           <div className="grid grid-between">
             <div className="col col-lg col-8">
               <div className="dataset-validation">
@@ -191,7 +164,10 @@ const DraftContainer: React.FC<DraftContainerProps> = ({ dataset }) => {
               </DatasetPageTabContainer>
             </div>
             <div className="col sidebar">
-              {' '}
+              <MetaDataBlock
+                heading="OpenNeuro Accession Number"
+                item={datasetId}
+              />
               <EditDescriptionList
                 className="dmb-inline-list"
                 datasetId={datasetId}

--- a/packages/openneuro-app/src/scripts/dataset/draft-container.tsx
+++ b/packages/openneuro-app/src/scripts/dataset/draft-container.tsx
@@ -123,7 +123,7 @@ const DraftContainer: React.FC<DraftContainerProps> = ({ dataset }) => {
           hasDraftChanges={hasDraftChanges}
           hasSnapshot={dataset.snapshots.length !== 0}
         />
-        <div className="container">
+        <div className="dataset-content container">
           <div className="grid grid-between">
             <div className="col col-lg col-8">
               <div className="dataset-validation">

--- a/packages/openneuro-app/src/scripts/dataset/files/files.jsx
+++ b/packages/openneuro-app/src/scripts/dataset/files/files.jsx
@@ -8,6 +8,18 @@ import { WarnButton } from '@openneuro/components/warn-button'
 import { AccordionWrap } from '@openneuro/components/accordion'
 import styled from '@emotion/styled'
 import { Tooltip } from '@openneuro/components/tooltip'
+import bytes from 'bytes'
+
+const FileTreeMeta = styled.span`
+  position: absolute;
+  top: 8px;
+  right: 8px;
+`
+
+const FileTreeMetaLabel = styled.label`
+  font-weight: bold;
+  padding-left: 1ch;
+`
 
 const StyleWrapper = styled.div`
   .filetree-wrapper {
@@ -28,6 +40,7 @@ const Files = ({
   files,
   editMode = false,
   datasetPermissions,
+  summary,
 }) => {
   const [filesToDelete, setFilesToDelete] = useState({})
   const [isDeleting, setIsDeleting] = useState(false)
@@ -108,6 +121,14 @@ const Files = ({
         </Media>
         <Media greaterThanOrEqual="medium">
           <div className="filetree-item">
+            {summary && (
+              <FileTreeMeta>
+                <FileTreeMetaLabel>Files:</FileTreeMetaLabel>{' '}
+                {summary.totalFiles}{' '}
+                <FileTreeMetaLabel>Size:</FileTreeMetaLabel>{' '}
+                {bytes(summary.size)}
+              </FileTreeMeta>
+            )}
             <FileTree
               datasetId={datasetId}
               snapshotTag={snapshotTag}
@@ -136,6 +157,7 @@ Files.propTypes = {
   editMode: PropTypes.bool,
   fetchMore: PropTypes.func,
   datasetPermissions: PropTypes.object,
+  summary: PropTypes.object,
 }
 
 export default Files

--- a/packages/openneuro-app/src/scripts/dataset/routes/dataset-default.tsx
+++ b/packages/openneuro-app/src/scripts/dataset/routes/dataset-default.tsx
@@ -38,6 +38,7 @@ export const DatasetDefault = ({ dataset, hasEdit }) => (
       files={dataset.draft.files}
       editMode={hasEdit}
       datasetPermissions={dataset.permissions}
+      summary={dataset.draft?.summary}
     />
     <Comments
       datasetId={dataset.id}

--- a/packages/openneuro-app/src/scripts/dataset/routes/dataset-default.tsx
+++ b/packages/openneuro-app/src/scripts/dataset/routes/dataset-default.tsx
@@ -11,14 +11,6 @@ import EditDescriptionField from '../fragments/edit-description-field'
  */
 export const DatasetDefault = ({ dataset, hasEdit }) => (
   <>
-    <Files
-      datasetId={dataset.id}
-      snapshotTag={null}
-      datasetName={dataset.draft.description.Name}
-      files={dataset.draft.files}
-      editMode={hasEdit}
-      datasetPermissions={dataset.permissions}
-    />
     <MetaDataBlock
       heading="README"
       className="dataset-readme markdown-body"
@@ -38,6 +30,14 @@ export const DatasetDefault = ({ dataset, hasEdit }) => (
           </ReadMore>
         </EditDescriptionField>
       )}
+    />
+    <Files
+      datasetId={dataset.id}
+      snapshotTag={null}
+      datasetName={dataset.draft.description.Name}
+      files={dataset.draft.files}
+      editMode={hasEdit}
+      datasetPermissions={dataset.permissions}
     />
     <Comments
       datasetId={dataset.id}

--- a/packages/openneuro-app/src/scripts/dataset/routes/snapshot-default.tsx
+++ b/packages/openneuro-app/src/scripts/dataset/routes/snapshot-default.tsx
@@ -28,6 +28,7 @@ export const SnapshotDefault = ({ dataset, snapshot }) => (
       files={snapshot.files}
       editMode={false}
       datasetPermissions={dataset.permissions}
+      summary={snapshot?.summary}
     />
     <Comments
       datasetId={dataset.id}

--- a/packages/openneuro-app/src/scripts/dataset/routes/snapshot-default.tsx
+++ b/packages/openneuro-app/src/scripts/dataset/routes/snapshot-default.tsx
@@ -10,14 +10,6 @@ import Comments from '../comments/comments'
  */
 export const SnapshotDefault = ({ dataset, snapshot }) => (
   <>
-    <Files
-      datasetId={dataset.id}
-      snapshotTag={snapshot.tag}
-      datasetName={snapshot.description.Name}
-      files={snapshot.files}
-      editMode={false}
-      datasetPermissions={dataset.permissions}
-    />
     <MetaDataBlock
       heading="README"
       item={
@@ -28,6 +20,14 @@ export const SnapshotDefault = ({ dataset, snapshot }) => (
         </ReadMore>
       }
       className="dataset-readme markdown-body"
+    />
+    <Files
+      datasetId={dataset.id}
+      snapshotTag={snapshot.tag}
+      datasetName={snapshot.description.Name}
+      files={snapshot.files}
+      editMode={false}
+      datasetPermissions={dataset.permissions}
     />
     <Comments
       datasetId={dataset.id}

--- a/packages/openneuro-app/src/scripts/dataset/snapshot-container.tsx
+++ b/packages/openneuro-app/src/scripts/dataset/snapshot-container.tsx
@@ -20,7 +20,6 @@ import {
   ValidationBlock,
   CloneDropdown,
   DatasetHeader,
-  DatasetHeaderMeta,
   DatasetGitAccess,
   VersionList,
   DatasetTools,
@@ -41,6 +40,7 @@ import { SNAPSHOT_FIELDS } from '../datalad/dataset/dataset-query-fragments.js'
 import { DOILink } from './fragments/doi-link'
 import { TabRoutesSnapshot } from './routes/tab-routes-snapshot'
 import schemaGenerator from '../utils/json-ld.js'
+import { FollowToggles } from './common/follow-toggles'
 
 const formatDate = dateObject =>
   new Date(dateObject).toISOString().split('T')[0]
@@ -100,10 +100,26 @@ export const SnapshotContainer: React.FC<SnapshotContainerProps> = ({
       <div
         className={`dataset dataset-draft dataset-page dataset-page-${modality?.toLowerCase()}`}>
         {summary && (
-          <DatasetHeader
-            pageHeading={description.Name}
-            modality={summary?.modalities[0]}
-          />
+          <>
+            <DatasetHeader
+              pageHeading={description.Name}
+              modality={summary?.modalities[0]}>
+              <FollowToggles>
+                <FollowDataset
+                  profile={profile}
+                  datasetId={dataset.id}
+                  following={dataset.following}
+                  followers={dataset.followers.length}
+                />
+                <StarDataset
+                  profile={profile}
+                  datasetId={dataset.id}
+                  starred={dataset.starred}
+                  stars={dataset.stars.length}
+                />
+              </FollowToggles>
+            </DatasetHeader>
+          </>
         )}
         {snapshot?.deprecated && (
           <DatasetAlertVersion

--- a/packages/openneuro-app/src/scripts/dataset/snapshot-container.tsx
+++ b/packages/openneuro-app/src/scripts/dataset/snapshot-container.tsx
@@ -114,33 +114,6 @@ export const SnapshotContainer: React.FC<SnapshotContainerProps> = ({
           />
         )}
         <div className="container">
-          <div className="grid grid-between dataset-header-meta">
-            <div className="col col-8 col-lg">
-              {summary && (
-                <DatasetHeaderMeta
-                  size={snapshot.size}
-                  totalFiles={summary.totalFiles}
-                  datasetId={datasetId}
-                />
-              )}
-            </div>
-            <div className="col follow-bookmark">
-              <FollowDataset
-                profile={profile}
-                datasetId={dataset.id}
-                following={dataset.following}
-                followers={dataset.followers.length}
-              />
-              <StarDataset
-                profile={profile}
-                datasetId={dataset.id}
-                starred={dataset.starred}
-                stars={dataset.stars.length}
-              />
-            </div>
-          </div>
-        </div>
-        <div className="container">
           <div className="grid grid-between">
             <div className="col col-lg col-8">
               <div className="dataset-validation">
@@ -181,6 +154,10 @@ export const SnapshotContainer: React.FC<SnapshotContainerProps> = ({
               </DatasetPageTabContainer>
             </div>
             <div className="col sidebar">
+              <MetaDataBlock
+                heading="OpenNeuro Accession Number"
+                item={datasetId}
+              />
               <MetaDataBlock
                 heading="Authors"
                 item={

--- a/packages/openneuro-app/src/scripts/dataset/snapshot-container.tsx
+++ b/packages/openneuro-app/src/scripts/dataset/snapshot-container.tsx
@@ -113,7 +113,7 @@ export const SnapshotContainer: React.FC<SnapshotContainerProps> = ({
             hasEdit={hasEdit}
           />
         )}
-        <div className="container">
+        <div className="dataset-content container">
           <div className="grid grid-between">
             <div className="col col-lg col-8">
               <div className="dataset-validation">

--- a/packages/openneuro-components/src/count-toggle/count-toggle.scss
+++ b/packages/openneuro-components/src/count-toggle/count-toggle.scss
@@ -6,10 +6,10 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  background: transparent;
+  background: #eee;
   &:hover {
     text-decoration: none;
-    background-color: #eee;
+    background-color: white;
   }
   i {
     margin: 2px 13px 0 5px;
@@ -21,9 +21,8 @@
 
     &.count-span {
       border-left: 1px solid #aaa;
-      margin-left: 30px;
-      padding: 7px 3px 7px 10px;
-      margin: -7px 0 -7px 12px;
+      margin-left: 14px;
+      padding: 3px 3px 3px 10px;
     }
   }
 

--- a/packages/openneuro-components/src/dataset/DatasetHeader.tsx
+++ b/packages/openneuro-components/src/dataset/DatasetHeader.tsx
@@ -5,12 +5,14 @@ export interface DatasetHeaderProps {
   modality: string
   pageHeading: string
   renderEditor?: () => React.ReactNode
+  children?: JSX.Element
 }
 
 export const DatasetHeader: React.FC<DatasetHeaderProps> = ({
   pageHeading,
   modality,
   renderEditor,
+  children,
 }) => {
   return (
     <div className="dataset-header">
@@ -31,6 +33,7 @@ export const DatasetHeader: React.FC<DatasetHeaderProps> = ({
                 </div>
               </Link>
               {renderEditor?.() || pageHeading}
+              {children}
             </h1>
           </div>
         </div>

--- a/packages/openneuro-components/src/dataset/DatasetToolButton.tsx
+++ b/packages/openneuro-components/src/dataset/DatasetToolButton.tsx
@@ -12,7 +12,7 @@ interface DatasetToolStyleProps {
 export const DatasetToolStyle = styled.span<DatasetToolStyleProps>(
   props => `
   display: flex;
-  margin: 0 auto 20px;
+  margin: 0 auto 10px;
   flex-basis: auto;
   padding: 0 15px;
   justify-content: center;

--- a/packages/openneuro-components/src/dataset/dataset-page.scss
+++ b/packages/openneuro-components/src/dataset/dataset-page.scss
@@ -1,8 +1,6 @@
 @import '../scss/variables';
 .dataset {
   .dataset-header {
-    padding: 20px 0;
-    margin-bottom: 40px;
     h1 {
       display: flex;
       align-items: center;
@@ -26,10 +24,10 @@
   }
 
   .dataset-header-meta {
-    margin: 40px 0 0;
+    margin: 20px 0 0;
     font-size: 14px;
     .col {
-      margin-bottom: 40px;
+      margin-bottom: 20px;
     }
     span {
       margin: 0 2px 0 10px;

--- a/packages/openneuro-components/src/dataset/dataset-page.scss
+++ b/packages/openneuro-components/src/dataset/dataset-page.scss
@@ -70,7 +70,7 @@
   .dataset-validation {
     display: flex;
     justify-content: space-between;
-    margin-bottom: 50px;
+    margin-bottom: 25px;
     @media (max-width: 767px) {
       flex-wrap: wrap;
       justify-content: flex-start;

--- a/packages/openneuro-components/src/dataset/dataset-page.scss
+++ b/packages/openneuro-components/src/dataset/dataset-page.scss
@@ -49,6 +49,7 @@
     }
   }
   .dataset-header-alert {
+    margin-bottom: 20px;
     padding: 10px 20px;
     background: #b5f1b5;
     display: flex;

--- a/packages/openneuro-components/src/dataset/dataset-page.scss
+++ b/packages/openneuro-components/src/dataset/dataset-page.scss
@@ -49,7 +49,6 @@
     }
   }
   .dataset-header-alert {
-    margin-bottom: 20px;
     padding: 10px 20px;
     background: #b5f1b5;
     display: flex;
@@ -65,6 +64,10 @@
     span[data-tooltip] {
       display: inline;
     }
+  }
+
+  .dataset-content {
+    margin-top: 25px;
   }
 
   .dataset-validation {

--- a/packages/openneuro-components/src/dataset/dataset-page.scss
+++ b/packages/openneuro-components/src/dataset/dataset-page.scss
@@ -5,6 +5,7 @@
       display: flex;
       align-items: center;
       color: #fff;
+      font-size: 24px;
       @media (max-width: 767px) {
         font-size: 20px;
         flex-wrap: wrap;
@@ -14,8 +15,8 @@
     .hexagon-wrapper {
       margin-right: 10px;
       @media (max-width: 767px) {
-        width: 65px;
-        height: 65px;
+        width: 56px;
+        height: 56px;
         div.label {
           font-size: 17px;
         }
@@ -23,31 +24,6 @@
     }
   }
 
-  .dataset-header-meta {
-    margin: 20px 0 0;
-    font-size: 14px;
-    .col {
-      margin-bottom: 20px;
-    }
-    span {
-      margin: 0 2px 0 10px;
-      font-weight: bold;
-      &:first-child {
-        margin-left: 0;
-      }
-    }
-    .follow-bookmark {
-      display: flex;
-      justify-content: flex-start;
-      flex-wrap: wrap;
-      .toggle-counter-wrap {
-        margin-bottom: 10px;
-        &:first-child {
-          margin-right: 30px;
-        }
-      }
-    }
-  }
   .dataset-header-alert {
     padding: 10px 20px;
     background: #b5f1b5;

--- a/packages/openneuro-components/src/header/Header.tsx
+++ b/packages/openneuro-components/src/header/Header.tsx
@@ -45,8 +45,7 @@ export const Header = ({
             isOpen
               ? 'navbar-inner-wrap nav-open'
               : 'navbar-inner-wrap nav-closed'
-          }
-        >
+          }>
           <div className="navbar-brand">
             <NavLink to="/">
               <Logo horizontal dark={false} />
@@ -56,16 +55,14 @@ export const Header = ({
           <div className="navbar-navigation">
             <span
               className="mobile-collapse-toggle"
-              onClick={() => setOpen(prev => !prev)}
-            >
+              onClick={() => setOpen(prev => !prev)}>
               <i className="fas fa-bars"></i>
               <span>menu bar</span>
             </span>
             <ul>
               <span
                 className="mobile-nav-close-x"
-                onClick={() => setOpen(prev => !prev)}
-              >
+                onClick={() => setOpen(prev => !prev)}>
                 &times;
               </span>
               <li>
@@ -76,8 +73,7 @@ export const Header = ({
                     e.preventDefault()
                     setOpen(prev => !prev)
                     navigateToNewSearch()
-                  }}
-                >
+                  }}>
                   Search
                 </NavLink>
               </li>
@@ -87,8 +83,7 @@ export const Header = ({
                   onClick={() => {
                     setOpen(prev => !prev)
                     toggleSupport()
-                  }}
-                >
+                  }}>
                   Support
                 </span>
               </li>
@@ -130,8 +125,7 @@ export const Header = ({
         className="freshdesk-support"
         isOpen={isOpenSupport}
         toggle={toggleSupport}
-        closeText="Close"
-      >
+        closeText="Close">
         <h3>OpenNeuro Support</h3>
         <p>
           Please email issues or questions to

--- a/packages/openneuro-components/src/header/header.scss
+++ b/packages/openneuro-components/src/header/header.scss
@@ -33,26 +33,6 @@ header {
   fill: $on-dark-aqua;
 }
 
-.swoop-hide-overflow {
-  overflow: hidden;
-  position: absolute;
-  width: 100%;
-  height: 330px;
-  bottom: 0;
-}
-
-.header-swoop {
-  background: $on-dark-aqua;
-  width: calc(100% + 104vw);
-  height: 330px;
-  border-radius: 100%;
-  margin: 0 0 0 -26vw;
-  position: absolute;
-  transform: scale(1.05) rotate(-2deg);
-  z-index: 2;
-  bottom: 81px;
-}
-
 .navbar-navigation {
   @media (max-width: 800px) {
     margin-top: 20px;


### PR DESCRIPTION
This PR moves to a denser presentation of the datasets page, trimming some whitespace and moving non-essential information lower to give a better view of the readme and file tree on common screen sizes.

* Reduces dataset title header height, especially on medium viewport sizes
* Places README ahead of the file tree on the default draft and snapshot tabs
* Moves follow and bookmark dataset buttons into header, responsive with the title text
* Moves file size and file count to Files component to the right of the top level folder
* Moves accession number to right sidebar
* Cleans up some dead CSS from previous iterations and moves some into shared components for drafts and snapshots