### PR TITLE
ENH: Support viewing MGH/MGZ files in browser

### DIFF
--- a/packages/openneuro-app/src/scripts/dataset/files/file-viewer-type.jsx
+++ b/packages/openneuro-app/src/scripts/dataset/files/file-viewer-type.jsx
@@ -19,7 +19,7 @@ const FileViewerType = ({ path, url, data }) => {
     path.endsWith('.txt')
   ) {
     return <FileViewerText data={data} />
-  } else if (path.endsWith('.nii.gz') || path.endsWith('.nii') || path.endswith('.mgh') || path.endswith('.mgz') {
+  } else if (path.endsWith('.nii.gz') || path.endsWith('.nii') || path.endsWith('.mgh') || path.endsWith('.mgz')) {
     return <FileViewerNifti imageUrl={url} />
   } else if (path.endsWith('.json')) {
     return <FileViewerJson data={data} />

--- a/packages/openneuro-app/src/scripts/dataset/files/file-viewer-type.jsx
+++ b/packages/openneuro-app/src/scripts/dataset/files/file-viewer-type.jsx
@@ -19,7 +19,7 @@ const FileViewerType = ({ path, url, data }) => {
     path.endsWith('.txt')
   ) {
     return <FileViewerText data={data} />
-  } else if (path.endsWith('.nii.gz') || path.endsWith('.nii')) {
+  } else if (path.endsWith('.nii.gz') || path.endsWith('.nii') || path.endswith('.mgh') || path.endswith('.mgz') {
     return <FileViewerNifti imageUrl={url} />
   } else if (path.endsWith('.json')) {
     return <FileViewerJson data={data} />


### PR DESCRIPTION
This will allow us to more easily look in FreeSurfer derivatives. `.mgh`/`.mgz` is the FreeSurfer volumetric format, roughly equivalent to NIfTI. I've verified that NiiVue supports it through https://niivue.github.io/niivue/features/basic.multiplanar.html.

Please let me know if there's a test that I can provide.