### PR TITLE
fix: Don't cache draft fallbacks for latestSnapshot forever

### DIFF
--- a/packages/openneuro-server/src/graphql/resolvers/snapshots.js
+++ b/packages/openneuro-server/src/graphql/resolvers/snapshots.js
@@ -13,6 +13,7 @@ import DeprecatedSnapshot from '../../models/deprecatedSnapshot'
 import { redis } from '../../libs/redis'
 import CacheItem, { CacheType } from '../../cache/item'
 import { normalizeDOI } from '../../libs/doi/normalize'
+import { getDraftHead } from '../../datalad/dataset'
 
 export const snapshots = obj => {
   return datalad.getSnapshots(obj.id)
@@ -219,8 +220,12 @@ export const latestSnapshot = async (obj, _, context) => {
   if (snapshotTag) {
     return await snapshot(obj, { datasetId: obj.id, tag: snapshotTag }, context)
   } else {
-    // In the case where there are no real snapshots, return HEAD as a snapshot
-    return await snapshot(obj, { datasetId: obj.id, tag: 'HEAD' }, context)
+    // In the case where there are no real snapshots, return most recent commit as snapshot
+    return await snapshot(
+      obj,
+      { datasetId: obj.id, tag: await getDraftHead(obj.id) },
+      context,
+    )
   }
 }
 


### PR DESCRIPTION
Use the actual commit hash instead of HEAD in the cache key for latestSnapshot when no snapshot exist. The latestSnapshot resolver has this fallback behavior to let search treat the draft as an in progress snapshot before 1.0.0 is created.

This would occasionally lead to snapshots failing to get created because an older version of the HEAD snapshot object was maintained and contained missing or invalid dataset_description.json or CHANGES files. Less obviously, sometimes an older version of these files would be used to mint the DOI and succeed.

Fixes #2590