### PR TITLE
deps: Update bids-validator to 1.9.8

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,6 +15,7 @@ stages:
 
 # Build base image for nodejs
 setup_nodejs:
+  tags: [ saas-linux-medium-amd64 ]
   stage: dependencies
   script:
     - docker login -u $CI_REGISTRY_USER -p $CI_REGISTRY_PASSWORD $CI_REGISTRY
@@ -24,6 +25,7 @@ setup_nodejs:
     - docker push $CI_REGISTRY_IMAGE/node:latest
 
 test_nodejs:
+  tags: [ saas-linux-medium-amd64 ]
   stage: test
   needs: ["setup_nodejs"]
   script:
@@ -33,6 +35,7 @@ test_nodejs:
     - docker run $ci_env -e CI=true $CI_REGISTRY_IMAGE/node:$CI_COMMIT_SHA yarn ci-coverage
 
 build_server:
+  tags: [ saas-linux-medium-amd64 ]
   stage: package
   needs: ["setup_nodejs"]
   script:
@@ -45,6 +48,7 @@ build_server:
     - docker push $CI_REGISTRY_IMAGE/server:latest
 
 build_app:
+  tags: [ saas-linux-large-amd64 ]
   stage: package
   needs: ["setup_nodejs"]
   script:
@@ -69,6 +73,7 @@ build_indexer:
     - docker push $CI_REGISTRY_IMAGE/indexer:latest
 
 build_datalad_service:
+  tags: [ saas-linux-medium-amd64 ]
   stage: dependencies
   needs: []
   script:

--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -8368,7 +8368,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@types/react-router-dom", "npm:5.3.3"],\
             ["@types/testing-library__jest-dom", "npm:5.14.1"],\
             ["babel-jest", "virtual:4112afb9dad10978c159910bf10db9840b981b1333117623c8a4a8cf77481344a0a24735a5506e2920c18e3cfa2cc179489824b6a56c988bb070f4f60da40974#npm:29.0.2"],\
-            ["bids-validator", "npm:1.9.3"],\
+            ["bids-validator", "npm:1.9.8"],\
             ["bytes", "npm:3.1.0"],\
             ["comlink", "npm:4.3.1"],\
             ["core-js", "npm:3.25.1"],\
@@ -8418,7 +8418,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@openneuro/client", "workspace:packages/openneuro-client"],\
             ["@types/mkdirp", "npm:1.0.2"],\
             ["@types/node", "npm:16.11.13"],\
-            ["bids-validator", "npm:1.9.3"],\
+            ["bids-validator", "npm:1.9.8"],\
             ["cli-progress", "npm:3.9.1"],\
             ["commander", "npm:7.2.0"],\
             ["core-js", "npm:3.18.0"],\
@@ -12451,10 +12451,10 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
         }]\
       ]],\
       ["bids-validator", [\
-        ["npm:1.9.3", {\
-          "packageLocation": "./.yarn/cache/bids-validator-npm-1.9.3-02a034ed19-f0e6713fe2.zip/node_modules/bids-validator/",\
+        ["npm:1.9.8", {\
+          "packageLocation": "./.yarn/cache/bids-validator-npm-1.9.8-06a6574078-531d1d880e.zip/node_modules/bids-validator/",\
           "packageDependencies": [\
-            ["bids-validator", "npm:1.9.3"],\
+            ["bids-validator", "npm:1.9.8"],\
             ["@aws-sdk/client-s3", "npm:3.33.0"],\
             ["ajv", "npm:6.12.6"],\
             ["bytes", "npm:3.1.0"],\
@@ -12463,7 +12463,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["date-fns", "npm:2.24.0"],\
             ["events", "npm:3.3.0"],\
             ["exifreader", "npm:4.2.0"],\
-            ["hed-validator", "npm:3.6.0"],\
+            ["hed-validator", "npm:3.8.0"],\
             ["ignore", "npm:4.0.6"],\
             ["is-utf8", "npm:0.2.1"],\
             ["jshint", "npm:2.13.1"],\
@@ -18041,13 +18041,16 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
         }]\
       ]],\
       ["hed-validator", [\
-        ["npm:3.6.0", {\
-          "packageLocation": "./.yarn/cache/hed-validator-npm-3.6.0-7399865048-1dad68474f.zip/node_modules/hed-validator/",\
+        ["npm:3.8.0", {\
+          "packageLocation": "./.yarn/cache/hed-validator-npm-3.8.0-a2aeac5f28-e2978e3155.zip/node_modules/hed-validator/",\
           "packageDependencies": [\
-            ["hed-validator", "npm:3.6.0"],\
+            ["hed-validator", "npm:3.8.0"],\
+            ["buffer", "npm:6.0.3"],\
             ["date-and-time", "npm:0.14.2"],\
             ["date-fns", "npm:2.24.0"],\
+            ["events", "npm:3.3.0"],\
             ["lodash", "npm:4.17.21"],\
+            ["path", "npm:0.12.7"],\
             ["pluralize", "npm:8.0.0"],\
             ["semver", "npm:7.3.5"],\
             ["then-request", "npm:6.0.2"],\

--- a/packages/openneuro-app/Dockerfile
+++ b/packages/openneuro-app/Dockerfile
@@ -1,7 +1,7 @@
 FROM openneuro/node AS app
 
 WORKDIR /srv/packages/openneuro-app
-RUN NODE_OPTIONS=--max_old_space_size=4096 yarn build && cp maintenance.html src/dist && cp src/assets/favicon.ico src/dist
+RUN NODE_OPTIONS=--max_old_space_size=8192 yarn build && cp maintenance.html src/dist && cp src/assets/favicon.ico src/dist
 
 FROM nginx:alpine AS web
 

--- a/packages/openneuro-app/package.json
+++ b/packages/openneuro-app/package.json
@@ -10,7 +10,7 @@
   },
   "scripts": {
     "start": "vite",
-    "build": "vite build --outDir dist"
+    "build": "vite build --outDir dist --debug"
   },
   "author": "Squishymedia",
   "dependencies": {

--- a/packages/openneuro-app/package.json
+++ b/packages/openneuro-app/package.json
@@ -22,7 +22,7 @@
     "@niivue/niivue": "0.23.1",
     "@openneuro/client": "^4.10.0",
     "@openneuro/components": "^4.10.0",
-    "bids-validator": "1.9.3",
+    "bids-validator": "1.9.8",
     "bytes": "^3.0.0",
     "comlink": "^4.0.5",
     "date-fns": "^2.16.1",

--- a/packages/openneuro-app/package.json
+++ b/packages/openneuro-app/package.json
@@ -10,7 +10,7 @@
   },
   "scripts": {
     "start": "vite",
-    "build": "vite build --outDir dist --debug"
+    "build": "vite build --outDir dist"
   },
   "author": "Squishymedia",
   "dependencies": {

--- a/packages/openneuro-app/src/scripts/dataset/__tests__/__snapshots__/snapshot-container.spec.tsx.snap
+++ b/packages/openneuro-app/src/scripts/dataset/__tests__/__snapshots__/snapshot-container.spec.tsx.snap
@@ -1474,7 +1474,7 @@ OCI-1131441 (R. Poldrack, PI) in any publications.
             >
               Uploaded by
             </h2>
-            Test User on 2021-12-17 - 9 months ago
+            Test User on 2021-12-17 - 10 months ago
           </div>
           <div
             class="dataset-meta-block undefined"
@@ -1484,7 +1484,7 @@ OCI-1131441 (R. Poldrack, PI) in any publications.
             >
               Last Updated
             </h2>
-            2021-12-17 - 9 months ago
+            2021-12-17 - 10 months ago
           </div>
           <div
             class="dataset-meta-block undefined"

--- a/packages/openneuro-cli/package.json
+++ b/packages/openneuro-cli/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@apollo/client": "3.4.17",
     "@openneuro/client": "^4.10.0",
-    "bids-validator": "1.9.3",
+    "bids-validator": "1.9.8",
     "cli-progress": "^3.8.2",
     "commander": "7.2.0",
     "cross-fetch": "^3.0.5",

--- a/services/datalad/package.json
+++ b/services/datalad/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "bids-validator": "1.9.3"
+    "bids-validator": "1.9.8"
   }
 }

--- a/services/datalad/yarn.lock
+++ b/services/datalad/yarn.lock
@@ -2,870 +2,1079 @@
 # Manual changes might be lost - proceed with caution!
 
 __metadata:
-  version: 5
+  version: 6
   cacheKey: 8
 
-"@aws-crypto/crc32@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "@aws-crypto/crc32@npm:1.0.0"
+"@aws-crypto/crc32@npm:2.0.0":
+  version: 2.0.0
+  resolution: "@aws-crypto/crc32@npm:2.0.0"
   dependencies:
+    "@aws-crypto/util": ^2.0.0
+    "@aws-sdk/types": ^3.1.0
     tslib: ^1.11.1
-  checksum: 45f870abaa13304f354132a0081d576c6f55daa50bd277bc05e971f6f39448b827825f6bfaae853d44d46ffd1f53e0659025a1e73b07d4ebc7f9160d4807dbd7
+  checksum: 88ab906da8304a430c655496e363835f3c7ca870db0dec50bb9d53ed0f446337de60c85ba7baa4528c8363bee708474785649262ebfde23a1e099eb69318b53e
   languageName: node
   linkType: hard
 
-"@aws-crypto/ie11-detection@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "@aws-crypto/ie11-detection@npm:1.0.0"
+"@aws-crypto/crc32c@npm:2.0.0":
+  version: 2.0.0
+  resolution: "@aws-crypto/crc32c@npm:2.0.0"
   dependencies:
+    "@aws-crypto/util": ^2.0.0
+    "@aws-sdk/types": ^3.1.0
     tslib: ^1.11.1
-  checksum: c6d157a0ca81e34f22efc9434b72c9fc657131f4d0b63db7271e08b31f9706a25d88d753e57e792b6ab2cb266527599dd997db389f3ec4562c26ffe10abcdc81
+  checksum: 776e1e61b3bde018b815d3973774a4ec3cd88c282046e49bb5a2625ac7db923068aad708a8e4c21b62a80e50a5c58324a32621b9ba82b7b2ecab66370c4fe893
   languageName: node
   linkType: hard
 
-"@aws-crypto/sha256-browser@npm:^1.0.0":
-  version: 1.1.0
-  resolution: "@aws-crypto/sha256-browser@npm:1.1.0"
+"@aws-crypto/ie11-detection@npm:^2.0.0":
+  version: 2.0.2
+  resolution: "@aws-crypto/ie11-detection@npm:2.0.2"
   dependencies:
-    "@aws-crypto/ie11-detection": ^1.0.0
-    "@aws-crypto/sha256-js": ^1.1.0
-    "@aws-crypto/supports-web-crypto": ^1.0.0
+    tslib: ^1.11.1
+  checksum: 713293deea8eefd3ab43dc05e62228571d27754e7293f8ec2fd8a0c693fbbfc55213e6599387776e3cdbc951965dc62e24e92b9c4a853e4a50d00ae6a9f6b2bd
+  languageName: node
+  linkType: hard
+
+"@aws-crypto/sha1-browser@npm:2.0.0":
+  version: 2.0.0
+  resolution: "@aws-crypto/sha1-browser@npm:2.0.0"
+  dependencies:
+    "@aws-crypto/ie11-detection": ^2.0.0
+    "@aws-crypto/supports-web-crypto": ^2.0.0
     "@aws-sdk/types": ^3.1.0
     "@aws-sdk/util-locate-window": ^3.0.0
     "@aws-sdk/util-utf8-browser": ^3.0.0
     tslib: ^1.11.1
-  checksum: c8cfec74e77eee34ae70782fc51ba5dea53fa90207250f1564ed20c37bc52331e37f7e8bea8d3d0bad9b8426561dc91da06efcd8680c7934a42fd16a30552c25
+  checksum: 72c0b24800cd79328fef934553e7a5d5929c90877d7e9a661614542dd29d0d99ee1594bd59fc028ee9ec595d77df56645a396c6336cff3c7784a564302d4a254
   languageName: node
   linkType: hard
 
-"@aws-crypto/sha256-js@npm:^1.0.0, @aws-crypto/sha256-js@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "@aws-crypto/sha256-js@npm:1.1.0"
+"@aws-crypto/sha256-browser@npm:2.0.0":
+  version: 2.0.0
+  resolution: "@aws-crypto/sha256-browser@npm:2.0.0"
   dependencies:
+    "@aws-crypto/ie11-detection": ^2.0.0
+    "@aws-crypto/sha256-js": ^2.0.0
+    "@aws-crypto/supports-web-crypto": ^2.0.0
+    "@aws-crypto/util": ^2.0.0
     "@aws-sdk/types": ^3.1.0
+    "@aws-sdk/util-locate-window": ^3.0.0
     "@aws-sdk/util-utf8-browser": ^3.0.0
     tslib: ^1.11.1
-  checksum: ad2ec3a6a2c2c254a4eeb7a6563ac5086883c649f255dd40fcf4fcf9ff095427a68ddcbe13c4a2fd4153fb855e5d9f1d7687c32b01137bec4219c3c69bad2fa5
+  checksum: 7bc1ff042d0c53a46c0fc3824bd97fb3ed1df7dc030b8a995889471052860b8c8ade469c97866fafd8249a3144d0f48b0f1054f357e2b403606009381c4b8f0e
   languageName: node
   linkType: hard
 
-"@aws-crypto/supports-web-crypto@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "@aws-crypto/supports-web-crypto@npm:1.0.0"
+"@aws-crypto/sha256-js@npm:2.0.0":
+  version: 2.0.0
+  resolution: "@aws-crypto/sha256-js@npm:2.0.0"
+  dependencies:
+    "@aws-crypto/util": ^2.0.0
+    "@aws-sdk/types": ^3.1.0
+    tslib: ^1.11.1
+  checksum: e4abf9baec6bed19d380f92a999a41ac5bdd8890dfd45971d29054c298854c5b7087e7de633413f2e64618ef8238ccf4c0b75797c73063c74bbba3cb5d8b2581
+  languageName: node
+  linkType: hard
+
+"@aws-crypto/sha256-js@npm:^2.0.0":
+  version: 2.0.2
+  resolution: "@aws-crypto/sha256-js@npm:2.0.2"
+  dependencies:
+    "@aws-crypto/util": ^2.0.2
+    "@aws-sdk/types": ^3.110.0
+    tslib: ^1.11.1
+  checksum: 9125ec65a2b05fce908ac2289ba97b995a299f2d717684804211df8e8bcffd8cd9b8861582240655b88f2255c46fcee34026f75c057ffb22f44b6a76cd43f65a
+  languageName: node
+  linkType: hard
+
+"@aws-crypto/supports-web-crypto@npm:^2.0.0":
+  version: 2.0.2
+  resolution: "@aws-crypto/supports-web-crypto@npm:2.0.2"
   dependencies:
     tslib: ^1.11.1
-  checksum: 2d5878e3d5e2b7c94b51e33ceaa2e0d350dcc31067f557a4e598f80681dc4d1c5437e69db45f0b76f4e0a1cee2dbe4ccb1b25ea33ec70fef26b03db70106ab4a
+  checksum: 03d04d29292dc1b76db9bc6becd05f52fa79adee0ec084f971b0767f7e73250dd0422bea57636015f8c27f38aefcd1d9c58800a4749cf35339296c8d670f3ccb
   languageName: node
   linkType: hard
 
-"@aws-sdk/abort-controller@npm:3.10.0":
-  version: 3.10.0
-  resolution: "@aws-sdk/abort-controller@npm:3.10.0"
+"@aws-crypto/util@npm:^2.0.0, @aws-crypto/util@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "@aws-crypto/util@npm:2.0.2"
   dependencies:
-    "@aws-sdk/types": 3.10.0
-    tslib: ^1.8.0
-  checksum: 861c7ca14bb773b64454bac8b96d54090110fb5f3871f14182ecd4d243d180b61a78425edc3ed1f43213e744229a8a0cb0a4acc751fb877866336afa4d4d02c7
+    "@aws-sdk/types": ^3.110.0
+    "@aws-sdk/util-utf8-browser": ^3.0.0
+    tslib: ^1.11.1
+  checksum: 13cb33a39005b09c062398d361043c2224bc8ba42b1432bad52e15bc4bf9ffad4facdddc394b3cc71b3fb8d86a7ec325fd1afa107b5fde0dab84a7e32d311d7f
   languageName: node
   linkType: hard
 
-"@aws-sdk/chunked-blob-reader-native@npm:3.10.0":
-  version: 3.10.0
-  resolution: "@aws-sdk/chunked-blob-reader-native@npm:3.10.0"
+"@aws-sdk/abort-controller@npm:3.178.0":
+  version: 3.178.0
+  resolution: "@aws-sdk/abort-controller@npm:3.178.0"
   dependencies:
-    "@aws-sdk/util-base64-browser": 3.10.0
-    tslib: ^1.8.0
-  checksum: 2ebac55d1569b04f5010a12dcab02b15a99db0cd149c87c7819dd936e010066e184f17223311d20e9024201dd09a9dcfffb6f6f7d65e7dae31e6f3102fc6bd9f
+    "@aws-sdk/types": 3.178.0
+    tslib: ^2.3.1
+  checksum: 6e2730b4fc20c7fdb6d36595feb3d2d2f8e4ba8be27a916a77066b7c48465cc098d3ba6971b4ca29c51c4f6de3adb08a329fba04358a54a5311869c74233782d
   languageName: node
   linkType: hard
 
-"@aws-sdk/chunked-blob-reader@npm:3.10.0":
-  version: 3.10.0
-  resolution: "@aws-sdk/chunked-blob-reader@npm:3.10.0"
+"@aws-sdk/chunked-blob-reader-native@npm:3.170.0":
+  version: 3.170.0
+  resolution: "@aws-sdk/chunked-blob-reader-native@npm:3.170.0"
   dependencies:
-    tslib: ^1.8.0
-  checksum: 82ff18dcf4701bbcbb9d21cad89fc79b588fc5ab4ba2229162b16fd95983938ab25019fd4994bd082dd195384618f5e40bc262d79f9cbcd788f4ed0317a18a85
+    "@aws-sdk/util-base64-browser": 3.170.0
+    tslib: ^2.3.1
+  checksum: e1912aaeb32ef2c2040868c6476d273d16b9e6c913f49483648c827308f257adfa8e1b6429194994d6364a389c3b240eb37a6a0f665f9dbd72c60d65ae9cb2e7
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/chunked-blob-reader@npm:3.170.0":
+  version: 3.170.0
+  resolution: "@aws-sdk/chunked-blob-reader@npm:3.170.0"
+  dependencies:
+    tslib: ^2.3.1
+  checksum: cd26800b9a8b11d9ad73766ec911779470027140aa928c6640d0092395825963b76cda84759d0faafa1f39ddfb9c9c3b2e5ec7ffd2f05462d12b5c04e07ac810
   languageName: node
   linkType: hard
 
 "@aws-sdk/client-s3@npm:^3.9.0":
-  version: 3.11.0
-  resolution: "@aws-sdk/client-s3@npm:3.11.0"
+  version: 3.181.0
+  resolution: "@aws-sdk/client-s3@npm:3.181.0"
   dependencies:
-    "@aws-crypto/sha256-browser": ^1.0.0
-    "@aws-crypto/sha256-js": ^1.0.0
-    "@aws-sdk/config-resolver": 3.10.0
-    "@aws-sdk/credential-provider-node": 3.11.0
-    "@aws-sdk/eventstream-serde-browser": 3.10.0
-    "@aws-sdk/eventstream-serde-config-resolver": 3.10.0
-    "@aws-sdk/eventstream-serde-node": 3.10.0
-    "@aws-sdk/fetch-http-handler": 3.10.0
-    "@aws-sdk/hash-blob-browser": 3.10.0
-    "@aws-sdk/hash-node": 3.10.0
-    "@aws-sdk/hash-stream-node": 3.10.0
-    "@aws-sdk/invalid-dependency": 3.10.0
-    "@aws-sdk/md5-js": 3.10.0
-    "@aws-sdk/middleware-apply-body-checksum": 3.10.0
-    "@aws-sdk/middleware-bucket-endpoint": 3.10.0
-    "@aws-sdk/middleware-content-length": 3.10.0
-    "@aws-sdk/middleware-expect-continue": 3.10.0
-    "@aws-sdk/middleware-host-header": 3.10.0
-    "@aws-sdk/middleware-location-constraint": 3.10.0
-    "@aws-sdk/middleware-logger": 3.10.0
-    "@aws-sdk/middleware-retry": 3.10.0
-    "@aws-sdk/middleware-sdk-s3": 3.10.0
-    "@aws-sdk/middleware-serde": 3.10.0
-    "@aws-sdk/middleware-signing": 3.10.0
-    "@aws-sdk/middleware-ssec": 3.10.0
-    "@aws-sdk/middleware-stack": 3.10.0
-    "@aws-sdk/middleware-user-agent": 3.10.0
-    "@aws-sdk/node-config-provider": 3.10.0
-    "@aws-sdk/node-http-handler": 3.10.0
-    "@aws-sdk/protocol-http": 3.10.0
-    "@aws-sdk/smithy-client": 3.10.0
-    "@aws-sdk/types": 3.10.0
-    "@aws-sdk/url-parser": 3.10.0
-    "@aws-sdk/url-parser-native": 3.10.0
-    "@aws-sdk/util-base64-browser": 3.10.0
-    "@aws-sdk/util-base64-node": 3.10.0
-    "@aws-sdk/util-body-length-browser": 3.10.0
-    "@aws-sdk/util-body-length-node": 3.10.0
-    "@aws-sdk/util-user-agent-browser": 3.10.0
-    "@aws-sdk/util-user-agent-node": 3.10.0
-    "@aws-sdk/util-utf8-browser": 3.10.0
-    "@aws-sdk/util-utf8-node": 3.10.0
-    "@aws-sdk/util-waiter": 3.10.0
-    "@aws-sdk/xml-builder": 3.10.0
+    "@aws-crypto/sha1-browser": 2.0.0
+    "@aws-crypto/sha256-browser": 2.0.0
+    "@aws-crypto/sha256-js": 2.0.0
+    "@aws-sdk/client-sts": 3.181.0
+    "@aws-sdk/config-resolver": 3.178.0
+    "@aws-sdk/credential-provider-node": 3.181.0
+    "@aws-sdk/eventstream-serde-browser": 3.178.0
+    "@aws-sdk/eventstream-serde-config-resolver": 3.178.0
+    "@aws-sdk/eventstream-serde-node": 3.178.0
+    "@aws-sdk/fetch-http-handler": 3.178.0
+    "@aws-sdk/hash-blob-browser": 3.178.0
+    "@aws-sdk/hash-node": 3.178.0
+    "@aws-sdk/hash-stream-node": 3.178.0
+    "@aws-sdk/invalid-dependency": 3.178.0
+    "@aws-sdk/md5-js": 3.178.0
+    "@aws-sdk/middleware-bucket-endpoint": 3.178.0
+    "@aws-sdk/middleware-content-length": 3.178.0
+    "@aws-sdk/middleware-expect-continue": 3.178.0
+    "@aws-sdk/middleware-flexible-checksums": 3.178.0
+    "@aws-sdk/middleware-host-header": 3.178.0
+    "@aws-sdk/middleware-location-constraint": 3.178.0
+    "@aws-sdk/middleware-logger": 3.178.0
+    "@aws-sdk/middleware-recursion-detection": 3.178.0
+    "@aws-sdk/middleware-retry": 3.178.0
+    "@aws-sdk/middleware-sdk-s3": 3.178.0
+    "@aws-sdk/middleware-serde": 3.178.0
+    "@aws-sdk/middleware-signing": 3.179.0
+    "@aws-sdk/middleware-ssec": 3.178.0
+    "@aws-sdk/middleware-stack": 3.178.0
+    "@aws-sdk/middleware-user-agent": 3.178.0
+    "@aws-sdk/node-config-provider": 3.178.0
+    "@aws-sdk/node-http-handler": 3.178.0
+    "@aws-sdk/protocol-http": 3.178.0
+    "@aws-sdk/signature-v4-multi-region": 3.180.0
+    "@aws-sdk/smithy-client": 3.180.0
+    "@aws-sdk/types": 3.178.0
+    "@aws-sdk/url-parser": 3.178.0
+    "@aws-sdk/util-base64-browser": 3.170.0
+    "@aws-sdk/util-base64-node": 3.170.0
+    "@aws-sdk/util-body-length-browser": 3.170.0
+    "@aws-sdk/util-body-length-node": 3.170.0
+    "@aws-sdk/util-defaults-mode-browser": 3.180.0
+    "@aws-sdk/util-defaults-mode-node": 3.180.0
+    "@aws-sdk/util-stream-browser": 3.178.0
+    "@aws-sdk/util-stream-node": 3.178.0
+    "@aws-sdk/util-user-agent-browser": 3.178.0
+    "@aws-sdk/util-user-agent-node": 3.178.0
+    "@aws-sdk/util-utf8-browser": 3.170.0
+    "@aws-sdk/util-utf8-node": 3.170.0
+    "@aws-sdk/util-waiter": 3.180.0
+    "@aws-sdk/xml-builder": 3.170.0
+    entities: 2.2.0
     fast-xml-parser: 3.19.0
-    tslib: ^2.0.0
-  checksum: 6e4920dd436728337cde00944ee593a84643c169637a5445e77acf0e9eac455106b335ed632906f1e2f60d26f3cefefde3087a61d2b6e39fb20ccea550c7fe9f
+    tslib: ^2.3.1
+  checksum: cadb55aeea65eb908aa6e59cc18fc4ef46c6c9f98c35b57da1846f9ad350caa67e94255272cd0a7aaf20d6b5c6239f960b2013e534cdc7d158a77b4319da7abd
   languageName: node
   linkType: hard
 
-"@aws-sdk/client-sso@npm:3.11.0":
-  version: 3.11.0
-  resolution: "@aws-sdk/client-sso@npm:3.11.0"
+"@aws-sdk/client-sso@npm:3.181.0":
+  version: 3.181.0
+  resolution: "@aws-sdk/client-sso@npm:3.181.0"
   dependencies:
-    "@aws-crypto/sha256-browser": ^1.0.0
-    "@aws-crypto/sha256-js": ^1.0.0
-    "@aws-sdk/config-resolver": 3.10.0
-    "@aws-sdk/fetch-http-handler": 3.10.0
-    "@aws-sdk/hash-node": 3.10.0
-    "@aws-sdk/invalid-dependency": 3.10.0
-    "@aws-sdk/middleware-content-length": 3.10.0
-    "@aws-sdk/middleware-host-header": 3.10.0
-    "@aws-sdk/middleware-logger": 3.10.0
-    "@aws-sdk/middleware-retry": 3.10.0
-    "@aws-sdk/middleware-serde": 3.10.0
-    "@aws-sdk/middleware-stack": 3.10.0
-    "@aws-sdk/middleware-user-agent": 3.10.0
-    "@aws-sdk/node-config-provider": 3.10.0
-    "@aws-sdk/node-http-handler": 3.10.0
-    "@aws-sdk/protocol-http": 3.10.0
-    "@aws-sdk/smithy-client": 3.10.0
-    "@aws-sdk/types": 3.10.0
-    "@aws-sdk/url-parser": 3.10.0
-    "@aws-sdk/url-parser-native": 3.10.0
-    "@aws-sdk/util-base64-browser": 3.10.0
-    "@aws-sdk/util-base64-node": 3.10.0
-    "@aws-sdk/util-body-length-browser": 3.10.0
-    "@aws-sdk/util-body-length-node": 3.10.0
-    "@aws-sdk/util-user-agent-browser": 3.10.0
-    "@aws-sdk/util-user-agent-node": 3.10.0
-    "@aws-sdk/util-utf8-browser": 3.10.0
-    "@aws-sdk/util-utf8-node": 3.10.0
-    tslib: ^2.0.0
-  checksum: 7cd586edc0ee6cb42b377e9dc086be20695a705ad631007c0aae84abae51fddb6dacef442706190d09d3a2f8617d7b338e97b28158febcb616e84ef7dced7455
+    "@aws-crypto/sha256-browser": 2.0.0
+    "@aws-crypto/sha256-js": 2.0.0
+    "@aws-sdk/config-resolver": 3.178.0
+    "@aws-sdk/fetch-http-handler": 3.178.0
+    "@aws-sdk/hash-node": 3.178.0
+    "@aws-sdk/invalid-dependency": 3.178.0
+    "@aws-sdk/middleware-content-length": 3.178.0
+    "@aws-sdk/middleware-host-header": 3.178.0
+    "@aws-sdk/middleware-logger": 3.178.0
+    "@aws-sdk/middleware-recursion-detection": 3.178.0
+    "@aws-sdk/middleware-retry": 3.178.0
+    "@aws-sdk/middleware-serde": 3.178.0
+    "@aws-sdk/middleware-stack": 3.178.0
+    "@aws-sdk/middleware-user-agent": 3.178.0
+    "@aws-sdk/node-config-provider": 3.178.0
+    "@aws-sdk/node-http-handler": 3.178.0
+    "@aws-sdk/protocol-http": 3.178.0
+    "@aws-sdk/smithy-client": 3.180.0
+    "@aws-sdk/types": 3.178.0
+    "@aws-sdk/url-parser": 3.178.0
+    "@aws-sdk/util-base64-browser": 3.170.0
+    "@aws-sdk/util-base64-node": 3.170.0
+    "@aws-sdk/util-body-length-browser": 3.170.0
+    "@aws-sdk/util-body-length-node": 3.170.0
+    "@aws-sdk/util-defaults-mode-browser": 3.180.0
+    "@aws-sdk/util-defaults-mode-node": 3.180.0
+    "@aws-sdk/util-user-agent-browser": 3.178.0
+    "@aws-sdk/util-user-agent-node": 3.178.0
+    "@aws-sdk/util-utf8-browser": 3.170.0
+    "@aws-sdk/util-utf8-node": 3.170.0
+    tslib: ^2.3.1
+  checksum: ae4a635fcf496d3efc493ec99d8e2e6fe2c736b62fd6ac575ff62c8690ee006a386637845fb5b9129fcf7e5f80ab8fc9674c03312ded1516c6c8debc4d656431
   languageName: node
   linkType: hard
 
-"@aws-sdk/config-resolver@npm:3.10.0":
-  version: 3.10.0
-  resolution: "@aws-sdk/config-resolver@npm:3.10.0"
+"@aws-sdk/client-sts@npm:3.181.0":
+  version: 3.181.0
+  resolution: "@aws-sdk/client-sts@npm:3.181.0"
   dependencies:
-    "@aws-sdk/signature-v4": 3.10.0
-    "@aws-sdk/types": 3.10.0
-    tslib: ^1.8.0
-  checksum: 1a71385c620d9325776ab3eb7e4de550f1bc9a56c478b456f0a82ce4cd82cfaff431bca65a210a2dd142a373c7588c7aaa474e1202a8f6192529a225a5dfc0b4
+    "@aws-crypto/sha256-browser": 2.0.0
+    "@aws-crypto/sha256-js": 2.0.0
+    "@aws-sdk/config-resolver": 3.178.0
+    "@aws-sdk/credential-provider-node": 3.181.0
+    "@aws-sdk/fetch-http-handler": 3.178.0
+    "@aws-sdk/hash-node": 3.178.0
+    "@aws-sdk/invalid-dependency": 3.178.0
+    "@aws-sdk/middleware-content-length": 3.178.0
+    "@aws-sdk/middleware-host-header": 3.178.0
+    "@aws-sdk/middleware-logger": 3.178.0
+    "@aws-sdk/middleware-recursion-detection": 3.178.0
+    "@aws-sdk/middleware-retry": 3.178.0
+    "@aws-sdk/middleware-sdk-sts": 3.179.0
+    "@aws-sdk/middleware-serde": 3.178.0
+    "@aws-sdk/middleware-signing": 3.179.0
+    "@aws-sdk/middleware-stack": 3.178.0
+    "@aws-sdk/middleware-user-agent": 3.178.0
+    "@aws-sdk/node-config-provider": 3.178.0
+    "@aws-sdk/node-http-handler": 3.178.0
+    "@aws-sdk/protocol-http": 3.178.0
+    "@aws-sdk/smithy-client": 3.180.0
+    "@aws-sdk/types": 3.178.0
+    "@aws-sdk/url-parser": 3.178.0
+    "@aws-sdk/util-base64-browser": 3.170.0
+    "@aws-sdk/util-base64-node": 3.170.0
+    "@aws-sdk/util-body-length-browser": 3.170.0
+    "@aws-sdk/util-body-length-node": 3.170.0
+    "@aws-sdk/util-defaults-mode-browser": 3.180.0
+    "@aws-sdk/util-defaults-mode-node": 3.180.0
+    "@aws-sdk/util-user-agent-browser": 3.178.0
+    "@aws-sdk/util-user-agent-node": 3.178.0
+    "@aws-sdk/util-utf8-browser": 3.170.0
+    "@aws-sdk/util-utf8-node": 3.170.0
+    entities: 2.2.0
+    fast-xml-parser: 3.19.0
+    tslib: ^2.3.1
+  checksum: e9cf6b407f1500633fd3b9b9994abad8c222b225e9c6b58ad55f906123ad1fe0a8646f700aec66c9769526b6e93dffae5303bb091c76b320d478450d3d9cd68f
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-env@npm:3.10.0":
-  version: 3.10.0
-  resolution: "@aws-sdk/credential-provider-env@npm:3.10.0"
+"@aws-sdk/config-resolver@npm:3.178.0":
+  version: 3.178.0
+  resolution: "@aws-sdk/config-resolver@npm:3.178.0"
   dependencies:
-    "@aws-sdk/property-provider": 3.10.0
-    "@aws-sdk/types": 3.10.0
-    tslib: ^1.8.0
-  checksum: 4415aa0a87d2f2838c8e6448410aa9c7b94a27cbb44af787b5b497fdbd09121c3ba151b0201dbccfbe57fc7312aa45e4084f3de2dd967f9be29cf83009c7fcaa
+    "@aws-sdk/signature-v4": 3.178.0
+    "@aws-sdk/types": 3.178.0
+    "@aws-sdk/util-config-provider": 3.170.0
+    "@aws-sdk/util-middleware": 3.178.0
+    tslib: ^2.3.1
+  checksum: 6befe982a46531386fa99fe7e4dacded66381876326c9b6d3e6045c17f0bdb38dbac796890e6a68321bf74071de4630c04644dd42020c88214a66b97de8f8583
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-imds@npm:3.10.0":
-  version: 3.10.0
-  resolution: "@aws-sdk/credential-provider-imds@npm:3.10.0"
+"@aws-sdk/credential-provider-env@npm:3.178.0":
+  version: 3.178.0
+  resolution: "@aws-sdk/credential-provider-env@npm:3.178.0"
   dependencies:
-    "@aws-sdk/property-provider": 3.10.0
-    "@aws-sdk/types": 3.10.0
-    tslib: ^1.8.0
-  checksum: 1bc955a0697a24d4cf04e85d15045b75668bae346bf658963eb509560c592550ffbe7c6fc59f1b615783dee98834991b2bcaf2898bb907e67f8e19a1a244950c
+    "@aws-sdk/property-provider": 3.178.0
+    "@aws-sdk/types": 3.178.0
+    tslib: ^2.3.1
+  checksum: 22498437e8e73105e702d85232f28acd6d245c4d4f43244605d73fc04e04bf69052c7f16012f0557a551b20eec8545ade0eb70cb040045423788f3af888d7b1e
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-ini@npm:3.11.0":
-  version: 3.11.0
-  resolution: "@aws-sdk/credential-provider-ini@npm:3.11.0"
+"@aws-sdk/credential-provider-imds@npm:3.178.0":
+  version: 3.178.0
+  resolution: "@aws-sdk/credential-provider-imds@npm:3.178.0"
   dependencies:
-    "@aws-sdk/credential-provider-web-identity": 3.11.0
-    "@aws-sdk/property-provider": 3.10.0
-    "@aws-sdk/shared-ini-file-loader": 3.10.0
-    "@aws-sdk/types": 3.10.0
-    tslib: ^1.8.0
-  checksum: b0421d1c1b487f5e5c0c0ae68a55f4f4d92b7a5dada09a258f2d808b37138d26473b3fb1205be863ef6eeb2b19c9480ed3395afaa78b58bef9859656531e4dd4
+    "@aws-sdk/node-config-provider": 3.178.0
+    "@aws-sdk/property-provider": 3.178.0
+    "@aws-sdk/types": 3.178.0
+    "@aws-sdk/url-parser": 3.178.0
+    tslib: ^2.3.1
+  checksum: 548a6f0c69fc5a6d922b3ed3bd90eb6fc0d3ec8d16d3cc8dca82da0ca22bd9907cf848d01731a5bc85ad53398d55a2acaa2831be07ce08189c98aaf95f6c837a
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-node@npm:3.11.0":
-  version: 3.11.0
-  resolution: "@aws-sdk/credential-provider-node@npm:3.11.0"
+"@aws-sdk/credential-provider-ini@npm:3.181.0":
+  version: 3.181.0
+  resolution: "@aws-sdk/credential-provider-ini@npm:3.181.0"
   dependencies:
-    "@aws-sdk/credential-provider-env": 3.10.0
-    "@aws-sdk/credential-provider-imds": 3.10.0
-    "@aws-sdk/credential-provider-ini": 3.11.0
-    "@aws-sdk/credential-provider-process": 3.11.0
-    "@aws-sdk/credential-provider-sso": 3.11.0
-    "@aws-sdk/property-provider": 3.10.0
-    "@aws-sdk/shared-ini-file-loader": 3.10.0
-    "@aws-sdk/types": 3.10.0
-    tslib: ^1.8.0
-  checksum: 48cee9d19c1d6b5dd238f54725550235a3a4d7fe62349b796aad2bb6a92daf812e72c5bd1f4d11941c10005127c4f168dfa48939786826ca7dbd1acd643fbf82
+    "@aws-sdk/credential-provider-env": 3.178.0
+    "@aws-sdk/credential-provider-imds": 3.178.0
+    "@aws-sdk/credential-provider-sso": 3.181.0
+    "@aws-sdk/credential-provider-web-identity": 3.178.0
+    "@aws-sdk/property-provider": 3.178.0
+    "@aws-sdk/shared-ini-file-loader": 3.178.0
+    "@aws-sdk/types": 3.178.0
+    tslib: ^2.3.1
+  checksum: 5f405a6d366b9ffb7d84adcf8c6685fe89f847a730268ce7ddc873624c6f4feb09b860d2fd249618a78b138cb245643ec4d4923f8341451767813e18eeccf72d
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-process@npm:3.11.0":
-  version: 3.11.0
-  resolution: "@aws-sdk/credential-provider-process@npm:3.11.0"
+"@aws-sdk/credential-provider-node@npm:3.181.0":
+  version: 3.181.0
+  resolution: "@aws-sdk/credential-provider-node@npm:3.181.0"
   dependencies:
-    "@aws-sdk/credential-provider-ini": 3.11.0
-    "@aws-sdk/property-provider": 3.10.0
-    "@aws-sdk/shared-ini-file-loader": 3.10.0
-    "@aws-sdk/types": 3.10.0
-    tslib: ^1.8.0
-  checksum: 5e8f7eeebdf3ebf0df3954d9dfd6d7ee6392c95f1908df54ae1358216d72c9bf34c4b084b1c486a943cd1d20c20c8d670d138cccb344ef7fd648be816410d4b3
+    "@aws-sdk/credential-provider-env": 3.178.0
+    "@aws-sdk/credential-provider-imds": 3.178.0
+    "@aws-sdk/credential-provider-ini": 3.181.0
+    "@aws-sdk/credential-provider-process": 3.178.0
+    "@aws-sdk/credential-provider-sso": 3.181.0
+    "@aws-sdk/credential-provider-web-identity": 3.178.0
+    "@aws-sdk/property-provider": 3.178.0
+    "@aws-sdk/shared-ini-file-loader": 3.178.0
+    "@aws-sdk/types": 3.178.0
+    tslib: ^2.3.1
+  checksum: b84bd76833f8ce3632f136f053a43c538614140b5eec99be19a0d7ca9e305772cba3142201b2ece5ebbc508a7013e8102a8c35f68812eb47710a9025c6e4a764
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-sso@npm:3.11.0":
-  version: 3.11.0
-  resolution: "@aws-sdk/credential-provider-sso@npm:3.11.0"
+"@aws-sdk/credential-provider-process@npm:3.178.0":
+  version: 3.178.0
+  resolution: "@aws-sdk/credential-provider-process@npm:3.178.0"
   dependencies:
-    "@aws-sdk/client-sso": 3.11.0
-    "@aws-sdk/credential-provider-ini": 3.11.0
-    "@aws-sdk/property-provider": 3.10.0
-    "@aws-sdk/shared-ini-file-loader": 3.10.0
-    "@aws-sdk/types": 3.10.0
-    tslib: ^1.8.0
-  checksum: 0178fca8d81cc7712b60dd8ba473f1f1ebc56d78ff75a163b2b99da0c7f7b2806800d2557f0b47cf891c5500a5cd5c4af8e9e370b26c190642d707e4ca6803f4
+    "@aws-sdk/property-provider": 3.178.0
+    "@aws-sdk/shared-ini-file-loader": 3.178.0
+    "@aws-sdk/types": 3.178.0
+    tslib: ^2.3.1
+  checksum: 7ca452d7963d118f2855ebe87862dc064cf5eddf3b8cb21386c359da891f98b1bd5dc8fd98c830d2606225cc370febd91537273230c6e13bec3984e05888435c
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-web-identity@npm:3.11.0":
-  version: 3.11.0
-  resolution: "@aws-sdk/credential-provider-web-identity@npm:3.11.0"
+"@aws-sdk/credential-provider-sso@npm:3.181.0":
+  version: 3.181.0
+  resolution: "@aws-sdk/credential-provider-sso@npm:3.181.0"
   dependencies:
-    "@aws-sdk/property-provider": 3.10.0
-    "@aws-sdk/types": 3.10.0
-    tslib: ^1.8.0
-  checksum: 9d91b786853b1e2aea691f5f3f50678bbdf5aeeacc313ad516a62b5f9c989c3de170df5a2e0fafd9bb585df601ee683fb83532ebbfe7040faf6d90c9ba8bd356
+    "@aws-sdk/client-sso": 3.181.0
+    "@aws-sdk/property-provider": 3.178.0
+    "@aws-sdk/shared-ini-file-loader": 3.178.0
+    "@aws-sdk/types": 3.178.0
+    tslib: ^2.3.1
+  checksum: 0f215c802fe700a76e660366463bd38e229ecff4abeaaac3d69d2d62117a11e80cbeed9da6ef5f73d9830f83009969c2f6cb0b4bbf0febaf59fe4eea448f805d
   languageName: node
   linkType: hard
 
-"@aws-sdk/eventstream-marshaller@npm:3.10.0":
-  version: 3.10.0
-  resolution: "@aws-sdk/eventstream-marshaller@npm:3.10.0"
+"@aws-sdk/credential-provider-web-identity@npm:3.178.0":
+  version: 3.178.0
+  resolution: "@aws-sdk/credential-provider-web-identity@npm:3.178.0"
   dependencies:
-    "@aws-crypto/crc32": ^1.0.0
-    "@aws-sdk/types": 3.10.0
-    "@aws-sdk/util-hex-encoding": 3.10.0
-    tslib: ^1.8.0
-  checksum: 4565ded8972bdf0a8d769088ef26d92f2da2f211dc3635bdb7825678b1b1faee05d9e3288f9de9fa9128e79dc623918e71e8f2b27ab7627e3a5d97cde471ec70
+    "@aws-sdk/property-provider": 3.178.0
+    "@aws-sdk/types": 3.178.0
+    tslib: ^2.3.1
+  checksum: 7761bfb8d2046f29ceb3d1020da07fcb0684008ec9529b3daf8c0dab8924f22929274fb31e0740b66f508b3dc31b409ec3175000a9778af3d2025cf4ae1163df
   languageName: node
   linkType: hard
 
-"@aws-sdk/eventstream-serde-browser@npm:3.10.0":
-  version: 3.10.0
-  resolution: "@aws-sdk/eventstream-serde-browser@npm:3.10.0"
+"@aws-sdk/eventstream-codec@npm:3.178.0":
+  version: 3.178.0
+  resolution: "@aws-sdk/eventstream-codec@npm:3.178.0"
   dependencies:
-    "@aws-sdk/eventstream-marshaller": 3.10.0
-    "@aws-sdk/eventstream-serde-universal": 3.10.0
-    "@aws-sdk/types": 3.10.0
-    tslib: ^1.8.0
-  checksum: 592fdaa5789e71f7e7fe8b6023c7ec5447682487339d6496892a6c6fa13948989779ca93e5776cebfab8f9a9ed6543130a36c63926c70b1ef48f1c3b7bc7fcee
+    "@aws-crypto/crc32": 2.0.0
+    "@aws-sdk/types": 3.178.0
+    "@aws-sdk/util-hex-encoding": 3.170.0
+    tslib: ^2.3.1
+  checksum: a049eb487d663bff95fb03e0dd0a5ad29751ee12a8afa880a0f18de6f99c868814a48289f0f458a462a14ebd91a598eae5b2400b60e8115d0cf69d2eb1dad9b0
   languageName: node
   linkType: hard
 
-"@aws-sdk/eventstream-serde-config-resolver@npm:3.10.0":
-  version: 3.10.0
-  resolution: "@aws-sdk/eventstream-serde-config-resolver@npm:3.10.0"
+"@aws-sdk/eventstream-serde-browser@npm:3.178.0":
+  version: 3.178.0
+  resolution: "@aws-sdk/eventstream-serde-browser@npm:3.178.0"
   dependencies:
-    "@aws-sdk/types": 3.10.0
-    tslib: ^1.8.0
-  checksum: 5a1cc8c40e2880e7154155f0fe58aa585cb2f2cea0df9a67623e43ed2d67d80661fceebbfcb570024fcbcffe150a9e8fab4078ad04e298f10665a8df449350e3
+    "@aws-sdk/eventstream-serde-universal": 3.178.0
+    "@aws-sdk/types": 3.178.0
+    tslib: ^2.3.1
+  checksum: ec1e2c7772cfe00f95e57c3a33ffa6189d7455edf915ce5035d8cc385c5d772c68b966f0570cc1a3c9d06ee51078b8e577223ab5c0b818e37a8f022719bb7295
   languageName: node
   linkType: hard
 
-"@aws-sdk/eventstream-serde-node@npm:3.10.0":
-  version: 3.10.0
-  resolution: "@aws-sdk/eventstream-serde-node@npm:3.10.0"
+"@aws-sdk/eventstream-serde-config-resolver@npm:3.178.0":
+  version: 3.178.0
+  resolution: "@aws-sdk/eventstream-serde-config-resolver@npm:3.178.0"
   dependencies:
-    "@aws-sdk/eventstream-marshaller": 3.10.0
-    "@aws-sdk/eventstream-serde-universal": 3.10.0
-    "@aws-sdk/types": 3.10.0
-    tslib: ^1.8.0
-  checksum: 0c51a6bf434dd98c5cc557367a1613f1a60c652f3f8559d2db078850a946c900cc920bbc3232622de2043f42fbca19f6da6110f5d531c25a4a5038f6aa479515
+    "@aws-sdk/types": 3.178.0
+    tslib: ^2.3.1
+  checksum: 1c7f906b31e3241e1360f25e6bc3a10108c7b208d9eda979bb28d875cb7e60371aa0de5c332448f88a8cdf6454989af2c3dc6321c9239b0d03ad9b6f808b554b
   languageName: node
   linkType: hard
 
-"@aws-sdk/eventstream-serde-universal@npm:3.10.0":
-  version: 3.10.0
-  resolution: "@aws-sdk/eventstream-serde-universal@npm:3.10.0"
+"@aws-sdk/eventstream-serde-node@npm:3.178.0":
+  version: 3.178.0
+  resolution: "@aws-sdk/eventstream-serde-node@npm:3.178.0"
   dependencies:
-    "@aws-sdk/eventstream-marshaller": 3.10.0
-    "@aws-sdk/types": 3.10.0
-    tslib: ^1.8.0
-  checksum: ab334abfadbcc634ad57e53671858e9db108ee54350094c856e2d032c3ce1b2c6b5a661aff4cd3407f543318a2c3f54e7bd50ae827badb2c1528196c134c8749
+    "@aws-sdk/eventstream-serde-universal": 3.178.0
+    "@aws-sdk/types": 3.178.0
+    tslib: ^2.3.1
+  checksum: d11754f29b02fa36d31cb0f88aa17d6ebfebab0137ef380cb81e883e7a2358d1c2dfc065bb67802036950decb6859c46eb8f56166741fc89aea0ecf0cd824391
   languageName: node
   linkType: hard
 
-"@aws-sdk/fetch-http-handler@npm:3.10.0":
-  version: 3.10.0
-  resolution: "@aws-sdk/fetch-http-handler@npm:3.10.0"
+"@aws-sdk/eventstream-serde-universal@npm:3.178.0":
+  version: 3.178.0
+  resolution: "@aws-sdk/eventstream-serde-universal@npm:3.178.0"
   dependencies:
-    "@aws-sdk/protocol-http": 3.10.0
-    "@aws-sdk/querystring-builder": 3.10.0
-    "@aws-sdk/types": 3.10.0
-    "@aws-sdk/util-base64-browser": 3.10.0
-    tslib: ^1.8.0
-  checksum: bb458572bea6d094710ef2927647a7e0b7f82b7a32920524c806ae6a34bb405ac54d547d10e53cda5cdcdbef198b53f1b582642514b272154a072c615ee2abcf
+    "@aws-sdk/eventstream-codec": 3.178.0
+    "@aws-sdk/types": 3.178.0
+    tslib: ^2.3.1
+  checksum: cfd0e42adcab21ad3989a87a0ea257a86aad2e58626ee49aad9cf9f230e22b491b373301eb5333b9133851601828e80a64238fdab0b895922f5f15b6b64a6fe2
   languageName: node
   linkType: hard
 
-"@aws-sdk/hash-blob-browser@npm:3.10.0":
-  version: 3.10.0
-  resolution: "@aws-sdk/hash-blob-browser@npm:3.10.0"
+"@aws-sdk/fetch-http-handler@npm:3.178.0":
+  version: 3.178.0
+  resolution: "@aws-sdk/fetch-http-handler@npm:3.178.0"
   dependencies:
-    "@aws-sdk/chunked-blob-reader": 3.10.0
-    "@aws-sdk/chunked-blob-reader-native": 3.10.0
-    "@aws-sdk/types": 3.10.0
-    tslib: ^1.8.0
-  checksum: 931e268b883d7c9c30c2c0fc234cf34f44ccca0f568c05dfc5fa00b0dccd53f7b3d1a22a949896f31cc95d8b34647f82a72741adbd3fcf5f779a58d41c528e01
+    "@aws-sdk/protocol-http": 3.178.0
+    "@aws-sdk/querystring-builder": 3.178.0
+    "@aws-sdk/types": 3.178.0
+    "@aws-sdk/util-base64-browser": 3.170.0
+    tslib: ^2.3.1
+  checksum: d0f5e4d2c156b55d9febc699e0220e267f028e59e611d93e45ea0bcb7486494faf92efb57bbebedb87f01c9b934985dc91456229e82194cb44f47150f044ac47
   languageName: node
   linkType: hard
 
-"@aws-sdk/hash-node@npm:3.10.0":
-  version: 3.10.0
-  resolution: "@aws-sdk/hash-node@npm:3.10.0"
+"@aws-sdk/hash-blob-browser@npm:3.178.0":
+  version: 3.178.0
+  resolution: "@aws-sdk/hash-blob-browser@npm:3.178.0"
   dependencies:
-    "@aws-sdk/types": 3.10.0
-    "@aws-sdk/util-buffer-from": 3.10.0
-    tslib: ^1.8.0
-  checksum: 3f9086de3b96693d62c263ef7a172a1b044cd50c1c9fa25fbaef141faceca8445b2d4f897bf65ceb387c3765848510ff23472b92134c4b79042c3d469d4de0ba
+    "@aws-sdk/chunked-blob-reader": 3.170.0
+    "@aws-sdk/chunked-blob-reader-native": 3.170.0
+    "@aws-sdk/types": 3.178.0
+    tslib: ^2.3.1
+  checksum: 2d7807bde86eeb9a4d3647a263bd8614d9ede5dfc9912fab6fae9c47d20b921183e49918fde3b917a18c74b4d99dfa2d42ea841305f496210aed549562e6edf3
   languageName: node
   linkType: hard
 
-"@aws-sdk/hash-stream-node@npm:3.10.0":
-  version: 3.10.0
-  resolution: "@aws-sdk/hash-stream-node@npm:3.10.0"
+"@aws-sdk/hash-node@npm:3.178.0":
+  version: 3.178.0
+  resolution: "@aws-sdk/hash-node@npm:3.178.0"
   dependencies:
-    "@aws-sdk/types": 3.10.0
-    tslib: ^1.8.0
-  checksum: c7f69fa117e13812c0b3983746acace2c76f392807aa1f46608d099e55ccc251093658c7dc3a19fc9aef17355e2a3c54b191cf9c68e4a20a8e66e8eafd8c1af8
+    "@aws-sdk/types": 3.178.0
+    "@aws-sdk/util-buffer-from": 3.170.0
+    tslib: ^2.3.1
+  checksum: 2158e226cd01ddba35156f847685ab1700333584acdf31a0f821be267c3a1d7b329a764684655eb4cf5a768ef2f7cbb36d24335ee3842a8e2f077d530e07e1e7
   languageName: node
   linkType: hard
 
-"@aws-sdk/invalid-dependency@npm:3.10.0":
-  version: 3.10.0
-  resolution: "@aws-sdk/invalid-dependency@npm:3.10.0"
+"@aws-sdk/hash-stream-node@npm:3.178.0":
+  version: 3.178.0
+  resolution: "@aws-sdk/hash-stream-node@npm:3.178.0"
   dependencies:
-    "@aws-sdk/types": 3.10.0
-    tslib: ^1.8.0
-  checksum: 8834fb0b51ec66675c38b6ef71c3bf67db2e91616ea1a727c48928f3794fe9a51aff6173ade3fa2ad23ddcd0d0833ad30596dcd8a8fed4594f0a0f95c4ba5ec8
+    "@aws-sdk/types": 3.178.0
+    tslib: ^2.3.1
+  checksum: 2159b983ab15ed344fecf7aff82b0259b12f94af8efb966c653c7922cfee9e4e04b7aab6d44b8058734f72ba45d36084ecd3ae65901efb5f6434617b1ff3e6be
   languageName: node
   linkType: hard
 
-"@aws-sdk/is-array-buffer@npm:3.10.0":
-  version: 3.10.0
-  resolution: "@aws-sdk/is-array-buffer@npm:3.10.0"
+"@aws-sdk/invalid-dependency@npm:3.178.0":
+  version: 3.178.0
+  resolution: "@aws-sdk/invalid-dependency@npm:3.178.0"
   dependencies:
-    tslib: ^1.8.0
-  checksum: 1222e1fb0220c0406c0cbb541707a13f5605bc313ebd10d448bc3555ce7edfa16a6f3a3ff6d7255b107ce710000367f7c673b7b5b5fc10437718c3bad01f4ae4
+    "@aws-sdk/types": 3.178.0
+    tslib: ^2.3.1
+  checksum: e7bbfbb18755c31d9c476f17b2dbe1fdf81881c03ea417a0900fa328f2099a0d0d0827c44065cad0b4e2060c3d6bf620b58c2900b087c752f7efd8d9a483dbe9
   languageName: node
   linkType: hard
 
-"@aws-sdk/md5-js@npm:3.10.0":
-  version: 3.10.0
-  resolution: "@aws-sdk/md5-js@npm:3.10.0"
+"@aws-sdk/is-array-buffer@npm:3.170.0":
+  version: 3.170.0
+  resolution: "@aws-sdk/is-array-buffer@npm:3.170.0"
   dependencies:
-    "@aws-sdk/types": 3.10.0
-    "@aws-sdk/util-utf8-browser": 3.10.0
-    tslib: ^1.8.0
-  checksum: 5bf633ce253b75840061dadae5d417090ad971882ff0a97144180891edfc09dffd6a34847d1141a71a24f38bd0fd9630dd7787064e0c8d260109f129ff07cea6
+    tslib: ^2.3.1
+  checksum: d0541a1ad691320115c5965a49f0bed557d188fd26ca7f06eebba2f9dfd0611c2636c15468e01e1de8c5121d4f8f0622e52b4ae716dab5c394eabc8511f701dc
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-apply-body-checksum@npm:3.10.0":
-  version: 3.10.0
-  resolution: "@aws-sdk/middleware-apply-body-checksum@npm:3.10.0"
+"@aws-sdk/md5-js@npm:3.178.0":
+  version: 3.178.0
+  resolution: "@aws-sdk/md5-js@npm:3.178.0"
   dependencies:
-    "@aws-sdk/is-array-buffer": 3.10.0
-    "@aws-sdk/protocol-http": 3.10.0
-    "@aws-sdk/types": 3.10.0
-    tslib: ^1.8.0
-  checksum: f96dc2f404eac3f06f37cd965002753fa3f063198c24ab44d7c2f3d9957b757d3586746ac04d2ec086f9f2feaf3d051e06f09bf28f2a0f403140f483bf501dfd
+    "@aws-sdk/types": 3.178.0
+    "@aws-sdk/util-utf8-browser": 3.170.0
+    "@aws-sdk/util-utf8-node": 3.170.0
+    tslib: ^2.3.1
+  checksum: 6bc082bce3a8d7e724a0228564a9c2aa7f8556b0b1393f7969301a40ac3ab037897ea7508692ae0186b51ca4e1948a503161d179aeb966a9b0e58e06f4b6dcfc
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-bucket-endpoint@npm:3.10.0":
-  version: 3.10.0
-  resolution: "@aws-sdk/middleware-bucket-endpoint@npm:3.10.0"
+"@aws-sdk/middleware-bucket-endpoint@npm:3.178.0":
+  version: 3.178.0
+  resolution: "@aws-sdk/middleware-bucket-endpoint@npm:3.178.0"
   dependencies:
-    "@aws-sdk/protocol-http": 3.10.0
-    "@aws-sdk/types": 3.10.0
-    "@aws-sdk/util-arn-parser": 3.10.0
-    tslib: ^1.8.0
-  checksum: 7c9e7aec781f13567c2af4e3007ef45dcec2875a4530e782e122c468871fe760b4a7a6ec5dcd62e82152b0c3c3eda93d40d5adb8c468ca7d6914f166cc407a32
+    "@aws-sdk/protocol-http": 3.178.0
+    "@aws-sdk/types": 3.178.0
+    "@aws-sdk/util-arn-parser": 3.170.0
+    "@aws-sdk/util-config-provider": 3.170.0
+    tslib: ^2.3.1
+  checksum: e511c6990936977d1ef8a0412b5338895ea59838e30c2a9ce6040b4795443133745808ef7af081ee1db9102e0867083409a3afb9d11b815564026c520dde2b8d
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-content-length@npm:3.10.0":
-  version: 3.10.0
-  resolution: "@aws-sdk/middleware-content-length@npm:3.10.0"
+"@aws-sdk/middleware-content-length@npm:3.178.0":
+  version: 3.178.0
+  resolution: "@aws-sdk/middleware-content-length@npm:3.178.0"
   dependencies:
-    "@aws-sdk/protocol-http": 3.10.0
-    "@aws-sdk/types": 3.10.0
-    tslib: ^1.8.0
-  checksum: d3f0bacc53fec14073a11a26c32de161348ad64ba8d50167b7d223efe5459d38f04dd7781aabc164a2d4e7749bdef6c2cea95a6ca4402b69b55f4a48bc533b95
+    "@aws-sdk/protocol-http": 3.178.0
+    "@aws-sdk/types": 3.178.0
+    tslib: ^2.3.1
+  checksum: 0d7a28df4e7d1544936f23a2f1d37a1b955a5054781f0d8eeba93057b8489f59e45f84d1d4a23ce3213633f90d48192283455b77481f1e2e614a72e647abe19e
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-expect-continue@npm:3.10.0":
-  version: 3.10.0
-  resolution: "@aws-sdk/middleware-expect-continue@npm:3.10.0"
+"@aws-sdk/middleware-expect-continue@npm:3.178.0":
+  version: 3.178.0
+  resolution: "@aws-sdk/middleware-expect-continue@npm:3.178.0"
   dependencies:
-    "@aws-sdk/middleware-header-default": 3.10.0
-    "@aws-sdk/protocol-http": 3.10.0
-    "@aws-sdk/types": 3.10.0
-    tslib: ^1.8.0
-  checksum: 6d59efd9ad632603ed0176983cad7b7a5cb414e206ae7623130fe6f0fbc15902d07c2469483e9ad7d64daaa1415296c725f3ce67fead4dce97d65383b40320a0
+    "@aws-sdk/protocol-http": 3.178.0
+    "@aws-sdk/types": 3.178.0
+    tslib: ^2.3.1
+  checksum: 6767ce2dc96fdff49ee93459dae71e4a15ce03db822247f2c1b9f20979d9d22fe172ba243d00feb1dd1bd6dc7227a1093ca4c1176129cf6f251f01d5f48136f7
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-header-default@npm:3.10.0":
-  version: 3.10.0
-  resolution: "@aws-sdk/middleware-header-default@npm:3.10.0"
+"@aws-sdk/middleware-flexible-checksums@npm:3.178.0":
+  version: 3.178.0
+  resolution: "@aws-sdk/middleware-flexible-checksums@npm:3.178.0"
   dependencies:
-    "@aws-sdk/protocol-http": 3.10.0
-    "@aws-sdk/types": 3.10.0
-    tslib: ^1.8.0
-  checksum: 5cf6d6defb18462649cbbdc60ba75e875b8ba3df50a882d9fcee53233a38d5c0f99ba1385d15701995fc021c16f97b179caa3573a8a0bb691e2e5aaa9ebf68eb
+    "@aws-crypto/crc32": 2.0.0
+    "@aws-crypto/crc32c": 2.0.0
+    "@aws-sdk/is-array-buffer": 3.170.0
+    "@aws-sdk/protocol-http": 3.178.0
+    "@aws-sdk/types": 3.178.0
+    tslib: ^2.3.1
+  checksum: 8a95dcad6b64a745ae2b1f244a863b5c5d2dda84da1bb32415f78aaaff5db1129750466b2956e9fca0c8eafe33d5346b28e1db5060684512ffd6e4adcb7fe33d
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-host-header@npm:3.10.0":
-  version: 3.10.0
-  resolution: "@aws-sdk/middleware-host-header@npm:3.10.0"
+"@aws-sdk/middleware-host-header@npm:3.178.0":
+  version: 3.178.0
+  resolution: "@aws-sdk/middleware-host-header@npm:3.178.0"
   dependencies:
-    "@aws-sdk/protocol-http": 3.10.0
-    "@aws-sdk/types": 3.10.0
-    tslib: ^1.8.0
-  checksum: abee1bdf702cdb112b3beca465cf0fe00597d50671b8677b662f3ee6a9c01cbf14e2400990f37f074fa83bc9b1e160c6ae7cbb11695308da81510e715c0c1d6d
+    "@aws-sdk/protocol-http": 3.178.0
+    "@aws-sdk/types": 3.178.0
+    tslib: ^2.3.1
+  checksum: d14db919d9abdec7b7061d35ecc90c75aa3edc723ac50f79e474cf6cd045a34fd7c9f27181f817c21081287b7cad0e312121f308b1f1d12889d1baad01817910
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-location-constraint@npm:3.10.0":
-  version: 3.10.0
-  resolution: "@aws-sdk/middleware-location-constraint@npm:3.10.0"
+"@aws-sdk/middleware-location-constraint@npm:3.178.0":
+  version: 3.178.0
+  resolution: "@aws-sdk/middleware-location-constraint@npm:3.178.0"
   dependencies:
-    "@aws-sdk/types": 3.10.0
-    tslib: ^1.8.0
-  checksum: de168ff04ecaf0e0e6072ba29448b732e819c16bda5c290293f13eee8f7dab2e558ecd402a3425b0df25af758e65fe7f40f6a9a1a8428820e04c0c93fd2c5d07
+    "@aws-sdk/types": 3.178.0
+    tslib: ^2.3.1
+  checksum: 89e58ecf3d70d4a1ceabae53d37143b523daa852a3687750b922fb728dbdb8c71dec838d637eb518b617f9c55e97bba2eae111d095516cb35d0d6f700b06ec98
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-logger@npm:3.10.0":
-  version: 3.10.0
-  resolution: "@aws-sdk/middleware-logger@npm:3.10.0"
+"@aws-sdk/middleware-logger@npm:3.178.0":
+  version: 3.178.0
+  resolution: "@aws-sdk/middleware-logger@npm:3.178.0"
   dependencies:
-    "@aws-sdk/types": 3.10.0
-    tslib: ^1.8.0
-  checksum: 5c9a919ee28fc02970f4dca0c4dee8b3fe3b85c138cf3d7a3ae97dabecc94e0c3f8e01c4325123e17987c9c9a86e5fe6fab5983f77f4b0143e50f077da8f5e7d
+    "@aws-sdk/types": 3.178.0
+    tslib: ^2.3.1
+  checksum: 17d08f51e4b55684443b53b5830713a97c3377db0882c850c0289a2db7bf669207aea26b74a8c627bc7a686c7097697f76b68baf22d7c6be555b4545c0ff93c6
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-retry@npm:3.10.0":
-  version: 3.10.0
-  resolution: "@aws-sdk/middleware-retry@npm:3.10.0"
+"@aws-sdk/middleware-recursion-detection@npm:3.178.0":
+  version: 3.178.0
+  resolution: "@aws-sdk/middleware-recursion-detection@npm:3.178.0"
   dependencies:
-    "@aws-sdk/protocol-http": 3.10.0
-    "@aws-sdk/service-error-classification": 3.10.0
-    "@aws-sdk/types": 3.10.0
-    react-native-get-random-values: ^1.4.0
-    tslib: ^1.8.0
-    uuid: ^3.0.0
-  checksum: c8dfa54f25306da3419af8015b207451ed64d0ac0d60dd963a3546239eabaf675861ed6181120271fe04476bc654088197c781244cc27412093eaff00eeb2ea7
+    "@aws-sdk/protocol-http": 3.178.0
+    "@aws-sdk/types": 3.178.0
+    tslib: ^2.3.1
+  checksum: 1d71f29eab868a546d2734ae49163bb0ff4b137d913e3fb2885ce2e16fe738e73088e9bd4a6726fe131a228087211e15b1a140c095422c48331d0743a8467762
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-sdk-s3@npm:3.10.0":
-  version: 3.10.0
-  resolution: "@aws-sdk/middleware-sdk-s3@npm:3.10.0"
+"@aws-sdk/middleware-retry@npm:3.178.0":
+  version: 3.178.0
+  resolution: "@aws-sdk/middleware-retry@npm:3.178.0"
   dependencies:
-    "@aws-sdk/protocol-http": 3.10.0
-    "@aws-sdk/types": 3.10.0
-    "@aws-sdk/util-arn-parser": 3.10.0
-    tslib: ^1.8.0
-  checksum: 8d6d54f11fbcea413addcb67fc494ac86217faa376efde0127ab03c6e98a3f4650e9fec4bb1ccbd033185ba4c57b0db442b10a3744eb8b23a2ff265824dda74e
+    "@aws-sdk/protocol-http": 3.178.0
+    "@aws-sdk/service-error-classification": 3.178.0
+    "@aws-sdk/types": 3.178.0
+    "@aws-sdk/util-middleware": 3.178.0
+    tslib: ^2.3.1
+    uuid: ^8.3.2
+  checksum: 3d2ce86e06fba813fff2e903ea12019f784527fa671b35a9d39f202444c77d4ad8e22e9c892910f94b4ea956b45190f0440fe039b66b28e5199a91bbffa0efd1
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-serde@npm:3.10.0":
-  version: 3.10.0
-  resolution: "@aws-sdk/middleware-serde@npm:3.10.0"
+"@aws-sdk/middleware-sdk-s3@npm:3.178.0":
+  version: 3.178.0
+  resolution: "@aws-sdk/middleware-sdk-s3@npm:3.178.0"
   dependencies:
-    "@aws-sdk/types": 3.10.0
-    tslib: ^1.8.0
-  checksum: 47e13fbaaa191847cf738fb94403cbd0dd8d1bc64ee77978c9774422dc688d60f802c093ac8343fe11d7970b699e20110b56c119f2d3a48a7cd622f7d42bfad9
+    "@aws-sdk/middleware-bucket-endpoint": 3.178.0
+    "@aws-sdk/protocol-http": 3.178.0
+    "@aws-sdk/types": 3.178.0
+    "@aws-sdk/util-arn-parser": 3.170.0
+    tslib: ^2.3.1
+  checksum: fa3d088b464d67e6f75e582e84a4e22d1c8de6e8991c4e4c411ba0cc84526b5c0b09f6d91e4e4b42b6db84800757cb2886256a077142f68d8f042fc58baa4af8
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-signing@npm:3.10.0":
-  version: 3.10.0
-  resolution: "@aws-sdk/middleware-signing@npm:3.10.0"
+"@aws-sdk/middleware-sdk-sts@npm:3.179.0":
+  version: 3.179.0
+  resolution: "@aws-sdk/middleware-sdk-sts@npm:3.179.0"
   dependencies:
-    "@aws-sdk/property-provider": 3.10.0
-    "@aws-sdk/protocol-http": 3.10.0
-    "@aws-sdk/signature-v4": 3.10.0
-    "@aws-sdk/types": 3.10.0
-    tslib: ^1.8.0
-  checksum: a753f11d3326efbf5a554eed71851d6d5274bf867f6b393e9b8f716343d1e55cdad9806360f76b1ce137e1e2601eb234979ef544cef0ba179098bccc90606aa1
+    "@aws-sdk/middleware-signing": 3.179.0
+    "@aws-sdk/property-provider": 3.178.0
+    "@aws-sdk/protocol-http": 3.178.0
+    "@aws-sdk/signature-v4": 3.178.0
+    "@aws-sdk/types": 3.178.0
+    tslib: ^2.3.1
+  checksum: 59781ac3c5ac1d0329f7b45d3d99f7203d064cdc7bf12fdf076701ed3fef90e6dd6c7c3fd226ec39995b7b70d73621285e915ed937cd1f70083c252d149dbf17
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-ssec@npm:3.10.0":
-  version: 3.10.0
-  resolution: "@aws-sdk/middleware-ssec@npm:3.10.0"
+"@aws-sdk/middleware-serde@npm:3.178.0":
+  version: 3.178.0
+  resolution: "@aws-sdk/middleware-serde@npm:3.178.0"
   dependencies:
-    "@aws-sdk/types": 3.10.0
-    tslib: ^1.8.0
-  checksum: 1429d5c8741cf8c8d84db4a54b450723f8935b943c8e554fca11969874edd485845acb7087d5d1956019d55ab3804b0ce863d11e02380c5d437bcf630b3742c0
+    "@aws-sdk/types": 3.178.0
+    tslib: ^2.3.1
+  checksum: dbd800ee4b943ed986513930c0221682412b4e57576259fe7c306d7a9776c0fca289e5b429ac5015fcd73ffe033e38c85e80d1bd9e5fa3acdb210dd2e22ca6dd
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-stack@npm:3.10.0":
-  version: 3.10.0
-  resolution: "@aws-sdk/middleware-stack@npm:3.10.0"
+"@aws-sdk/middleware-signing@npm:3.179.0":
+  version: 3.179.0
+  resolution: "@aws-sdk/middleware-signing@npm:3.179.0"
   dependencies:
-    tslib: ^1.8.0
-  checksum: 835cba74ef9974577ba8af1f6caeb15f237cc1f350bfde80d92eb662596112a41be5a4cbcb1e59c5ac8bf70112b81c8d459c8dc5ee1c63861c496d493e7e2bd3
+    "@aws-sdk/property-provider": 3.178.0
+    "@aws-sdk/protocol-http": 3.178.0
+    "@aws-sdk/signature-v4": 3.178.0
+    "@aws-sdk/types": 3.178.0
+    "@aws-sdk/util-middleware": 3.178.0
+    tslib: ^2.3.1
+  checksum: 8b7e0d0ad20bde7164d7a1efb1fe1d37b3935e96fd277084d2567e771fab3fa441059592a779954d1c94b6a37d156dd56f037021cf620463295f791f2d9bef93
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-user-agent@npm:3.10.0":
-  version: 3.10.0
-  resolution: "@aws-sdk/middleware-user-agent@npm:3.10.0"
+"@aws-sdk/middleware-ssec@npm:3.178.0":
+  version: 3.178.0
+  resolution: "@aws-sdk/middleware-ssec@npm:3.178.0"
   dependencies:
-    "@aws-sdk/protocol-http": 3.10.0
-    "@aws-sdk/types": 3.10.0
-    tslib: ^1.8.0
-  checksum: 108f1eb93a7100633a4ea50f7126021700c008ebc4d161cb0486ba82c9f5b938602ddc0e46c0efd221c866b6558e96d08edd9ddc6e771bc89664e0d076378925
+    "@aws-sdk/types": 3.178.0
+    tslib: ^2.3.1
+  checksum: ac8cb4c7b9702ac8fd276c9ebc55c5867377fe1181771281e3b079bd69a541500f04898f73be373380d93fd869b7c229c8d9e9e7399e307b28d39b67bce8991f
   languageName: node
   linkType: hard
 
-"@aws-sdk/node-config-provider@npm:3.10.0":
-  version: 3.10.0
-  resolution: "@aws-sdk/node-config-provider@npm:3.10.0"
+"@aws-sdk/middleware-stack@npm:3.178.0":
+  version: 3.178.0
+  resolution: "@aws-sdk/middleware-stack@npm:3.178.0"
   dependencies:
-    "@aws-sdk/property-provider": 3.10.0
-    "@aws-sdk/shared-ini-file-loader": 3.10.0
-    "@aws-sdk/types": 3.10.0
-    tslib: ^1.8.0
-  checksum: beeb6491fbfc6eeca06525cd4ddf0ddc7c2d67086f426b551532a6ad012d9f186918725c040c4b94957522e4402aaccd48901d4ec680279a67fd6a9adfe3fffb
+    tslib: ^2.3.1
+  checksum: ee7fafa5c2b404c85ceba41af5def110baed7118695fc0e2da5fa7a00d6f1b4f81d8bdd649d738f5acab3667820befcde1a8ed01fb0cb638c74a1f4eb49c7935
   languageName: node
   linkType: hard
 
-"@aws-sdk/node-http-handler@npm:3.10.0":
-  version: 3.10.0
-  resolution: "@aws-sdk/node-http-handler@npm:3.10.0"
+"@aws-sdk/middleware-user-agent@npm:3.178.0":
+  version: 3.178.0
+  resolution: "@aws-sdk/middleware-user-agent@npm:3.178.0"
   dependencies:
-    "@aws-sdk/abort-controller": 3.10.0
-    "@aws-sdk/protocol-http": 3.10.0
-    "@aws-sdk/querystring-builder": 3.10.0
-    "@aws-sdk/types": 3.10.0
-    tslib: ^1.8.0
-  checksum: 57f37a4f5d7d1e73d1acea0d3c7191262de02c1f78ab53b4213765e6ae0f8703b6243247ed667af877868de22cf84670bbfe037db0fc53eb5d5dc0b707439c3b
+    "@aws-sdk/protocol-http": 3.178.0
+    "@aws-sdk/types": 3.178.0
+    tslib: ^2.3.1
+  checksum: 3089cc63cf4094bb0a3380c33b9fdf94b630dfb3956fce95d32c87b496c24f7337567f6c941f5e01ee813deeca11320d1b0318be75d4170bfb9644ac8b356dac
   languageName: node
   linkType: hard
 
-"@aws-sdk/property-provider@npm:3.10.0":
-  version: 3.10.0
-  resolution: "@aws-sdk/property-provider@npm:3.10.0"
+"@aws-sdk/node-config-provider@npm:3.178.0":
+  version: 3.178.0
+  resolution: "@aws-sdk/node-config-provider@npm:3.178.0"
   dependencies:
-    "@aws-sdk/types": 3.10.0
-    tslib: ^1.8.0
-  checksum: 62a0b3ad8a8feacced8c71ca7d9eaa719780d89ad49d41b86ec96fbf5a43ec5a82697ca5816ee6794d5ddd8df95c88beff0a2844991076c380eac35c88e8e371
+    "@aws-sdk/property-provider": 3.178.0
+    "@aws-sdk/shared-ini-file-loader": 3.178.0
+    "@aws-sdk/types": 3.178.0
+    tslib: ^2.3.1
+  checksum: 3846a98e8613155b69c6bd91fdb19b57fca71f6f397bf7d6916c79309ff1604e4d57f6f1ec7979fb144609c0e2e3f5456e221fcbbf24a0a3d083f5274a129cbd
   languageName: node
   linkType: hard
 
-"@aws-sdk/protocol-http@npm:3.10.0":
-  version: 3.10.0
-  resolution: "@aws-sdk/protocol-http@npm:3.10.0"
+"@aws-sdk/node-http-handler@npm:3.178.0":
+  version: 3.178.0
+  resolution: "@aws-sdk/node-http-handler@npm:3.178.0"
   dependencies:
-    "@aws-sdk/types": 3.10.0
-    tslib: ^1.8.0
-  checksum: 1b73b2daad06801002fc6819a340f518b880fdf836826c4d90781cf5f2b2de032429ce97ee7104c6d3e89d1a7a01b1883fda7015ff74dd176b5ad37301888bb5
+    "@aws-sdk/abort-controller": 3.178.0
+    "@aws-sdk/protocol-http": 3.178.0
+    "@aws-sdk/querystring-builder": 3.178.0
+    "@aws-sdk/types": 3.178.0
+    tslib: ^2.3.1
+  checksum: 9a6682c70971a8b31c65eeb286da626a71c06fcd4f21ef53d87e22062eeae8370f43e5cd9e16e2997a80c4ff96a7b8aa84265c310a2a44dc568d9e5e9f7454ba
   languageName: node
   linkType: hard
 
-"@aws-sdk/querystring-builder@npm:3.10.0":
-  version: 3.10.0
-  resolution: "@aws-sdk/querystring-builder@npm:3.10.0"
+"@aws-sdk/property-provider@npm:3.178.0":
+  version: 3.178.0
+  resolution: "@aws-sdk/property-provider@npm:3.178.0"
   dependencies:
-    "@aws-sdk/types": 3.10.0
-    "@aws-sdk/util-uri-escape": 3.10.0
-    tslib: ^1.8.0
-  checksum: d1065ac98534fc9e64af467489d7f36d9c6b515677514250b83979a88ac35c39a110668e4413e57ca4351be27d5a5b734f0b206650f385886859755548d88b83
+    "@aws-sdk/types": 3.178.0
+    tslib: ^2.3.1
+  checksum: 5e190f67c05a0aea48a1d3db651d3abb70a2d7fa3dc14011108b5ad4a64c842f75d3395eca41a782bee1f2275fa59a978605010e2cbd640a14344ca3617767b1
   languageName: node
   linkType: hard
 
-"@aws-sdk/querystring-parser@npm:3.10.0":
-  version: 3.10.0
-  resolution: "@aws-sdk/querystring-parser@npm:3.10.0"
+"@aws-sdk/protocol-http@npm:3.178.0":
+  version: 3.178.0
+  resolution: "@aws-sdk/protocol-http@npm:3.178.0"
   dependencies:
-    "@aws-sdk/types": 3.10.0
-    tslib: ^1.8.0
-  checksum: 93a424d7d4b6263a826d6c927eddaf31483496fe38fec7b20f5e37cc91c3e06db0c4a8db827597bdd2266c4459519318d7ea21b2af63ea1479414b5c77d368d8
+    "@aws-sdk/types": 3.178.0
+    tslib: ^2.3.1
+  checksum: ce3d17ab6ec04e8299b57634694072851e737acd5148f1966f154a96a9018ad47917bea6f3a76cb10c2fe5dc903d4a73536db01276745c28b6f0fdb6b7db1f73
   languageName: node
   linkType: hard
 
-"@aws-sdk/service-error-classification@npm:3.10.0":
-  version: 3.10.0
-  resolution: "@aws-sdk/service-error-classification@npm:3.10.0"
-  checksum: 67a684b8aaadde43d7188a6d1544e390557cf71f5fa8c9d000c0f0fdff80a6fe920f5d4c7924f594a1fac14c4d6d5008fdd4cc31f4e69220cc183799fedb92dd
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/shared-ini-file-loader@npm:3.10.0":
-  version: 3.10.0
-  resolution: "@aws-sdk/shared-ini-file-loader@npm:3.10.0"
+"@aws-sdk/querystring-builder@npm:3.178.0":
+  version: 3.178.0
+  resolution: "@aws-sdk/querystring-builder@npm:3.178.0"
   dependencies:
-    tslib: ^1.8.0
-  checksum: 2260856eb1711b47757e8c2e936b5ddc32bff30f5857287c0c82a388e9919598d93c2057ddace13ae4641f44f4b857caeb53ed49489bde46cba5eeb62bbcef8c
+    "@aws-sdk/types": 3.178.0
+    "@aws-sdk/util-uri-escape": 3.170.0
+    tslib: ^2.3.1
+  checksum: f96f87c0e7e2b08677a0abca98473c411ac313adaca4c8d44e06d21ff2fcdbe682b87b8ed33ae47137a3af7b4cdd05e7b97852e363c2e5947e2cded18d2af3a8
   languageName: node
   linkType: hard
 
-"@aws-sdk/signature-v4@npm:3.10.0":
-  version: 3.10.0
-  resolution: "@aws-sdk/signature-v4@npm:3.10.0"
+"@aws-sdk/querystring-parser@npm:3.178.0":
+  version: 3.178.0
+  resolution: "@aws-sdk/querystring-parser@npm:3.178.0"
   dependencies:
-    "@aws-sdk/is-array-buffer": 3.10.0
-    "@aws-sdk/types": 3.10.0
-    "@aws-sdk/util-hex-encoding": 3.10.0
-    "@aws-sdk/util-uri-escape": 3.10.0
-    tslib: ^1.8.0
-  checksum: 335824bfc0b4d1ff288a202f6c119c771476f6e7a916245591b1e6d4ddda123e0165f83527204e38199ddcbfdab57a56887c0735726a16fa0ff13ac160565601
+    "@aws-sdk/types": 3.178.0
+    tslib: ^2.3.1
+  checksum: b6092981fec3765fc02e37a1dd32c320a8199e6d21ae5b7b663340c44a2039792e8dc214c911a4662d3dd784897034a6af7b9ce0946aa3854e9a8db27fd6cce2
   languageName: node
   linkType: hard
 
-"@aws-sdk/smithy-client@npm:3.10.0":
-  version: 3.10.0
-  resolution: "@aws-sdk/smithy-client@npm:3.10.0"
+"@aws-sdk/service-error-classification@npm:3.178.0":
+  version: 3.178.0
+  resolution: "@aws-sdk/service-error-classification@npm:3.178.0"
+  checksum: 04e041bec2924dbf21123d45ba90e8a2f21b6c92d655304401a4194b824b6a1787769da3cc1d9f1387f572c833155ad30a0c8e4feabeb7381a71f2f6befd848b
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/shared-ini-file-loader@npm:3.178.0":
+  version: 3.178.0
+  resolution: "@aws-sdk/shared-ini-file-loader@npm:3.178.0"
   dependencies:
-    "@aws-sdk/middleware-stack": 3.10.0
-    "@aws-sdk/types": 3.10.0
-    tslib: ^1.8.0
-  checksum: d4a39544a4627d1244c286eed9691aecb7a83ef94b4c3e5de71196f400dd91f64c395fadc3c24f51047861d4ebce9b89635310027b8fe6d45863811541a86178
+    tslib: ^2.3.1
+  checksum: 2d133e3e19960f5236b853605d4f152051206614260ca68c5f9783cb31b7983a46acdd0e12afc0783adac20c16b1ed2f01ef045874c808f0e0450e7bd264ff87
   languageName: node
   linkType: hard
 
-"@aws-sdk/types@npm:3.10.0, @aws-sdk/types@npm:^3.1.0":
-  version: 3.10.0
-  resolution: "@aws-sdk/types@npm:3.10.0"
-  checksum: 855bcaeaa72b131ffbf56b0ca976459ec148bd7b402b2cee4248d78890b0ac65966635a3e6c7f8d9665f387f7ced6198a23ca52b2aa6f2842383a963bc17f039
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/url-parser-native@npm:3.10.0":
-  version: 3.10.0
-  resolution: "@aws-sdk/url-parser-native@npm:3.10.0"
+"@aws-sdk/signature-v4-multi-region@npm:3.180.0":
+  version: 3.180.0
+  resolution: "@aws-sdk/signature-v4-multi-region@npm:3.180.0"
   dependencies:
-    "@aws-sdk/querystring-parser": 3.10.0
-    "@aws-sdk/types": 3.10.0
-    tslib: ^1.8.0
-    url: ^0.11.0
-  checksum: 6e6613f54cb9c6d8105d1a061739808a2f6102a237f27cd6f4e706f2517325c250c470813870eb8c8caaf63956932f280555ec9088424862cecc0a99bc12ffaf
+    "@aws-sdk/protocol-http": 3.178.0
+    "@aws-sdk/signature-v4": 3.178.0
+    "@aws-sdk/types": 3.178.0
+    "@aws-sdk/util-arn-parser": 3.170.0
+    tslib: ^2.3.1
+  peerDependencies:
+    "@aws-sdk/signature-v4-crt": ^3.118.0
+  peerDependenciesMeta:
+    "@aws-sdk/signature-v4-crt":
+      optional: true
+  checksum: 623c0bbf016028317116906921326608e33241256e20c9f0358fa7fdb2599c4bcda01e1740cf2386695a0bda0d11a4b1e3637b60996a5842e7c6e2db5fa65f3e
   languageName: node
   linkType: hard
 
-"@aws-sdk/url-parser@npm:3.10.0":
-  version: 3.10.0
-  resolution: "@aws-sdk/url-parser@npm:3.10.0"
+"@aws-sdk/signature-v4@npm:3.178.0":
+  version: 3.178.0
+  resolution: "@aws-sdk/signature-v4@npm:3.178.0"
   dependencies:
-    "@aws-sdk/querystring-parser": 3.10.0
-    "@aws-sdk/types": 3.10.0
-    tslib: ^1.8.0
-  checksum: 37ec6e2d91066d7c4609e80c4747b8d1acad1a36256b88e8dc5a860432d988108e81cb45401f43c558a04d1be5c8594dad6a214e99c4730115472f343c06f759
+    "@aws-sdk/is-array-buffer": 3.170.0
+    "@aws-sdk/types": 3.178.0
+    "@aws-sdk/util-hex-encoding": 3.170.0
+    "@aws-sdk/util-middleware": 3.178.0
+    "@aws-sdk/util-uri-escape": 3.170.0
+    tslib: ^2.3.1
+  checksum: 8c573efd3d17c440c001e905ec9bccd9277628dcac41b1f98e466ff2dd8e4ade6038e58ec08ddec37441e147f78c865de6f500796b883f6673f8d74ac00eb4f9
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-arn-parser@npm:3.10.0":
-  version: 3.10.0
-  resolution: "@aws-sdk/util-arn-parser@npm:3.10.0"
+"@aws-sdk/smithy-client@npm:3.180.0":
+  version: 3.180.0
+  resolution: "@aws-sdk/smithy-client@npm:3.180.0"
   dependencies:
-    tslib: ^1.8.0
-  checksum: 806ef381b773ee273cda3cbb3a3159ae8af2b541bafe5363d0b0454fdf13392dfcaf4db780f6f303bbfa5cce2ab8a69b9fc0b0ddfd8f6406aed954e4d1c08d96
+    "@aws-sdk/middleware-stack": 3.178.0
+    "@aws-sdk/types": 3.178.0
+    tslib: ^2.3.1
+  checksum: e0ee40a496812829ce53e4624661443107c0449ed8e1c85efeace44b5d54afbe381bb2488f8b96058f0c26519c24643e9645e1e3735a4b35a9e2c4289be7fd17
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-base64-browser@npm:3.10.0":
-  version: 3.10.0
-  resolution: "@aws-sdk/util-base64-browser@npm:3.10.0"
-  dependencies:
-    tslib: ^1.8.0
-  checksum: 4508ac6d32fc84b34b90b044bbcf3eb616bf84b7ad6372983e7d124e4adc2ca116eab8793b8567ce4bd400d37ab271b369b5063c06509da585d15fa829e3f843
+"@aws-sdk/types@npm:3.178.0, @aws-sdk/types@npm:^3.1.0, @aws-sdk/types@npm:^3.110.0":
+  version: 3.178.0
+  resolution: "@aws-sdk/types@npm:3.178.0"
+  checksum: 9d339078953481c4db38c23a590638b7058698f204ea317369a132d06142bfde65beaf6f6ac724180e98f73917ef6a041aa61e44f447ffff43cc845c771c2510
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-base64-node@npm:3.10.0":
-  version: 3.10.0
-  resolution: "@aws-sdk/util-base64-node@npm:3.10.0"
+"@aws-sdk/url-parser@npm:3.178.0":
+  version: 3.178.0
+  resolution: "@aws-sdk/url-parser@npm:3.178.0"
   dependencies:
-    "@aws-sdk/util-buffer-from": 3.10.0
-    tslib: ^1.8.0
-  checksum: fa64be50ae8e6ae40aded7fdb9372843286f76bb2f62b8114db26199610b707b388476bf0cad9ef43846d2e9413b8e2ec1e627a75f3332997eb3590d67cbbeae
+    "@aws-sdk/querystring-parser": 3.178.0
+    "@aws-sdk/types": 3.178.0
+    tslib: ^2.3.1
+  checksum: 4f029aa446c7d52527289da1e9db9ea2dd70a28831c9d12a4b4f56f9683e10d35b6fdf1cb3ab00c819c27eeb0b711bbe6a07aaf580d6ae562b0d846e0fb11c76
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-body-length-browser@npm:3.10.0":
-  version: 3.10.0
-  resolution: "@aws-sdk/util-body-length-browser@npm:3.10.0"
+"@aws-sdk/util-arn-parser@npm:3.170.0":
+  version: 3.170.0
+  resolution: "@aws-sdk/util-arn-parser@npm:3.170.0"
   dependencies:
-    tslib: ^1.8.0
-  checksum: 33454e23c8602f6f4c29589a5cf413b6f5326b9d05636c162f31e638b4e77c0880f8b4ebd196d18cae9d8665ee82378cf224a9c585f857a6902b45bb4cbb1972
+    tslib: ^2.3.1
+  checksum: 032d1d11b6e2a5047b8c1f2b5e993cbafbe97bb65f64eca305631b4644c06300c372bf5b05c5771169f84e599dc6db6e6845af58056066f8a7dad49cfd58cec5
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-body-length-node@npm:3.10.0":
-  version: 3.10.0
-  resolution: "@aws-sdk/util-body-length-node@npm:3.10.0"
+"@aws-sdk/util-base64-browser@npm:3.170.0":
+  version: 3.170.0
+  resolution: "@aws-sdk/util-base64-browser@npm:3.170.0"
   dependencies:
-    tslib: ^1.8.0
-  checksum: 1bdd5ab3e180eb3dcd4b1e5b843b4acdefebf1b275945c947142e5da140e4babb4060b108ab01cd471f0127afe89417333c6de9af8a1eabfe90a497b8ef57b6d
+    tslib: ^2.3.1
+  checksum: 74ac479478029f3349782c8235f33135c1e817c16999badde8b9d6b5eac9df52a8388ce1b666dcd8ae891e33e81482ea3cd50b1d35cfda23468275a680e45da2
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-buffer-from@npm:3.10.0":
-  version: 3.10.0
-  resolution: "@aws-sdk/util-buffer-from@npm:3.10.0"
+"@aws-sdk/util-base64-node@npm:3.170.0":
+  version: 3.170.0
+  resolution: "@aws-sdk/util-base64-node@npm:3.170.0"
   dependencies:
-    "@aws-sdk/is-array-buffer": 3.10.0
-    tslib: ^1.8.0
-  checksum: 7364889482f1920706a61582a141a08da1f748c1ebb79157feafcaf585622830e2089333a750fcd3cb1bc54543df57adaf7c79df649aa470172d9573ffae48f6
+    "@aws-sdk/util-buffer-from": 3.170.0
+    tslib: ^2.3.1
+  checksum: e65e543049e42a0e8e7535ea259f504e9adde02fedc266b5a18fb1c665fdfa285ffe8a1c48438c0e100bf2ba37fc61479bd7d516f7c052fd4885b14563c869a1
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-hex-encoding@npm:3.10.0":
-  version: 3.10.0
-  resolution: "@aws-sdk/util-hex-encoding@npm:3.10.0"
+"@aws-sdk/util-body-length-browser@npm:3.170.0":
+  version: 3.170.0
+  resolution: "@aws-sdk/util-body-length-browser@npm:3.170.0"
   dependencies:
-    tslib: ^1.8.0
-  checksum: a3838137c00731a9be7181c906b34589d12742ca8256b0efb5071c19e407716188437991a1ee7c79fd703c90bd088ab02db074a76c5a9498f39d5f1123c16923
+    tslib: ^2.3.1
+  checksum: fff80b2e77c1e703746f334bda85bcf0f5d97c2e2719493257d67febd74e1a62632abe486836acf618859326b26f9edae03479ee6a13090e692b76c10182843d
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-body-length-node@npm:3.170.0":
+  version: 3.170.0
+  resolution: "@aws-sdk/util-body-length-node@npm:3.170.0"
+  dependencies:
+    tslib: ^2.3.1
+  checksum: b503be9a89a12230d991bdc07d61f6fc0b6c282ce94eb0aafa07f500df97c93f85e7a9d046fbac7881d856317c2f5d30eb0025069669da26f11be1932513e8c2
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-buffer-from@npm:3.170.0":
+  version: 3.170.0
+  resolution: "@aws-sdk/util-buffer-from@npm:3.170.0"
+  dependencies:
+    "@aws-sdk/is-array-buffer": 3.170.0
+    tslib: ^2.3.1
+  checksum: 5880609b1fde1a7bb6c27c0fc87c7b80ae9eea74c41ca0d3c96d9f8ecd9d579cc612698b76f862dae51d9edd016d5617f8647fe6e15dd357e949d4ebb4919b9a
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-config-provider@npm:3.170.0":
+  version: 3.170.0
+  resolution: "@aws-sdk/util-config-provider@npm:3.170.0"
+  dependencies:
+    tslib: ^2.3.1
+  checksum: f1be922c466cbaf8e25f9b0d21a23e9f1de0aeedd36a5ce7b8745bf89d4744c10066d626c985660abec79c46f5f01a8d4b2b51e7b7303c3b0b5383fb1dc16f39
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-defaults-mode-browser@npm:3.180.0":
+  version: 3.180.0
+  resolution: "@aws-sdk/util-defaults-mode-browser@npm:3.180.0"
+  dependencies:
+    "@aws-sdk/property-provider": 3.178.0
+    "@aws-sdk/types": 3.178.0
+    bowser: ^2.11.0
+    tslib: ^2.3.1
+  checksum: bb31885190da82504d009958e0bce53cb9e916f1e0544dba8b10cf409e6575e939d36e451f588667ffad305dd247a4ef567c3666ef5181ddc1d8a062e378374f
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-defaults-mode-node@npm:3.180.0":
+  version: 3.180.0
+  resolution: "@aws-sdk/util-defaults-mode-node@npm:3.180.0"
+  dependencies:
+    "@aws-sdk/config-resolver": 3.178.0
+    "@aws-sdk/credential-provider-imds": 3.178.0
+    "@aws-sdk/node-config-provider": 3.178.0
+    "@aws-sdk/property-provider": 3.178.0
+    "@aws-sdk/types": 3.178.0
+    tslib: ^2.3.1
+  checksum: 9129c16e98d15653e87c5f6e63aac4698e52c24f3c89335d94a74d26631ad35c8b889bc4f5ae7acf111048254204f4992eed9ee35ed54e8d7e52ea4447d8e086
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-hex-encoding@npm:3.170.0":
+  version: 3.170.0
+  resolution: "@aws-sdk/util-hex-encoding@npm:3.170.0"
+  dependencies:
+    tslib: ^2.3.1
+  checksum: f2e8a9b33f2394080e5ad4bfd9d8c7e8a9821d018e90e6c569f0e1c251def6a1620f3e13f1a368418198e4223693e997b9fb3cbb54a31b3917e705dfb5684ea5
   languageName: node
   linkType: hard
 
 "@aws-sdk/util-locate-window@npm:^3.0.0":
-  version: 3.10.0
-  resolution: "@aws-sdk/util-locate-window@npm:3.10.0"
+  version: 3.170.0
+  resolution: "@aws-sdk/util-locate-window@npm:3.170.0"
   dependencies:
-    tslib: ^1.8.0
-  checksum: 57868a9b3bc831fcd2c71c25fe5b13cd45e2c6c67b286b91c8de1115ae231186037cdceb53783ae6ad89fcd4a323d8fa25242bff228805a8518cecac02e2f3ab
+    tslib: ^2.3.1
+  checksum: 68482addfd016dd168b083b70202d1537bed10cfff1f4700a4711d14a8066e9a6fe1bfa30c953380efb96ca3b935e253ef166d87f6722d4db3afa82d84456e64
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-uri-escape@npm:3.10.0":
-  version: 3.10.0
-  resolution: "@aws-sdk/util-uri-escape@npm:3.10.0"
+"@aws-sdk/util-middleware@npm:3.178.0":
+  version: 3.178.0
+  resolution: "@aws-sdk/util-middleware@npm:3.178.0"
   dependencies:
-    tslib: ^1.8.0
-  checksum: a6727f4056d37348173e710f5ea108c362e26a83d069e697fdce9359daba35b2e95bb2ebfd6d1a38d899b1424d83956fe3716522bd837f85518fa2773fae24ea
+    tslib: ^2.3.1
+  checksum: 82bf08d11fe32b35817ac5df41ef9146b350bcf24b96ff173c67e8b6e7ea34c198c65a8c02f11361b00057b00c2ff98a990c4b8e3f551a790947bfd9d43438c4
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-user-agent-browser@npm:3.10.0":
-  version: 3.10.0
-  resolution: "@aws-sdk/util-user-agent-browser@npm:3.10.0"
+"@aws-sdk/util-stream-browser@npm:3.178.0":
+  version: 3.178.0
+  resolution: "@aws-sdk/util-stream-browser@npm:3.178.0"
   dependencies:
-    "@aws-sdk/types": 3.10.0
+    "@aws-sdk/fetch-http-handler": 3.178.0
+    "@aws-sdk/types": 3.178.0
+    "@aws-sdk/util-base64-browser": 3.170.0
+    "@aws-sdk/util-hex-encoding": 3.170.0
+    "@aws-sdk/util-utf8-browser": 3.170.0
+    tslib: ^2.3.1
+  checksum: 97f548f031f8360fc9cfbbc9e2619e9970d835dab94fe814a1ae0ca828774c23025d5ea7504c33c9d7d14c9aad89f13bc4245ce3815760f9e633e7fcdac14bd3
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-stream-node@npm:3.178.0":
+  version: 3.178.0
+  resolution: "@aws-sdk/util-stream-node@npm:3.178.0"
+  dependencies:
+    "@aws-sdk/node-http-handler": 3.178.0
+    "@aws-sdk/types": 3.178.0
+    "@aws-sdk/util-buffer-from": 3.170.0
+    tslib: ^2.3.1
+  checksum: 77a3c1e1c61f8670db68264e4375d61b0bc71dbd93156d0d77354ed4529d53c7c309c6cc1566d5bdb04658cba5696f04365acdd96026c4b1b865468266728a56
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-uri-escape@npm:3.170.0":
+  version: 3.170.0
+  resolution: "@aws-sdk/util-uri-escape@npm:3.170.0"
+  dependencies:
+    tslib: ^2.3.1
+  checksum: abcccc8c49cd01deebb97a1d764d97d8bcb2b669682a0bedf26b2e34c0338bd54e9eeea89bd7579d9404434cdfb72467fb71d3a69ebc88c8fb1a9f899f69af70
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-user-agent-browser@npm:3.178.0":
+  version: 3.178.0
+  resolution: "@aws-sdk/util-user-agent-browser@npm:3.178.0"
+  dependencies:
+    "@aws-sdk/types": 3.178.0
     bowser: ^2.11.0
-    tslib: ^1.8.0
-  checksum: 6c1f7fefe583815f9252bab2bac6531078bf5088a6349f00986803ecea647afdc9c4119cf4e01652c123585ba192a2648500092c65365e5372c96502c73b71f6
+    tslib: ^2.3.1
+  checksum: 494dc5994f68b86cced4a8fd4e6a19699b1e1c72a2cfd6169f838bae379e6588e2bef6a9cff4b04d33014f7dfe1bc47b8ba77b064bdedc0b3da612eea6429757
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-user-agent-node@npm:3.10.0":
-  version: 3.10.0
-  resolution: "@aws-sdk/util-user-agent-node@npm:3.10.0"
+"@aws-sdk/util-user-agent-node@npm:3.178.0":
+  version: 3.178.0
+  resolution: "@aws-sdk/util-user-agent-node@npm:3.178.0"
   dependencies:
-    "@aws-sdk/node-config-provider": 3.10.0
-    "@aws-sdk/types": 3.10.0
-    tslib: ^1.8.0
-  checksum: b68b307d7e28314d71b45c18dbaa6bdb9bd40c1bcde6f1354b42a06c097105b8aa4a4e5905e1626c875368c5ef77bbd88cb244f62c8f062d3ec62e37b8035deb
+    "@aws-sdk/node-config-provider": 3.178.0
+    "@aws-sdk/types": 3.178.0
+    tslib: ^2.3.1
+  peerDependencies:
+    aws-crt: ">=1.0.0"
+  peerDependenciesMeta:
+    aws-crt:
+      optional: true
+  checksum: 3a174cb1c3aa861939ffa2e9a43350049113d7c71a26553bdd65db0d7608f617355ceba0b9fccd085d25bd1d0074e8e47faa09adb28326ebd00aef6ae78bb1c6
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-utf8-browser@npm:3.10.0, @aws-sdk/util-utf8-browser@npm:^3.0.0":
-  version: 3.10.0
-  resolution: "@aws-sdk/util-utf8-browser@npm:3.10.0"
+"@aws-sdk/util-utf8-browser@npm:3.170.0, @aws-sdk/util-utf8-browser@npm:^3.0.0":
+  version: 3.170.0
+  resolution: "@aws-sdk/util-utf8-browser@npm:3.170.0"
   dependencies:
-    tslib: ^1.8.0
-  checksum: 5eefbbc73e31c79954847588bdbbcd9f7132f95b19b9a63f834975c92983c6ae5b0d4d815ab9ba6ffd5bacbe9825ce79d9baea1e831a0e5eff0608f0d6d93010
+    tslib: ^2.3.1
+  checksum: 08c2e14dd1d77276a674a927971f5072af5565f3dcbddf7f67d562ea8e4714e493f79621e9783019578dbb749b54827bddc6a2510cd660021616efd94a7599be
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-utf8-node@npm:3.10.0":
-  version: 3.10.0
-  resolution: "@aws-sdk/util-utf8-node@npm:3.10.0"
+"@aws-sdk/util-utf8-node@npm:3.170.0":
+  version: 3.170.0
+  resolution: "@aws-sdk/util-utf8-node@npm:3.170.0"
   dependencies:
-    "@aws-sdk/util-buffer-from": 3.10.0
-    tslib: ^1.8.0
-  checksum: 8fcfe2769d79a26c617d90456338e3964a6ff2ff86edfe220dcbfb9e51b4df01e4ff2c04c3ee97394e06749e7f2f90acc761b70140534551876ee703c33a2df9
+    "@aws-sdk/util-buffer-from": 3.170.0
+    tslib: ^2.3.1
+  checksum: 85ca76d6420f316fe5dd69b12203bee0bbf7368d48bd167c037bef494f44c48e1f63da821d1006149657f6a33157e335c8c1ca133f5d720bdf9a144e32379dc8
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-waiter@npm:3.10.0":
-  version: 3.10.0
-  resolution: "@aws-sdk/util-waiter@npm:3.10.0"
+"@aws-sdk/util-waiter@npm:3.180.0":
+  version: 3.180.0
+  resolution: "@aws-sdk/util-waiter@npm:3.180.0"
   dependencies:
-    "@aws-sdk/abort-controller": 3.10.0
-    "@aws-sdk/types": 3.10.0
-    tslib: ^1.8.0
-  checksum: a4699cdfdb6798bb7611167eff95c6209fd27e65ffc9d7306638b4961925169dc59c0288935b77074b5de0af6009d4f6db601cb8e893fff113d42816b15b728a
+    "@aws-sdk/abort-controller": 3.178.0
+    "@aws-sdk/types": 3.178.0
+    tslib: ^2.3.1
+  checksum: f2bcf231e674dc6d5b58eb14831ffb80e292e82cf47c5a53262e1e82b2c88f97b9ec412a91e88e3bd0a79e8ba943b0caeeb7d29dc5efc4ae86a0ae5a72205de2
   languageName: node
   linkType: hard
 
-"@aws-sdk/xml-builder@npm:3.10.0":
-  version: 3.10.0
-  resolution: "@aws-sdk/xml-builder@npm:3.10.0"
+"@aws-sdk/xml-builder@npm:3.170.0":
+  version: 3.170.0
+  resolution: "@aws-sdk/xml-builder@npm:3.170.0"
   dependencies:
-    tslib: ^1.8.0
-  checksum: de9d3404726081c4ab2cd574fd5e461253e61b8b020f2e73100cac76d77c7c5a7b323a9cffcac364e640774f22dc8b35feef4a215902e861a60dec3484f25c7c
+    tslib: ^2.3.1
+  checksum: 7b94c360feda151c83607315a26c5c6eb75ccad9e6c005a3b75e2f5994c1853374a759e0711041826c21fc5b68efa8934ef18dc4a2c18d24920e2d0497491cd5
   languageName: node
   linkType: hard
 
 "@types/concat-stream@npm:^1.6.0":
-  version: 1.6.0
-  resolution: "@types/concat-stream@npm:1.6.0"
+  version: 1.6.1
+  resolution: "@types/concat-stream@npm:1.6.1"
   dependencies:
     "@types/node": "*"
-  checksum: e7ad32de633984b38ffbee4fce000bd05e92df949c2f21d8230c19c3e32841cb3ffb57a87f6c3602c7705bc142c1a48766ed5d1643c08dfb7c3de5c681e3829a
+  checksum: 7d211e74331affd3578b5469244f5cef84a93775f38332adb3ef12413559a23862bc682c6873d0a404b01c9d5d5f7d3ae091fe835b435b633eb420e3055b3e56
   languageName: node
   linkType: hard
 
@@ -878,31 +1087,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:*":
-  version: 13.5.0
-  resolution: "@types/node@npm:13.5.0"
-  checksum: 0e74b86948e478b1c8d22e602c8d85175793f2685c9e102670159912f858246679c90e348f036fdfcdd0e71713ee9098fbeec0934a1f007f8e966c6d938e7c00
+"@types/node@npm:*, @types/node@npm:^8.0.0":
+  version: 8.10.66
+  resolution: "@types/node@npm:8.10.66"
+  checksum: c52039de862654a139abdc6a51de532a69dd80516ac35a959c3b3a2831ecbaaf065b0df5f9db943f5e28b544ebb9a891730d52b52f7a169b86a82bc060210000
   languageName: node
   linkType: hard
 
 "@types/node@npm:^10.0.3":
-  version: 10.17.13
-  resolution: "@types/node@npm:10.17.13"
-  checksum: fe9f1574869344b0e58f5877c13903e4445356b921c976ca63ea2c8d286c3d4aded317011030dd4be7b94d5e3766a601cb7cfe3eda496bd6aef1846ab8c6c09b
-  languageName: node
-  linkType: hard
-
-"@types/node@npm:^8.0.0":
-  version: 8.10.59
-  resolution: "@types/node@npm:8.10.59"
-  checksum: 509a93b538e937a7227cf52b51da8d05d08e547994053434f92e4fe0545e641d9130e5ac66ffae946f1fea13f85e7b0ec958fab7aa250ac32e848937b3aa91cb
+  version: 10.17.60
+  resolution: "@types/node@npm:10.17.60"
+  checksum: 2cdb3a77d071ba8513e5e8306fa64bf50e3c3302390feeaeff1fd325dd25c8441369715dfc8e3701011a72fed5958c7dfa94eb9239a81b3c286caa4d97db6eef
   languageName: node
   linkType: hard
 
 "@types/qs@npm:^6.2.31":
-  version: 6.9.0
-  resolution: "@types/qs@npm:6.9.0"
-  checksum: a2d2008a4e5cf92a9e51622cbcfd404172de3b14af3de2b9af99885a954eea1d62579d600adf93d2cbd3c4ba64a3ff8de72841bfc1b04d7eafe9ee50de15cbc9
+  version: 6.9.7
+  resolution: "@types/qs@npm:6.9.7"
+  checksum: 7fd6f9c25053e9b5bb6bc9f9f76c1d89e6c04f7707a7ba0e44cc01f17ef5284adb82f230f542c2d5557d69407c9a40f0f3515e8319afd14e1e16b5543ac6cdba
   languageName: node
   linkType: hard
 
@@ -913,39 +1115,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ajv@npm:^5.3.0":
-  version: 5.5.2
-  resolution: "ajv@npm:5.5.2"
+"ajv@npm:^6.10.2, ajv@npm:^6.5.2":
+  version: 6.12.6
+  resolution: "ajv@npm:6.12.6"
   dependencies:
-    co: ^4.6.0
-    fast-deep-equal: ^1.0.0
-    fast-json-stable-stringify: ^2.0.0
-    json-schema-traverse: ^0.3.0
-  checksum: a69645c843e1676b0ae1c5192786e546427f808f386d26127c6585479378066c64341ceec0b127b6789d79628e71d2a732d402f575b98f9262db230d7b715a94
-  languageName: node
-  linkType: hard
-
-"ajv@npm:^6.5.2":
-  version: 6.5.3
-  resolution: "ajv@npm:6.5.3"
-  dependencies:
-    fast-deep-equal: ^2.0.1
+    fast-deep-equal: ^3.1.1
     fast-json-stable-stringify: ^2.0.0
     json-schema-traverse: ^0.4.1
     uri-js: ^4.2.2
-  checksum: 787f5a6a69a75f48723bcdb5d17eea0bfbac39bd83ff96b8e82e8f1f7e40be3558a26252152ff917ccca14176b31a3dba4e219ed2f4195a72f6fbd97530f419a
-  languageName: node
-  linkType: hard
-
-"ajv@npm:^6.9.1":
-  version: 6.10.0
-  resolution: "ajv@npm:6.10.0"
-  dependencies:
-    fast-deep-equal: ^2.0.1
-    fast-json-stable-stringify: ^2.0.0
-    json-schema-traverse: ^0.4.1
-    uri-js: ^4.2.2
-  checksum: b4c8b35f59e3789557b11efc73e139d9afd3c06172dd0c5b2b9fcd3239bcc399185559611df02f74efe1dc501f7c7561402f000125ba4b3a360cc02df6969144
+  checksum: 874972efe5c4202ab0a68379481fbd3d1b5d0a7bd6d3cc21d40d3536ebff3352a2a1fabb632d4fd2cc7fe4cbdcd5ed6782084c9bbf7f32a1536d18f9da5007d4
   languageName: node
   linkType: hard
 
@@ -956,17 +1134,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ansi-regex@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "ansi-regex@npm:4.0.0"
-  checksum: 172fb51c277af2ad1173fc8193253f8802379d727a51493d3f1632b1a0d9004dd809ee4354cf77f7cd4a8cd27b6256168dd39662c99891410afa987ca606448e
+"ansi-regex@npm:^4.1.0":
+  version: 4.1.1
+  resolution: "ansi-regex@npm:4.1.1"
+  checksum: b1a6ee44cb6ecdabaa770b2ed500542714d4395d71c7e5c25baa631f680fb2ad322eb9ba697548d498a6fd366949fc8b5bfcf48d49a32803611f648005b01888
   languageName: node
   linkType: hard
 
-"ansi-regex@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "ansi-regex@npm:5.0.0"
-  checksum: b1bb4e992a5d96327bb4f72eaba9f8047f1d808d273ad19d399e266bfcc7fb19a4d1a127a32f7bc61fe46f1a94a4d04ec4c424e3fbe184929aa866323d8ed4ce
+"ansi-regex@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "ansi-regex@npm:5.0.1"
+  checksum: 2aa4bb54caf2d622f1afdad09441695af2a83aa3fe8b8afa581d205e57ed4261c183c4d3877cee25794443fde5876417d859c108078ab788d6af7e4fe52eb66b
   languageName: node
   linkType: hard
 
@@ -995,33 +1173,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"asn1@npm:~0.2.3":
-  version: 0.2.4
-  resolution: "asn1@npm:0.2.4"
-  dependencies:
-    safer-buffer: ~2.1.0
-  checksum: aa5d6f77b1e0597df53824c68cfe82d1d89ce41cb3520148611f025fbb3101b2d25dd6a40ad34e4fac10f6b19ed5e8628cd4b7d212261e80e83f02b39ee5663c
-  languageName: node
-  linkType: hard
-
-"assert-plus@npm:1.0.0, assert-plus@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "assert-plus@npm:1.0.0"
-  checksum: 19b4340cb8f0e6a981c07225eacac0e9d52c2644c080198765d63398f0075f83bbc0c8e95474d54224e297555ad0d631c1dcd058adb1ddc2437b41a6b424ac64
-  languageName: node
-  linkType: hard
-
 "astral-regex@npm:^1.0.0":
   version: 1.0.0
   resolution: "astral-regex@npm:1.0.0"
   checksum: 93417fc0879531cd95ace2560a54df865c9461a3ac0714c60cbbaa5f1f85d2bee85489e78d82f70b911b71ac25c5f05fc5a36017f44c9bb33c701bee229ff848
-  languageName: node
-  linkType: hard
-
-"async@npm:~1.0.0":
-  version: 1.0.0
-  resolution: "async@npm:1.0.0"
-  checksum: 04d4e57806b1a46b1635a3d821a9bcc06f893d6828a0468ceb494d1857b565754cbbaed22529aef79749dbbe7cf5080bfdb346b54be0e9cd35c41d7ef8d7911f
   languageName: node
   linkType: hard
 
@@ -1032,24 +1187,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"aws-sign2@npm:~0.7.0":
-  version: 0.7.0
-  resolution: "aws-sign2@npm:0.7.0"
-  checksum: b148b0bb0778098ad8cf7e5fc619768bcb51236707ca1d3e5b49e41b171166d8be9fdc2ea2ae43d7decf02989d0aaa3a9c4caa6f320af95d684de9b548a71525
-  languageName: node
-  linkType: hard
-
-"aws4@npm:^1.8.0":
-  version: 1.8.0
-  resolution: "aws4@npm:1.8.0"
-  checksum: 3314f3607f2b79028500e8eb98e1ba30a4fa6e2c5bedb7c471ad8ace444899f30cea32de31ec86ab4a1e34b65d523482c51a9895c6fc229c3bf75e50b68afeae
-  languageName: node
-  linkType: hard
-
 "balanced-match@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "balanced-match@npm:1.0.0"
-  checksum: 9b67bfe558772f40cf743a3469b48b286aecec2ea9fe80c48d74845e53aab1cef524fafedf123a63019b49ac397760573ef5f173f539423061f7217cbb5fbd40
+  version: 1.0.2
+  resolution: "balanced-match@npm:1.0.2"
+  checksum: 9706c088a283058a8a99e0bf91b0a2f75497f185980d9ffa8b304de1d9e58ebda7c72c07ebf01dadedaac5b2907b2c6f566f660d62bd336c3468e960403b9d65
   languageName: node
   linkType: hard
 
@@ -1060,18 +1201,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bcrypt-pbkdf@npm:^1.0.0":
-  version: 1.0.2
-  resolution: "bcrypt-pbkdf@npm:1.0.2"
-  dependencies:
-    tweetnacl: ^0.14.3
-  checksum: 4edfc9fe7d07019609ccf797a2af28351736e9d012c8402a07120c4453a3b789a15f2ee1530dc49eee8f7eb9379331a8dd4b3766042b9e502f74a68e7f662291
-  languageName: node
-  linkType: hard
-
-"bids-validator@npm:1.9.3":
-  version: 1.9.3
-  resolution: "bids-validator@npm:1.9.3"
+"bids-validator@npm:1.9.8":
+  version: 1.9.8
+  resolution: "bids-validator@npm:1.9.8"
   dependencies:
     "@aws-sdk/client-s3": ^3.9.0
     ajv: ^6.5.2
@@ -1081,7 +1213,7 @@ __metadata:
     date-fns: ^2.7.0
     events: ^3.3.0
     exifreader: ^4.1.0
-    hed-validator: ^3.5.0
+    hed-validator: ^3.8.0
     ignore: ^4.0.2
     is-utf8: ^0.2.1
     jshint: ^2.9.6
@@ -1100,7 +1232,7 @@ __metadata:
     yargs: ^16.2.0
   bin:
     bids-validator: bin/bids-validator
-  checksum: f0e6713fe26f8ab8d539fed910a18d36cd051eca26bf84768ff664d95ae040653d5cbf8a5d33ccc3cd5721c7861eed10ecd2a879402482d366b4e6a428e1ce5a
+  checksum: 531d1d880e95981d77a0bc2b65a888e9fa676495ef15fc17defc6147087f2ae532929b6b26fa1649a8d3d37bc6b52d0777f81d42e156affd158e06cf55c3c364
   languageName: node
   linkType: hard
 
@@ -1122,13 +1254,13 @@ __metadata:
   linkType: hard
 
 "buffer-from@npm:^1.0.0":
-  version: 1.1.1
-  resolution: "buffer-from@npm:1.1.1"
-  checksum: ccc53b69736008bff764497367c4d24879ba7122bc619ee499ff47eef3a5b885ca496e87272e7ebffa0bec3804c83f84041c616f6e3318f40624e27c1d80f045
+  version: 1.1.2
+  resolution: "buffer-from@npm:1.1.2"
+  checksum: 0448524a562b37d4d7ed9efd91685a5b77a50672c556ea254ac9a6d30e3403a517d8981f10e565db24e8339413b43c97ca2951f10e399c6125a0d8911f5679bb
   languageName: node
   linkType: hard
 
-"buffer@npm:*":
+"buffer@npm:*, buffer@npm:^6.0.3":
   version: 6.0.3
   resolution: "buffer@npm:6.0.3"
   dependencies:
@@ -1139,9 +1271,19 @@ __metadata:
   linkType: hard
 
 "bytes@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "bytes@npm:3.0.0"
-  checksum: a2b386dd8188849a5325f58eef69c3b73c51801c08ffc6963eddc9be244089ba32d19347caf6d145c86f315ae1b1fc7061a32b0c1aa6379e6a719090287ed101
+  version: 3.1.2
+  resolution: "bytes@npm:3.1.2"
+  checksum: e4bcd3948d289c5127591fbedf10c0b639ccbf00243504e4e127374a15c3bc8eed0d28d4aaab08ff6f1cf2abc0cce6ba3085ed32f4f90e82a5683ce0014e1b6e
+  languageName: node
+  linkType: hard
+
+"call-bind@npm:^1.0.0":
+  version: 1.0.2
+  resolution: "call-bind@npm:1.0.2"
+  dependencies:
+    function-bind: ^1.1.1
+    get-intrinsic: ^1.0.2
+  checksum: f8e31de9d19988a4b80f3e704788c4a2d6b6f3d17cfec4f57dc29ced450c53a49270dc66bf0fbd693329ee948dd33e6c90a329519aef17474a4d961e8d6426b0
   languageName: node
   linkType: hard
 
@@ -1191,13 +1333,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"co@npm:^4.6.0":
-  version: 4.6.0
-  resolution: "co@npm:4.6.0"
-  checksum: 5210d9223010eb95b29df06a91116f2cf7c8e0748a9013ed853b53f362ea0e822f1e5bb054fb3cefc645239a4cf966af1f6133a3b43f40d591f3b68ed6cf0510
-  languageName: node
-  linkType: hard
-
 "code-point-at@npm:^1.0.0":
   version: 1.1.0
   resolution: "code-point-at@npm:1.1.0"
@@ -1237,26 +1372,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"colors@npm:1.0.x":
-  version: 1.0.3
-  resolution: "colors@npm:1.0.3"
-  checksum: 234e8d3ab7e4003851cdd6a1f02eaa16dabc502ee5f4dc576ad7959c64b7477b15bd21177bab4055a4c0a66aa3d919753958030445f87c39a253d73b7a3637f5
-  languageName: node
-  linkType: hard
-
 "colors@npm:^1.4.0":
   version: 1.4.0
   resolution: "colors@npm:1.4.0"
   checksum: 98aa2c2418ad87dedf25d781be69dc5fc5908e279d9d30c34d8b702e586a0474605b3a189511482b9d5ed0d20c867515d22749537f7bc546256c6014f3ebdcec
-  languageName: node
-  linkType: hard
-
-"combined-stream@npm:1.0.6, combined-stream@npm:~1.0.6":
-  version: 1.0.6
-  resolution: "combined-stream@npm:1.0.6"
-  dependencies:
-    delayed-stream: ~1.0.0
-  checksum: 7c89a0cdfbbd2665433302b1cf364ccc7191d9e5c12e99b4a75828f8a67af8115bc14f299ac6ca3501621cdb4d1824c1453bee2bd82701f9d7433289364b1e92
   languageName: node
   linkType: hard
 
@@ -1276,7 +1395,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"concat-stream@npm:1.6.2, concat-stream@npm:^1.6.0, concat-stream@npm:^1.6.2":
+"concat-stream@npm:^1.6.0, concat-stream@npm:^1.6.2":
   version: 1.6.2
   resolution: "concat-stream@npm:1.6.2"
   dependencies:
@@ -1297,35 +1416,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"core-util-is@npm:1.0.2, core-util-is@npm:~1.0.0":
-  version: 1.0.2
-  resolution: "core-util-is@npm:1.0.2"
-  checksum: 7a4c925b497a2c91421e25bf76d6d8190f0b2359a9200dbeed136e63b2931d6294d3b1893eda378883ed363cd950f44a12a401384c609839ea616befb7927dab
+"core-util-is@npm:~1.0.0":
+  version: 1.0.3
+  resolution: "core-util-is@npm:1.0.3"
+  checksum: 9de8597363a8e9b9952491ebe18167e3b36e7707569eed0ebf14f8bba773611376466ae34575bca8cfe3c767890c859c74056084738f09d4e4a6f902b2ad7d99
   languageName: node
   linkType: hard
 
 "cross-fetch@npm:^3.0.6":
-  version: 3.1.4
-  resolution: "cross-fetch@npm:3.1.4"
+  version: 3.1.5
+  resolution: "cross-fetch@npm:3.1.5"
   dependencies:
-    node-fetch: 2.6.1
-  checksum: 2107e5e633aa327bdacab036b1907c7ddd28651ede0c1d4fd14db04510944d56849a8255e2f5b8f9a1da0e061b6cee943f6819fe29ed9a130195e7fadd82a4ff
-  languageName: node
-  linkType: hard
-
-"cycle@npm:1.0.x":
-  version: 1.0.3
-  resolution: "cycle@npm:1.0.3"
-  checksum: b9f131094fb832a8c4ba18c6d2dc9c87fc80d3242847a45f0a5f70911b2acab68abc1c25eb23e5155fcf2135a27d8fcc3635556745b03b488c4f360cfbc352df
-  languageName: node
-  linkType: hard
-
-"dashdash@npm:^1.12.0":
-  version: 1.14.1
-  resolution: "dashdash@npm:1.14.1"
-  dependencies:
-    assert-plus: ^1.0.0
-  checksum: 3634c249570f7f34e3d34f866c93f866c5b417f0dd616275decae08147dcdf8fccfaa5947380ccfb0473998ea3a8057c0b4cd90c875740ee685d0624b2983598
+    node-fetch: 2.6.7
+  checksum: f6b8c6ee3ef993ace6277fd789c71b6acf1b504fd5f5c7128df4ef2f125a429e29cd62dc8c127523f04a5f2fa4771ed80e3f3d9695617f441425045f505cf3bb
   languageName: node
   linkType: hard
 
@@ -1336,17 +1439,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"date-fns@npm:^2.17.0":
-  version: 2.19.0
-  resolution: "date-fns@npm:2.19.0"
-  checksum: c8b727aa10941d76977c48c72bda3b33adeb6a89d67763c95689ef7c18729a564a6e01e87fd5f65ba44b6866e8282d636d5e8bc598f099b925597bb109a0880c
-  languageName: node
-  linkType: hard
-
-"date-fns@npm:^2.7.0":
-  version: 2.8.0
-  resolution: "date-fns@npm:2.8.0"
-  checksum: c39e6f5294260a50abc7359eaeb9d3dfdf0813e249fe179296f1d81cc6684ba45639435bf0e03d087989c3dcec923f4aeb5a487aaa5b6de361a9f62914bec039
+"date-fns@npm:^2.17.0, date-fns@npm:^2.7.0":
+  version: 2.29.3
+  resolution: "date-fns@npm:2.29.3"
+  checksum: e01cf5b62af04e05dfff921bb9c9933310ed0e1ae9a81eb8653452e64dc841acf7f6e01e1a5ae5644d0337e9a7f936175fd2cb6819dc122fdd9c5e86c56be484
   languageName: node
   linkType: hard
 
@@ -1354,15 +1450,6 @@ __metadata:
   version: 0.1.4
   resolution: "date-now@npm:0.1.4"
   checksum: 7f4762ce64c3535cb004d8f8517dae23b57fed221ffd661ef7db0142dc639a66e95700da10e98b9225d86dd2655d81a3d7bc2186adcb09a6a8e13647265a621d
-  languageName: node
-  linkType: hard
-
-"debug@npm:2.6.9":
-  version: 2.6.9
-  resolution: "debug@npm:2.6.9"
-  dependencies:
-    ms: 2.0.0
-  checksum: d2f51589ca66df60bf36e1fa6e4386b318c3f1e06772280eea5b1ae9fd3d05e9c2b7fd8a7d862457d00853c75b00451aa2d7459b924629ee385287a650f58fe6
   languageName: node
   linkType: hard
 
@@ -1381,26 +1468,26 @@ __metadata:
   linkType: hard
 
 "dom-serializer@npm:0":
-  version: 0.1.0
-  resolution: "dom-serializer@npm:0.1.0"
+  version: 0.2.2
+  resolution: "dom-serializer@npm:0.2.2"
   dependencies:
-    domelementtype: ~1.1.1
-    entities: ~1.1.1
-  checksum: e70554199404073bcbbd9546a8e62d3033410aa88eaaa64e1e33f3e25e105da9501d6c1fbac3f8534b9d042e266498f67e76194deafde322dce936e63c9397c4
+    domelementtype: ^2.0.1
+    entities: ^2.0.0
+  checksum: 376344893e4feccab649a14ca1a46473e9961f40fe62479ea692d4fee4d9df1c00ca8654811a79c1ca7b020096987e1ca4fb4d7f8bae32c1db800a680a0e5d5e
   languageName: node
   linkType: hard
 
 "domelementtype@npm:1":
-  version: 1.3.0
-  resolution: "domelementtype@npm:1.3.0"
-  checksum: 42e203923c12eac5b0e34865baf9098f67db290eccecbb8a5e6ea6734fafe58c976a890a83f799e51069cc27a115fb53a5095af72b2f11491cbbfda16f8ca29a
+  version: 1.3.1
+  resolution: "domelementtype@npm:1.3.1"
+  checksum: 7893da40218ae2106ec6ffc146b17f203487a52f5228b032ea7aa470e41dfe03e1bd762d0ee0139e792195efda765434b04b43cddcf63207b098f6ae44b36ad6
   languageName: node
   linkType: hard
 
-"domelementtype@npm:~1.1.1":
-  version: 1.1.3
-  resolution: "domelementtype@npm:1.1.3"
-  checksum: c8eaffec5a05b3aadf79bffd046c59e5d4f76b7d11a8c1d94d43284b518c765d99da7a42413c241499d133f646ed9cc5aa8dd4551316375a8b73dfc95dea3209
+"domelementtype@npm:^2.0.1":
+  version: 2.3.0
+  resolution: "domelementtype@npm:2.3.0"
+  checksum: ee837a318ff702622f383409d1f5b25dd1024b692ef64d3096ff702e26339f8e345820f29a68bcdcea8cfee3531776b3382651232fbeae95612d6f0a75efb4f6
   languageName: node
   linkType: hard
 
@@ -1420,16 +1507,6 @@ __metadata:
     dom-serializer: 0
     domelementtype: 1
   checksum: 800d1f9d1c2e637267dae078ff6e24461e6be1baeb52fa70f2e7e7520816c032a925997cd15d822de53ef9896abb1f35e5c439d301500a9cd6b46a395f6f6ca0
-  languageName: node
-  linkType: hard
-
-"ecc-jsbn@npm:~0.1.1":
-  version: 0.1.2
-  resolution: "ecc-jsbn@npm:0.1.2"
-  dependencies:
-    jsbn: ~0.1.0
-    safer-buffer: ^2.1.0
-  checksum: 22fef4b6203e5f31d425f5b711eb389e4c6c2723402e389af394f8411b76a488fa414d309d866e2b577ce3e8462d344205545c88a8143cc21752a5172818888a
   languageName: node
   linkType: hard
 
@@ -1454,17 +1531,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"entities@npm:~1.1.1":
-  version: 1.1.1
-  resolution: "entities@npm:1.1.1"
-  checksum: 7229144ec8a0176da8757e8552b3808106a815eeae12334abd1dd0e561118afb3d1a5cc485c3b32d996e21b444012fa4171457f1d68f0e1a484a85007a45605d
-  languageName: node
-  linkType: hard
-
-"es6-promise@npm:^4.0.3":
-  version: 4.2.4
-  resolution: "es6-promise@npm:4.2.4"
-  checksum: 69106a5855839e3f923a4fe0ea6b9ff7d6f0171e958d16054655f43b53a349408477211392887ccb04827a010806389bb87da3aa26b48972bc818bfd2cee5ce9
+"entities@npm:2.2.0, entities@npm:^2.0.0":
+  version: 2.2.0
+  resolution: "entities@npm:2.2.0"
+  checksum: 19010dacaf0912c895ea262b4f6128574f9ccf8d4b3b65c7e8334ad0079b3706376360e28d8843ff50a78aabcb8f08f0a32dbfacdc77e47ed77ca08b713669b3
   languageName: node
   linkType: hard
 
@@ -1483,14 +1553,14 @@ __metadata:
   linkType: hard
 
 "exifreader@npm:^4.1.0":
-  version: 4.2.0
-  resolution: "exifreader@npm:4.2.0"
+  version: 4.5.1
+  resolution: "exifreader@npm:4.5.1"
   dependencies:
     "@xmldom/xmldom": ^0.7.5
   dependenciesMeta:
     "@xmldom/xmldom":
       optional: true
-  checksum: 91bc2e263b5e8f856d7697bcae793a7de3a638efb2559ec4bb4f13a6fe90e9f7262c0480903ee842a42e1a2a0932aafe227f555b424798e99f475d6cbffd9313
+  checksum: 31ac70bc035cc7cde0cc3bb1500be50323f0a42ecfd7684c159ae45560471d7fab3c28bb13de03797f3da335ebb0e68027fe9effe130ff3b76564b65e8e0afdc
   languageName: node
   linkType: hard
 
@@ -1501,73 +1571,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"extend@npm:~3.0.2":
-  version: 3.0.2
-  resolution: "extend@npm:3.0.2"
-  checksum: a50a8309ca65ea5d426382ff09f33586527882cf532931cb08ca786ea3146c0553310bda688710ff61d7668eba9f96b923fe1420cdf56a2c3eaf30fcab87b515
-  languageName: node
-  linkType: hard
-
-"extract-zip@npm:^1.6.5":
-  version: 1.6.7
-  resolution: "extract-zip@npm:1.6.7"
-  dependencies:
-    concat-stream: 1.6.2
-    debug: 2.6.9
-    mkdirp: 0.5.1
-    yauzl: 2.4.1
-  bin:
-    extract-zip: cli.js
-  checksum: 27047b70ab043785f1fc89f7c041e0f97046e7c187685e119b073cffbbc8e7173b7f05a5ec7edb7d621dc6a86daf67441878ecb29d0dd078ae22764d0a934164
-  languageName: node
-  linkType: hard
-
-"extsprintf@npm:1.3.0":
-  version: 1.3.0
-  resolution: "extsprintf@npm:1.3.0"
-  checksum: cee7a4a1e34cffeeec18559109de92c27517e5641991ec6bab849aa64e3081022903dd53084f2080d0d2530803aa5ee84f1e9de642c365452f9e67be8f958ce2
-  languageName: node
-  linkType: hard
-
-"extsprintf@npm:^1.2.0":
-  version: 1.4.0
-  resolution: "extsprintf@npm:1.4.0"
-  checksum: 184dc8a413eb4b1ff16bdce797340e7ded4d28511d56a1c9afa5a95bcff6ace154063823eaf0206dbbb0d14059d74f382a15c34b7c0636fa74a7e681295eb67e
-  languageName: node
-  linkType: hard
-
-"eyes@npm:0.1.x":
-  version: 0.1.8
-  resolution: "eyes@npm:0.1.8"
-  checksum: c31703a92bf36ba75ee8d379ee7985c24ee6149f3a6175f44cec7a05b178c38bce9836d3ca48c9acb0329a960ac2c4b2ead4e60cdd4fe6e8c92cad7cd6913687
-  languageName: node
-  linkType: hard
-
-"fast-base64-decode@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "fast-base64-decode@npm:1.0.0"
-  checksum: 4c59eb1775a7f132333f296c5082476fdcc8f58d023c42ed6d378d2e2da4c328c7a71562f271181a725dd17cdaa8f2805346cc330cdbad3b8e4b9751508bd0a3
-  languageName: node
-  linkType: hard
-
-"fast-deep-equal@npm:^1.0.0":
-  version: 1.1.0
-  resolution: "fast-deep-equal@npm:1.1.0"
-  checksum: 69b4c9534d9805f13a341aa72f69641d0b9ae3cc8beb25c64e68a257241c7bb34370266db27ae4fc3c4da0518448c01a5f587a096a211471c86a38facd9a1486
-  languageName: node
-  linkType: hard
-
-"fast-deep-equal@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "fast-deep-equal@npm:2.0.1"
-  checksum: b701835a87985e0ec4925bdf1f0c1e7eb56309b5d12d534d5b4b69d95a54d65bb16861c081781ead55f73f12d6c60ba668713391ee7fbf6b0567026f579b7b0b
+"fast-deep-equal@npm:^3.1.1":
+  version: 3.1.3
+  resolution: "fast-deep-equal@npm:3.1.3"
+  checksum: e21a9d8d84f53493b6aa15efc9cfd53dd5b714a1f23f67fb5dc8f574af80df889b3bce25dc081887c6d25457cce704e636395333abad896ccdec03abaf1f3f9d
   languageName: node
   linkType: hard
 
 "fast-json-stable-stringify@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "fast-json-stable-stringify@npm:2.0.0"
-  checksum: 5f776089e60a20ccdf5fd17c90590a4bb7c04c4240b2ffde1caad3949f7876a57af7094323dcb432fa6534367768ac6c6b5433a16c5241d0e2cdf0b51b7d4c9f
+  version: 2.1.0
+  resolution: "fast-json-stable-stringify@npm:2.1.0"
+  checksum: b191531e36c607977e5b1c47811158733c34ccb3bfde92c44798929e9b4154884378536d26ad90dfecd32e1ffc09c545d23535ad91b3161a27ddbb8ebe0cbecb
   languageName: node
   linkType: hard
 
@@ -1577,22 +1591,6 @@ __metadata:
   bin:
     xml2js: cli.js
   checksum: d9da9145f73d90c05ee2746d80c78eca4da0249dea8c81ea8f1a6e1245e62988ed4a040dbd1c7229b1e0bdcbf69d33c882e0ac337d10c7eedb159a4dc9779327
-  languageName: node
-  linkType: hard
-
-"fd-slicer@npm:~1.0.1":
-  version: 1.0.1
-  resolution: "fd-slicer@npm:1.0.1"
-  dependencies:
-    pend: ~1.2.0
-  checksum: 5a264d6da228eed31ec7b60b385667fe04c7d0ed5bd069b9fe32be51dd6ab1e1cc36b443b718948e28dbfd4d52963cffc02361d658a8e3983f009f4762d85e24
-  languageName: node
-  linkType: hard
-
-"forever-agent@npm:~0.6.1":
-  version: 0.6.1
-  resolution: "forever-agent@npm:0.6.1"
-  checksum: 766ae6e220f5fe23676bb4c6a99387cec5b7b62ceb99e10923376e27bfea72f3c3aeec2ba5f45f3f7ba65d6616965aa7c20b15002b6860833bb6e394dea546a8
   languageName: node
   linkType: hard
 
@@ -1607,32 +1605,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"form-data@npm:~2.3.2":
-  version: 2.3.2
-  resolution: "form-data@npm:2.3.2"
-  dependencies:
-    asynckit: ^0.4.0
-    combined-stream: 1.0.6
-    mime-types: ^2.1.12
-  checksum: 86f303d2d6c3d687d13ade309d17f85cdecba536d3c867485ef153d6082f9a9dde54939f149a4b42c00c3a7f100689ec335d711ad7bb7f2aed139ee1905161ce
-  languageName: node
-  linkType: hard
-
-"fs-extra@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "fs-extra@npm:1.0.0"
-  dependencies:
-    graceful-fs: ^4.1.2
-    jsonfile: ^2.1.0
-    klaw: ^1.0.0
-  checksum: 9d3642621f42c810e9a32e6ecf97f6f827fdffb001316504d2102d87b4505b8bda1197d43e38e5b1db1faa240b022380b489a0e378b739e1cadef0df9aad4b5f
-  languageName: node
-  linkType: hard
-
 "fs.realpath@npm:^1.0.0":
   version: 1.0.0
   resolution: "fs.realpath@npm:1.0.0"
   checksum: 99ddea01a7e75aa276c250a04eedeffe5662bce66c65c07164ad6264f9de18fb21be9433ead460e54cff20e31721c811f4fb5d70591799df5f85dce6d6746fd0
+  languageName: node
+  linkType: hard
+
+"function-bind@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "function-bind@npm:1.1.1"
+  checksum: b32fbaebb3f8ec4969f033073b43f5c8befbb58f1a79e12f1d7490358150359ebd92f49e72ff0144f65f2c48ea2a605bff2d07965f548f6474fd8efd95bf361a
   languageName: node
   linkType: hard
 
@@ -1643,75 +1626,62 @@ __metadata:
   languageName: node
   linkType: hard
 
-"getpass@npm:^0.1.1":
-  version: 0.1.7
-  resolution: "getpass@npm:0.1.7"
+"get-intrinsic@npm:^1.0.2":
+  version: 1.1.3
+  resolution: "get-intrinsic@npm:1.1.3"
   dependencies:
-    assert-plus: ^1.0.0
-  checksum: ab18d55661db264e3eac6012c2d3daeafaab7a501c035ae0ccb193c3c23e9849c6e29b6ac762b9c2adae460266f925d55a3a2a3a3c8b94be2f222df94d70c046
+    function-bind: ^1.1.1
+    has: ^1.0.3
+    has-symbols: ^1.0.3
+  checksum: 152d79e87251d536cf880ba75cfc3d6c6c50e12b3a64e1ea960e73a3752b47c69f46034456eae1b0894359ce3bc64c55c186f2811f8a788b75b638b06fab228a
   languageName: node
   linkType: hard
 
 "glob@npm:^7.1.1":
-  version: 7.1.2
-  resolution: "glob@npm:7.1.2"
+  version: 7.2.3
+  resolution: "glob@npm:7.2.3"
   dependencies:
     fs.realpath: ^1.0.0
     inflight: ^1.0.4
     inherits: 2
-    minimatch: ^3.0.4
+    minimatch: ^3.1.1
     once: ^1.3.0
     path-is-absolute: ^1.0.0
-  checksum: 821460a6cbd4e1f7feff8c24fb3eaecc2014569bd7dfd80c411fe15a5ec6f23cfdb7181574220fb52f8164cb8e9c558b68a36def4aa2a6b971641e838b8b7675
+  checksum: 29452e97b38fa704dabb1d1045350fb2467cf0277e155aa9ff7077e90ad81d1ea9d53d3ee63bd37c05b09a065e90f16aec4a65f5b8de401d1dac40bc5605d133
   languageName: node
   linkType: hard
 
-"graceful-fs@npm:^4.1.2, graceful-fs@npm:^4.1.6, graceful-fs@npm:^4.1.9":
-  version: 4.1.11
-  resolution: "graceful-fs@npm:4.1.11"
-  checksum: 263cfa68580ca25c312e67211aa34ef18209c0ab163b0213c5edc0325e8d078f0fb5684dc746e8bef7705ae1c9e0f448d733327e73411c5a07944f9186efd396
+"has-symbols@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "has-symbols@npm:1.0.3"
+  checksum: a054c40c631c0d5741a8285010a0777ea0c068f99ed43e5d6eb12972da223f8af553a455132fdb0801bdcfa0e0f443c0c03a68d8555aa529b3144b446c3f2410
   languageName: node
   linkType: hard
 
-"har-schema@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "har-schema@npm:2.0.0"
-  checksum: d8946348f333fb09e2bf24cc4c67eabb47c8e1d1aa1c14184c7ffec1140a49ec8aa78aa93677ae452d71d5fc0fdeec20f0c8c1237291fc2bcb3f502a5d204f9b
-  languageName: node
-  linkType: hard
-
-"har-validator@npm:~5.1.0":
-  version: 5.1.0
-  resolution: "har-validator@npm:5.1.0"
+"has@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "has@npm:1.0.3"
   dependencies:
-    ajv: ^5.3.0
-    har-schema: ^2.0.0
-  checksum: c6c4cde8caf3bf8e111d9fd3eaddfec8a7a3d1ebf4ea4b9cdfd73c2dbef4c198de8129ad52d930dc2bce10587e25d82156bceab8668a3b65f3dd53572c83af23
+    function-bind: ^1.1.1
+  checksum: b9ad53d53be4af90ce5d1c38331e712522417d017d5ef1ebd0507e07c2fbad8686fffb8e12ddecd4c39ca9b9b47431afbb975b8abf7f3c3b82c98e9aad052792
   languageName: node
   linkType: hard
 
-"hasha@npm:^2.2.0":
-  version: 2.2.0
-  resolution: "hasha@npm:2.2.0"
+"hed-validator@npm:^3.8.0":
+  version: 3.8.0
+  resolution: "hed-validator@npm:3.8.0"
   dependencies:
-    is-stream: ^1.0.1
-    pinkie-promise: ^2.0.0
-  checksum: 1855680c0e8a1b92686f816f2f224e184e5f2422f2ddef4f05184ea57bf954cecc017598af08b84c6aa723ccc38353469d4f143869ecfafedf1c50aec0e7ed4e
-  languageName: node
-  linkType: hard
-
-"hed-validator@npm:^3.5.0":
-  version: 3.6.0
-  resolution: "hed-validator@npm:3.6.0"
-  dependencies:
+    buffer: ^6.0.3
     date-and-time: ^0.14.2
     date-fns: ^2.17.0
+    events: ^3.3.0
     lodash: ^4.17.21
+    path: ^0.12.7
     pluralize: ^8.0.0
     semver: ^7.3.4
     then-request: ^6.0.2
     xml2js: ^0.4.23
-  checksum: 1dad68474f66dfbc08ec3c93b1bf88aefe62b65edcc9f99b5b4f9c06bb4650b8c00bc62e6a63ca32a2ac07f040a9571acebc2ce7cf2f610f7ae21b3ab556611a
+  checksum: e2978e3155a02197378ffa2d2a7a85e297670bf17beb0fae1727141dae3806815bfb857b30911d6f24f1cbdce1e7fb1133f9ca470da6cd9eb55bc70c81131f54
   languageName: node
   linkType: hard
 
@@ -1749,17 +1719,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"http-signature@npm:~1.2.0":
-  version: 1.2.0
-  resolution: "http-signature@npm:1.2.0"
-  dependencies:
-    assert-plus: ^1.0.0
-    jsprim: ^1.2.2
-    sshpk: ^1.7.0
-  checksum: 3324598712266a9683585bb84a75dec4fd550567d5e0dd4a0fff6ff3f74348793404d3eeac4918fa0902c810eeee1a86419e4a2e92a164132dfe6b26743fb47c
-  languageName: node
-  linkType: hard
-
 "ieee754@npm:^1.2.1":
   version: 1.2.1
   resolution: "ieee754@npm:1.2.1"
@@ -1784,24 +1743,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"inherits@npm:2, inherits@npm:^2.0.3, inherits@npm:~2.0.1, inherits@npm:~2.0.3":
-  version: 2.0.3
-  resolution: "inherits@npm:2.0.3"
-  checksum: 78cb8d7d850d20a5e9a7f3620db31483aa00ad5f722ce03a55b110e5a723539b3716a3b463e2b96ce3fe286f33afc7c131fa2f91407528ba80cea98a7545d4c0
-  languageName: node
-  linkType: hard
-
-"inherits@npm:2.0.1":
-  version: 2.0.1
-  resolution: "inherits@npm:2.0.1"
-  checksum: 6536b9377296d4ce8ee89c5c543cb75030934e61af42dba98a428e7d026938c5985ea4d1e3b87743a5b834f40ed1187f89c2d7479e9d59e41d2d1051aefba07b
-  languageName: node
-  linkType: hard
-
-"inherits@npm:~2.0.4":
+"inherits@npm:2, inherits@npm:^2.0.3, inherits@npm:~2.0.1, inherits@npm:~2.0.3, inherits@npm:~2.0.4":
   version: 2.0.4
   resolution: "inherits@npm:2.0.4"
   checksum: 4a48a733847879d6cf6691860a6b1e3f0f4754176e4d71494c41f3475553768b10f84b5ce1d40fbd0e34e6bfbb864ee35858ad4dd2cf31e02fc4a154b724d7f1
+  languageName: node
+  linkType: hard
+
+"inherits@npm:2.0.3":
+  version: 2.0.3
+  resolution: "inherits@npm:2.0.3"
+  checksum: 78cb8d7d850d20a5e9a7f3620db31483aa00ad5f722ce03a55b110e5a723539b3716a3b463e2b96ce3fe286f33afc7c131fa2f91407528ba80cea98a7545d4c0
   languageName: node
   linkType: hard
 
@@ -1835,20 +1787,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-stream@npm:^1.0.1":
-  version: 1.1.0
-  resolution: "is-stream@npm:1.1.0"
-  checksum: 063c6bec9d5647aa6d42108d4c59723d2bd4ae42135a2d4db6eadbd49b7ea05b750fd69d279e5c7c45cf9da753ad2c00d8978be354d65aa9f6bb434969c6a2ae
-  languageName: node
-  linkType: hard
-
-"is-typedarray@npm:~1.0.0":
-  version: 1.0.0
-  resolution: "is-typedarray@npm:1.0.0"
-  checksum: 3508c6cd0a9ee2e0df2fa2e9baabcdc89e911c7bd5cf64604586697212feec525aa21050e48affb5ffc3df20f0f5d2e2cf79b08caa64e1ccc9578e251763aef7
-  languageName: node
-  linkType: hard
-
 "is-utf8@npm:^0.2.1":
   version: 0.2.1
   resolution: "is-utf8@npm:0.2.1"
@@ -1870,57 +1808,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"isexe@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "isexe@npm:2.0.0"
-  checksum: 26bf6c5480dda5161c820c5b5c751ae1e766c587b1f951ea3fcfc973bafb7831ae5b54a31a69bd670220e42e99ec154475025a468eae58ea262f813fdc8d1c62
-  languageName: node
-  linkType: hard
-
-"isstream@npm:0.1.x, isstream@npm:~0.1.2":
-  version: 0.1.2
-  resolution: "isstream@npm:0.1.2"
-  checksum: 1eb2fe63a729f7bdd8a559ab552c69055f4f48eb5c2f03724430587c6f450783c8f1cd936c1c952d0a927925180fcc892ebd5b174236cf1065d4bd5bdb37e963
-  languageName: node
-  linkType: hard
-
-"jsbn@npm:~0.1.0":
-  version: 0.1.1
-  resolution: "jsbn@npm:0.1.1"
-  checksum: e5ff29c1b8d965017ef3f9c219dacd6e40ad355c664e277d31246c90545a02e6047018c16c60a00f36d561b3647215c41894f5d869ada6908a2e0ce4200c88f2
-  languageName: node
-  linkType: hard
-
 "jshint@npm:^2.9.6":
-  version: 2.9.6
-  resolution: "jshint@npm:2.9.6"
+  version: 2.13.5
+  resolution: "jshint@npm:2.13.5"
   dependencies:
     cli: ~1.0.0
     console-browserify: 1.1.x
     exit: 0.1.x
     htmlparser2: 3.8.x
-    lodash: ~4.17.10
+    lodash: ~4.17.21
     minimatch: ~3.0.2
-    phantom: ~4.0.1
-    phantomjs-prebuilt: ~2.1.7
-    shelljs: 0.3.x
     strip-json-comments: 1.0.x
-    unicode-5.2.0: ^0.7.5
-  dependenciesMeta:
-    phantom:
-      optional: true
-    phantomjs-prebuilt:
-      optional: true
   bin:
-    jshint: ./bin/jshint
-  checksum: 8d6e1c3d64480abc3ad45be7ac368e2c2dab04c58c15f062dcd97586fd7baca997a445118365b13b001e220d54439aec333d847b918f7b749aafd2907e5c952f
-  languageName: node
-  linkType: hard
-
-"json-schema-traverse@npm:^0.3.0":
-  version: 0.3.1
-  resolution: "json-schema-traverse@npm:0.3.1"
-  checksum: a685c36222023471c25c86cddcff506306ecb8f8941922fd356008419889c41c38e1c16d661d5499d0a561b34f417693e9bb9212ba2b2b2f8f8a345a49e4ec1a
+    jshint: bin/jshint
+  checksum: 2d1920855d21cd98dde2293e4c91da64d9154c00f8f8e27de17b7ddce3ab7cb45b25e8a395e809c12da11634c3284f95c9dbd9b05c8984a10c7a79e58f5c2e0f
   languageName: node
   linkType: hard
 
@@ -1928,63 +1829,6 @@ __metadata:
   version: 0.4.1
   resolution: "json-schema-traverse@npm:0.4.1"
   checksum: 7486074d3ba247769fda17d5181b345c9fb7d12e0da98b22d1d71a5db9698d8b4bd900a3ec1a4ffdd60846fc2556274a5c894d0c48795f14cb03aeae7b55260b
-  languageName: node
-  linkType: hard
-
-"json-schema@npm:0.2.3":
-  version: 0.2.3
-  resolution: "json-schema@npm:0.2.3"
-  checksum: bbc2070988fb5f2a2266a31b956f1b5660e03ea7eaa95b33402901274f625feb586ae0c485e1df854fde40a7f0dc679f3b3ca8e5b8d31f8ea07a0d834de785c7
-  languageName: node
-  linkType: hard
-
-"json-stringify-safe@npm:~5.0.1":
-  version: 5.0.1
-  resolution: "json-stringify-safe@npm:5.0.1"
-  checksum: 48ec0adad5280b8a96bb93f4563aa1667fd7a36334f79149abd42446d0989f2ddc58274b479f4819f1f00617957e6344c886c55d05a4e15ebb4ab931e4a6a8ee
-  languageName: node
-  linkType: hard
-
-"jsonfile@npm:^2.1.0":
-  version: 2.4.0
-  resolution: "jsonfile@npm:2.4.0"
-  dependencies:
-    graceful-fs: ^4.1.6
-  dependenciesMeta:
-    graceful-fs:
-      optional: true
-  checksum: f5064aabbc9e35530dc471d8b203ae1f40dbe949ddde4391c6f6a6d310619a15f0efdae5587df594d1d70c555193aaeee9d2ed4aec9ffd5767bd5e4e62d49c3d
-  languageName: node
-  linkType: hard
-
-"jsprim@npm:^1.2.2":
-  version: 1.4.1
-  resolution: "jsprim@npm:1.4.1"
-  dependencies:
-    assert-plus: 1.0.0
-    extsprintf: 1.3.0
-    json-schema: 0.2.3
-    verror: 1.10.0
-  checksum: 6bcb20ec265ae18bb48e540a6da2c65f9c844f7522712d6dfcb01039527a49414816f4869000493363f1e1ea96cbad00e46188d5ecc78257a19f152467587373
-  languageName: node
-  linkType: hard
-
-"kew@npm:^0.7.0":
-  version: 0.7.0
-  resolution: "kew@npm:0.7.0"
-  checksum: f21ccf245647ae9a89bcf98e479a355989f1b54aeff24af62d0cbf11a67cf7e7ffc59c3bcf05a70b68ae2a2c669f8004aea33cef69f04f0733d888afaa26d178
-  languageName: node
-  linkType: hard
-
-"klaw@npm:^1.0.0":
-  version: 1.3.1
-  resolution: "klaw@npm:1.3.1"
-  dependencies:
-    graceful-fs: ^4.1.9
-  dependenciesMeta:
-    graceful-fs:
-      optional: true
-  checksum: 8f69e4797c26e7c3f2426bfa85f38a3da3c2cb1b4c6bd850d2377aed440d41ce9d806f2885c2e2e224372c56af4b1d43b8a499adecf9a05e7373dc6b8b7c52e4
   languageName: node
   linkType: hard
 
@@ -1997,14 +1841,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash@npm:^4.17.11, lodash@npm:~4.17.10":
-  version: 4.17.19
-  resolution: "lodash@npm:4.17.19"
-  checksum: a5cc77099fae9f0052003e8242b06d7572be7c88cbe5152ddf5a3d97bc795cfaf73f10befeb6e23efac84fae94e2255d398cb371349cb3f878c9792a0213cacd
-  languageName: node
-  linkType: hard
-
-"lodash@npm:^4.17.21":
+"lodash@npm:^4.17.14, lodash@npm:^4.17.21, lodash@npm:~4.17.21":
   version: 4.17.21
   resolution: "lodash@npm:4.17.21"
   checksum: eb835a2e51d381e561e508ce932ea50a8e5a68f4ebdd771ea240d3048244a8d13658acbd502cd4829768c56f2e16bdd4340b9ea141297d472517b83868e677f7
@@ -2020,23 +1857,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mime-db@npm:~1.36.0":
-  version: 1.36.0
-  resolution: "mime-db@npm:1.36.0"
-  checksum: e56d61941c6a669e2de83719b8e007a5a47b89f07794ba35a9c7a4acbb679c5ad759b79efdc6429ae4ac2f6447352559971f03caaaa4717eea20798aa38769e1
+"mime-db@npm:1.52.0":
+  version: 1.52.0
+  resolution: "mime-db@npm:1.52.0"
+  checksum: 0d99a03585f8b39d68182803b12ac601d9c01abfa28ec56204fa330bc9f3d1c5e14beb049bafadb3dbdf646dfb94b87e24d4ec7b31b7279ef906a8ea9b6a513f
   languageName: node
   linkType: hard
 
-"mime-types@npm:^2.1.12, mime-types@npm:~2.1.19":
-  version: 2.1.20
-  resolution: "mime-types@npm:2.1.20"
+"mime-types@npm:^2.1.12":
+  version: 2.1.35
+  resolution: "mime-types@npm:2.1.35"
   dependencies:
-    mime-db: ~1.36.0
-  checksum: 5e79a783c9995e2c2dec81ba7ddb4eb42b53d78fd4d92514289e944d4030117168dbf7687d7d1e80f8f6af907f63621fd5c24c97962d13740647f942e8b217a9
+    mime-db: 1.52.0
+  checksum: 89a5b7f1def9f3af5dad6496c5ed50191ae4331cc5389d7c521c8ad28d5fdad2d06fd81baf38fed813dc4e46bb55c8145bb0ff406330818c9cf712fb2e9b3836
   languageName: node
   linkType: hard
 
-"minimatch@npm:3.0.4, minimatch@npm:^3.0.4, minimatch@npm:~3.0.2":
+"minimatch@npm:3.0.4":
   version: 3.0.4
   resolution: "minimatch@npm:3.0.4"
   dependencies:
@@ -2045,28 +1882,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimist@npm:0.0.8":
-  version: 0.0.8
-  resolution: "minimist@npm:0.0.8"
-  checksum: 042f8b626b1fa44dffc23bac55771425ac4ee9d267b56f9064c07713e516e1799f3ba933bb628d2475a210caf7dcdb98161611baa1f0daf49309a944cb4bc48f
-  languageName: node
-  linkType: hard
-
-"mkdirp@npm:0.5.1":
-  version: 0.5.1
-  resolution: "mkdirp@npm:0.5.1"
+"minimatch@npm:^3.1.1":
+  version: 3.1.2
+  resolution: "minimatch@npm:3.1.2"
   dependencies:
-    minimist: 0.0.8
-  bin:
-    mkdirp: bin/cmd.js
-  checksum: ed1ab49bb1d06c88dba7cfe930a3186f2605b5465aab7c8f24119baaba6e38f9ab4ac1695c68f476c65a48df2a69a8495049cd6e26c360ea082151a0771343d2
+    brace-expansion: ^1.1.7
+  checksum: c154e566406683e7bcb746e000b84d74465b3a832c45d59912b9b55cd50dee66e5c4b1e5566dba26154040e51672f9aa450a9aef0c97cfc7336b78b7afb9540a
   languageName: node
   linkType: hard
 
-"ms@npm:2.0.0":
-  version: 2.0.0
-  resolution: "ms@npm:2.0.0"
-  checksum: 0e6a22b8b746d2e0b65a430519934fefd41b6db0682e3477c10f60c76e947c4c0ad06f63ffdf1d78d335f83edee8c0aa928aa66a36c7cd95b69b26f468d527f4
+"minimatch@npm:~3.0.2":
+  version: 3.0.8
+  resolution: "minimatch@npm:3.0.8"
+  dependencies:
+    brace-expansion: ^1.1.7
+  checksum: 850cca179cad715133132693e6963b0db64ab0988c4d211415b087fc23a3e46321e2c5376a01bf5623d8782aba8bdf43c571e2e902e51fdce7175c7215c29f8b
   languageName: node
   linkType: hard
 
@@ -2082,10 +1912,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-fetch@npm:2.6.1":
-  version: 2.6.1
-  resolution: "node-fetch@npm:2.6.1"
-  checksum: 91075bedd57879117e310fbcc36983ad5d699e522edb1ebcdc4ee5294c982843982652925c3532729fdc86b2d64a8a827797a745f332040d91823c8752ee4d7c
+"node-fetch@npm:2.6.7":
+  version: 2.6.7
+  resolution: "node-fetch@npm:2.6.7"
+  dependencies:
+    whatwg-url: ^5.0.0
+  peerDependencies:
+    encoding: ^0.1.0
+  peerDependenciesMeta:
+    encoding:
+      optional: true
+  checksum: 8d816ffd1ee22cab8301c7756ef04f3437f18dace86a1dae22cf81db8ef29c0bf6655f3215cb0cdb22b420b6fe141e64b26905e7f33f9377a7fa59135ea3e10b
   languageName: node
   linkType: hard
 
@@ -2096,10 +1933,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"oauth-sign@npm:~0.9.0":
-  version: 0.9.0
-  resolution: "oauth-sign@npm:0.9.0"
-  checksum: 8f5497a127967866a3c67094c21efd295e46013a94e6e828573c62220e9af568cc1d2d04b16865ba583e430510fa168baf821ea78f355146d8ed7e350fc44c64
+"object-inspect@npm:^1.9.0":
+  version: 1.12.2
+  resolution: "object-inspect@npm:1.12.2"
+  checksum: a534fc1b8534284ed71f25ce3a496013b7ea030f3d1b77118f6b7b1713829262be9e6243acbcb3ef8c626e2b64186112cb7f6db74e37b2789b9c789ca23048b2
   languageName: node
   linkType: hard
 
@@ -2122,25 +1959,25 @@ __metadata:
   linkType: hard
 
 "p-limit@npm:^2.1.0":
-  version: 2.1.0
-  resolution: "p-limit@npm:2.1.0"
+  version: 2.3.0
+  resolution: "p-limit@npm:2.3.0"
   dependencies:
     p-try: ^2.0.0
-  checksum: 6189278108c00423d6d8553d117724a5241ce7c2186a4109717237a6973db34fb6799632dfcfdec7f913190a49b13e82a28ed77274847a15cfc6c3e1a6af695e
+  checksum: 84ff17f1a38126c3314e91ecfe56aecbf36430940e2873dadaa773ffe072dc23b7af8e46d4b6485d302a11673fe94c6b67ca2cfbb60c989848b02100d0594ac1
   languageName: node
   linkType: hard
 
 "p-try@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "p-try@npm:2.0.0"
-  checksum: 5afa1a7fd27d6a557323d2d97b0aa117e3861f8afe18067573e8daa7665e746fcc954b4ff5c74d8e0e9188adac300fa1b1ef730e999b637c0de36a65fce53890
+  version: 2.2.0
+  resolution: "p-try@npm:2.2.0"
+  checksum: f8a8e9a7693659383f06aec604ad5ead237c7a261c18048a6e1b5b85a5f8a067e469aa24f5bc009b991ea3b058a87f5065ef4176793a200d4917349881216cae
   languageName: node
   linkType: hard
 
 "pako@npm:^1.0.6":
-  version: 1.0.6
-  resolution: "pako@npm:1.0.6"
-  checksum: 61dad05dc00605d8264e0d8501016d9f999b6e8e957712f7779d668cd2bd340de29a4d03ac44fbd3e630bbb7933fecd6dbf13b7d14a67720ced049461619ade5
+  version: 1.0.11
+  resolution: "pako@npm:1.0.11"
+  checksum: 1be2bfa1f807608c7538afa15d6f25baa523c30ec870a3228a89579e474a4d992f4293859524e46d5d87fd30fa17c5edf34dbef0671251d9749820b488660b16
   languageName: node
   linkType: hard
 
@@ -2168,66 +2005,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pend@npm:~1.2.0":
-  version: 1.2.0
-  resolution: "pend@npm:1.2.0"
-  checksum: 6c72f5243303d9c60bd98e6446ba7d30ae29e3d56fdb6fae8767e8ba6386f33ee284c97efe3230a0d0217e2b1723b8ab490b1bbf34fcbb2180dbc8a9de47850d
-  languageName: node
-  linkType: hard
-
-"performance-now@npm:^2.1.0":
-  version: 2.1.0
-  resolution: "performance-now@npm:2.1.0"
-  checksum: 534e641aa8f7cba160f0afec0599b6cecefbb516a2e837b512be0adbe6c1da5550e89c78059c7fabc5c9ffdf6627edabe23eb7c518c4500067a898fa65c2b550
-  languageName: node
-  linkType: hard
-
-"phantom@npm:~4.0.1":
-  version: 4.0.12
-  resolution: "phantom@npm:4.0.12"
-  dependencies:
-    phantomjs-prebuilt: ^2.1.16
-    split: ^1.0.1
-    winston: ^2.4.0
-  checksum: d85f2ac0aefde2ddf4edf50fd526edb8f9a7986b4f83a08c409803641ca5788d3e8f7f6053be0bc30cf1d003c200d35c89aa0712f0b289f2aa76bff1a99c18e8
-  languageName: node
-  linkType: hard
-
-"phantomjs-prebuilt@npm:^2.1.16, phantomjs-prebuilt@npm:~2.1.7":
-  version: 2.1.16
-  resolution: "phantomjs-prebuilt@npm:2.1.16"
-  dependencies:
-    es6-promise: ^4.0.3
-    extract-zip: ^1.6.5
-    fs-extra: ^1.0.0
-    hasha: ^2.2.0
-    kew: ^0.7.0
-    progress: ^1.1.8
-    request: ^2.81.0
-    request-progress: ^2.0.1
-    which: ^1.2.10
-  bin:
-    phantomjs: ./bin/phantomjs
-  checksum: 1fbfa1b172644a9eaeedf6eb8b566b3043480c0175e8a2c4b4bf59c6bddb369a3b153e8d354b3509a7b471abc424857db1955d8fbd7a9d1be3e220518c7c6ce0
-  languageName: node
-  linkType: hard
-
-"pinkie-promise@npm:^2.0.0":
-  version: 2.0.1
-  resolution: "pinkie-promise@npm:2.0.1"
-  dependencies:
-    pinkie: ^2.0.0
-  checksum: b53a4a2e73bf56b6f421eef711e7bdcb693d6abb474d57c5c413b809f654ba5ee750c6a96dd7225052d4b96c4d053cdcb34b708a86fceed4663303abee52fcca
-  languageName: node
-  linkType: hard
-
-"pinkie@npm:^2.0.0":
-  version: 2.0.4
-  resolution: "pinkie@npm:2.0.4"
-  checksum: b12b10afea1177595aab036fc220785488f67b4b0fc49e7a27979472592e971614fa1c728e63ad3e7eb748b4ec3c3dbd780819331dad6f7d635c77c10537b9db
-  languageName: node
-  linkType: hard
-
 "pluralize@npm:^8.0.0":
   version: 8.0.0
   resolution: "pluralize@npm:8.0.0"
@@ -2236,9 +2013,9 @@ __metadata:
   linkType: hard
 
 "process-nextick-args@npm:~2.0.0":
-  version: 2.0.0
-  resolution: "process-nextick-args@npm:2.0.0"
-  checksum: 15209b12304b0e52ce9a1817fe28280bf126758ba3a6636cbfda41af872ea6212b3fce57dbff07fc27c2c4bb4c32c5e4bd1f66b066366edf95a0165766c01c69
+  version: 2.0.1
+  resolution: "process-nextick-args@npm:2.0.1"
+  checksum: 1d38588e520dab7cea67cbbe2efdd86a10cc7a074c09657635e34f035277b59fbb57d09d8638346bf7090f8e8ebc070c96fa5fd183b777fff4f5edff5e9466cf
   languageName: node
   linkType: hard
 
@@ -2249,40 +2026,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"progress@npm:^1.1.8":
-  version: 1.1.8
-  resolution: "progress@npm:1.1.8"
-  checksum: 789c824156e03a7353b190fc63da46bc42b210250cebaa2dca447a6a740f5469f34ed30f768cdef088ca720a8c3c42dd743958e8bc6a35b2d2a1a83171ad2c56
-  languageName: node
-  linkType: hard
-
 "promise@npm:^8.0.0":
-  version: 8.0.3
-  resolution: "promise@npm:8.0.3"
+  version: 8.2.0
+  resolution: "promise@npm:8.2.0"
   dependencies:
     asap: ~2.0.6
-  checksum: 7d026b0f8a83fd1b5a5552f0e5f0ad87114711d9ed5427db5721bbc991f5609ec6d880fb09e6448559acc738a9125ddeced95bdfdc16c081826d611afca4cb3f
-  languageName: node
-  linkType: hard
-
-"psl@npm:^1.1.24":
-  version: 1.1.29
-  resolution: "psl@npm:1.1.29"
-  checksum: 63868cc7ad59358acca6fce7d334ae0b388c8ddc957f9705bfc65cda28c9f2e150eb5cc76dfdd3a7707c8d8c3c531fda386db80a38f56eb114f66fa676f8f439
-  languageName: node
-  linkType: hard
-
-"punycode@npm:1.3.2":
-  version: 1.3.2
-  resolution: "punycode@npm:1.3.2"
-  checksum: b8807fd594b1db33335692d1f03e8beeddde6fda7fbb4a2e32925d88d20a3aa4cd8dcc0c109ccaccbd2ba761c208dfaaada83007087ea8bfb0129c9ef1b99ed6
-  languageName: node
-  linkType: hard
-
-"punycode@npm:^1.4.1":
-  version: 1.4.1
-  resolution: "punycode@npm:1.4.1"
-  checksum: fa6e698cb53db45e4628559e557ddaf554103d2a96a1d62892c8f4032cd3bc8871796cae9eabc1bc700e2b6677611521ce5bb1d9a27700086039965d0cf34518
+  checksum: 45d65ffe4fbd9172ef848f790ac1366822e63f063a5ef42a14e75b577ffa3c37870a9d8472729d9d429d7c8a770428f9d13650b52aafaa361dcc69cf84873b20
   languageName: node
   linkType: hard
 
@@ -2294,52 +2043,29 @@ __metadata:
   linkType: hard
 
 "qs@npm:^6.4.0":
-  version: 6.9.1
-  resolution: "qs@npm:6.9.1"
-  checksum: b8ad80e09bb52232963aadd9276b8d3802723c9ecd31388ff129a7ab5542e7dc67c43a05b2250f973be460d2c734f16d8d908216e5340024349763ee5e19666c
-  languageName: node
-  linkType: hard
-
-"qs@npm:~6.5.2":
-  version: 6.5.2
-  resolution: "qs@npm:6.5.2"
-  checksum: 24af7b9928ba2141233fba2912876ff100403dba1b08b20c3b490da9ea6c636760445ea2211a079e7dfa882a5cf8f738337b3748c8bdd0f93358fa8881d2db8f
-  languageName: node
-  linkType: hard
-
-"querystring@npm:0.2.0":
-  version: 0.2.0
-  resolution: "querystring@npm:0.2.0"
-  checksum: 8258d6734f19be27e93f601758858c299bdebe71147909e367101ba459b95446fbe5b975bf9beb76390156a592b6f4ac3a68b6087cea165c259705b8b4e56a69
-  languageName: node
-  linkType: hard
-
-"react-native-get-random-values@npm:^1.4.0":
-  version: 1.6.0
-  resolution: "react-native-get-random-values@npm:1.6.0"
+  version: 6.11.0
+  resolution: "qs@npm:6.11.0"
   dependencies:
-    fast-base64-decode: ^1.0.0
-  peerDependencies:
-    react-native: ">=0.56"
-  checksum: 620203bdcced0d052e6562f438a85b51f9a95c976198cfb1b1e7d900b06c89c54d37555df0f867a58066e757d9d3a5b49763bab67567a66cce7bb8d2c714af87
+    side-channel: ^1.0.4
+  checksum: 6e1f29dd5385f7488ec74ac7b6c92f4d09a90408882d0c208414a34dd33badc1a621019d4c799a3df15ab9b1d0292f97c1dd71dc7c045e69f81a8064e5af7297
   languageName: node
   linkType: hard
 
 "readable-stream@npm:1.1":
-  version: 1.1.13
-  resolution: "readable-stream@npm:1.1.13"
+  version: 1.1.14
+  resolution: "readable-stream@npm:1.1.14"
   dependencies:
     core-util-is: ~1.0.0
     inherits: ~2.0.1
     isarray: 0.0.1
     string_decoder: ~0.10.x
-  checksum: 7048f0ffbd01e4221cbddfcb7c0e083b982d575ca97615985234b3e4767aed34104271043b92414d91bc5ab0b69c0545f7e4ea202186c6692465333a59948cad
+  checksum: 17dfeae3e909945a4a1abc5613ea92d03269ef54c49288599507fc98ff4615988a1c39a999dcf9aacba70233d9b7040bc11a5f2bfc947e262dedcc0a8b32b5a0
   languageName: node
   linkType: hard
 
 "readable-stream@npm:^2.2.2":
-  version: 2.3.6
-  resolution: "readable-stream@npm:2.3.6"
+  version: 2.3.7
+  resolution: "readable-stream@npm:2.3.7"
   dependencies:
     core-util-is: ~1.0.0
     inherits: ~2.0.3
@@ -2348,7 +2074,7 @@ __metadata:
     safe-buffer: ~5.1.1
     string_decoder: ~1.1.1
     util-deprecate: ~1.0.1
-  checksum: 686bbf9e2300cd24bbd71ba8999202613ef19441da9223bfe2c7da4f0dfab233302e2604846e9b8e814664ccdf365881e593da963ac9e2120abfa21f14f257fb
+  checksum: e4920cf7549a60f8aaf694d483a0e61b2a878b969d224f89b3bc788b8d920075132c4b55a7494ee944c7b6a9a0eada28a7f6220d80b0312ece70bbf08eeca755
   languageName: node
   linkType: hard
 
@@ -2363,43 +2089,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"request-progress@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "request-progress@npm:2.0.1"
-  dependencies:
-    throttleit: ^1.0.0
-  checksum: 66e7ce68a6f3b6cbf20e0d9e0ffc9cc4be0cc86c8051f7a329421bef8fb8da8bb7e893bc7e139a0d7f011feed5a5fce422fb809f5b6a59b91a282d4caf16417d
-  languageName: node
-  linkType: hard
-
-"request@npm:^2.81.0":
-  version: 2.88.0
-  resolution: "request@npm:2.88.0"
-  dependencies:
-    aws-sign2: ~0.7.0
-    aws4: ^1.8.0
-    caseless: ~0.12.0
-    combined-stream: ~1.0.6
-    extend: ~3.0.2
-    forever-agent: ~0.6.1
-    form-data: ~2.3.2
-    har-validator: ~5.1.0
-    http-signature: ~1.2.0
-    is-typedarray: ~1.0.0
-    isstream: ~0.1.2
-    json-stringify-safe: ~5.0.1
-    mime-types: ~2.1.19
-    oauth-sign: ~0.9.0
-    performance-now: ^2.1.0
-    qs: ~6.5.2
-    safe-buffer: ^5.1.2
-    tough-cookie: ~2.4.3
-    tunnel-agent: ^0.6.0
-    uuid: ^3.3.2
-  checksum: aecf4f8cdb0ebd5feac5e29b748d6ab376ac5717ddcbc5a6bb24cc3808bde755ff0fa3a8379a2d25f6c4b969ced1ac065d22a615c71747cd305731efa643e30d
-  languageName: node
-  linkType: hard
-
 "require-directory@npm:^2.1.1":
   version: 2.1.1
   resolution: "require-directory@npm:2.1.1"
@@ -2411,11 +2100,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "root-workspace-0b6124@workspace:."
   dependencies:
-    bids-validator: 1.9.3
+    bids-validator: 1.9.8
   languageName: unknown
   linkType: soft
 
-"safe-buffer@npm:^5.0.1, safe-buffer@npm:^5.1.2, safe-buffer@npm:~5.1.0, safe-buffer@npm:~5.1.1":
+"safe-buffer@npm:~5.1.0, safe-buffer@npm:~5.1.1":
   version: 5.1.2
   resolution: "safe-buffer@npm:5.1.2"
   checksum: f2f1f7943ca44a594893a852894055cf619c1fbcb611237fc39e461ae751187e7baf4dc391a72125e0ac4fb2d8c5c0b3c71529622e6a58f46b960211e704903c
@@ -2429,13 +2118,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"safer-buffer@npm:^2.0.2, safer-buffer@npm:^2.1.0, safer-buffer@npm:~2.1.0":
-  version: 2.1.2
-  resolution: "safer-buffer@npm:2.1.2"
-  checksum: cab8f25ae6f1434abee8d80023d7e72b598cf1327164ddab31003c51215526801e40b66c5e65d658a0af1e9d6478cadcb4c745f4bd6751f97d8644786c0978b0
-  languageName: node
-  linkType: hard
-
 "sax@npm:>=0.6.0":
   version: 1.2.4
   resolution: "sax@npm:1.2.4"
@@ -2443,32 +2125,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^7.3.2":
-  version: 7.3.2
-  resolution: "semver@npm:7.3.2"
-  bin:
-    semver: bin/semver.js
-  checksum: 692f4900dadb43919614b0df9af23fe05743051cda0d1735b5e4d76f93c9e43a266fae73cfc928f5d1489f022c5c0e65dfd2900fcf5b1839c4e9a239729afa7b
-  languageName: node
-  linkType: hard
-
-"semver@npm:^7.3.4":
-  version: 7.3.4
-  resolution: "semver@npm:7.3.4"
+"semver@npm:^7.3.2, semver@npm:^7.3.4":
+  version: 7.3.7
+  resolution: "semver@npm:7.3.7"
   dependencies:
     lru-cache: ^6.0.0
   bin:
     semver: bin/semver.js
-  checksum: 96451bfd7cba9b60ee87571959dc47e87c95b2fe58a9312a926340fee9907fc7bc062c352efdaf5bb24b2dff59c145e14faf7eb9d718a84b4751312531b39f43
+  checksum: 2fa3e877568cd6ce769c75c211beaed1f9fce80b28338cadd9d0b6c40f2e2862bafd62c19a6cff42f3d54292b7c623277bcab8816a2b5521cf15210d43e75232
   languageName: node
   linkType: hard
 
-"shelljs@npm:0.3.x":
-  version: 0.3.0
-  resolution: "shelljs@npm:0.3.0"
-  bin:
-    shjs: ./bin/shjs
-  checksum: 6e57d6bff3bb101525f251fd80358b983fb9c8175dc31593496bfcdf66701b78dba33b9319e38026ac31b2c80875794fc71bd2fdd9cdb86fbeb81fcbfce28d7b
+"side-channel@npm:^1.0.4":
+  version: 1.0.4
+  resolution: "side-channel@npm:1.0.4"
+  dependencies:
+    call-bind: ^1.0.0
+    get-intrinsic: ^1.0.2
+    object-inspect: ^1.9.0
+  checksum: 351e41b947079c10bd0858364f32bb3a7379514c399edb64ab3dce683933483fc63fb5e4efe0a15a2e8a7e3c436b6a91736ddb8d8c6591b0460a24bb4a1ee245
   languageName: node
   linkType: hard
 
@@ -2480,52 +2155,6 @@ __metadata:
     astral-regex: ^1.0.0
     is-fullwidth-code-point: ^2.0.0
   checksum: 4e82995aa59cef7eb03ef232d73c2239a15efa0ace87a01f3012ebb942e963fbb05d448ce7391efcd52ab9c32724164aba2086f5143e0445c969221dde3b6b1e
-  languageName: node
-  linkType: hard
-
-"split@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "split@npm:1.0.1"
-  dependencies:
-    through: 2
-  checksum: 12f4554a5792c7e98bb3e22b53c63bfa5ef89aa704353e1db608a55b51f5b12afaad6e4a8ecf7843c15f273f43cdadd67b3705cc43d48a75c2cf4641d51f7e7a
-  languageName: node
-  linkType: hard
-
-"sshpk@npm:^1.7.0":
-  version: 1.14.2
-  resolution: "sshpk@npm:1.14.2"
-  dependencies:
-    asn1: ~0.2.3
-    assert-plus: ^1.0.0
-    bcrypt-pbkdf: ^1.0.0
-    dashdash: ^1.12.0
-    ecc-jsbn: ~0.1.1
-    getpass: ^0.1.1
-    jsbn: ~0.1.0
-    safer-buffer: ^2.0.2
-    tweetnacl: ~0.14.0
-  dependenciesMeta:
-    bcrypt-pbkdf:
-      optional: true
-    ecc-jsbn:
-      optional: true
-    jsbn:
-      optional: true
-    tweetnacl:
-      optional: true
-  bin:
-    sshpk-conv: bin/sshpk-conv
-    sshpk-sign: bin/sshpk-sign
-    sshpk-verify: bin/sshpk-verify
-  checksum: 475405f2e26f9d08673a90d51e3f067de4d384e3756a2b0736b90c24f91fb24d04acc816d846c53cfd731a6e8b7399b1ae971280b759b6c7a5257618b18be3c6
-  languageName: node
-  linkType: hard
-
-"stack-trace@npm:0.0.x":
-  version: 0.0.10
-  resolution: "stack-trace@npm:0.0.10"
-  checksum: 473036ad32f8c00e889613153d6454f9be0536d430eb2358ca51cad6b95cea08a3cc33cc0e34de66b0dad221582b08ed2e61ef8e13f4087ab690f388362d6610
   languageName: node
   linkType: hard
 
@@ -2551,24 +2180,24 @@ __metadata:
   linkType: hard
 
 "string-width@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "string-width@npm:3.0.0"
+  version: 3.1.0
+  resolution: "string-width@npm:3.1.0"
   dependencies:
     emoji-regex: ^7.0.1
     is-fullwidth-code-point: ^2.0.0
-    strip-ansi: ^5.0.0
-  checksum: 80c25fe942903b529ed41b7c55edd9bdf799fc42701f2336d9ec6e4ea673057fbdf0549776dd9b151083b46d603c87ef4135c5d813422e65b34aed25a981024f
+    strip-ansi: ^5.1.0
+  checksum: 57f7ca73d201682816d573dc68bd4bb8e1dff8dc9fcf10470fdfc3474135c97175fec12ea6a159e67339b41e86963112355b64529489af6e7e70f94a7caf08b2
   languageName: node
   linkType: hard
 
 "string-width@npm:^4.1.0, string-width@npm:^4.2.0":
-  version: 4.2.2
-  resolution: "string-width@npm:4.2.2"
+  version: 4.2.3
+  resolution: "string-width@npm:4.2.3"
   dependencies:
     emoji-regex: ^8.0.0
     is-fullwidth-code-point: ^3.0.0
-    strip-ansi: ^6.0.0
-  checksum: 343e089b0e66e0f72aab4ad1d9b6f2c9cc5255844b0c83fd9b53f2a3b3fd0421bdd6cb05be96a73117eb012db0887a6c1d64ca95aaa50c518e48980483fea0ab
+    strip-ansi: ^6.0.1
+  checksum: e52c10dc3fbfcd6c3a15f159f54a90024241d0f149cf8aed2982a2d801d2e64df0bf1dc351cf8e95c3319323f9f220c16e740b06faecd53e2462df1d2b5443fb
   languageName: node
   linkType: hard
 
@@ -2606,21 +2235,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"strip-ansi@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "strip-ansi@npm:5.0.0"
+"strip-ansi@npm:^5.1.0":
+  version: 5.2.0
+  resolution: "strip-ansi@npm:5.2.0"
   dependencies:
-    ansi-regex: ^4.0.0
-  checksum: 6086c613359762e7c770d07499ad1b234336c7e98480d1072b2740780f1857eff67cbbafcc99a0575dd10ac7e2d11dd5f11a0d63e31311c568acd3e80b9a815d
+    ansi-regex: ^4.1.0
+  checksum: bdb5f76ade97062bd88e7723aa019adbfacdcba42223b19ccb528ffb9fb0b89a5be442c663c4a3fb25268eaa3f6ea19c7c3fbae830bd1562d55adccae1fcec46
   languageName: node
   linkType: hard
 
-"strip-ansi@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "strip-ansi@npm:6.0.0"
+"strip-ansi@npm:^6.0.0, strip-ansi@npm:^6.0.1":
+  version: 6.0.1
+  resolution: "strip-ansi@npm:6.0.1"
   dependencies:
-    ansi-regex: ^5.0.0
-  checksum: 04c3239ede44c4d195b0e66c0ad58b932f08bec7d05290416d361ff908ad282ecdaf5d9731e322c84f151d427436bde01f05b7422c3ec26dd927586736b0e5d0
+    ansi-regex: ^5.0.1
+  checksum: f3cd25890aef3ba6e1a74e20896c21a46f482e93df4a06567cebf2b57edabb15133f1f94e57434e0a958d61186087b1008e89c94875d019910a213181a14fc8c
   languageName: node
   linkType: hard
 
@@ -2634,14 +2263,14 @@ __metadata:
   linkType: hard
 
 "table@npm:^5.2.3":
-  version: 5.2.3
-  resolution: "table@npm:5.2.3"
+  version: 5.4.6
+  resolution: "table@npm:5.4.6"
   dependencies:
-    ajv: ^6.9.1
-    lodash: ^4.17.11
+    ajv: ^6.10.2
+    lodash: ^4.17.14
     slice-ansi: ^2.1.0
     string-width: ^3.0.0
-  checksum: 05e47adcf084336312c06253323adeabbd2839ee62f4bc15757c81b9b18aed3adcc550fe7d3ec3e9a089f20a7eb3f5553f3d56a30c706d03bb35620db9a95883
+  checksum: 9e35d3efa788edc17237eef8852f8e4b9178efd65a7d115141777b2ee77df4b7796c05f4ed3712d858f98894ac5935a481ceeb6dcb9895e2f67a61cce0e63b6c
   languageName: node
   linkType: hard
 
@@ -2664,57 +2293,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"throttleit@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "throttleit@npm:1.0.0"
-  checksum: 1b2db4d2454202d589e8236c07a69d2fab838876d370030ebea237c34c0a7d1d9cf11c29f994531ebb00efd31e9728291042b7754f2798a8352ec4463455b659
+"tr46@npm:~0.0.3":
+  version: 0.0.3
+  resolution: "tr46@npm:0.0.3"
+  checksum: 726321c5eaf41b5002e17ffbd1fb7245999a073e8979085dacd47c4b4e8068ff5777142fc6726d6ca1fd2ff16921b48788b87225cbc57c72636f6efa8efbffe3
   languageName: node
   linkType: hard
 
-"through@npm:2":
-  version: 2.3.8
-  resolution: "through@npm:2.3.8"
-  checksum: a38c3e059853c494af95d50c072b83f8b676a9ba2818dcc5b108ef252230735c54e0185437618596c790bbba8fcdaef5b290405981ffa09dce67b1f1bf190cbd
-  languageName: node
-  linkType: hard
-
-"tough-cookie@npm:~2.4.3":
-  version: 2.4.3
-  resolution: "tough-cookie@npm:2.4.3"
-  dependencies:
-    psl: ^1.1.24
-    punycode: ^1.4.1
-  checksum: af5c7b03f22fc60b7a03339414d7e5b4d68aea84bcc591b4bfab73d85f71e218ff9ebdf94042205051faf980bdb2eeec5c8cf6ea5368fd9f878d2c3f718640b7
-  languageName: node
-  linkType: hard
-
-"tslib@npm:^1.11.1, tslib@npm:^1.8.0":
+"tslib@npm:^1.11.1":
   version: 1.14.1
   resolution: "tslib@npm:1.14.1"
   checksum: dbe628ef87f66691d5d2959b3e41b9ca0045c3ee3c7c7b906cc1e328b39f199bb1ad9e671c39025bd56122ac57dfbf7385a94843b1cc07c60a4db74795829acd
   languageName: node
   linkType: hard
 
-"tslib@npm:^2.0.0":
-  version: 2.1.0
-  resolution: "tslib@npm:2.1.0"
-  checksum: aa189c8179de0427b0906da30926fd53c59d96ec239dff87d6e6bc831f608df0cbd6f77c61dabc074408bd0aa0b9ae4ec35cb2c15f729e32f37274db5730cb78
-  languageName: node
-  linkType: hard
-
-"tunnel-agent@npm:^0.6.0":
-  version: 0.6.0
-  resolution: "tunnel-agent@npm:0.6.0"
-  dependencies:
-    safe-buffer: ^5.0.1
-  checksum: 05f6510358f8afc62a057b8b692f05d70c1782b70db86d6a1e0d5e28a32389e52fa6e7707b6c5ecccacc031462e4bc35af85ecfe4bbc341767917b7cf6965711
-  languageName: node
-  linkType: hard
-
-"tweetnacl@npm:^0.14.3, tweetnacl@npm:~0.14.0":
-  version: 0.14.5
-  resolution: "tweetnacl@npm:0.14.5"
-  checksum: 6061daba1724f59473d99a7bb82e13f211cdf6e31315510ae9656fefd4779851cb927adad90f3b488c8ed77c106adc0421ea8055f6f976ff21b27c5c4e918487
+"tslib@npm:^2.3.1":
+  version: 2.4.0
+  resolution: "tslib@npm:2.4.0"
+  checksum: 8c4aa6a3c5a754bf76aefc38026134180c053b7bd2f81338cb5e5ebf96fefa0f417bff221592bf801077f5bf990562f6264fecbc42cd3309b33872cb6fc3b113
   languageName: node
   linkType: hard
 
@@ -2725,29 +2321,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"unicode-5.2.0@npm:^0.7.5":
-  version: 0.7.5
-  resolution: "unicode-5.2.0@npm:0.7.5"
-  checksum: f7f50cc0cc1ed07f8f25cb1dcfef2a1a438286816830c88c9ac895fd581cfff3211a8f2bf58ec5a0e6bc12829e5b8cc13b4fb569e72beebdf39d778a9ba04996
-  languageName: node
-  linkType: hard
-
 "uri-js@npm:^4.2.2":
-  version: 4.2.2
-  resolution: "uri-js@npm:4.2.2"
+  version: 4.4.1
+  resolution: "uri-js@npm:4.4.1"
   dependencies:
     punycode: ^2.1.0
-  checksum: 5a91c55d8ae6d9a1ff9dc1b0774888a99aae7cc6e9056c57b709275c0f6753b05cd1a9f2728a1479244b93a9f57ab37c60d277a48d9f2d032d6ae65837bf9bc7
-  languageName: node
-  linkType: hard
-
-"url@npm:^0.11.0":
-  version: 0.11.0
-  resolution: "url@npm:0.11.0"
-  dependencies:
-    punycode: 1.3.2
-    querystring: 0.2.0
-  checksum: 50d100d3dd2d98b9fe3ada48cadb0b08aa6be6d3ac64112b867b56b19be4bfcba03c2a9a0d7922bfd7ac17d4834e88537749fe182430dfd9b68e520175900d90
+  checksum: 7167432de6817fe8e9e0c9684f1d2de2bb688c94388f7569f7dbdb1587c9f4ca2a77962f134ec90be0cc4d004c939ff0d05acc9f34a0db39a3c797dada262633
   languageName: node
   linkType: hard
 
@@ -2759,51 +2338,37 @@ __metadata:
   linkType: hard
 
 "util@npm:^0.10.3":
-  version: 0.10.3
-  resolution: "util@npm:0.10.3"
+  version: 0.10.4
+  resolution: "util@npm:0.10.4"
   dependencies:
-    inherits: 2.0.1
-  checksum: bd800f5d237a82caddb61723a6cbe45297d25dd258651a31335a4d5d981fd033cb4771f82db3d5d59b582b187cb69cfe727dc6f4d8d7826f686ee6c07ce611e0
+    inherits: 2.0.3
+  checksum: 913f9a90d05a60e91f91af01b8bd37e06bca4cc02d7b49e01089f9d5b78be2fffd61fb1a41b517de7238c5fc7337fa939c62d1fb4eb82e014894c7bee6637aaf
   languageName: node
   linkType: hard
 
-"uuid@npm:^3.0.0":
-  version: 3.4.0
-  resolution: "uuid@npm:3.4.0"
+"uuid@npm:^8.3.2":
+  version: 8.3.2
+  resolution: "uuid@npm:8.3.2"
   bin:
-    uuid: ./bin/uuid
-  checksum: 58de2feed61c59060b40f8203c0e4ed7fd6f99d42534a499f1741218a1dd0c129f4aa1de797bcf822c8ea5da7e4137aa3673431a96dae729047f7aca7b27866f
+    uuid: dist/bin/uuid
+  checksum: 5575a8a75c13120e2f10e6ddc801b2c7ed7d8f3c8ac22c7ed0c7b2ba6383ec0abda88c905085d630e251719e0777045ae3236f04c812184b7c765f63a70e58df
   languageName: node
   linkType: hard
 
-"uuid@npm:^3.3.2":
-  version: 3.3.2
-  resolution: "uuid@npm:3.3.2"
-  bin:
-    uuid: ./bin/uuid
-  checksum: 8793629d2799f500aeea9fcd0aec6c4e9fbcc4d62ed42159ad96be345c3fffac1bbf61a23e18e2782600884fee05e6d4012ce4b70d0037c8e987533ae6a77870
+"webidl-conversions@npm:^3.0.0":
+  version: 3.0.1
+  resolution: "webidl-conversions@npm:3.0.1"
+  checksum: c92a0a6ab95314bde9c32e1d0a6dfac83b578f8fa5f21e675bc2706ed6981bc26b7eb7e6a1fab158e5ce4adf9caa4a0aee49a52505d4d13c7be545f15021b17c
   languageName: node
   linkType: hard
 
-"verror@npm:1.10.0":
-  version: 1.10.0
-  resolution: "verror@npm:1.10.0"
+"whatwg-url@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "whatwg-url@npm:5.0.0"
   dependencies:
-    assert-plus: ^1.0.0
-    core-util-is: 1.0.2
-    extsprintf: ^1.2.0
-  checksum: c431df0bedf2088b227a4e051e0ff4ca54df2c114096b0c01e1cbaadb021c30a04d7dd5b41ab277bcd51246ca135bf931d4c4c796ecae7a4fef6d744ecef36ea
-  languageName: node
-  linkType: hard
-
-"which@npm:^1.2.10":
-  version: 1.3.1
-  resolution: "which@npm:1.3.1"
-  dependencies:
-    isexe: ^2.0.0
-  bin:
-    which: ./bin/which
-  checksum: f2e185c6242244b8426c9df1510e86629192d93c1a986a7d2a591f2c24869e7ffd03d6dac07ca863b2e4c06f59a4cc9916c585b72ee9fa1aa609d0124df15e04
+    tr46: ~0.0.3
+    webidl-conversions: ^3.0.0
+  checksum: b8daed4ad3356cc4899048a15b2c143a9aed0dfae1f611ebd55073310c7b910f522ad75d727346ad64203d7e6c79ef25eafd465f4d12775ca44b90fa82ed9e2c
   languageName: node
   linkType: hard
 
@@ -2813,20 +2378,6 @@ __metadata:
   bin:
     window-size: cli.js
   checksum: 409accca0b1373c69897400e3cc6a56a2acc8a6ba9009f0cd8e4adda4ebf308e50425d3bd375c0c08efb803c8f0b09d84d7266faa05422b3fadfe6ee422d0aef
-  languageName: node
-  linkType: hard
-
-"winston@npm:^2.4.0":
-  version: 2.4.4
-  resolution: "winston@npm:2.4.4"
-  dependencies:
-    async: ~1.0.0
-    colors: 1.0.x
-    cycle: 1.0.x
-    eyes: 0.1.x
-    isstream: 0.1.x
-    stack-trace: 0.0.x
-  checksum: e3f7b31c1270e701b143d49efbea4186e3df1ff4dab2ceeec3f7496193cf99e494574a76f0a6e2983e6c53940e88199ae04d472c4c5ea2bb23b311700850cd93
   languageName: node
   linkType: hard
 
@@ -2883,9 +2434,9 @@ __metadata:
   linkType: hard
 
 "y18n@npm:^5.0.5":
-  version: 5.0.6
-  resolution: "y18n@npm:5.0.6"
-  checksum: 4bf2c6c20276985657a25a00916e127a8125d96968289bcb16fd55ad4c8361a30fdd402b4b9e49b345dbc869e648122ddde35071ed0b5c68f0ce2e7dad36a62b
+  version: 5.0.8
+  resolution: "y18n@npm:5.0.8"
+  checksum: 54f0fb95621ee60898a38c572c515659e51cc9d9f787fb109cef6fde4befbe1c4602dc999d30110feee37456ad0f1660fa2edcfde6a9a740f86a290999550d30
   languageName: node
   linkType: hard
 
@@ -2904,9 +2455,9 @@ __metadata:
   linkType: hard
 
 "yargs-parser@npm:^20.2.2":
-  version: 20.2.7
-  resolution: "yargs-parser@npm:20.2.7"
-  checksum: ec0ea9e1b5699977380583f5ab1c0e2c6fc5f1ed374eb3053c458df00c543effba53628ad3297f3ccc769660518d5e376fd1cfb298b8e37077421aca8d75ae89
+  version: 20.2.9
+  resolution: "yargs-parser@npm:20.2.9"
+  checksum: 8bb69015f2b0ff9e17b2c8e6bfe224ab463dd00ca211eece72a4cd8a906224d2703fb8a326d36fdd0e68701e201b2a60ed7cf81ce0fd9b3799f9fe7745977ae3
   languageName: node
   linkType: hard
 
@@ -2937,14 +2488,5 @@ __metadata:
     window-size: ^0.1.4
     y18n: ^3.2.0
   checksum: 3e0f7fc1bc2052bcaaa7354cbd33d05a86fc0f236432d107ecd088989fbd175174c562d17e762727acbf25d04e8520d43625f7581b2a6ce55ce10034e80675fc
-  languageName: node
-  linkType: hard
-
-"yauzl@npm:2.4.1":
-  version: 2.4.1
-  resolution: "yauzl@npm:2.4.1"
-  dependencies:
-    fd-slicer: ~1.0.1
-  checksum: 7ce67c296c777d0713cac88aff66d7b2101aef7077df293c556007670507c8ce44303cb4fcbc334dfd29b0720b45f2d8468f52b49710d101b2f5fef664d0fb22
   languageName: node
   linkType: hard

--- a/yarn.lock
+++ b/yarn.lock
@@ -4950,7 +4950,7 @@ __metadata:
     "@types/react-router-dom": 5.3.3
     "@types/testing-library__jest-dom": ^5.14.0
     babel-jest: 29.0.2
-    bids-validator: 1.9.3
+    bids-validator: 1.9.8
     bytes: ^3.0.0
     comlink: ^4.0.5
     core-js: 3.25.1
@@ -4998,7 +4998,7 @@ __metadata:
     "@openneuro/client": ^4.10.0
     "@types/mkdirp": ^1.0.1
     "@types/node": 16.11.13
-    bids-validator: 1.9.3
+    bids-validator: 1.9.8
     cli-progress: ^3.8.2
     commander: 7.2.0
     core-js: ^3.10.1
@@ -8082,9 +8082,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bids-validator@npm:1.9.3":
-  version: 1.9.3
-  resolution: "bids-validator@npm:1.9.3"
+"bids-validator@npm:1.9.8":
+  version: 1.9.8
+  resolution: "bids-validator@npm:1.9.8"
   dependencies:
     "@aws-sdk/client-s3": ^3.9.0
     ajv: ^6.5.2
@@ -8094,7 +8094,7 @@ __metadata:
     date-fns: ^2.7.0
     events: ^3.3.0
     exifreader: ^4.1.0
-    hed-validator: ^3.5.0
+    hed-validator: ^3.8.0
     ignore: ^4.0.2
     is-utf8: ^0.2.1
     jshint: ^2.9.6
@@ -8113,7 +8113,7 @@ __metadata:
     yargs: ^16.2.0
   bin:
     bids-validator: bin/bids-validator
-  checksum: f0e6713fe26f8ab8d539fed910a18d36cd051eca26bf84768ff664d95ae040653d5cbf8a5d33ccc3cd5721c7861eed10ecd2a879402482d366b4e6a428e1ce5a
+  checksum: 531d1d880e95981d77a0bc2b65a888e9fa676495ef15fc17defc6147087f2ae532929b6b26fa1649a8d3d37bc6b52d0777f81d42e156affd158e06cf55c3c364
   languageName: node
   linkType: hard
 
@@ -8338,7 +8338,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"buffer@npm:*":
+"buffer@npm:*, buffer@npm:^6.0.3":
   version: 6.0.3
   resolution: "buffer@npm:6.0.3"
   dependencies:
@@ -12876,18 +12876,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hed-validator@npm:^3.5.0":
-  version: 3.6.0
-  resolution: "hed-validator@npm:3.6.0"
+"hed-validator@npm:^3.8.0":
+  version: 3.8.0
+  resolution: "hed-validator@npm:3.8.0"
   dependencies:
+    buffer: ^6.0.3
     date-and-time: ^0.14.2
     date-fns: ^2.17.0
+    events: ^3.3.0
     lodash: ^4.17.21
+    path: ^0.12.7
     pluralize: ^8.0.0
     semver: ^7.3.4
     then-request: ^6.0.2
     xml2js: ^0.4.23
-  checksum: 1dad68474f66dfbc08ec3c93b1bf88aefe62b65edcc9f99b5b4f9c06bb4650b8c00bc62e6a63ca32a2ac07f040a9571acebc2ce7cf2f610f7ae21b3ab556611a
+  checksum: e2978e3155a02197378ffa2d2a7a85e297670bf17beb0fae1727141dae3806815bfb857b30911d6f24f1cbdce1e7fb1133f9ca470da6cd9eb55bc70c81131f54
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Update to the [latest release](https://github.com/bids-standard/bids-validator/releases/tag/v1.9.8).