### PR TITLE
fix(app): Show correct command line for dataset downloads via CLI

### DIFF
--- a/packages/openneuro-app/src/scripts/dataset/routes/download-dataset.tsx
+++ b/packages/openneuro-app/src/scripts/dataset/routes/download-dataset.tsx
@@ -10,7 +10,7 @@ import { DatasetPageBorder } from './styles/dataset-page-border'
 import { HeaderRow3 } from './styles/header-row'
 
 const DownloadDataset = ({ worker, datasetPermissions }) => {
-  const { datasetId, snapshotId: snapshotTag } = useParams()
+  const { datasetId, tag: snapshotTag } = useParams()
   const workerId = worker?.split('-').pop()
   return (
     <DatasetPageBorder>


### PR DESCRIPTION
The openneuro-cli example on snapshot download pages incorrectly shows the example for downloading the draft.