### PR TITLE
fix(app): Prevent a crash when modality is undefined instead of null/string

### DIFF
--- a/packages/openneuro-components/src/dataset/DatasetHeader.tsx
+++ b/packages/openneuro-components/src/dataset/DatasetHeader.tsx
@@ -24,10 +24,10 @@ export const DatasetHeader: React.FC<DatasetHeaderProps> = ({
                 <div className="hexagon-wrapper">
                   <div className="hexagon no-modality"></div>
                   <div className="label">
-                    {modality === null ? (
-                      <i className="fa fa-circle-o-notch fa-spin"></i>
-                    ) : (
+                    {modality ? (
                       modality.substr(0, 4)
+                    ) : (
+                      <i className="fa fa-circle-o-notch fa-spin"></i>
                     )}
                   </div>
                 </div>

--- a/packages/openneuro-components/src/dataset/__tests__/DatasetHeaders.spec.tsx
+++ b/packages/openneuro-components/src/dataset/__tests__/DatasetHeaders.spec.tsx
@@ -1,0 +1,19 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { DatasetHeader } from '../DatasetHeader'
+import '@testing-library/jest-dom/extend-expect'
+
+describe('DatasetHeader component', () => {
+  it('renders with an undefined modality', () => {
+    render(
+      <DatasetHeader
+        pageHeading="test page"
+        modality={undefined}
+        renderEditor={() => <></>}
+      />,
+      { wrapper: MemoryRouter },
+    )
+    expect(screen.queryByRole('heading')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
Adds a test and fixes #2680 