### PR TITLE
feat(app): Encode search queries in a query parameter for the URL

### DIFF
--- a/packages/openneuro-app/src/scripts/search/__tests__/search-params-ctx.spec.tsx
+++ b/packages/openneuro-app/src/scripts/search/__tests__/search-params-ctx.spec.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 import { SearchParamsProvider, SearchParamsCtx } from '../search-params-ctx'
+import AuthorInput from '../inputs/author-input'
 import { MemoryRouter } from 'react-router-dom'
 import '@testing-library/jest-dom'
 
@@ -19,7 +20,6 @@ export const searchRender = (ui, { providerProps, ...renderOptions }) => {
 describe('SearchParamsProvider', () => {
   it('restores URL searchParams state', () => {
     const route = '/search?query={"authors"%3A["Test+Author"]}'
-    const value = {}
     const wrapper = ({ children }) => (
       <MemoryRouter initialEntries={[route]}>
         <SearchParamsProvider>{children}</SearchParamsProvider>
@@ -33,6 +33,32 @@ describe('SearchParamsProvider', () => {
     )
     expect(screen.getByText(/^Received:/).textContent).toBe(
       'Received: Test Author',
+    )
+  })
+  it('edits array fields correctly', () => {
+    const route = '/search?query={"authors"%3A["Test+Author"]}'
+    const wrapper = ({ children }) => (
+      <MemoryRouter initialEntries={[route]}>
+        <SearchParamsProvider>{children}</SearchParamsProvider>
+      </MemoryRouter>
+    )
+    render(
+      <SearchParamsCtx.Consumer>
+        {value => (
+          <>
+            <AuthorInput />
+            <span>Received: {value.searchParams.authors.join(', ')}</span>
+          </>
+        )}
+      </SearchParamsCtx.Consumer>,
+      { wrapper },
+    )
+    const textInput = screen.getByRole('textbox')
+    const button = screen.getByRole('button')
+    fireEvent.change(textInput, { target: { value: 'New Author' } })
+    fireEvent.click(button)
+    expect(screen.getByText(/^Received:/).textContent).toBe(
+      'Received: Test Author, New Author',
     )
   })
 })

--- a/packages/openneuro-app/src/scripts/search/__tests__/search-params-ctx.spec.tsx
+++ b/packages/openneuro-app/src/scripts/search/__tests__/search-params-ctx.spec.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
-import { render } from '@testing-library/react'
-import { SearchParamsCtx } from '../search-params-ctx'
+import { render, screen } from '@testing-library/react'
+import { SearchParamsProvider, SearchParamsCtx } from '../search-params-ctx'
+import { MemoryRouter } from 'react-router-dom'
 import '@testing-library/jest-dom'
 
 /**
@@ -15,6 +16,23 @@ export const searchRender = (ui, { providerProps, ...renderOptions }) => {
   )
 }
 
-describe('SearchParamsCtx', () => {
-  it('initializes with expected defaults', () => {})
+describe('SearchParamsProvider', () => {
+  it('restores URL searchParams state', () => {
+    const route = '/search?query={"authors"%3A["Test+Author"]}'
+    const value = {}
+    const wrapper = ({ children }) => (
+      <MemoryRouter initialEntries={[route]}>
+        <SearchParamsProvider>{children}</SearchParamsProvider>
+      </MemoryRouter>
+    )
+    render(
+      <SearchParamsCtx.Consumer>
+        {value => <span>Received: {value.searchParams.authors.pop()}</span>}
+      </SearchParamsCtx.Consumer>,
+      { wrapper },
+    )
+    expect(screen.getByText(/^Received:/).textContent).toBe(
+      'Received: Test Author',
+    )
+  })
 })

--- a/packages/openneuro-app/src/scripts/search/search-params-ctx.tsx
+++ b/packages/openneuro-app/src/scripts/search/search-params-ctx.tsx
@@ -1,10 +1,5 @@
-import React, {
-  createContext,
-  useState,
-  useContext,
-  FC,
-  ReactNode,
-} from 'react'
+import React, { createContext, useContext, FC, ReactNode } from 'react'
+import { useSearchParams } from 'react-router-dom'
 import initialSearchParams from './initial-search-params'
 
 export const SearchParamsCtx = createContext(null)
@@ -16,9 +11,34 @@ interface SearchParamsProviderProps {
 export const SearchParamsProvider: FC<SearchParamsProviderProps> = ({
   children,
 }) => {
-  const [searchParams, setSearchParams] = useState(initialSearchParams)
+  const [searchQuery, setSearch] = useSearchParams()
+
+  let searchParams
+  try {
+    const query = searchQuery.get('query')
+    if (query) {
+      searchParams = JSON.parse(decodeURIComponent(query))
+    }
+  } catch (err) {
+    console.error(err)
+  }
+
+  const setSearchParams = newParamsCall => {
+    const merged = { ...searchParams, ...newParamsCall(searchParams) }
+    setSearch(
+      {
+        query: encodeURIComponent(JSON.stringify(merged)),
+      },
+      { replace: true },
+    )
+  }
+
   return (
-    <SearchParamsCtx.Provider value={{ searchParams, setSearchParams }}>
+    <SearchParamsCtx.Provider
+      value={{
+        searchParams: { ...initialSearchParams, ...searchParams },
+        setSearchParams,
+      }}>
       {children}
     </SearchParamsCtx.Provider>
   )

--- a/packages/openneuro-app/src/scripts/search/search-params-ctx.tsx
+++ b/packages/openneuro-app/src/scripts/search/search-params-ctx.tsx
@@ -17,7 +17,7 @@ export const SearchParamsProvider: FC<SearchParamsProviderProps> = ({
   try {
     const query = searchQuery.get('query')
     if (query) {
-      searchParams = JSON.parse(decodeURIComponent(query))
+      searchParams = JSON.parse(query)
     }
   } catch (err) {
     console.error(err)
@@ -27,7 +27,7 @@ export const SearchParamsProvider: FC<SearchParamsProviderProps> = ({
     const merged = { ...searchParams, ...newParamsCall(searchParams) }
     setSearch(
       {
-        query: encodeURIComponent(JSON.stringify(merged)),
+        query: JSON.stringify(merged),
       },
       { replace: true },
     )


### PR DESCRIPTION
This encodes search parameters in the URL so that specific searches and can be shared by copying the link.

- [x] Needs an integration test that validates the encode/decode step and router interaction.
- [x] Add test to verify adding/removing array values from search state.