### PR TITLE
Fix bug preventing modality cube links from working

### DIFF
--- a/packages/openneuro-app/src/scripts/search/__helpers__/search-render.tsx
+++ b/packages/openneuro-app/src/scripts/search/__helpers__/search-render.tsx
@@ -1,0 +1,15 @@
+import React from 'react'
+import { SearchParamsCtx } from '../search-params-ctx'
+import { render } from '@testing-library/react'
+
+/**
+ * Render with SearchParamsCtx state
+ */
+export const searchRender = (ui, { providerProps, ...renderOptions }) => {
+  return render(
+    <SearchParamsCtx.Provider {...providerProps}>
+      {ui}
+    </SearchParamsCtx.Provider>,
+    renderOptions,
+  )
+}

--- a/packages/openneuro-app/src/scripts/search/__tests__/search-params-ctx.spec.tsx
+++ b/packages/openneuro-app/src/scripts/search/__tests__/search-params-ctx.spec.tsx
@@ -2,20 +2,9 @@ import React from 'react'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { SearchParamsProvider, SearchParamsCtx } from '../search-params-ctx'
 import AuthorInput from '../inputs/author-input'
+import initialSearchParams from '../initial-search-params'
 import { MemoryRouter } from 'react-router-dom'
 import '@testing-library/jest-dom'
-
-/**
- * Render with SearchParamsCtx state
- */
-export const searchRender = (ui, { providerProps, ...renderOptions }) => {
-  return render(
-    <SearchParamsCtx.Provider {...providerProps}>
-      {ui}
-    </SearchParamsCtx.Provider>,
-    renderOptions,
-  )
-}
 
 describe('SearchParamsProvider', () => {
   it('restores URL searchParams state', () => {
@@ -60,5 +49,30 @@ describe('SearchParamsProvider', () => {
     expect(screen.getByText(/^Received:/).textContent).toBe(
       'Received: Test Author, New Author',
     )
+  })
+  it('setSearchParams is callable with object argument', () => {
+    const route = '/search?query={"authors"%3A["Test+Author"]}'
+    const wrapper = ({ children }) => (
+      <MemoryRouter initialEntries={[route]}>
+        <SearchParamsProvider>{children}</SearchParamsProvider>
+      </MemoryRouter>
+    )
+
+    let setSearchParams
+
+    render(
+      <SearchParamsCtx.Consumer>
+        {value => {
+          setSearchParams = value.setSearchParams
+          return <span>Received: {value.searchParams.authors.pop()}</span>
+        }}
+      </SearchParamsCtx.Consumer>,
+      { wrapper },
+    )
+    expect(screen.getByText(/^Received:/).textContent).toBe(
+      'Received: Test Author',
+    )
+
+    expect(() => setSearchParams(initialSearchParams)).not.toThrow()
   })
 })

--- a/packages/openneuro-app/src/scripts/search/inputs/__tests__/sort-by-select.spec.tsx
+++ b/packages/openneuro-app/src/scripts/search/inputs/__tests__/sort-by-select.spec.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { screen } from '@testing-library/react'
-import { searchRender } from '../../__tests__/search-params-ctx.spec'
+import { searchRender } from '../../__helpers__/search-render'
 import SortBySelect from '../sort-by-select'
 import initialSearchParams from '../../initial-search-params'
 

--- a/packages/openneuro-app/src/scripts/search/search-params-ctx.tsx
+++ b/packages/openneuro-app/src/scripts/search/search-params-ctx.tsx
@@ -1,6 +1,6 @@
 import React, { createContext, useContext, FC, ReactNode } from 'react'
 import { useSearchParams } from 'react-router-dom'
-import initialSearchParams from './initial-search-params'
+import initialSearchParams, { SearchParams } from './initial-search-params'
 
 export const SearchParamsCtx = createContext(null)
 
@@ -23,8 +23,13 @@ export const SearchParamsProvider: FC<SearchParamsProviderProps> = ({
     console.error(err)
   }
 
-  const setSearchParams = newParamsCall => {
-    const merged = { ...searchParams, ...newParamsCall(searchParams) }
+  const setSearchParams = (
+    newParams: SearchParams | ((prevState: SearchParams) => SearchParams),
+  ): void => {
+    const merged =
+      typeof newParams == 'function'
+        ? { ...searchParams, ...newParams(searchParams) }
+        : { ...searchParams, ...newParams }
     setSearch(
       {
         query: JSON.stringify(merged),


### PR DESCRIPTION
The setState callback that is mimicked by SearchParamsProvider in #2684 also needs to support the object case. Adds a test for this behavior.