### PR TITLE
feat(cli): Add ls command to list files and sizes in a snapshot

### DIFF
--- a/packages/openneuro-cli/src/actions.js
+++ b/packages/openneuro-cli/src/actions.js
@@ -9,6 +9,7 @@ import { getSnapshots } from './snapshots.js'
 import { getDownload } from './download.js'
 import { configuredClient } from './configuredClient.js'
 import { validateApiKey } from './validateApiKey'
+import { lsSnapshot } from './ls.js'
 
 /**
  * Login action to save an auth key locally
@@ -282,4 +283,27 @@ export const download = (datasetId, destination, cmd) => {
     getDownload(destination, datasetId, null, apmTransaction, client)
   }
   apmTransaction.end()
+}
+
+/**
+ * List files for a snapshot
+ *
+ * @param {string} datasetId
+ * @param {object} cmd
+ */
+export const ls = (datasetId, cmd) => {
+  const client = configuredClient()
+  if (!cmd.snapshot) {
+    return getSnapshots(client)(datasetId).then(({ data }) => {
+      if (data.dataset && data.dataset.snapshots) {
+        const tags = data.dataset.snapshots.map(snap => snap.tag)
+        tags.reverse()
+        return promptTags(tags).then(choices => {
+          lsSnapshot(client, datasetId, choices.tag)
+        })
+      }
+    })
+  } else {
+    return lsSnapshot(client, datasetId, cmd.snapshot)
+  }
 }

--- a/packages/openneuro-cli/src/cli.js
+++ b/packages/openneuro-cli/src/cli.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import commander from 'commander'
 import { version } from './lerna.json'
-import { login, upload, download } from './actions.js'
+import { login, upload, download, ls } from './actions.js'
 import { gitCredential } from './gitCredential.js'
 import { gitAnnexRemote } from './gitAnnexRemote.js'
 import { create } from './createDataset.js'
@@ -67,6 +67,12 @@ commander
   .action(() => {
     create()
   })
+
+commander
+  .command('ls <datasetId>')
+  .description('Lists files from a snapshotted dataset version.')
+  .option('-s, --snapshot [snapshotVersion]')
+  .action(ls)
 
 const processName = process.argv[1].endsWith('index.js')
   ? process.env.npm_lifecycle_event

--- a/packages/openneuro-cli/src/datasets.js
+++ b/packages/openneuro-cli/src/datasets.js
@@ -50,21 +50,38 @@ export const getDatasetFiles = async (
   tree = null,
 ) => {
   const files = []
+  await _getDatasetFiles(client, datasetId, f => files.push(f), path, tree)
+  return files
+}
+
+/**
+ * Get an existing dataset's files
+ * @param {object} client GraphQL client
+ * @param {*} datasetId
+ */
+export const _getDatasetFiles = async (
+  client,
+  datasetId,
+  callback,
+  path = '',
+  tree = null,
+) => {
+  const files = []
   const { data } = await client.query({
     query: getDraftFiles,
     variables: { id: datasetId, tree },
   })
   for (const f of data.dataset.draft.files) {
     if (f.directory) {
-      const nestedFiles = await getDatasetFiles(
+      await _getDatasetFiles(
         client,
         datasetId,
+        callback,
         path ? `${path}/${f.filename}` : f.filename,
         f.id,
       )
-      files.push(...nestedFiles)
     } else {
-      files.push({
+      callback({
         ...f,
         filename: path ? `${path}/${f.filename}` : f.filename,
       })

--- a/packages/openneuro-cli/src/ls.js
+++ b/packages/openneuro-cli/src/ls.js
@@ -1,0 +1,13 @@
+import { _getDatasetFiles } from './datasets'
+
+export function lsSnapshot(client, datasetId, tree) {
+  return _getDatasetFiles(
+    client,
+    datasetId,
+    f => {
+      process.stdout.write(`${f.filename}\t${f.size}\n`)
+    },
+    '',
+    tree,
+  )
+}


### PR DESCRIPTION
Adds a simple ls command to list a snapshots files.

```shell
> openneuro ls ds000001 -s 1.0.0
CHANGES 286
README  1175
dataset_description.json        615
participants.tsv        216
task-balloonanalogrisktask_bold.json    73
sub-01/anat/sub-01_T1w.nii.gz   5663237
sub-01/anat/sub-01_inplaneT2.nii.gz     669578
sub-01/func/sub-01_task-balloonanalogrisktask_run-01_bold.nii.gz        47241449
sub-01/func/sub-01_task-balloonanalogrisktask_run-01_events.tsv 8610
sub-01/func/sub-01_task-balloonanalogrisktask_run-02_bold.nii.gz        47282515
sub-01/func/sub-01_task-balloonanalogrisktask_run-02_events.tsv 8568
sub-01/func/sub-01_task-balloonanalogrisktask_run-03_bold.nii.gz        47347339
sub-01/func/sub-01_task-balloonanalogrisktask_run-03_events.tsv 8132
...
```