### PR TITLE
fix(cli): Fix missing files when downloading with a command line "--draft" or "--snapshot" argument

### DIFF
--- a/packages/openneuro-cli/src/actions.js
+++ b/packages/openneuro-cli/src/actions.js
@@ -277,9 +277,15 @@ export const download = (datasetId, destination, cmd) => {
       }
     })
   } else if (cmd.snapshot) {
-    getDownload(destination, datasetId, cmd.snapshot, apmTransaction, client)
+    return getDownload(
+      destination,
+      datasetId,
+      cmd.snapshot,
+      apmTransaction,
+      client,
+    )
   } else {
-    getDownload(destination, datasetId, null, apmTransaction, client)
+    return getDownload(destination, datasetId, null, apmTransaction, client)
   }
   apmTransaction.end()
 }


### PR DESCRIPTION
This implementation worked either way before because there was always one promise resolving the download. Now that we have a promise for each tree object, we need to return the top level promise to flow control to prevent an early exit before we fetch more than one directory tree.