### PR TITLE
Prevent clearing front page search parameter during navigation

### DIFF
--- a/packages/openneuro-app/src/scripts/__mocks__/config.ts
+++ b/packages/openneuro-app/src/scripts/__mocks__/config.ts
@@ -23,4 +23,7 @@ export const config = {
   sentry: {
     environment: 'unit-tests',
   },
+  support: {
+    url: 'https://example.com/test-suite',
+  },
 }

--- a/packages/openneuro-app/src/scripts/__utils__/mock-app-shell.tsx
+++ b/packages/openneuro-app/src/scripts/__utils__/mock-app-shell.tsx
@@ -1,0 +1,22 @@
+import React from 'react'
+import { MemoryRouter } from 'react-router-dom'
+import { MockedProvider } from '@apollo/client/testing'
+import { SearchParamsCtx } from '../search/search-params-ctx'
+import { UserModalOpenCtx } from '../utils/user-login-modal-ctx'
+import initialSearchParams from '../search/initial-search-params'
+
+/**
+ * Reusable shell component that provides any context required by major component trees
+ */
+export const MockAppShell = ({ children, route = '/' }) => (
+  <MockedProvider>
+    <SearchParamsCtx.Provider
+      value={{
+        searchParams: initialSearchParams,
+      }}>
+      <UserModalOpenCtx.Provider value={false}>
+        <MemoryRouter initialEntries={[route]}>{children}</MemoryRouter>
+      </UserModalOpenCtx.Provider>
+    </SearchParamsCtx.Provider>
+  </MockedProvider>
+)

--- a/packages/openneuro-app/src/scripts/common/containers/__tests__/header.spec.tsx
+++ b/packages/openneuro-app/src/scripts/common/containers/__tests__/header.spec.tsx
@@ -10,10 +10,13 @@ jest.mock(
 
 const mockNavigate = jest.fn()
 
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
-  useNavigate: () => mockNavigate,
-}))
+jest.mock('react-router-dom', () => {
+  const reactRouterDom = jest.requireActual('react-router-dom')
+  return {
+    ...reactRouterDom,
+    useNavigate: () => mockNavigate,
+  }
+})
 
 describe('HeaderContainer component', () => {
   it('navigates prepopulated search when you use the home page search box', async () => {

--- a/packages/openneuro-app/src/scripts/common/containers/__tests__/header.spec.tsx
+++ b/packages/openneuro-app/src/scripts/common/containers/__tests__/header.spec.tsx
@@ -1,0 +1,31 @@
+import React from 'react'
+import { MockAppShell } from '../../../__utils__/mock-app-shell'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { HeaderContainer } from '../header'
+
+jest.mock(
+  '../../../uploader/uploader-view.jsx',
+  () => () => 'mocked UploaderView',
+)
+
+const mockNavigate = jest.fn()
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockNavigate,
+}))
+
+describe('HeaderContainer component', () => {
+  it('navigates prepopulated search when you use the home page search box', async () => {
+    render(<HeaderContainer />, { wrapper: MockAppShell })
+    const searchbox = screen.getByRole('textbox')
+    const button = screen.getByLabelText('Search')
+    await fireEvent.change(searchbox, { target: { value: 'test argument' } })
+    await fireEvent.click(button)
+    await waitFor(() =>
+      expect(mockNavigate).toHaveBeenCalledWith(
+        '/search?query={"keywords":["test argument"]}',
+      ),
+    )
+  })
+})

--- a/packages/openneuro-app/src/scripts/common/containers/header.tsx
+++ b/packages/openneuro-app/src/scripts/common/containers/header.tsx
@@ -5,8 +5,6 @@ import UploadProgress from '../../uploader/upload-progress.jsx'
 import { Header, LandingExpandedHeader } from '@openneuro/components/header'
 import { Input } from '@openneuro/components/input'
 import ModalitySelect from '../../search/inputs/modality-select'
-import { SearchParamsCtx } from '../../search/search-params-ctx'
-import initialSearchParams from '../../search/initial-search-params'
 import { UserModalOpenCtx } from '../../utils/user-login-modal-ctx'
 import { useLocation, useNavigate } from 'react-router-dom'
 import { useCookies } from 'react-cookie'
@@ -18,7 +16,8 @@ import loginUrls from '../../authentication/loginUrls'
 import UploaderView from '../../uploader/uploader-view.jsx'
 import UploadButton from '../../uploader/upload-button.jsx'
 import UploadProgressButton from '../../uploader/upload-progress-button.jsx'
-const HeaderContainer: FC = () => {
+
+export const HeaderContainer: FC = () => {
   const navigate = useNavigate()
 
   const { pathname: currentPath } = useLocation()
@@ -27,22 +26,17 @@ const HeaderContainer: FC = () => {
   const [cookies] = useCookies()
   const profile = getUnexpiredProfile(cookies)
 
-  const { setSearchParams } = useContext(SearchParamsCtx)
   const { userModalOpen, setUserModalOpen } = useContext(UserModalOpenCtx)
 
   const [newKeyword, setNewKeyword, newKeywordRef] = useState('')
 
   const handleSubmit = () => {
-    // reset search params and set keyword to initiate new search, then navigate to global search page
-    setSearchParams(() => ({
-      ...initialSearchParams,
+    const query = JSON.stringify({
       keywords: newKeywordRef.current ? [newKeywordRef.current] : [],
-    }))
+    })
     setNewKeyword('')
-    navigate('/search')
+    navigate(`/search?query=${query}`)
   }
-
-  const clearSearchParams = () => setSearchParams(initialSearchParams)
 
   const toggleLoginModal = (): void => {
     setUserModalOpen(prevState => ({
@@ -133,9 +127,6 @@ const HeaderContainer: FC = () => {
             )}
             onSearch={() => {
               handleSubmit()
-            }}
-            clearSearchParams={() => {
-              clearSearchParams()
             }}
           />
         )}

--- a/packages/openneuro-app/src/scripts/uploader/uploader-view.jsx
+++ b/packages/openneuro-app/src/scripts/uploader/uploader-view.jsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import BlockNavigation from '../common/partials/block-navigation.jsx'
-import UploaderContext from './uploader-context.js'
 import UploaderSetupRoutes from './uploader-setup-routes.jsx'
 import UploaderStatusRoutes from './uploader-status-routes.jsx'
 

--- a/packages/openneuro-components/src/header/LandingExpandedHeader.tsx
+++ b/packages/openneuro-components/src/header/LandingExpandedHeader.tsx
@@ -15,7 +15,6 @@ export interface LandingExpandedHeaderProps {
   renderFacetSelect: () => React.ReactNode
   renderSearchInput: () => React.ReactNode
   onSearch: () => void
-  clearSearchParams: () => void
 }
 
 export const LandingExpandedHeader: React.FC<LandingExpandedHeaderProps> = ({
@@ -25,7 +24,6 @@ export const LandingExpandedHeader: React.FC<LandingExpandedHeaderProps> = ({
   renderFacetSelect,
   renderSearchInput,
   onSearch,
-  clearSearchParams,
 }) => {
   const aggregateCounts = (modality: string): React.ReactNode =>
     renderAggregateCounts ? renderAggregateCounts(modality) : null
@@ -39,7 +37,6 @@ export const LandingExpandedHeader: React.FC<LandingExpandedHeaderProps> = ({
           cubeImage={item.cubeImage}
           stats={aggregateCounts(item.label)}
           onClick={redirectPath => e => {
-            clearSearchParams()
             navigate(redirectPath)
           }}
         />

--- a/packages/openneuro-components/src/page/Page.tsx
+++ b/packages/openneuro-components/src/page/Page.tsx
@@ -46,7 +46,6 @@ export const Page = ({ children, headerArgs, className }: PageProps) => {
                 />
               )}
               onSearch={() => console.log('User search by keyword.')}
-              clearSearchParams={() => {}}
             />
           )}
         />


### PR DESCRIPTION
The search parameter was set here and then would be immediately cleared by the navigate call. This skips setting it on the context and includes it in the URL. Adds a test which verifies this behavior to prevent future regressions.

Fixes #2696