### PR TITLE
fix(app): Don't depend on parent routes in DeprecateSnapshotPage

### DIFF
--- a/packages/openneuro-app/src/scripts/dataset/routes/__tests__/deprecate-snapshot-page.spec.tsx
+++ b/packages/openneuro-app/src/scripts/dataset/routes/__tests__/deprecate-snapshot-page.spec.tsx
@@ -1,0 +1,12 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { DeprecateSnapshotPage } from '../deprecate-snapshot-page'
+
+describe('DeprecateSnapshotPage component', () => {
+  it('renders accession number and tag', () => {
+    render(<DeprecateSnapshotPage datasetId="ds000001" snapshotTag="1.0.0" />)
+    expect(
+      screen.getByText(/Deprecate ds000001 version 1\.0\.0/),
+    ).toBeInTheDocument()
+  })
+})

--- a/packages/openneuro-app/src/scripts/dataset/routes/deprecate-snapshot-page.tsx
+++ b/packages/openneuro-app/src/scripts/dataset/routes/deprecate-snapshot-page.tsx
@@ -6,8 +6,15 @@ import LoggedIn from '../../authentication/logged-in.jsx'
 import { DatasetPageBorder } from './styles/dataset-page-border'
 import { HeaderRow3 } from './styles/header-row'
 
-export const DeprecateSnapshotPage = (): React.ReactElement => {
-  const { datasetId, snapshotTag } = useParams()
+interface DeprecateSnapshotProps {
+  datasetId: string
+  snapshotTag: string
+}
+
+export const DeprecateSnapshotPage = ({
+  datasetId,
+  snapshotTag,
+}: DeprecateSnapshotProps): React.ReactElement => {
   const [reason, setReason] = useState('')
 
   return (

--- a/packages/openneuro-app/src/scripts/dataset/routes/tab-routes-snapshot.tsx
+++ b/packages/openneuro-app/src/scripts/dataset/routes/tab-routes-snapshot.tsx
@@ -27,7 +27,15 @@ export const TabRoutesSnapshot = ({ dataset, snapshot }) => {
         path="derivatives"
         element={<Derivatives derivatives={dataset.derivatives} />}
       />
-      <Route path="deprecate" element={<DeprecateSnapshotPage />} />
+      <Route
+        path="deprecate"
+        element={
+          <DeprecateSnapshotPage
+            datasetId={dataset.id}
+            snapshotTag={snapshot.tag}
+          />
+        }
+      />
       <Route path="file-display/:filePath" element={<FileDisplayRoute />} />
       <Route path="metadata" element={<AddMetadata dataset={dataset} />} />
     </Routes>


### PR DESCRIPTION
Fixes regression causing the snapshot tag value to be missing.

Fixes  #2699