### PR TITLE
fix(app): Set snapshotTag value for FileDisplay on snapshots

### DIFF
--- a/packages/openneuro-app/src/scripts/dataset/files/file-display.jsx
+++ b/packages/openneuro-app/src/scripts/dataset/files/file-display.jsx
@@ -82,8 +82,19 @@ FileDisplay.propTypes = {
   snapshotTag: PropTypes.string,
 }
 
-export const FileDisplayRoute = () => {
-  return <FileDisplay {...useParams()} />
+export const FileDisplayRoute = ({ datasetId, snapshotTag }) => {
+  return (
+    <FileDisplay
+      datasetId={datasetId}
+      snapshotTag={snapshotTag}
+      {...useParams()}
+    />
+  )
+}
+
+FileDisplayRoute.propTypes = {
+  datasetId: PropTypes.string,
+  snapshotTag: PropTypes.string,
 }
 
 export default FileDisplay

--- a/packages/openneuro-app/src/scripts/dataset/routes/tab-routes-draft.tsx
+++ b/packages/openneuro-app/src/scripts/dataset/routes/tab-routes-draft.tsx
@@ -58,7 +58,10 @@ export const TabRoutesDraft = ({ dataset, hasEdit }) => {
           />
         }
       />
-      <Route path="file-display/:filePath" element={<FileDisplayRoute />} />
+      <Route
+        path="file-display/:filePath"
+        element={<FileDisplayRoute datasetId={dataset.id} />}
+      />
       <Route path="metadata" element={<AddMetadata dataset={dataset} />} />
     </Routes>
   )

--- a/packages/openneuro-app/src/scripts/dataset/routes/tab-routes-snapshot.tsx
+++ b/packages/openneuro-app/src/scripts/dataset/routes/tab-routes-snapshot.tsx
@@ -36,7 +36,12 @@ export const TabRoutesSnapshot = ({ dataset, snapshot }) => {
           />
         }
       />
-      <Route path="file-display/:filePath" element={<FileDisplayRoute />} />
+      <Route
+        path="file-display/:filePath"
+        element={
+          <FileDisplayRoute datasetId={dataset.id} snapshotTag={snapshot.tag} />
+        }
+      />
       <Route path="metadata" element={<AddMetadata dataset={dataset} />} />
     </Routes>
   )


### PR DESCRIPTION
Fixes an issue where the FileDisplay component would not use the snapshot version in the URL for loading a file.

Previously the 1.0.1 snapshot would try to load a file like this:
https://openneuro.org/crn/datasets/ds001033/files/sub-02:anat:sub-02_T1w.nii.gz

Correct URL looks like this:
https://openneuro.org/crn/datasets/ds001033/snapshots/1.0.1/files/sub-02:anat:sub-02_T1w.nii.gz

This is a regression caused by the React Router V6 updates.