### PR TITLE
feat: Show ORCID iDs for dataset uploaders

### DIFF
--- a/packages/openneuro-app/src/@types/custom.d.ts
+++ b/packages/openneuro-app/src/@types/custom.d.ts
@@ -5,6 +5,12 @@ declare module '*.png' {
   export = value
 }
 
+// Allow .svg imports
+declare module '*.svg' {
+  const value: string
+  export = value
+}
+
 // Allow .scss imports
 declare module '*.scss' {
   const value: string

--- a/packages/openneuro-app/src/assets/ORCIDiD_iconvector.svg
+++ b/packages/openneuro-app/src/assets/ORCIDiD_iconvector.svg
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 19.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 256 256" style="enable-background:new 0 0 256 256;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#A6CE39;}
+	.st1{fill:#FFFFFF;}
+</style>
+<path class="st0" d="M256,128c0,70.7-57.3,128-128,128C57.3,256,0,198.7,0,128C0,57.3,57.3,0,128,0C198.7,0,256,57.3,256,128z"/>
+<g>
+	<path class="st1" d="M86.3,186.2H70.9V79.1h15.4v48.4V186.2z"/>
+	<path class="st1" d="M108.9,79.1h41.6c39.6,0,57,28.3,57,53.6c0,27.5-21.5,53.6-56.8,53.6h-41.8V79.1z M124.3,172.4h24.5
+		c34.9,0,42.9-26.5,42.9-39.7c0-21.5-13.7-39.7-43.7-39.7h-23.7V172.4z"/>
+	<path class="st1" d="M88.7,56.8c0,5.5-4.5,10.1-10.1,10.1c-5.6,0-10.1-4.6-10.1-10.1c0-5.6,4.5-10.1,10.1-10.1
+		C84.2,46.7,88.7,51.3,88.7,56.8z"/>
+</g>
+</svg>

--- a/packages/openneuro-app/src/scripts/dataset/dataset-query.jsx
+++ b/packages/openneuro-app/src/scripts/dataset/dataset-query.jsx
@@ -53,6 +53,7 @@ export const getDatasetPage = gql`
         id
         name
         email
+        orcid
       }
       analytics {
         downloads
@@ -108,6 +109,7 @@ export const getDraftPage = gql`
         id
         name
         email
+        orcid
       }
       analytics {
         downloads

--- a/packages/openneuro-app/src/scripts/dataset/draft-container.tsx
+++ b/packages/openneuro-app/src/scripts/dataset/draft-container.tsx
@@ -28,6 +28,7 @@ import {
   VersionList,
   DatasetTools,
 } from '@openneuro/components/dataset'
+import { Username } from '../users/username'
 
 import { FollowDataset } from './mutations/follow'
 import { StarDataset } from './mutations/star'
@@ -283,7 +284,7 @@ const DraftContainer: React.FC<DraftContainerProps> = ({ dataset }) => {
                 heading="Uploaded by"
                 item={
                   <>
-                    {dataset.uploader.name} on {dateAdded} -{' '}
+                    <Username user={dataset.uploader} /> on {dateAdded} -{' '}
                     {dateAddedDifference} ago
                   </>
                 }

--- a/packages/openneuro-app/src/scripts/dataset/snapshot-container.tsx
+++ b/packages/openneuro-app/src/scripts/dataset/snapshot-container.tsx
@@ -25,6 +25,7 @@ import {
   VersionList,
   DatasetTools,
 } from '@openneuro/components/dataset'
+import { Username } from '../users/username'
 import { Loading } from '@openneuro/components/loading'
 
 import {
@@ -285,7 +286,7 @@ export const SnapshotContainer: React.FC<SnapshotContainerProps> = ({
                 heading="Uploaded by"
                 item={
                   <>
-                    {dataset.uploader.name} on {dateAdded} -{' '}
+                    <Username user={dataset.uploader} /> on {dateAdded} -{' '}
                     {dateAddedDifference} ago
                   </>
                 }

--- a/packages/openneuro-app/src/scripts/search/use-search-results.tsx
+++ b/packages/openneuro-app/src/scripts/search/use-search-results.tsx
@@ -39,6 +39,7 @@ const searchQuery = gql`
           uploader {
             id
             name
+            orcid
           }
           public
           permissions {

--- a/packages/openneuro-app/src/scripts/users/username.tsx
+++ b/packages/openneuro-app/src/scripts/users/username.tsx
@@ -1,0 +1,20 @@
+import React from 'react'
+import ORCIDiDLogo from '../../assets/ORCIDiD_iconvector.svg'
+
+/**
+ * Display component for usernames showing ORCID linking if connected
+ */
+export const Username = ({ user }) => {
+  if (user.orcid) {
+    return (
+      <>
+        {user.name}{' '}
+        <a href={`https://orcid.org/${user.orcid}`}>
+          <img src={ORCIDiDLogo} width="16" height="16" alt="ORCID logo" />
+        </a>
+      </>
+    )
+  } else {
+    return user.name
+  }
+}

--- a/packages/openneuro-client/src/datasets.js
+++ b/packages/openneuro-client/src/datasets.js
@@ -11,6 +11,7 @@ export const getDataset = gql`
         id
         name
         email
+        orcid
       }
       draft {
         id
@@ -119,6 +120,7 @@ export const getDatasets = gql`
           uploader {
             id
             name
+            orcid
           }
           public
           permissions {

--- a/packages/openneuro-server/src/graphql/schema.js
+++ b/packages/openneuro-server/src/graphql/schema.js
@@ -304,6 +304,7 @@ export const typeDefs = `
     id: ID!
     provider: UserProvider
     avatar: String
+    orcid: String
     created: DateTime!
     modified: DateTime
     lastSeen: DateTime
@@ -317,7 +318,6 @@ export const typeDefs = `
   enum UserProvider {
     google
     orcid
-    globus
   }
 
   # Connection for a list of datasets

--- a/packages/openneuro-server/src/libs/authentication/passport.js
+++ b/packages/openneuro-server/src/libs/authentication/passport.js
@@ -32,6 +32,7 @@ const loadProfile = profile => {
       name: profile.info.name,
       provider: profile.provider,
       providerId: profile.orcid,
+      orcid: profile.orcid,
     }
   } else {
     // Some unknown profile type

--- a/packages/openneuro-server/src/models/user.ts
+++ b/packages/openneuro-server/src/models/user.ts
@@ -8,6 +8,7 @@ export interface UserDocument extends Document {
   name: string
   provider: StaticRangeInit
   providerId: string
+  orcid: string
   refresh: string
   admin: boolean
   blocked: boolean
@@ -21,6 +22,7 @@ const userSchema = new Schema({
   name: String,
   provider: String, // Login provider
   providerId: String, // Login provider unique id
+  orcid: String, // ORCID iD regardless of provider id
   refresh: String,
   admin: { type: Boolean, default: false },
   blocked: { type: Boolean, default: false },


### PR DESCRIPTION
This is part one of ORCID updates to show a user's ORCID iD in several places. This includes the API changes and one of the frontend changes to demo it, displaying the id in the [recommended](https://info.orcid.org/brand-guidelines/#h-orcid-logos-and-icons) minimal structure.

![image](https://user-images.githubusercontent.com/11369795/207704806-e40175d0-de63-4afb-a1a3-616c926f4017.png)

This supports the display half of this for Google auth users as well but does not include support for linking to your Google account yet.