### PR TITLE
fix(worker): Update local and remote defaults to main branch

### DIFF
--- a/services/datalad/datalad_service/common/bids.py
+++ b/services/datalad/datalad_service/common/bids.py
@@ -10,6 +10,9 @@ def read_dataset_description(dataset_path, commit):
         return json.loads(raw_description)
     except json.decoder.JSONDecodeError:
         return None
+    except KeyError:
+        # dataset_description.json does not exist
+        return None
 
 
 def dataset_sort(file):

--- a/services/datalad/datalad_service/common/bids.py
+++ b/services/datalad/datalad_service/common/bids.py
@@ -1,3 +1,17 @@
+import json
+
+from datalad_service.common.git import git_show
+
+
+def read_dataset_description(dataset_path, commit):
+    try:
+        raw_description = git_show(
+            dataset_path, commit, 'dataset_description.json')
+        return json.loads(raw_description)
+    except json.decoder.JSONDecodeError:
+        return None
+
+
 def dataset_sort(file):
     """BIDS aware sorting of dataset file listings"""
     filename = file.get('filename')

--- a/services/datalad/datalad_service/common/git.py
+++ b/services/datalad/datalad_service/common/git.py
@@ -40,8 +40,22 @@ def git_tag_tree(repo, tag):
     return repo.get(tag_reference.target).tree_id
 
 
+def git_rename_master_to_main(repo):
+    # Make sure the main branch is used, update if needed
+    # Always update the symbolic reference for HEAD
+    repo.references['HEAD'].set_target('refs/heads/main')
+    master_branch = repo.branches.get('master')
+    if master_branch:
+        main_branch = master_branch.rename('main', True)
+        # Abort the commit if this didn't work
+        if not main_branch.is_head():
+            raise Exception('Unable to rename master branch to main')
+
+
 def git_commit(repo, file_paths, author=None, message="[OpenNeuro] Recorded changes", parents=None):
     """Commit array of paths at HEAD."""
+    # master -> main if required
+    git_rename_master_to_main(repo)
     # Refresh index with git-annex specific handling
     annex_command = ["git-annex", "add"] + file_paths
     subprocess.run(annex_command, check=True, cwd=repo.workdir)
@@ -61,6 +75,6 @@ def git_commit_index(repo, author=None, message="[OpenNeuro] Recorded changes", 
         parent_commits = parents
     tree = repo.index.write_tree()
     commit = repo.create_commit(
-        'refs/heads/master', author, committer, message, tree, parent_commits)
+        'refs/heads/main', author, committer, message, tree, parent_commits)
     repo.head.set_target(commit)
     return commit

--- a/services/datalad/datalad_service/common/git.py
+++ b/services/datalad/datalad_service/common/git.py
@@ -42,14 +42,14 @@ def git_tag_tree(repo, tag):
 
 def git_rename_master_to_main(repo):
     # Make sure the main branch is used, update if needed
-    # Always update the symbolic reference for HEAD
-    repo.references['HEAD'].set_target('refs/heads/main')
     master_branch = repo.branches.get('master')
     if master_branch:
         main_branch = master_branch.rename('main', True)
         # Abort the commit if this didn't work
         if not main_branch.is_head():
             raise Exception('Unable to rename master branch to main')
+    # Always update the symbolic reference for HEAD
+    repo.references['HEAD'].set_target('refs/heads/main')
 
 
 def git_commit(repo, file_paths, author=None, message="[OpenNeuro] Recorded changes", parents=None):

--- a/services/datalad/datalad_service/common/git.py
+++ b/services/datalad/datalad_service/common/git.py
@@ -9,6 +9,10 @@ COMMITTER_NAME = 'Git Worker'
 COMMITTER_EMAIL = 'git@openneuro.org'
 
 
+class OpenNeuroGitError(Exception):
+    """OpenNeuro git repo states that should not arise under normal use but may be a valid git operation in other contexts."""
+
+
 def git_show(path, commitish, obj):
     repo = pygit2.Repository(path)
     commit, _ = repo.resolve_refish(commitish)
@@ -54,6 +58,10 @@ def git_rename_master_to_main(repo):
 
 def git_commit(repo, file_paths, author=None, message="[OpenNeuro] Recorded changes", parents=None):
     """Commit array of paths at HEAD."""
+    # Early abort for this commit if HEAD is not main or master
+    if repo.references['HEAD'].target not in ['refs/heads/main', 'refs/heads/master']:
+        raise OpenNeuroGitError(
+            'HEAD points at invalid branch name and commit was aborted')
     # master -> main if required
     git_rename_master_to_main(repo)
     # Refresh index with git-annex specific handling

--- a/services/datalad/datalad_service/common/git.py
+++ b/services/datalad/datalad_service/common/git.py
@@ -47,7 +47,7 @@ def git_tag_tree(repo, tag):
 def git_rename_master_to_main(repo):
     # Make sure the main branch is used, update if needed
     master_branch = repo.branches.get('master')
-    if master_branch:
+    if repo.references['HEAD'].target == master_branch:
         main_branch = master_branch.rename('main', True)
         # Abort the commit if this didn't work
         if not main_branch.is_head():

--- a/services/datalad/datalad_service/tasks/dataset.py
+++ b/services/datalad/datalad_service/tasks/dataset.py
@@ -38,14 +38,18 @@ def create_datalad_config(dataset_path):
         configfile.write(config)
 
 
-def create_dataset(store, dataset, author=None):
-    """Create a DataLad git-annex repo for a new dataset."""
+def create_dataset(store, dataset, author=None, initial_head='main'):
+    """Create a DataLad git-annex repo for a new dataset.
+
+    initial_head is only meant for tests and is overridden by the implementation of git_commit
+    """
     dataset_path = store.get_dataset_path(dataset)
     if os.path.isdir(dataset_path):
         raise Exception('Dataset already exists')
     if not author:
         author = pygit2.Signature(COMMITTER_NAME, COMMITTER_EMAIL)
-    repo = pygit2.init_repository(dataset_path, False)
+    repo = pygit2.init_repository(
+        dataset_path, False, initial_head=initial_head)
     init_annex(dataset_path)
     # Setup .gitattributes to limit what files are annexed by default
     with open(os.path.join(dataset_path, '.gitattributes'), 'w') as gitattributes:

--- a/services/datalad/datalad_service/tasks/publish.py
+++ b/services/datalad/datalad_service/tasks/publish.py
@@ -69,7 +69,7 @@ def export_dataset(dataset_path, cookies=None, s3_export=s3_export, github_expor
     If the dataset has not been configured with public remotes, this is a noop.
     """
     if is_git_annex_remote(dataset_path, get_s3_remote()):
-        dataset = os.path.basename(dataset_path)
+        dataset_id = os.path.basename(dataset_path)
         repo = pygit2.Repository(dataset_path)
         tags = git_tag(repo)
         # Iterate over all tags and push those
@@ -78,9 +78,9 @@ def export_dataset(dataset_path, cookies=None, s3_export=s3_export, github_expor
         # Once all S3 tags are exported, update GitHub
         if github_enabled:
             # Perform all GitHub export steps
-            github_export(dataset_path, tag.name)
+            github_export(dataset_id, dataset_path, tag.name)
         # Drop cache once all exports are complete
-        clear_dataset_cache(dataset, cookies)
+        clear_dataset_cache(dataset_id, cookies)
 
 
 def check_remote_has_version(dataset_path, remote, tag):

--- a/services/datalad/tests/conftest.py
+++ b/services/datalad/tests/conftest.py
@@ -57,7 +57,7 @@ def datalad_store(tmpdir_factory):
     ds_path = str(path.join(DATASET_ID))
     # Create an empty dataset for testing
     ds = Dataset(ds_path)
-    ds.create()
+    ds.create(initopts=['--initial-branch', 'main'])
     ds.no_annex(BIDS_NO_ANNEX)
 
     json_path = os.path.join(ds_path, 'dataset_description.json')

--- a/services/datalad/tests/test_bids.py
+++ b/services/datalad/tests/test_bids.py
@@ -1,4 +1,9 @@
-from datalad_service.common.bids import dataset_sort
+import os
+
+from pygit2 import Repository
+
+from datalad_service.common.bids import dataset_sort, read_dataset_description
+from datalad_service.common.git import git_commit
 
 
 def test_sort_bids_top_level():
@@ -58,3 +63,21 @@ def test_sort_bids_top_level():
     assert sorted_files[0].get('filename') == 'CHANGES'
     assert sorted_files[1].get('filename') == 'README'
     assert sorted_files[2].get('filename') == 'dataset_description.json'
+
+
+def test_read_dataset_description(new_dataset):
+    description = read_dataset_description(new_dataset.path, 'HEAD')
+    assert description['Name'] == 'Test fixture new dataset'
+
+
+def test_read_dataset_description_invalid_json(new_dataset):
+    repo = Repository(new_dataset.path)
+    open(os.path.join(new_dataset.path, "dataset_description.json"), "w").close()
+    git_commit(repo, ['dataset_description.json'])
+    description = read_dataset_description(new_dataset.path, 'HEAD')
+    assert description is None
+
+
+def test_read_dataset_description_missing(new_dataset):
+    description = read_dataset_description(new_dataset.path, 'git-annex')
+    assert description is None

--- a/services/datalad/tests/test_datalad.py
+++ b/services/datalad/tests/test_datalad.py
@@ -25,6 +25,23 @@ def test_create_dataset(datalad_store):
         assert False, "dataset datalad id is not a valid uuid4"
 
 
+def test_create_dataset_master(datalad_store):
+    ds_id = 'ds000025'
+    author = pygit2.Signature('test author', 'test@example.com')
+    create_dataset(datalad_store, ds_id, author, 'master')
+    ds = Dataset(os.path.join(datalad_store.annex_path, ds_id))
+    assert ds.repo is not None
+    # Verify the dataset is created with datalad config
+    assert ds.id is not None
+    assert len(ds.id) == 36
+    try:
+        uuid.UUID(ds.id, version=4)
+    except ValueError:
+        assert False, "dataset datalad id is not a valid uuid4"
+    # Verify the branch is now set to main
+    assert ds.repo.get_active_branch() == 'main'
+
+
 def test_delete_dataset(datalad_store, new_dataset):
     delete_dataset(new_dataset.path)
     assert not os.path.exists(new_dataset.path)

--- a/services/datalad/tests/test_datalad.py
+++ b/services/datalad/tests/test_datalad.py
@@ -7,9 +7,10 @@ import pytest
 import pygit2
 from datalad.api import Dataset
 
+from datalad_service.common.annex import init_annex
+from datalad_service.common.git import OpenNeuroGitError
 from datalad_service.tasks.dataset import *
 from datalad_service.tasks.files import commit_files
-from datalad_service.common.git import OpenNeuroGitError
 
 
 def test_create_dataset(datalad_store):
@@ -29,17 +30,23 @@ def test_create_dataset(datalad_store):
 
 def test_create_dataset_master(datalad_store):
     ds_id = 'ds000025'
-    author = pygit2.Signature('test author', 'test@example.com')
-    create_dataset(datalad_store, ds_id, author, 'master')
-    ds = Dataset(os.path.join(datalad_store.annex_path, ds_id))
+    ds_path = os.path.join(datalad_store.annex_path, ds_id)
+    repo = pygit2.init_repository(
+        ds_path, False, initial_head='master')
+    # Create an empty commit
+    tree = repo.index.write_tree()
+    test_author = pygit2.Signature('Test User', 'test@example.com')
+    repo.create_commit(
+        'refs/heads/master', test_author, test_author, 'test', tree, [])
+    # Setup empty annex
+    init_annex(ds_path)
+    ds = Dataset(ds_path)
     assert ds.repo is not None
-    # Verify the dataset is created with datalad config
-    assert ds.id is not None
-    assert len(ds.id) == 36
-    try:
-        uuid.UUID(ds.id, version=4)
-    except ValueError:
-        assert False, "dataset datalad id is not a valid uuid4"
+    # Create a new commit
+    file_path = os.path.join(ds.path, 'LICENSE')
+    with open(file_path, 'w') as fd:
+        fd.write("""MIT""")
+    commit_files(datalad_store, ds_id, ['LICENSE'])
     # Verify the branch is now set to main
     assert ds.repo.get_active_branch() == 'main'
 

--- a/services/datalad/tests/test_git.py
+++ b/services/datalad/tests/test_git.py
@@ -33,7 +33,7 @@ def test_git_refs_resource(client):
     assert len(lines) == 6
     assert 'service=git-receive-pack' in lines[0]
     # Check master ref looks right
-    assert lines[3][0:4] == '003f'
+    assert lines[3][0:4] == '003d'
     assert lines[3][4:44].isalnum()  # 40 character sha256
     assert lines[3][44] == ' '  # delimiter
     assert lines[3][45:] == 'refs/heads/main'

--- a/services/datalad/tests/test_git.py
+++ b/services/datalad/tests/test_git.py
@@ -36,7 +36,7 @@ def test_git_refs_resource(client):
     assert lines[3][0:4] == '003f'
     assert lines[3][4:44].isalnum()  # 40 character sha256
     assert lines[3][44] == ' '  # delimiter
-    assert lines[3][45:] == 'refs/heads/master'
+    assert lines[3][45:] == 'refs/heads/main'
 
 
 def test_git_upload_resource(client):

--- a/services/datalad/tests/test_publish.py
+++ b/services/datalad/tests/test_publish.py
@@ -53,5 +53,6 @@ def test_export_snapshots(no_init_remote, client, new_dataset):
                     call(new_dataset.path, 's3-PUBLIC', 'refs/tags/2.0.0')]
     s3_export_mock.assert_has_calls(expect_calls)
     assert github_export_mock.call_count == 1
-    expect_calls = [call(new_dataset.path, 'refs/tags/2.0.0')]
+    dataset_id = os.path.basename(new_dataset.path)
+    expect_calls = [call(dataset_id, new_dataset.path, 'refs/tags/2.0.0')]
     github_export_mock.assert_has_calls(expect_calls)

--- a/services/datalad/tests/test_snapshots.py
+++ b/services/datalad/tests/test_snapshots.py
@@ -88,8 +88,8 @@ def test_pre_snapshot_edit(client, new_dataset):
     response = client.simulate_post(
         '/datasets/{}/snapshots/{}'.format(ds_id, snapshot_id), json={'skip_publishing': True})
     assert response.status == falcon.HTTP_OK
-    # Validate that create_snapshot has not moved master commit
-    with open(os.path.join(new_dataset.path, '.git/refs/heads/master')) as fd:
+    # Validate that create_snapshot has not moved main commit
+    with open(os.path.join(new_dataset.path, '.git/refs/heads/main')) as fd:
         current_ref = fd.read()[:-1]
         assert commit_ref == current_ref
 


### PR DESCRIPTION
This updates some mismatched master branch usage to always use main.

* On new commits, this will rename the master branch to main if required before making the commit. Updates symbolic HEAD reference so that new operations implicitly use the main branch.
* When pushing to GitHub, both main and master branches are pushed. Sets the default branch and repo description/name on pushes.
* New test that creates a default master branch Datalad repo and then updates it to use main on git_commit.