### PR TITLE
Fix retry file upload errors with native fetch on Node 18

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,5 +3,5 @@
   "packages": ["packages/*"],
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "version": "4.14.0"
+  "version": "4.14.1-alpha.0"
 }

--- a/packages/openneuro-app/package.json
+++ b/packages/openneuro-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openneuro/app",
-  "version": "4.14.0",
+  "version": "4.14.1-alpha.0",
   "description": "React JS web frontend for the OpenNeuro platform.",
   "license": "MIT",
   "main": "public/client.js",
@@ -20,8 +20,8 @@
     "@emotion/react": "11.6.0",
     "@emotion/styled": "11.6.0",
     "@niivue/niivue": "0.23.1",
-    "@openneuro/client": "^4.14.0",
-    "@openneuro/components": "^4.14.0",
+    "@openneuro/client": "^4.14.1-alpha.0",
+    "@openneuro/components": "^4.14.1-alpha.0",
     "bids-validator": "1.9.9",
     "bytes": "^3.0.0",
     "comlink": "^4.0.5",

--- a/packages/openneuro-cli/README.md
+++ b/packages/openneuro-cli/README.md
@@ -9,7 +9,7 @@ This tool allows you to upload and download [OpenNeuro.org](https://openneuro.or
 
 ## Install
 
-1. Install [Node.js](https://nodejs.org) (version 16 or higher)
+1. Install [Node.js](https://nodejs.org) (version 18 or higher)
 2. In a terminal type: `npm install -g @openneuro/cli`
 
 If you are using [yarn](https://yarnpkg.com/) you can also perform the installation with `yarn global add @openneuro/cli`

--- a/packages/openneuro-cli/package.json
+++ b/packages/openneuro-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openneuro/cli",
-  "version": "4.14.0",
+  "version": "4.14.1-alpha.0",
   "description": "OpenNeuro command line uploader / editor.",
   "main": "index.js",
   "repository": "git@github.com:OpenNeuroOrg/openneuro.git",
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@apollo/client": "3.7.2",
-    "@openneuro/client": "^4.14.0",
+    "@openneuro/client": "^4.14.1-alpha.0",
     "bids-validator": "1.9.9",
     "cli-progress": "^3.8.2",
     "commander": "7.2.0",

--- a/packages/openneuro-client/package.json
+++ b/packages/openneuro-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openneuro/client",
-  "version": "4.14.0",
+  "version": "4.14.1-alpha.0",
   "description": "OpenNeuro shared client library.",
   "main": "dist/index.js",
   "browser": "src/index.js",
@@ -27,7 +27,7 @@
   "devDependencies": {
     "@babel/preset-typescript": "^7.14.5",
     "@babel/runtime-corejs3": "^7.13.10",
-    "@openneuro/server": "^4.14.0",
+    "@openneuro/server": "^4.14.1-alpha.0",
     "apollo-server": "^2.23.0",
     "core-js": "^3.10.1",
     "vitest": "^0.25.2"

--- a/packages/openneuro-components/package.json
+++ b/packages/openneuro-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openneuro/components",
-  "version": "4.14.0",
+  "version": "4.14.1-alpha.0",
   "description": "OpenNeuro component library and Storybook configuration",
   "main": "dist/index.js",
   "browser": "src/index.js",

--- a/packages/openneuro-indexer/package.json
+++ b/packages/openneuro-indexer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openneuro/indexer",
-  "version": "4.14.0",
+  "version": "4.14.1-alpha.0",
   "description": "OpenNeuro elastic search indexing tool",
   "main": "./dist/index.js",
   "types": "./src/index.d.ts",
@@ -11,8 +11,8 @@
   "dependencies": {
     "@apollo/client": "3.7.2",
     "@elastic/elasticsearch": "7.15.0",
-    "@openneuro/client": "^4.14.0",
-    "@openneuro/search": "^4.14.0",
+    "@openneuro/client": "^4.14.1-alpha.0",
+    "@openneuro/search": "^4.14.1-alpha.0",
     "apollo-link-retry": "^2.2.16",
     "ts-node": "^9.1.1",
     "typescript": "4.5.4"

--- a/packages/openneuro-search/package.json
+++ b/packages/openneuro-search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openneuro/search",
-  "version": "4.14.0",
+  "version": "4.14.1-alpha.0",
   "description": "OpenNeuro search client functions.",
   "main": "dist/index.js",
   "browser": "src/index.ts",

--- a/packages/openneuro-server/package.json
+++ b/packages/openneuro-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openneuro/server",
-  "version": "4.14.0",
+  "version": "4.14.1-alpha.0",
   "description": "Core service for the OpenNeuro platform.",
   "license": "MIT",
   "main": "src/server.js",
@@ -17,7 +17,7 @@
   "dependencies": {
     "@apollo/client": "3.7.2",
     "@elastic/elasticsearch": "7.15.0",
-    "@openneuro/search": "^4.14.0",
+    "@openneuro/search": "^4.14.1-alpha.0",
     "@passport-next/passport-google-oauth2": "^1.0.0",
     "@sentry/node": "^4.5.3",
     "apollo-server": "2.25.4",


### PR DESCRIPTION
Two fixes here as reported in #2742

1. File upload retries were broken after the switch to native fetch, it's standard that a Request object cannot be reused and our implementation reused this since it works on non-standard polyfills we had been using.
2. The npm install of the CLI tool was not working because Node's implementation of fetch does not support the standard argument of a web stream as the body of the request. Instead we switch to a non-standard Node only method of building the request here passing in an AsyncIterable as the body.