### PR TITLE
Fix missing/incorrect dataset titles for snapshots

### DIFF
--- a/packages/openneuro-server/src/datalad/__tests__/description.spec.js
+++ b/packages/openneuro-server/src/datalad/__tests__/description.spec.js
@@ -1,7 +1,6 @@
 import request from 'superagent'
 import {
   getDescriptionObject,
-  defaultDescription,
   repairDescriptionTypes,
   appendSeniorAuthor,
 } from '../description.js'
@@ -96,9 +95,7 @@ describe('datalad dataset descriptions', () => {
       body: { Name: 'Balloon Analog Risk-taking Task' },
       type: 'application/json',
     })
-    const description = await getDescriptionObject('ds000001')([
-      { filename: 'dataset_description.json', id: '12345' },
-    ])
+    const description = await getDescriptionObject('ds000001', '1.0.0')
     expect(description).toEqual({ Name: 'Balloon Analog Risk-taking Task' })
   })
   it('handles a corrupted response', async () => {
@@ -106,15 +103,11 @@ describe('datalad dataset descriptions', () => {
     request.__setMockResponse({
       body: Buffer.from('0x5f3759df', 'hex'),
     })
-    const description = await getDescriptionObject('ds000001')([
-      { filename: 'dataset_description.json', id: '12345' },
-    ])
-    expect(description).toEqual(defaultDescription)
+    const description = await getDescriptionObject('ds000001', '1.0.0')
+    expect(description).toEqual({ Name: 'ds000001', BIDSVersion: '1.8.0' })
   })
   it('works without a dataset_description.json being present', async () => {
-    const description = await getDescriptionObject('ds000001')([
-      { filename: 'LICENSE', id: '12345' },
-    ])
-    expect(description).toEqual(defaultDescription)
+    const description = await getDescriptionObject('ds000001', '1.0.0')
+    expect(description).toEqual({ Name: 'ds000001', BIDSVersion: '1.8.0' })
   })
 })

--- a/packages/openneuro-server/src/datalad/description.js
+++ b/packages/openneuro-server/src/datalad/description.js
@@ -11,17 +11,16 @@ import { getDatasetWorker } from '../libs/datalad-service'
 import CacheItem, { CacheType } from '../cache/item'
 import { datasetOrSnapshot } from '../utils/datasetOrSnapshot'
 
-export const defaultDescription = {
-  Name: 'Unnamed Dataset',
-  BIDSVersion: '1.1.1',
-}
-
 /**
  * Find dataset_description.json id and fetch description object
  * @param {string} datasetId
  * @returns {(files: [Record<string, unknown>]) => Promise<Record<string, unknown>>} Promise resolving to dataset_description.json contents or defaults
  */
 export const getDescriptionObject = datasetId => files => {
+  const defaultDescription = {
+    Name: datasetId,
+    BIDSVersion: '1.8.0',
+  }
   const file = files.find(f => f.filename === 'dataset_description.json')
   if (file) {
     return request

--- a/packages/openneuro-server/src/datalad/files.js
+++ b/packages/openneuro-server/src/datalad/files.js
@@ -34,13 +34,19 @@ export const getFileName = (path, filename) => {
  * @param {String} datasetId
  * @param {String} path - Relative path for the file
  * @param {String} filename
+ * @param {String} [revision] - Git hash of commit or tree owning this file
  */
-export const fileUrl = (datasetId, path, filename) => {
+export const fileUrl = (datasetId, path, filename, revision) => {
   const fileName = getFileName(path, filename)
-  const url = `http://${getDatasetWorker(
-    datasetId,
-  )}/datasets/${datasetId}/files/${fileName}`
-  return url
+  if (revision) {
+    return `http://${getDatasetWorker(
+      datasetId,
+    )}/datasets/${datasetId}/snapshots/${revision}/files/${fileName}`
+  } else {
+    return `http://${getDatasetWorker(
+      datasetId,
+    )}/datasets/${datasetId}/files/${fileName}`
+  }
 }
 
 /**


### PR DESCRIPTION
* Returns the accession number instead of "Unnamed Dataset" when dataset_description.json is missing or contains unreadable JSON.
* Fixes an issue where some snapshot queries would return the draft dataset_description.json when using the Description field.