### PR TITLE
fix(cli): Fix warning about max listeners while uploading files

### DIFF
--- a/packages/openneuro-cli/src/upload.js
+++ b/packages/openneuro-cli/src/upload.js
@@ -1,3 +1,4 @@
+import { setMaxListeners } from 'events'
 import cliProgress from 'cli-progress'
 import path from 'path'
 import inquirer from 'inquirer'
@@ -152,6 +153,8 @@ export const uploadFiles = async ({
   const controller = new AbortController()
   // Limit open file handles for streams to avoid consuming extra file handles
   const MAX_STREAM_HANDLES = 512
+  // Raise listeners to stream handles + 16 slots for downstream listeners
+  setMaxListeners(MAX_STREAM_HANDLES + 16, controller.signal)
   for (let n = 0; n < files.length; n += MAX_STREAM_HANDLES) {
     const filesChunk = files.slice(n, n + MAX_STREAM_HANDLES)
     const requests = filesChunk.map(file => {


### PR DESCRIPTION
This AbortController is meant to control cancellation for all pending upload requests, which is up to MAX_STREAM_HANDLES. The additional 16 are for any later listeners that need to add additional events (one is used to determine if the request is aborted but leaving space for others in the future).

```
=======================================================================
87 files to be uploaded with a total size of 394.2 MB
? Begin upload? Yes
=======================================================================
Starting a new upload (22d5e277) to dataset: 'ds001081'
ds001081 [----------------------------------------] 0% | ETA: 0s | 0/87
(node:511129) MaxListenersExceededWarning: Possible EventTarget memory leak detected. 11 abort listeners added to [AbortSignal]. Use events.setMaxListeners() to increase limit
    at [kNewListener] (node:internal/event_target:472:17)
    at [kNewListener] (node:internal/abort_controller:180:24)
    at AbortSignal.addEventListener (node:internal/event_target:581:23)
    at new Request (node:internal/deps/undici/undici:5669:20)
    at /home/nell/openneuro-cli/node_modules/@openneuro/cli/src/upload.js:162:14
    at Array.map (<anonymous>)
    at uploadFiles (/home/nell/openneuro-cli/node_modules/@openneuro/cli/src/upload.js:158:33)
    at uploadDataset (/home/nell/openneuro-cli/node_modules/@openneuro/cli/src/actions.js:99:13)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
```

This is just a warning but related to the issue in #2748 and #2750