### PR TITLE
fix(cli): Improve retry delay interval and reduce parallelism

### DIFF
--- a/packages/openneuro-client/src/__tests__/uploads.spec.js
+++ b/packages/openneuro-client/src/__tests__/uploads.spec.js
@@ -18,9 +18,9 @@ describe('upload implementation', () => {
     it('returns a minimum of 2', () => {
       expect(uploadParallelism([{ size: 10 }], 10)).toBe(2)
     })
-    it('returns a maxium of 16', () => {
+    it('returns a maxium of 8', () => {
       expect(uploadParallelism([{ size: 1000000000000 }], 1000000000000)).toBe(
-        16,
+        8,
       )
     })
     it('returns a useful value in the middle for some datasets', () => {

--- a/packages/openneuro-client/src/uploads.js
+++ b/packages/openneuro-client/src/uploads.js
@@ -85,8 +85,8 @@ export function hashFileList(datasetId, files) {
 export function uploadParallelism(requests, bytes) {
   const averageSize = bytes / requests.length
   const parallelism = averageSize / 524288 // 512KB
-  if (parallelism > 16) {
-    return 16
+  if (parallelism > 8) {
+    return 8
   } else if (parallelism < 2) {
     return 2
   } else {
@@ -110,7 +110,7 @@ export function parseFilename(url) {
  */
 export async function retryDelay(step, request) {
   if (step <= 4) {
-    await new Promise(r => setTimeout(r, step ** 4))
+    await new Promise(r => setTimeout(r, step ** 2 * 1000))
   } else {
     throw new Error(
       `Failed to upload file after ${step} attempts - "${request.url}"`,


### PR DESCRIPTION
This should improve reliability for large and long running uploads. Delay is increased to n^2 seconds per retry. Reducing parallelism to 8 reduces the risk of stampede effects failing multiple retries. Main issue here is the retry delay is initially tiny (it is milliseconds but seconds was likely the intention?) which results in a lot of requests and then later retries fail quickly just because of request volume. Halving the max running requests and extending the delay on the first few requests by starting with a one second delay reduces the request count to avoid repeat failures.

This should fix #2748 and #2750