### PR TITLE
docs: Add a workaround for downloading annexed objects with the openneuro special remote handler

### DIFF
--- a/docs/git.md
+++ b/docs/git.md
@@ -122,5 +122,5 @@ git annex copy --to openneuro
 To download annexed objects from the remote, you may need to manually ask git-annex update the local state of the OpenNeuro remote. You can force this update for all files:
 
 ```shell
-git-annex fsck --fast --from openneuro
+git annex fsck --fast --from openneuro
 ```

--- a/docs/git.md
+++ b/docs/git.md
@@ -118,3 +118,9 @@ After this you can use regular git-annex or datalad commands to upload or downlo
 # To upload any annexed objects to the remote
 git annex copy --to openneuro
 ```
+
+To download annexed objects from the remote, you may need to manually ask git-annex update the local state of the OpenNeuro remote. You can force this update for all files:
+
+```shell
+git-annex fsck --fast --from openneuro
+```


### PR DESCRIPTION
Just adding this workaround needed to refresh the available remote objects while getting to the bottom of the underlying issue.