### PR TITLE
fix(cli): Support Node.js 18.13.0+ and 19.1.0+

### DIFF
--- a/packages/openneuro-cli/src/__tests__/setDuplexIfRequired.spec.js
+++ b/packages/openneuro-cli/src/__tests__/setDuplexIfRequired.spec.js
@@ -1,0 +1,29 @@
+import { setDuplexIfRequired } from '../setDuplexIfRequired.js'
+
+describe('setDuplexIfRequired', () => {
+  it('sets duplex on Node 18.13.0', () => {
+    const requestOptions = {}
+    setDuplexIfRequired('18.13.0', requestOptions)
+    expect(requestOptions.duplex).toBe('half')
+  })
+  it('does not set duplex on Node 18.12.1', () => {
+    const requestOptions = {}
+    setDuplexIfRequired('18.12.1', requestOptions)
+    expect(requestOptions.duplex).toBeUndefined()
+  })
+  it('sets duplex on Node 19.1.0', () => {
+    const requestOptions = {}
+    setDuplexIfRequired('19.1.0', requestOptions)
+    expect(requestOptions.duplex).toBe('half')
+  })
+  it('does not set on Node 19.0.1', () => {
+    const requestOptions = {}
+    setDuplexIfRequired('19.0.1', requestOptions)
+    expect(requestOptions.duplex).toBeUndefined()
+  })
+  it('does not set on Node 16.18.1', () => {
+    const requestOptions = {}
+    setDuplexIfRequired('16.18.1', requestOptions)
+    expect(requestOptions.duplex).toBeUndefined()
+  })
+})

--- a/packages/openneuro-cli/src/setDuplexIfRequired.js
+++ b/packages/openneuro-cli/src/setDuplexIfRequired.js
@@ -1,0 +1,10 @@
+/**
+ * Duplex argument is required for Node 18.13.0 and 19.1.0 or later, but not supported at all earlier
+ */
+export function setDuplexIfRequired(version, requestOptions) {
+  const m = version.match(/(\d+)\.(\d+)\.(\d+)/)
+  const [major, minor, patch] = m.slice(1).map(_ => parseInt(_))
+  if ((major >= 18 && minor >= 13) || (major >= 19 && minor >= 1)) {
+    requestOptions.duplex = 'half'
+  }
+}

--- a/packages/openneuro-cli/src/transferKey.js
+++ b/packages/openneuro-cli/src/transferKey.js
@@ -2,6 +2,7 @@ import { Readable } from 'stream'
 import { createWriteStream } from 'fs'
 import { open } from 'fs/promises'
 import { once } from 'events'
+import { setDuplexIfRequired } from './setDuplexIfRequired'
 
 /**
  * Create a Request object for this url and key
@@ -33,7 +34,12 @@ export function keyRequest(state, key, options) {
 export async function storeKey(state, key, file) {
   const f = await open(file, 'r')
   const body = f.readableWebStream()
-  const request = keyRequest(state, key, { body, method: 'POST' })
+  const requestOptions = {
+    body,
+    method: 'POST',
+  }
+  setDuplexIfRequired(process.version, requestOptions)
+  const request = keyRequest(state, key, requestOptions)
   const response = await fetch(request)
   if (response.status === 200) {
     return true


### PR DESCRIPTION
duplex: 'half' is now required on Request objects with a stream body (POST).