### PR TITLE
fix(cli): Revert to node-fetch, native fetch is broken

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -8281,10 +8281,12 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["core-js", "npm:3.18.0"],\
             ["elastic-apm-node", "npm:3.12.1"],\
             ["esm", "npm:3.2.25"],\
+            ["fetch-h2", "npm:3.0.2"],\
             ["inquirer", "npm:5.2.0"],\
             ["jwt-decode", "npm:3.1.2"],\
             ["metro-memory-fs", "npm:0.73.3"],\
             ["mkdirp", "npm:1.0.4"],\
+            ["node-fetch", "virtual:90f6a129d8adfee793b93ece48b319375c46f70206be38f532b28e127912d214b54604b30e8cb269ad6cd82b0db01373baefbe471fefa8ff4f96f22e6afba034#npm:2.6.9"],\
             ["react", "npm:17.0.2"],\
             ["vitest", "virtual:133165406520d697b59bfd8a87da656a1201b50380fa7b6c96355187dd672b60916478120380b134e3b9f4bd0e9b90596200bbcdd3d1635211c23f790d0912a9#npm:0.25.2"]\
           ],\
@@ -9741,6 +9743,13 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@types/tough-cookie", "npm:4.0.1"]\
           ],\
           "linkType": "HARD"\
+        }],\
+        ["npm:4.0.2", {\
+          "packageLocation": "./.yarn/cache/@types-tough-cookie-npm-4.0.2-9e61f877e6-e055556ffd.zip/node_modules/@types/tough-cookie/",\
+          "packageDependencies": [\
+            ["@types/tough-cookie", "npm:4.0.2"]\
+          ],\
+          "linkType": "HARD"\
         }]\
       ]],\
       ["@types/treeify", [\
@@ -10574,6 +10583,15 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "packagePeers": [\
             "@types/ajv",\
             "ajv"\
+          ],\
+          "linkType": "HARD"\
+        }]\
+      ]],\
+      ["already", [\
+        ["npm:2.2.1", {\
+          "packageLocation": "./.yarn/cache/already-npm-2.2.1-764d18dba8-34f16dd91d.zip/node_modules/already/",\
+          "packageDependencies": [\
+            ["already", "npm:2.2.1"]\
           ],\
           "linkType": "HARD"\
         }]\
@@ -12744,6 +12762,15 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "packageDependencies": [\
             ["caller-path", "npm:2.0.0"],\
             ["caller-callsite", "npm:2.0.0"]\
+          ],\
+          "linkType": "HARD"\
+        }]\
+      ]],\
+      ["callguard", [\
+        ["npm:2.0.0", {\
+          "packageLocation": "./.yarn/cache/callguard-npm-2.0.0-2a595eb843-0dccd585ff.zip/node_modules/callguard/",\
+          "packageDependencies": [\
+            ["callguard", "npm:2.0.0"]\
           ],\
           "linkType": "HARD"\
         }]\
@@ -16459,6 +16486,22 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "linkType": "HARD"\
         }]\
       ]],\
+      ["fetch-h2", [\
+        ["npm:3.0.2", {\
+          "packageLocation": "./.yarn/cache/fetch-h2-npm-3.0.2-d066cbb0f9-7814fd95e5.zip/node_modules/fetch-h2/",\
+          "packageDependencies": [\
+            ["fetch-h2", "npm:3.0.2"],\
+            ["@types/tough-cookie", "npm:4.0.2"],\
+            ["already", "npm:2.2.1"],\
+            ["callguard", "npm:2.0.0"],\
+            ["get-stream", "npm:6.0.1"],\
+            ["through2", "npm:4.0.2"],\
+            ["to-arraybuffer", "npm:1.0.1"],\
+            ["tough-cookie", "npm:4.0.0"]\
+          ],\
+          "linkType": "HARD"\
+        }]\
+      ]],\
       ["fflate", [\
         ["npm:0.7.3", {\
           "packageLocation": "./.yarn/cache/fflate-npm-0.7.3-875c2ba15f-6d0908c546.zip/node_modules/fflate/",\
@@ -17075,6 +17118,13 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "packageDependencies": [\
             ["get-stream", "npm:5.2.0"],\
             ["pump", "npm:3.0.0"]\
+          ],\
+          "linkType": "HARD"\
+        }],\
+        ["npm:6.0.1", {\
+          "packageLocation": "./.yarn/cache/get-stream-npm-6.0.1-83e51a4642-e04ecece32.zip/node_modules/get-stream/",\
+          "packageDependencies": [\
+            ["get-stream", "npm:6.0.1"]\
           ],\
           "linkType": "HARD"\
         }]\
@@ -21532,6 +21582,27 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "packageDependencies": [\
             ["node-fetch", "npm:2.6.5"],\
             ["whatwg-url", "npm:5.0.0"]\
+          ],\
+          "linkType": "HARD"\
+        }],\
+        ["npm:2.6.9", {\
+          "packageLocation": "./.yarn/cache/node-fetch-npm-2.6.9-9fc9a54529-acb04f9ce7.zip/node_modules/node-fetch/",\
+          "packageDependencies": [\
+            ["node-fetch", "npm:2.6.9"]\
+          ],\
+          "linkType": "SOFT"\
+        }],\
+        ["virtual:90f6a129d8adfee793b93ece48b319375c46f70206be38f532b28e127912d214b54604b30e8cb269ad6cd82b0db01373baefbe471fefa8ff4f96f22e6afba034#npm:2.6.9", {\
+          "packageLocation": "./.yarn/__virtual__/node-fetch-virtual-e65c32dbfb/0/cache/node-fetch-npm-2.6.9-9fc9a54529-acb04f9ce7.zip/node_modules/node-fetch/",\
+          "packageDependencies": [\
+            ["node-fetch", "virtual:90f6a129d8adfee793b93ece48b319375c46f70206be38f532b28e127912d214b54604b30e8cb269ad6cd82b0db01373baefbe471fefa8ff4f96f22e6afba034#npm:2.6.9"],\
+            ["@types/encoding", null],\
+            ["encoding", null],\
+            ["whatwg-url", "npm:5.0.0"]\
+          ],\
+          "packagePeers": [\
+            "@types/encoding",\
+            "encoding"\
           ],\
           "linkType": "HARD"\
         }]\
@@ -27045,6 +27116,15 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "packageDependencies": [\
             ["tmp", "npm:0.2.1"],\
             ["rimraf", "npm:3.0.2"]\
+          ],\
+          "linkType": "HARD"\
+        }]\
+      ]],\
+      ["to-arraybuffer", [\
+        ["npm:1.0.1", {\
+          "packageLocation": "./.yarn/cache/to-arraybuffer-npm-1.0.1-a57b097c21-31433c10b3.zip/node_modules/to-arraybuffer/",\
+          "packageDependencies": [\
+            ["to-arraybuffer", "npm:1.0.1"]\
           ],\
           "linkType": "HARD"\
         }]\

--- a/packages/openneuro-cli/package.json
+++ b/packages/openneuro-cli/package.json
@@ -22,9 +22,11 @@
     "commander": "7.2.0",
     "elastic-apm-node": "3.12.1",
     "esm": "^3.0.16",
+    "fetch-h2": "^3.0.2",
     "inquirer": "^5.2.0",
     "jwt-decode": "^3.1.2",
     "mkdirp": "1.0.4",
+    "node-fetch": "2.6.9",
     "react": "^17.0.1"
   },
   "scripts": {

--- a/packages/openneuro-cli/src/cli.js
+++ b/packages/openneuro-cli/src/cli.js
@@ -5,10 +5,6 @@ import { login, upload, download, ls } from './actions.js'
 import { gitCredential } from './gitCredential.js'
 import { gitAnnexRemote } from './gitAnnexRemote.js'
 import { create } from './createDataset.js'
-import dns from 'dns'
-
-// this fixes a bug in Node.js - it should be fixed _eventually_ and can be removed: https://github.com/nodejs/undici/issues/1248
-dns.setDefaultResultOrder('ipv4first')
 
 commander.version(version).description('OpenNeuro command line tools.')
 

--- a/packages/openneuro-cli/src/configuredClient.js
+++ b/packages/openneuro-cli/src/configuredClient.js
@@ -1,9 +1,12 @@
 import { createClient } from '@openneuro/client'
 import { getToken, getUrl } from './config.js'
 import { version } from './lerna.json'
+import fetch from 'node-fetch'
 
-export const configuredClient = () =>
-  createClient(`${getUrl()}crn/graphql`, {
+export const configuredClient = () => {
+  return createClient(`${getUrl()}crn/graphql`, {
     getAuthorization: getToken,
     clientVersion: version,
+    fetch,
   })
+}

--- a/packages/openneuro-cli/src/download.js
+++ b/packages/openneuro-cli/src/download.js
@@ -4,7 +4,7 @@ import mkdirp from 'mkdirp'
 import cliProgress from 'cli-progress'
 import { getToken } from './config.js'
 import { downloadDataset } from './datasets'
-import { fetch } from 'fetch-h2'
+import fetch from 'node-fetch'
 
 export const checkDestination = destination => {
   if (fs.existsSync(destination)) {
@@ -67,7 +67,6 @@ export const downloadFile = async (
       const response = await fetch(fileUrl, {
         headers: getFetchHeaders(),
       })
-      // @ts-expect-error This is defined?
       const stream = response.body
       if (response.status === 200) {
         // Setup end/error handler with Promise interface

--- a/packages/openneuro-cli/src/download.js
+++ b/packages/openneuro-cli/src/download.js
@@ -1,10 +1,10 @@
 import fs from 'fs'
 import path from 'path'
-import { Readable } from 'stream'
 import mkdirp from 'mkdirp'
 import cliProgress from 'cli-progress'
 import { getToken } from './config.js'
 import { downloadDataset } from './datasets'
+import { fetch } from 'fetch-h2'
 
 export const checkDestination = destination => {
   if (fs.existsSync(destination)) {
@@ -67,8 +67,8 @@ export const downloadFile = async (
       const response = await fetch(fileUrl, {
         headers: getFetchHeaders(),
       })
-      /** @ts-expect-error @type {import('stream').Readable} */
-      const stream = Readable.fromWeb(response.body)
+      // @ts-expect-error This is defined?
+      const stream = response.body
       if (response.status === 200) {
         // Setup end/error handler with Promise interface
         const responsePromise = new Promise((resolve, reject) => {

--- a/packages/openneuro-cli/src/transferKey.js
+++ b/packages/openneuro-cli/src/transferKey.js
@@ -1,6 +1,6 @@
 import { createWriteStream, createReadStream } from 'fs'
 import { once } from 'events'
-import { fetch, Request } from 'fetch-h2'
+import fetch, { Request } from 'node-fetch'
 
 /**
  * Create a Request object for this url and key

--- a/packages/openneuro-cli/src/transferKey.js
+++ b/packages/openneuro-cli/src/transferKey.js
@@ -1,8 +1,6 @@
-import { Readable } from 'stream'
-import { createWriteStream } from 'fs'
-import { open } from 'fs/promises'
+import { createWriteStream, createReadStream } from 'fs'
 import { once } from 'events'
-import { setDuplexIfRequired } from './setDuplexIfRequired'
+import { fetch, Request } from 'fetch-h2'
 
 /**
  * Create a Request object for this url and key
@@ -32,13 +30,11 @@ export function keyRequest(state, key, options) {
  * @param {string} file File path
  */
 export async function storeKey(state, key, file) {
-  const f = await open(file, 'r')
-  const body = f.readableWebStream()
+  const body = createReadStream(file)
   const requestOptions = {
     body,
     method: 'POST',
   }
-  setDuplexIfRequired(process.version, requestOptions)
   const request = keyRequest(state, key, requestOptions)
   const response = await fetch(request)
   if (response.status === 200) {
@@ -62,8 +58,8 @@ export async function retrieveKey(state, key, file) {
     const response = await fetch(request)
     if (response.status === 200) {
       const writable = createWriteStream(file)
-      // @ts-ignore-error ReadableStream<any> is more accurate here but response.body returns incompatible ReadableStream<Uint8Array>?
-      const readable = Readable.fromWeb(response.body)
+      // @ts-expect-error
+      const readable = response.body
       readable.pipe(writable)
       await once(readable, 'close')
       return true

--- a/packages/openneuro-cli/src/transferKey.js
+++ b/packages/openneuro-cli/src/transferKey.js
@@ -58,8 +58,7 @@ export async function retrieveKey(state, key, file) {
     const response = await fetch(request)
     if (response.status === 200) {
       const writable = createWriteStream(file)
-      // @ts-expect-error
-      const readable = response.body
+      const readable = await response.readable()
       readable.pipe(writable)
       await once(readable, 'close')
       return true

--- a/packages/openneuro-cli/src/upload.js
+++ b/packages/openneuro-cli/src/upload.js
@@ -1,4 +1,3 @@
-import { setMaxListeners } from 'events'
 import cliProgress from 'cli-progress'
 import path from 'path'
 import inquirer from 'inquirer'

--- a/yarn.lock
+++ b/yarn.lock
@@ -5214,8 +5214,8 @@ __metadata:
     "@emotion/react": 11.6.0
     "@emotion/styled": 11.6.0
     "@niivue/niivue": 0.23.1
-    "@openneuro/client": ^4.15.1
-    "@openneuro/components": ^4.15.1
+    "@openneuro/client": ^4.15.2-alpha.11
+    "@openneuro/components": ^4.15.2-alpha.11
     "@testing-library/jest-dom": ^5.11.4
     "@testing-library/react": ^11.1.0
     "@types/jsdom": ^16
@@ -5267,7 +5267,7 @@ __metadata:
   dependencies:
     "@apollo/client": 3.7.2
     "@babel/runtime-corejs3": ^7.13.10
-    "@openneuro/client": ^4.15.1
+    "@openneuro/client": ^4.15.2-alpha.11
     "@types/mkdirp": 1.0.2
     "@types/node": 18.11.9
     bids-validator: 1.9.9
@@ -5276,10 +5276,12 @@ __metadata:
     core-js: ^3.10.1
     elastic-apm-node: 3.12.1
     esm: ^3.0.16
+    fetch-h2: ^3.0.2
     inquirer: ^5.2.0
     jwt-decode: ^3.1.2
     metro-memory-fs: ^0.73.3
     mkdirp: 1.0.4
+    node-fetch: 2.6.9
     react: ^17.0.1
     vitest: ^0.25.2
   bin:
@@ -5289,14 +5291,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@openneuro/client@^4.15.1, @openneuro/client@workspace:packages/openneuro-client":
+"@openneuro/client@^4.15.2-alpha.11, @openneuro/client@workspace:packages/openneuro-client":
   version: 0.0.0-use.local
   resolution: "@openneuro/client@workspace:packages/openneuro-client"
   dependencies:
     "@apollo/client": 3.7.2
     "@babel/preset-typescript": ^7.14.5
     "@babel/runtime-corejs3": ^7.13.10
-    "@openneuro/server": ^4.15.1
+    "@openneuro/server": ^4.15.2-alpha.11
     apollo-server: ^2.23.0
     core-js: ^3.10.1
     crypto-hash: ^1.3.0
@@ -5308,7 +5310,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@openneuro/components@^4.15.1, @openneuro/components@workspace:packages/openneuro-components":
+"@openneuro/components@^4.15.2-alpha.11, @openneuro/components@workspace:packages/openneuro-components":
   version: 0.0.0-use.local
   resolution: "@openneuro/components@workspace:packages/openneuro-components"
   dependencies:
@@ -5356,8 +5358,8 @@ __metadata:
     "@apollo/client": 3.7.2
     "@babel/runtime-corejs3": ^7.13.10
     "@elastic/elasticsearch": 7.15.0
-    "@openneuro/client": ^4.15.1
-    "@openneuro/search": ^4.15.1
+    "@openneuro/client": ^4.15.2-alpha.11
+    "@openneuro/search": ^4.15.2-alpha.11
     "@types/jsonwebtoken": ^8
     "@types/node": 18.11.9
     "@types/tsc-watch": ^4
@@ -5371,7 +5373,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@openneuro/search@^4.15.1, @openneuro/search@workspace:packages/openneuro-search":
+"@openneuro/search@^4.15.2-alpha.11, @openneuro/search@workspace:packages/openneuro-search":
   version: 0.0.0-use.local
   resolution: "@openneuro/search@workspace:packages/openneuro-search"
   dependencies:
@@ -5386,7 +5388,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@openneuro/server@^4.15.1, @openneuro/server@workspace:packages/openneuro-server":
+"@openneuro/server@^4.15.2-alpha.11, @openneuro/server@workspace:packages/openneuro-server":
   version: 0.0.0-use.local
   resolution: "@openneuro/server@workspace:packages/openneuro-server"
   dependencies:
@@ -5398,7 +5400,7 @@ __metadata:
     "@babel/preset-env": ^7.6.3
     "@babel/runtime-corejs3": ^7.13.10
     "@elastic/elasticsearch": 7.15.0
-    "@openneuro/search": ^4.15.1
+    "@openneuro/search": ^4.15.2-alpha.11
     "@passport-next/passport-google-oauth2": ^1.0.0
     "@sentry/node": ^4.5.3
     "@types/draft-js": ^0.10.43
@@ -6523,6 +6525,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/tough-cookie@npm:^4.0.0":
+  version: 4.0.2
+  resolution: "@types/tough-cookie@npm:4.0.2"
+  checksum: e055556ffdaa39ad85ede0af192c93f93f986f4bd9e9426efdc2948e3e2632db3a4a584d4937dbf6d7620527419bc99e6182d3daf2b08685e710f2eda5291905
+  languageName: node
+  linkType: hard
+
 "@types/treeify@npm:^1.0.0":
   version: 1.0.0
   resolution: "@types/treeify@npm:1.0.0"
@@ -7206,6 +7215,13 @@ __metadata:
     require-from-string: ^2.0.2
     uri-js: ^4.2.2
   checksum: 690ffb9408415fdab43686b3f92037ba0c8362f5d0709a123ba3fb546e6ad81414455f80a2b5cc432ce924afe9864671198f022bc331a19c072d4ede152ec3ca
+  languageName: node
+  linkType: hard
+
+"already@npm:^2.2.1":
+  version: 2.2.1
+  resolution: "already@npm:2.2.1"
+  checksum: 34f16dd91d8dd48f74b0f5a751872697c745cd815e758d32552166789928690254bdddc964423bdece5b201ae583ddc477f4f97ecc5d6d54ec0edcf1bd3ddb77
   languageName: node
   linkType: hard
 
@@ -8845,6 +8861,13 @@ __metadata:
   dependencies:
     caller-callsite: ^2.0.0
   checksum: 3e12ccd0c71ec10a057aac69e3ec175b721ca858c640df021ef0d25999e22f7c1d864934b596b7d47038e9b56b7ec315add042abbd15caac882998b50102fb12
+  languageName: node
+  linkType: hard
+
+"callguard@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "callguard@npm:2.0.0"
+  checksum: 0dccd585ff46f89b64ce2cf212c6bb36d4ba6c681b1b811ed225f15e1fc6a458714dfd93c3e0c54790bb1da307a6223e51a6d1b589bc5a9a8b93d32cb77d756d
   languageName: node
   linkType: hard
 
@@ -12029,6 +12052,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fetch-h2@npm:^3.0.2":
+  version: 3.0.2
+  resolution: "fetch-h2@npm:3.0.2"
+  dependencies:
+    "@types/tough-cookie": ^4.0.0
+    already: ^2.2.1
+    callguard: ^2.0.0
+    get-stream: ^6.0.1
+    through2: ^4.0.2
+    to-arraybuffer: ^1.0.1
+    tough-cookie: ^4.0.0
+  checksum: 7814fd95e51b3b4529eb3807b7b2b044d548decf284fa39b5d8946f80e4ae44f4eb9e0d813a709cfee2c6a2de53c1a4e74181a657c5c022ac1355bd4d647561e
+  languageName: node
+  linkType: hard
+
 "fflate@npm:^0.7.3":
   version: 0.7.3
   resolution: "fflate@npm:0.7.3"
@@ -12588,6 +12626,13 @@ fsevents@~2.3.2:
   dependencies:
     pump: ^3.0.0
   checksum: 8bc1a23174a06b2b4ce600df38d6c98d2ef6d84e020c1ddad632ad75bac4e092eeb40e4c09e0761c35fc2dbc5e7fff5dab5e763a383582c4a167dd69a905bd12
+  languageName: node
+  linkType: hard
+
+"get-stream@npm:^6.0.1":
+  version: 6.0.1
+  resolution: "get-stream@npm:6.0.1"
+  checksum: e04ecece32c92eebf5b8c940f51468cd53554dcbb0ea725b2748be583c9523d00128137966afce410b9b051eb2ef16d657cd2b120ca8edafcf5a65e81af63cad
   languageName: node
   linkType: hard
 
@@ -16495,6 +16540,20 @@ fsevents@~2.3.2:
   version: 2.6.1
   resolution: "node-fetch@npm:2.6.1"
   checksum: 91075bedd57879117e310fbcc36983ad5d699e522edb1ebcdc4ee5294c982843982652925c3532729fdc86b2d64a8a827797a745f332040d91823c8752ee4d7c
+  languageName: node
+  linkType: hard
+
+"node-fetch@npm:2.6.9":
+  version: 2.6.9
+  resolution: "node-fetch@npm:2.6.9"
+  dependencies:
+    whatwg-url: ^5.0.0
+  peerDependencies:
+    encoding: ^0.1.0
+  peerDependenciesMeta:
+    encoding:
+      optional: true
+  checksum: acb04f9ce7224965b2b59e71b33c639794d8991efd73855b0b250921382b38331ffc9d61bce502571f6cc6e11a8905ca9b1b6d4aeb586ab093e2756a1fd190d0
   languageName: node
   linkType: hard
 
@@ -21179,7 +21238,7 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"through2@npm:^4.0.0":
+"through2@npm:^4.0.0, through2@npm:^4.0.2":
   version: 4.0.2
   resolution: "through2@npm:4.0.2"
   dependencies:
@@ -21240,6 +21299,13 @@ resolve@^2.0.0-next.3:
   dependencies:
     rimraf: ^3.0.0
   checksum: 8b1214654182575124498c87ca986ac53dc76ff36e8f0e0b67139a8d221eaecfdec108c0e6ec54d76f49f1f72ab9325500b246f562b926f85bcdfca8bf35df9e
+  languageName: node
+  linkType: hard
+
+"to-arraybuffer@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "to-arraybuffer@npm:1.0.1"
+  checksum: 31433c10b388722729f5da04c6b2a06f40dc84f797bb802a5a171ced1e599454099c6c5bc5118f4b9105e7d049d3ad9d0f71182b77650e4fdb04539695489941
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes #2763 by reverting the switch to native fetch in a way that doesn't conflict with the experimental fetch option in Node 18. This should work on Node 18 but uses fetch-h2 (for uploads) and node-fetch (for Apollo). Drops several workarounds added to get things working with Node.js native fetch.