### PR TITLE
Automatically redirect when one is provided for a removed dataset

### DIFF
--- a/packages/openneuro-app/src/scripts/dataset/dataset-query.jsx
+++ b/packages/openneuro-app/src/scripts/dataset/dataset-query.jsx
@@ -162,6 +162,14 @@ export const DatasetQueryHook = ({ datasetId, draft }) => {
     if (error.message === 'You do not have access to read this dataset.') {
       return <FourOThreePage />
     } else if (error.message.includes('has been deleted')) {
+      for (const err of error.graphQLErrors) {
+        if (
+          err.extensions.code === 'DELETED_DATASET' &&
+          err.extensions.redirect
+        ) {
+          navigate(err.extensions.redirect)
+        }
+      }
       return <FourOFourPage message={error.message} />
     } else {
       try {


### PR DESCRIPTION
Looks like the UI for this was added as part of the redesign but the actual redirect step wasn't. This returns the redirect if it is a properly formatted URL pointing at another dataset, otherwise it is discarded. This will automatically redirect for most of the uses of this field so far, but we do have some DOI values that could be handled better.

Fixes #2765
