### PR TITLE
Normalize nested directory paths from annexed objects to eliminate failure to resolve '..' in symlinked paths

### DIFF
--- a/services/datalad/datalad_service/handlers/files.py
+++ b/services/datalad/datalad_service/handlers/files.py
@@ -22,8 +22,8 @@ class FilesResource(object):
             # If the file begins with an annex path, return that path
             if file_content[0:4096].find('.git/annex') != -1:
                 # Resolve absolute path for annex target
-                target_path = os.path.join(
-                    ds_path, os.path.dirname(filename), file_content)
+                target_path = os.path.normpath(os.path.join(
+                    ds_path, os.path.dirname(filename), file_content))
                 # Verify the annex path is within the dataset dir
                 if ds_path == os.path.commonpath((ds_path, target_path)):
                     fd = open(target_path, 'rb')


### PR DESCRIPTION
Includes a new test to cover this situation. This affects any nested annexed paths accessed with a commit identifier but I added a history step in the test since that wasn't covered and could have been related.

Fixes #2769 