### PR TITLE
Initial schema validator frontend support

### DIFF
--- a/packages/openneuro-app/src/scripts/uploader/upload-issues.jsx
+++ b/packages/openneuro-app/src/scripts/uploader/upload-issues.jsx
@@ -5,6 +5,7 @@ import { Loading } from '@openneuro/components/loading'
 import Results from '../validation/validation-results.jsx'
 import UploaderContext from './uploader-context.js'
 import validate from '../workers/validate'
+import schemaValidate from '../workers/schema'
 
 const UploadValidatorStatus = ({ issues, next, reset }) => {
   const errorCount = issues.errors.length
@@ -70,7 +71,11 @@ class UploadValidator extends React.Component {
         blacklistModalities: ['Microscopy'],
       },
     }
-    validate(this.props.files, options).then(this.done)
+    if (this.props.schemaValidator) {
+      schemaValidate(this.props.files, options).then(this.done)
+    } else {
+      validate(this.props.files, options).then(this.done)
+    }
   }
 
   /**
@@ -115,12 +120,14 @@ UploadValidator.propTypes = {
   files: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
   next: PropTypes.func,
   reset: PropTypes.func,
+  schemaValidator: PropTypes.bool,
 }
 
 const UploadIssues = () => (
   <UploaderContext.Consumer>
     {uploader => (
       <UploadValidator
+        schemaValidator={uploader.schemaValidator}
         files={uploader.selectedFiles}
         next={() => uploader.setLocation('/upload/metadata')}
         reset={() => uploader.setLocation('/upload')}

--- a/packages/openneuro-app/src/scripts/uploader/upload-select.jsx
+++ b/packages/openneuro-app/src/scripts/uploader/upload-select.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import FileSelect from './file-select'
 import UploaderContext from './uploader-context.js'
+import AdminUser from '../authentication/admin-user'
 
 const UploadSelect = () => (
   <div>
@@ -20,6 +21,18 @@ const UploadSelect = () => (
           </a>{' '}
           to upload
           <FileSelect onChange={uploader.selectFiles} />
+          <AdminUser>
+            <input
+              type="checkbox"
+              id="schema-validator-checkbox"
+              onChange={uploader.toggleSchemaValidator}
+              defaultChecked={uploader.schemaValidator}
+            />
+            <label htmlFor="schema-validator-checkbox">
+              {' '}
+              Use schema based validator
+            </label>
+          </AdminUser>
         </div>
       )}
     </UploaderContext.Consumer>

--- a/packages/openneuro-app/src/scripts/uploader/uploader.jsx
+++ b/packages/openneuro-app/src/scripts/uploader/uploader.jsx
@@ -67,6 +67,10 @@ export class UploadClient extends React.Component {
       failedFiles: new Set(),
       // Abort controller for abandoning the upload
       abortController: null,
+      // Enable the new schema validator
+      schemaValidator: false,
+      // Toggle schemaValidator flag
+      toggleSchemaValidator: this.toggleSchemaValidator,
     }
   }
 
@@ -78,6 +82,13 @@ export class UploadClient extends React.Component {
   setLocation = path => {
     gtag.pageview(path)
     this.setState({ location: locationFactory(path) })
+  }
+
+  /**
+   * Enable or disable schema based validation
+   */
+  toggleSchemaValidator = () => {
+    this.setState({ schemaValidator: !this.state.schemaValidator })
   }
 
   /**

--- a/packages/openneuro-app/src/scripts/validation/validation-results.issues.issue.jsx
+++ b/packages/openneuro-app/src/scripts/validation/validation-results.issues.issue.jsx
@@ -20,7 +20,7 @@ class Issue extends React.Component {
     if (error.character) {
       errLocation += 'Character: ' + error.character + ''
     }
-    if (errLocation == '' && error.evidence) {
+    if (errLocation === '' && error.evidence) {
       errLocation = 'Evidence: '
     }
     if (errLocation) {

--- a/packages/openneuro-app/src/scripts/validation/validation-results.issues.jsx
+++ b/packages/openneuro-app/src/scripts/validation/validation-results.issues.jsx
@@ -11,7 +11,7 @@ class Issues extends React.Component {
   render() {
     const issueFiles = this.props.issues
     const issues = issueFiles.map((issue, index) => {
-      let totalFiles = issue.files.length
+      let totalFiles = issue.files.length || issue.files.size
       if (issue.additionalFileCount) {
         totalFiles += issue.additionalFileCount
       }
@@ -32,7 +32,7 @@ class Issues extends React.Component {
       )
 
       // issue sub-errors
-      const subErrors = issue.files.map((error, index2) => {
+      const subErrors = Array.from(issue.files).map((error, index2) => {
         return error ? (
           <Issue
             type={this.props.issueType}

--- a/packages/openneuro-app/src/scripts/validation/validation-results.issues.jsx
+++ b/packages/openneuro-app/src/scripts/validation/validation-results.issues.jsx
@@ -33,15 +33,31 @@ class Issues extends React.Component {
 
       // issue sub-errors
       const subErrors = Array.from(issue.files).map((error, index2) => {
-        return error ? (
-          <Issue
-            type={this.props.issueType}
-            file={issue.file}
-            error={error}
-            index={index2}
-            key={index2}
-          />
-        ) : null
+        // Schema validator returns multiple files here
+        // map those to the old sub-issue model to display them
+        if (error?.length) {
+          return error.filter(Boolean).map((i, index3) => {
+            return (
+              <Issue
+                type={this.props.issueType}
+                file={i.file}
+                error={i}
+                index={index3}
+                key={index3}
+              />
+            )
+          })
+        } else {
+          return error ? (
+            <Issue
+              type={this.props.issueType}
+              file={issue.file}
+              error={error}
+              index={index2}
+              key={index2}
+            />
+          ) : null
+        }
       })
 
       if (issue.additionalFileCount > 0) {

--- a/packages/openneuro-app/src/scripts/validation/validation-results.jsx
+++ b/packages/openneuro-app/src/scripts/validation/validation-results.jsx
@@ -78,7 +78,7 @@ class ValidationResults extends React.Component {
   _countFiles(issues) {
     let numFiles = 0
     for (const issue of issues) {
-      numFiles += issue.files.length
+      numFiles += Array.from(issue.files).length
       if (issue.additionalFileCount) {
         numFiles += issue.additionalFileCount
       }

--- a/packages/openneuro-app/src/scripts/workers/schema.ts
+++ b/packages/openneuro-app/src/scripts/workers/schema.ts
@@ -1,0 +1,13 @@
+import { runValidator } from './schema.worker' // eslint-disable-line import/no-unresolved
+import { BIDSValidatorIssues } from './worker-interface'
+
+function init(files, options): Promise<BIDSValidatorIssues> {
+  return new Promise((resolve, reject) => {
+    void runValidator(files, options, ({ error, output }) => {
+      if (error) reject(error)
+      else resolve(output)
+    })
+  })
+}
+
+export default init

--- a/packages/openneuro-app/src/scripts/workers/schema.worker.ts
+++ b/packages/openneuro-app/src/scripts/workers/schema.worker.ts
@@ -1,0 +1,31 @@
+/* eslint-env worker */
+import { validate, fileListToTree } from '../utils/schema-validator.js'
+import { BIDSValidatorIssues } from './worker-interface'
+
+export async function runValidator(
+  files,
+  options,
+  cb,
+): Promise<BIDSValidatorIssues> {
+  let error
+  const output = {
+    issues: { errors: [], warnings: [] },
+    summary: {},
+  } as BIDSValidatorIssues
+  try {
+    const tree = await fileListToTree(files)
+    const result = await validate(tree, { json: true })
+    const issues = Array.from(result.issues, ([key, value]) => value)
+    console.log(issues)
+    output.issues.warnings = issues.filter(
+      issue => issue.severity === 'warning',
+    )
+    output.issues.errors = issues.filter(issue => issue.severity === 'error')
+    output.summary = result.summary
+    console.log(output)
+  } catch (err) {
+    error = err
+  }
+  cb({ error, output })
+  return output
+}

--- a/packages/openneuro-app/src/scripts/workers/schema.worker.ts
+++ b/packages/openneuro-app/src/scripts/workers/schema.worker.ts
@@ -16,13 +16,11 @@ export async function runValidator(
     const tree = await fileListToTree(files)
     const result = await validate(tree, { json: true })
     const issues = Array.from(result.issues, ([key, value]) => value)
-    console.log(issues)
     output.issues.warnings = issues.filter(
       issue => issue.severity === 'warning',
     )
     output.issues.errors = issues.filter(issue => issue.severity === 'error')
     output.summary = result.summary
-    console.log(output)
   } catch (err) {
     error = err
   }

--- a/packages/openneuro-app/src/scripts/workers/validate.worker.ts
+++ b/packages/openneuro-app/src/scripts/workers/validate.worker.ts
@@ -1,6 +1,13 @@
 /* eslint-env worker */
-import { validate, fileListToTree } from '../utils/schema-validator.js'
+import validate from 'bids-validator'
 import { BIDSValidatorIssues } from './worker-interface'
+
+const asyncValidateBIDS = (files, options): Promise<BIDSValidatorIssues> =>
+  new Promise(resolve => {
+    validate.BIDS(files, options, (issues, summary) =>
+      resolve({ issues, summary }),
+    )
+  })
 
 export async function runValidator(
   files,
@@ -8,18 +15,8 @@ export async function runValidator(
   cb,
 ): Promise<BIDSValidatorIssues> {
   let error, output: BIDSValidatorIssues
-  output = { issues: { errors: [], warnings: [] }, summary: {} }
   try {
-    const tree = await fileListToTree(files)
-    const result = await validate(tree, { json: true })
-    const issues = Array.from(result.issues, ([key, value]) => value)
-    console.log(issues)
-    output.issues.warnings = issues.filter(
-      issue => issue.severity === 'warning',
-    )
-    output.issues.errors = issues.filter(issue => issue.severity === 'error')
-    output.summary = result.summary
-    console.log(output)
+    output = await asyncValidateBIDS(files, options)
   } catch (err) {
     error = err
   }

--- a/packages/openneuro-app/src/scripts/workers/validate.worker.ts
+++ b/packages/openneuro-app/src/scripts/workers/validate.worker.ts
@@ -17,7 +17,7 @@ export async function runValidator(
     output.issues.warnings = issues.filter(
       issue => issue.severity === 'warning',
     )
-    output.issues.errors = issues.filter(issue => issue.severity === 'errors')
+    output.issues.errors = issues.filter(issue => issue.severity === 'error')
     output.summary = result.summary
     console.log(output)
   } catch (err) {

--- a/packages/openneuro-app/src/scripts/workers/worker-interface.ts
+++ b/packages/openneuro-app/src/scripts/workers/worker-interface.ts
@@ -1,5 +1,8 @@
 // Shared interface for BIDSValidatorIssues shared without cross import for validate and validate.worker
 export interface BIDSValidatorIssues {
-  issues: Record<string, unknown>[]
+  issues: {
+    errors: Record<string, unknown>[]
+    warnings: Record<string, unknown>[]
+  }
   summary: Record<string, unknown>
 }

--- a/packages/openneuro-app/vite.config.js
+++ b/packages/openneuro-app/vite.config.js
@@ -7,6 +7,7 @@ export default defineConfig({
   server: {
     port: 80,
     host: '0.0.0.0',
+    cors: true,
   },
   build: {
     sourcemap: true,


### PR DESCRIPTION
This fixes some of the remaining issues with using the schema validator client side.

* Allows site admins to configure which validator to use, defaulting the existing JS validator for regular users.
* Displays the Issue content better so it's more useful for debugging.
* Runs as its own worker.

This does not include the server side components, which is setting the option on the dataset to toggle which is used for display and running both validators on each change.

Also the entire schema validator is included here for testing this but ideally it would be an import from a CI build on the bids-validator repo. This is just the latest output of build.ts with one line added to have TypeScript ignore it as an external dependency.