### PR TITLE
Allow linking ORCID to existing non-ORCID oauth accounts

### DIFF
--- a/packages/openneuro-components/src/user/UserMenu.tsx
+++ b/packages/openneuro-components/src/user/UserMenu.tsx
@@ -41,9 +41,14 @@ export const UserMenu = ({ profile, signOutAndRedirect }: UserMenuProps) => {
             <li className="user-menu-link">
               <Link to="/keygen"> Obtain an API Key </Link>
             </li>
-            <li className="user-menu-link">
-              <a href="/crn/auth/orcid?link=true"> Link ORCID to my account </a>
-            </li>
+            {profile.provider !== 'orcid' && (
+              <li className="user-menu-link">
+                <a href="/crn/auth/orcid?link=true">
+                  {' '}
+                  Link ORCID to my account{' '}
+                </a>
+              </li>
+            )}
             {profile.admin && (
               <li className="user-menu-link">
                 <Link to="/admin">Admin</Link>

--- a/packages/openneuro-components/src/user/UserMenu.tsx
+++ b/packages/openneuro-components/src/user/UserMenu.tsx
@@ -41,6 +41,9 @@ export const UserMenu = ({ profile, signOutAndRedirect }: UserMenuProps) => {
             <li className="user-menu-link">
               <Link to="/keygen"> Obtain an API Key </Link>
             </li>
+            <li className="user-menu-link">
+              <a href="/crn/auth/orcid?link=true"> Link ORCID to my account </a>
+            </li>
             {profile.admin && (
               <li className="user-menu-link">
                 <Link to="/admin">Admin</Link>

--- a/packages/openneuro-server/src/libs/authentication/jwt.js
+++ b/packages/openneuro-server/src/libs/authentication/jwt.js
@@ -115,7 +115,7 @@ export const decodeJWT = token => {
   return jwt.decode(token)
 }
 
-const parsedJwtFromRequest = req => {
+export const parsedJwtFromRequest = req => {
   const jwt = jwtFromRequest(req)
   if (jwt) return decodeJWT(jwt)
   else return null

--- a/packages/openneuro-server/src/libs/authentication/orcid.js
+++ b/packages/openneuro-server/src/libs/authentication/orcid.js
@@ -1,4 +1,6 @@
 import passport from 'passport'
+import User from '../../models/user'
+import { parsedJwtFromRequest } from './jwt.js'
 
 export const requestAuth = passport.authenticate('orcid', {
   session: false,
@@ -16,7 +18,23 @@ export const authCallback = (req, res, next) =>
     if (!user) {
       return res.redirect('/')
     }
-    req.logIn(user, { session: false }, err => {
-      return next(err)
-    })
+    const existingAuth = parsedJwtFromRequest(req)
+    if (existingAuth) {
+      // Save ORCID to primary account
+      User.findOne({ id: existingAuth.sub }, (err, userModel) => {
+        if (err) {
+          return next(err)
+        } else {
+          userModel.orcid = user.providerId
+          return userModel.save().then(() => {
+            res.redirect('/')
+          })
+        }
+      })
+    } else {
+      // Complete login with ORCID as primary account
+      req.logIn(user, { session: false }, err => {
+        return next(err)
+      })
+    }
   })(req, res, next)

--- a/packages/openneuro-server/src/libs/authentication/passport.js
+++ b/packages/openneuro-server/src/libs/authentication/passport.js
@@ -55,7 +55,7 @@ export const verifyGoogleUser = (accessToken, refreshToken, profile, done) => {
       profileUpdate,
       { upsert: true, new: true, setDefaultsOnInsert: true },
     )
-      .then(user => done(null, addJWT(config)(user)))
+      .then(user => done(null, addJWT(config)(user.toObject())))
       .catch(err => done(err, null))
   } else {
     done(profileUpdate, null)
@@ -80,7 +80,7 @@ export const verifyORCIDUser = (
         { providerId: profile.orcid, provider: profile.provider },
         profileUpdate,
         { upsert: true, new: true, setDefaultsOnInsert: true },
-      ).then(user => done(null, addJWT(config)(user)))
+      ).then(user => done(null, addJWT(config)(user.toObject())))
     })
     .catch(err => done(err, null))
 }
@@ -110,7 +110,7 @@ export const setupPassportAuth = () => {
           // A user must already exist to use a JWT to auth a request
           User.findOne({ id: jwt.sub, provider: jwt.provider })
             .then(user => {
-              if (user) done(null, user)
+              if (user) done(null, user.toObject())
               else done(null, false)
             })
             .catch(done)

--- a/packages/openneuro-server/src/libs/orcid.js
+++ b/packages/openneuro-server/src/libs/orcid.js
@@ -20,12 +20,22 @@ export default {
         },
         (err, res) => {
           if (err) {
-            reject({
+            return reject({
               message:
                 'An unexpected ORCID login failure occurred, please try again later.',
             })
           }
-          const doc = new xmldoc.XmlDocument(res.body)
+          let doc
+          // Catch issues with parsing this response
+          try {
+            doc = new xmldoc.XmlDocument(res.body)
+          } catch (err) {
+            return reject({
+              type: 'config',
+              message:
+                'ORCID auth response invalid, most likely this is a misconfigured ORCID_API_ENDPOINT value',
+            })
+          }
           let name = doc.valueWithPath(
             'person:person.person:name.personal-details:credit-name',
           )
@@ -41,13 +51,13 @@ export default {
 
           if (!name) {
             if (!firstname) {
-              reject({
+              return reject({
                 type: 'given',
                 message:
                   'Your ORCID account does not have a given name, or it is not public. Please fix your account before continuing.',
               })
             } else if (!lastname) {
-              reject({
+              return reject({
                 type: 'family',
                 message:
                   'Your ORCID account does not have a family name, or it is not public. Please fix your account before continuing.',
@@ -58,7 +68,7 @@ export default {
           }
 
           if (!email) {
-            reject({
+            return reject({
               type: 'email',
               message:
                 'Your ORCID account does not have an e-mail, or your e-mail is not public. Please fix your account before continuing.',


### PR DESCRIPTION
Support linking your ORCID to any other primary accounts (Google). This doesn't merge these accounts but it does let enable ORCID features for your Google-authenticated account. Added a simple menu for this at the moment, it just lets you start the auth flow and will replace the ORCID account if you redo it with another account. You can only add this, not remove it, in this version.