### PR TITLE
Use preferred name instead of email and include ORCID link if available for comments

### DIFF
--- a/packages/openneuro-app/src/scripts/datalad/dataset/comments-fragments.js
+++ b/packages/openneuro-app/src/scripts/datalad/dataset/comments-fragments.js
@@ -8,7 +8,8 @@ export const DATASET_COMMENTS = gql`
       text
       createDate
       user {
-        email
+        name
+        orcid
       }
       parent {
         id

--- a/packages/openneuro-app/src/scripts/dataset/comments/__tests__/__snapshots__/comment.spec.jsx.snap
+++ b/packages/openneuro-app/src/scripts/dataset/comments/__tests__/__snapshots__/comment.spec.jsx.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1
 
-exports[`Comment component > renders with an empty comment 1`] = `
+exports[`Comment component > renders an ORCID user comment 1`] = `
 {
   "asFragment": [Function],
   "baseElement": <body>
@@ -11,7 +11,20 @@ exports[`Comment component > renders with an empty comment 1`] = `
         <div
           class="row comment-header"
         >
-          By example@example.com - almost 2 years ago
+          By 
+          Example Exampler
+           
+          <a
+            href="https://orcid.org/1234-5678-9101"
+          >
+            <img
+              alt="ORCID logo"
+              height="16"
+              src="/packages/openneuro-app/src/assets/ORCIDiD_iconvector.svg"
+              width="16"
+            />
+          </a>
+           - almost 2 years ago
         </div>
         <div
           class="row comment-body"
@@ -72,7 +85,203 @@ exports[`Comment component > renders with an empty comment 1`] = `
       <div
         class="row comment-header"
       >
-        By example@example.com - almost 2 years ago
+        By 
+        Example Exampler
+         
+        <a
+          href="https://orcid.org/1234-5678-9101"
+        >
+          <img
+            alt="ORCID logo"
+            height="16"
+            src="/packages/openneuro-app/src/assets/ORCIDiD_iconvector.svg"
+            width="16"
+          />
+        </a>
+         - almost 2 years ago
+      </div>
+      <div
+        class="row comment-body"
+      >
+        <div
+          class="DraftEditor-root"
+        >
+          <div
+            class="DraftEditor-editorContainer"
+          >
+            <div
+              class="public-DraftEditor-content"
+              contenteditable="false"
+              spellcheck="false"
+              style="outline: none; user-select: text; white-space: pre-wrap; word-wrap: break-word;"
+            >
+              <div
+                data-contents="true"
+              >
+                <div
+                  class=""
+                  data-block="true"
+                  data-editor="9001"
+                  data-offset-key="3sm42-0-0"
+                >
+                  <div
+                    class="public-DraftStyleDefault-block public-DraftStyleDefault-ltr"
+                    data-offset-key="3sm42-0-0"
+                  >
+                    <span
+                      data-offset-key="3sm42-0-0"
+                    >
+                      <br
+                        data-text="true"
+                      />
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="row replies"
+    >
+      <div
+        class="comment-reply"
+      />
+    </div>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;
+
+exports[`Comment component > renders with an empty comment 1`] = `
+{
+  "asFragment": [Function],
+  "baseElement": <body>
+    <div>
+      <div
+        class="comment"
+      >
+        <div
+          class="row comment-header"
+        >
+          By 
+          Example Exampler
+           - almost 2 years ago
+        </div>
+        <div
+          class="row comment-body"
+        >
+          <div
+            class="DraftEditor-root"
+          >
+            <div
+              class="DraftEditor-editorContainer"
+            >
+              <div
+                class="public-DraftEditor-content"
+                contenteditable="false"
+                spellcheck="false"
+                style="outline: none; user-select: text; white-space: pre-wrap; word-wrap: break-word;"
+              >
+                <div
+                  data-contents="true"
+                >
+                  <div
+                    class=""
+                    data-block="true"
+                    data-editor="9001"
+                    data-offset-key="3sm42-0-0"
+                  >
+                    <div
+                      class="public-DraftStyleDefault-block public-DraftStyleDefault-ltr"
+                      data-offset-key="3sm42-0-0"
+                    >
+                      <span
+                        data-offset-key="3sm42-0-0"
+                      >
+                        <br
+                          data-text="true"
+                        />
+                      </span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="row replies"
+      >
+        <div
+          class="comment-reply"
+        />
+      </div>
+    </div>
+  </body>,
+  "container": <div>
+    <div
+      class="comment"
+    >
+      <div
+        class="row comment-header"
+      >
+        By 
+        Example Exampler
+         - almost 2 years ago
       </div>
       <div
         class="row comment-body"

--- a/packages/openneuro-app/src/scripts/dataset/comments/__tests__/comment.spec.jsx
+++ b/packages/openneuro-app/src/scripts/dataset/comments/__tests__/comment.spec.jsx
@@ -17,7 +17,31 @@ describe('Comment component', () => {
         data={{
           id: '9001',
           text: emptyState,
-          user: { id: '1234', email: 'example@example.com' },
+          user: {
+            id: '1234',
+            email: 'example@example.com',
+            name: 'Example Exampler',
+          },
+          createDate: new Date('2019-04-02T19:56:41.222Z').toISOString(),
+        }}
+      />,
+    )
+    expect(wrapper).toMatchSnapshot()
+  })
+  it('renders an ORCID user comment', () => {
+    formatDistanceToNow.mockReturnValueOnce('almost 2 years')
+
+    const wrapper = render(
+      <Comment
+        data={{
+          id: '9001',
+          text: emptyState,
+          user: {
+            id: '1234',
+            email: 'example@example.com',
+            name: 'Example Exampler',
+            orcid: '1234-5678-9101',
+          },
           createDate: new Date('2019-04-02T19:56:41.222Z').toISOString(),
         }}
       />,

--- a/packages/openneuro-app/src/scripts/dataset/comments/comment.jsx
+++ b/packages/openneuro-app/src/scripts/dataset/comments/comment.jsx
@@ -11,6 +11,7 @@ import LoggedIn from '../../authentication/logged-in.jsx'
 import { toast } from 'react-toastify'
 import ToastContent from '../../common/partials/toast-content'
 import { Icon } from '@openneuro/components/icon'
+import { Username } from '../../users/username'
 
 const Comment = ({ datasetId, data, children }) => {
   const [replyMode, setReplyMode] = useState(false)
@@ -21,9 +22,8 @@ const Comment = ({ datasetId, data, children }) => {
     <>
       <div className="comment">
         <div className="row comment-header">
-          {`By ${data.user.email} - ${formatDistanceToNow(
-            parseISO(data.createDate),
-          )} ago`}
+          By <Username user={data.user} />
+          {` - ${formatDistanceToNow(parseISO(data.createDate))} ago`}
         </div>
         <div className="row comment-body">
           {editMode ? (

--- a/packages/openneuro-app/src/scripts/dataset/mutations/__tests__/__snapshots__/delete.spec.jsx.snap
+++ b/packages/openneuro-app/src/scripts/dataset/mutations/__tests__/__snapshots__/delete.spec.jsx.snap
@@ -14,37 +14,3 @@ exports[`DeleteDataset mutation > renders with common props 1`] = `
   </span>
 </DocumentFragment>
 `;
-
-exports[`DeleteDir mutation > renders with common props 1`] = `
-<DocumentFragment>
-  <span
-    class="delete-file"
-  >
-    <div
-      class="warn-btn edit-file"
-    >
-      <span
-        class=" "
-        data-flow="up"
-        data-tooltip="Delete undefined"
-      >
-        <span
-          class="warn-btn-click"
-        >
-          <button
-            aria-label=""
-            class="on-button on-button--medium on-button--default  btn-warn-component"
-            role="button"
-            type="button"
-          >
-            <i
-              aria-hidden="true"
-              class="fa fa-trash css-1qxtz39"
-            />
-          </button>
-        </span>
-      </span>
-    </div>
-  </span>
-</DocumentFragment>
-`;

--- a/packages/openneuro-app/src/scripts/users/username.tsx
+++ b/packages/openneuro-app/src/scripts/users/username.tsx
@@ -4,7 +4,7 @@ import ORCIDiDLogo from '../../assets/ORCIDiD_iconvector.svg'
 /**
  * Display component for usernames showing ORCID linking if connected
  */
-export const Username = ({ user }) => {
+export const Username = ({ user }): JSX.Element => {
   if (user.orcid) {
     return (
       <>
@@ -15,6 +15,6 @@ export const Username = ({ user }) => {
       </>
     )
   } else {
-    return user.name
+    return user.name as JSX.Element
   }
 }


### PR DESCRIPTION
For any ORCID user or Google user who has linked an ORCID, show the ORCID short badge. The user is now identified with the preferred name value set via their primary OAuth provider (previously email was used).

![image](https://user-images.githubusercontent.com/11369795/223553719-8b9d0539-4c69-4468-93c2-b4997a79d91b.png)