### PR TITLE
fix(server): Avoid hanging on API requests to Brainlife

### DIFF
--- a/packages/openneuro-server/src/graphql/resolvers/brainlife.ts
+++ b/packages/openneuro-server/src/graphql/resolvers/brainlife.ts
@@ -41,8 +41,11 @@ export const onBrainlife = async (
   dataset: DatasetOrSnapshot,
 ): Promise<boolean> => {
   try {
+    const abortController = new AbortController()
     const url = brainlifeQuery(dataset)
-    const res = await fetch(url.toString())
+    const timeout = setTimeout(() => abortController.abort(), 5000)
+    const res = await fetch(url.toString(), { signal: abortController.signal })
+    clearTimeout(timeout)
     const body = await res.json()
     if (Array.isArray(body) && body.length) {
       return true


### PR DESCRIPTION
Wait a maximum of five seconds before marking a dataset as unavailable on Brainlife. This prevents timeouts for queries including this value when the request is especially slow (longer than 60 seconds).