### PR TITLE
fix: Avoid re-export of already published snapshots

### DIFF
--- a/services/datalad/datalad_service/tasks/publish.py
+++ b/services/datalad/datalad_service/tasks/publish.py
@@ -72,13 +72,13 @@ def export_dataset(dataset_path, cookies=None, s3_export=s3_export, github_expor
         dataset_id = os.path.basename(dataset_path)
         repo = pygit2.Repository(dataset_path)
         tags = git_tag(repo)
-        # Iterate over all tags and push those
-        for tag in tags:
-            s3_export(dataset_path, get_s3_remote(), tag.name)
-        # Once all S3 tags are exported, update GitHub
-        if github_enabled:
-            # Perform all GitHub export steps
-            github_export(dataset_id, dataset_path, tag.name)
+        # Push the most recent tag
+        if tags:
+            s3_export(dataset_path, get_s3_remote(), tags[-1].name)
+            # Once all S3 tags are exported, update GitHub
+            if github_enabled:
+                # Perform all GitHub export steps
+                github_export(dataset_id, dataset_path, tags[-1].name)
         # Drop cache once all exports are complete
         clear_dataset_cache(dataset_id, cookies)
 

--- a/services/datalad/tests/test_publish.py
+++ b/services/datalad/tests/test_publish.py
@@ -48,9 +48,8 @@ def test_export_snapshots(no_init_remote, client, new_dataset):
     export_dataset(new_dataset.path, s3_export=s3_export_mock,
                    github_export=github_export_mock, github_enabled=True)
     # Verify export calls were made
-    assert s3_export_mock.call_count == 2
-    expect_calls = [call(new_dataset.path, 's3-PUBLIC', 'refs/tags/1.0.0'),
-                    call(new_dataset.path, 's3-PUBLIC', 'refs/tags/2.0.0')]
+    assert s3_export_mock.call_count == 1
+    expect_calls = [call(new_dataset.path, 's3-PUBLIC', 'refs/tags/2.0.0')]
     s3_export_mock.assert_has_calls(expect_calls)
     assert github_export_mock.call_count == 1
     dataset_id = os.path.basename(new_dataset.path)


### PR DESCRIPTION
This should be handled by a repair process rather than the main export when it is required for an interrupted export.