### PR TITLE
fix(app): Fix extra filename argument for directory deletion from FileTree

### DIFF
--- a/packages/openneuro-app/src/scripts/dataset/files/file-tree.tsx
+++ b/packages/openneuro-app/src/scripts/dataset/files/file-tree.tsx
@@ -94,7 +94,7 @@ const FileTree = ({
             {path === '' ? (
               bulkDeleteButton
             ) : (
-              <DeleteFile datasetId={datasetId} path={path} filename={name} />
+              <DeleteFile datasetId={datasetId} path={path} />
             )}
           </span>
         </Media>


### PR DESCRIPTION
This bug prevents deleting entire trees at certain levels.