### PR TITLE
Use external URLs for FileTree and getFile APIs

### DIFF
--- a/packages/openneuro-app/src/scripts/dataset/files/file-tree.tsx
+++ b/packages/openneuro-app/src/scripts/dataset/files/file-tree.tsx
@@ -139,6 +139,7 @@ const FileTree = ({
                   datasetId={datasetId}
                   snapshotTag={snapshotTag}
                   path={path}
+                  urls={file.urls}
                   size={file.size}
                   editMode={editMode}
                   toggleFileToDelete={toggleFileToDelete}

--- a/packages/openneuro-app/src/scripts/dataset/files/file.tsx
+++ b/packages/openneuro-app/src/scripts/dataset/files/file.tsx
@@ -91,6 +91,7 @@ interface FileProps {
   annexed: boolean
   annexKey: string
   datasetPermissions: string[]
+  urls: string[]
   toggleFileToDelete: ({
     id,
     path,
@@ -117,6 +118,7 @@ const File = ({
   datasetPermissions,
   toggleFileToDelete,
   isFileToBeDeleted,
+  urls,
 }: FileProps): JSX.Element => {
   const { icon, color } = getFileIcon(filename)
   const snapshotVersionPath = snapshotTag ? `/versions/${snapshotTag}` : ''
@@ -137,7 +139,10 @@ const File = ({
           <Tooltip tooltip={`Download: ${bytes.format(size) as string}`}>
             <span className="edit-file download-file">
               <a
-                href={apiPath(datasetId, snapshotTag, filePath(path, filename))}
+                href={
+                  urls?.[0] ||
+                  apiPath(datasetId, snapshotTag, filePath(path, filename))
+                }
                 download
                 aria-label="download file">
                 <i className="fa fa-download" />

--- a/packages/openneuro-app/src/scripts/dataset/routes/tab-routes-snapshot.tsx
+++ b/packages/openneuro-app/src/scripts/dataset/routes/tab-routes-snapshot.tsx
@@ -39,11 +39,7 @@ export const TabRoutesSnapshot = ({ dataset, snapshot }) => {
       <Route
         path="file-display/:filePath"
         element={
-          <FileDisplayRoute
-            dataset={snapshot}
-            datasetId={dataset.id}
-            snapshotTag={snapshot.tag}
-          />
+          <FileDisplayRoute datasetId={dataset.id} snapshotTag={snapshot.tag} />
         }
       />
       <Route path="metadata" element={<AddMetadata dataset={dataset} />} />

--- a/packages/openneuro-app/src/scripts/dataset/routes/tab-routes-snapshot.tsx
+++ b/packages/openneuro-app/src/scripts/dataset/routes/tab-routes-snapshot.tsx
@@ -39,7 +39,11 @@ export const TabRoutesSnapshot = ({ dataset, snapshot }) => {
       <Route
         path="file-display/:filePath"
         element={
-          <FileDisplayRoute datasetId={dataset.id} snapshotTag={snapshot.tag} />
+          <FileDisplayRoute
+            dataset={snapshot}
+            datasetId={dataset.id}
+            snapshotTag={snapshot.tag}
+          />
         }
       />
       <Route path="metadata" element={<AddMetadata dataset={dataset} />} />

--- a/packages/openneuro-server/src/handlers/datalad.js
+++ b/packages/openneuro-server/src/handlers/datalad.js
@@ -1,6 +1,7 @@
 import request from 'superagent'
 import { Readable } from 'node:stream'
 import mime from 'mime-types'
+import { getFiles } from '../datalad/files'
 import { getDatasetWorker } from '../libs/datalad-service'
 
 /**
@@ -15,27 +16,48 @@ import { getDatasetWorker } from '../libs/datalad-service'
 /**
  * Get a file from a dataset
  */
-export const getFile = (req, res) => {
+export const getFile = async (req, res) => {
   const { datasetId, snapshotId, filename } = req.params
   const worker = getDatasetWorker(datasetId)
-  res.set('Content-Type', mime.lookup(filename) || 'application/octet-stream')
-  const uri = snapshotId
-    ? `http://${worker}/datasets/${datasetId}/snapshots/${snapshotId}/files/${filename}`
-    : `http://${worker}/datasets/${datasetId}/files/${filename}`
-  return (
-    fetch(uri)
-      .then(r => {
-        // Set the content length (allow clients to catch HTTP issues better)
-        res.setHeader('Content-Length', Number(r.headers.get('content-length')))
-        return r.body
-      })
-      // @ts-expect-error
-      .then(stream => Readable.fromWeb(stream).pipe(res))
-      .catch(err => {
-        console.error(err)
-        res.status(500).send('Internal error transferring requested file')
-      })
-  )
+  // Find the right tree
+  const pathComponents = filename.split(':')
+  let tree = snapshotId || 'HEAD'
+  let file
+  for (const level of pathComponents) {
+    const files = await getFiles(datasetId, tree)
+    if (level == pathComponents.slice(-1)) {
+      file = files.find(f => !f.directory && f.filename === level)
+    } else {
+      tree = files.find(f => f.directory && f.filename === level).id
+    }
+  }
+  // Get the file URL and redirect if external or serve if local
+  if (file && file.urls[0].startsWith('https://s3.amazonaws.com/')) {
+    res.redirect(file.urls[0])
+  } else {
+    // Serve the file directly
+    res.set('Content-Type', mime.lookup(filename) || 'application/octet-stream')
+    const uri = snapshotId
+      ? `http://${worker}/datasets/${datasetId}/snapshots/${snapshotId}/files/${filename}`
+      : `http://${worker}/datasets/${datasetId}/files/${filename}`
+    return (
+      fetch(uri)
+        .then(r => {
+          // Set the content length (allow clients to catch HTTP issues better)
+          res.setHeader(
+            'Content-Length',
+            Number(r.headers.get('content-length')),
+          )
+          return r.body
+        })
+        // @ts-expect-error
+        .then(stream => Readable.fromWeb(stream).pipe(res))
+        .catch(err => {
+          console.error(err)
+          res.status(500).send('Internal error transferring requested file')
+        })
+    )
+  }
 }
 
 /**


### PR DESCRIPTION
This change prefers the S3 URL for a file if an exported copy of the data is available on S3.

* The FileTree component already had this information available to it but it wasn't passed into the display components for use.
* The getFile API itself now resolves the tree needed for a path (usually from cache) and will serve a 302 redirect to S3 if one is found.