### PR TITLE
feat(app): Add a shell script generator for snapshot downloads

### DIFF
--- a/packages/openneuro-app/src/scripts/dataset/download/download-script.tsx
+++ b/packages/openneuro-app/src/scripts/dataset/download/download-script.tsx
@@ -8,7 +8,7 @@ function inlineDownload(filename, data): void {
   const element = document.createElement('a')
   element.setAttribute(
     'href',
-    'data:text/plain;charset=utf-8,' + encodeURIComponent(data),
+    'data:text/x-shellscript;charset=utf-8,' + encodeURIComponent(data),
   )
   element.setAttribute('download', filename)
 

--- a/packages/openneuro-app/src/scripts/dataset/download/download-script.tsx
+++ b/packages/openneuro-app/src/scripts/dataset/download/download-script.tsx
@@ -1,0 +1,94 @@
+/**
+ * Generate a download script for this dataset
+ */
+import React from 'react'
+import { useLazyQuery, gql } from '@apollo/client'
+
+function inlineDownload(filename, data): void {
+  const element = document.createElement('a')
+  element.setAttribute(
+    'href',
+    'data:text/plain;charset=utf-8,' + encodeURIComponent(data),
+  )
+  element.setAttribute('download', filename)
+
+  element.style.display = 'none'
+  document.body.appendChild(element)
+
+  element.click()
+
+  document.body.removeChild(element)
+}
+
+function generateDownloadScript(data): string {
+  let script = '#!/bin/sh\n'
+  for (const f of data.snapshot.downloadFiles) {
+    script += `curl --create-dirs ${f.urls[0]} -o ${f.filename}\n`
+  }
+  return script
+}
+
+interface DownloadS3DerivativesProps {
+  datasetId: string
+  snapshotTag: string
+}
+
+const getSnapshotDownload = gql`
+  query snapshot($datasetId: ID!, $tag: String!) {
+    snapshot(datasetId: $datasetId, tag: $tag) {
+      id
+      downloadFiles {
+        id
+        directory
+        filename
+        urls
+        size
+      }
+    }
+  }
+`
+
+export const DownloadScript = ({
+  datasetId,
+  snapshotTag,
+}: DownloadS3DerivativesProps): JSX.Element => {
+  const [getDownload, { loading, data }] = useLazyQuery(getSnapshotDownload, {
+    variables: {
+      datasetId: datasetId,
+      tag: snapshotTag,
+    },
+    errorPolicy: 'all',
+  })
+  if (data) {
+    const script = generateDownloadScript(data)
+    inlineDownload(`${datasetId}-${snapshotTag}.sh`, script)
+  }
+  // This feature is only implemented for snapshots
+  if (snapshotTag) {
+    return (
+      <div>
+        <h4>Download with a shell script</h4>
+        <p>
+          A script is available to download with only curl. This may be useful
+          if your download environment makes it difficult to install DataLad or
+          Node.js.
+        </p>
+        <p>
+          {loading ? (
+            'Loading...'
+          ) : (
+            <a
+              href="#"
+              onClick={(): void => {
+                void getDownload()
+              }}>
+              Download shell script
+            </a>
+          )}
+        </p>
+      </div>
+    )
+  }
+}
+
+export default DownloadScript

--- a/packages/openneuro-app/src/scripts/dataset/routes/download-dataset.tsx
+++ b/packages/openneuro-app/src/scripts/dataset/routes/download-dataset.tsx
@@ -8,6 +8,7 @@ import DownloadCommandLine from '../download/download-command-line.jsx'
 import DownloadDatalad from '../download/download-datalad.jsx'
 import { DatasetPageBorder } from './styles/dataset-page-border'
 import { HeaderRow3 } from './styles/header-row'
+import { DownloadScript } from '../download/download-script'
 
 const DownloadDataset = ({ worker, datasetPermissions }) => {
   const { datasetId, tag: snapshotTag } = useParams()
@@ -34,6 +35,7 @@ const DownloadDataset = ({ worker, datasetPermissions }) => {
         workerId={workerId}
         datasetPermissions={datasetPermissions}
       />
+      <DownloadScript datasetId={datasetId} snapshotTag={snapshotTag} />
     </DatasetPageBorder>
   )
 }


### PR DESCRIPTION
This generates a shell script that can download a snapshot with `curl` as the only dependency. The script is generated and downloaded when you click the link at the bottom of the download page for a snapshot (not available for drafts).

```shell
#!/bin/sh
curl --create-dirs https://s3.amazonaws.com/openneuro.org/ds001033/CHANGES?versionId=versionKey-o CHANGES
curl --create-dirs https://s3.amazonaws.com/openneuro.org/ds001033/README?versionId=versionKey -o README
curl --create-dirs https://s3.amazonaws.com/openneuro.org/ds001033/dataset_description.json?versionId=versionKey-o dataset_description.json
curl --create-dirs https://s3.amazonaws.com/openneuro.org/ds001033/T1w.json?versionId=versionKey  -o T1w.json
curl --create-dirs https://s3.amazonaws.com/openneuro.org/ds001033/participants.tsv?versionId=versionKey -o participants.tsv
curl --create-dirs https://s3.amazonaws.com/openneuro.org/ds001033/sub-01/anat/sub-01_T1w.nii.gz?versionId=versionKey -o sub-01/anat/sub-01_T1w.nii.gz
```

Fixes #2648