### PR TITLE
FIX: &quote; should be &quot;

### DIFF
--- a/packages/openneuro-app/src/scripts/dataset/routes/snapshot.jsx
+++ b/packages/openneuro-app/src/scripts/dataset/routes/snapshot.jsx
@@ -63,9 +63,9 @@ const SnapshotRoute = ({ datasetId, snapshots, issues, description }) => {
           {updateToCC0 && (
             <p>
               <strong>Notice:</strong> The current license{' '}
-              <i>&quote;{draftLicense}&quote;</i> will be updated to
-              &quote;CC0&quote; when the version is created. Please see FAQ item
-              &quote;Are there any restrictions on the uploaded data?&quote; for
+              <i>&quot;{draftLicense}&quot;</i> will be updated to
+              &quot;CC0&quot; when the version is created. Please see FAQ item
+              &quot;Are there any restrictions on the uploaded data?&quot; for
               details.
             </p>
           )}


### PR DESCRIPTION
See, for example, https://openneuro.org/datasets/ds004585/snapshot, where the license is not yet set.