### PR TITLE
fix(app): Disable reviewer links creation without a dataset version

### DIFF
--- a/packages/openneuro-app/src/scripts/dataset/draft-container.tsx
+++ b/packages/openneuro-app/src/scripts/dataset/draft-container.tsx
@@ -76,7 +76,6 @@ const DraftContainer: React.FC<DraftContainerProps> = ({ dataset }) => {
   const [cookies] = useCookies()
   const profile = getUnexpiredProfile(cookies)
   const isAdmin = profile?.admin
-  const isReviewer = profile?.scopes?.includes('dataset:reviewer')
   const hasEdit =
     hasEditPermissions(dataset.permissions, profile?.sub) || isAdmin
   const hasDraftChanges =
@@ -95,8 +94,7 @@ const DraftContainer: React.FC<DraftContainerProps> = ({ dataset }) => {
           {description.Name} - {pageTitle}
         </title>
       </Helmet>
-      {!isReviewer &&
-        dataset.snapshots.length &&
+      {dataset.snapshots.length &&
         dataset.snapshots[dataset.snapshots.length - 1].tag &&
         !hasEdit && (
           <Navigate

--- a/packages/openneuro-app/src/scripts/dataset/draft-container.tsx
+++ b/packages/openneuro-app/src/scripts/dataset/draft-container.tsx
@@ -94,7 +94,7 @@ const DraftContainer: React.FC<DraftContainerProps> = ({ dataset }) => {
           {description.Name} - {pageTitle}
         </title>
       </Helmet>
-      {dataset.snapshots.length &&
+      {dataset.snapshots.length !== 0 &&
         dataset.snapshots[dataset.snapshots.length - 1].tag &&
         !hasEdit && (
           <Navigate

--- a/packages/openneuro-app/src/scripts/dataset/draft-container.tsx
+++ b/packages/openneuro-app/src/scripts/dataset/draft-container.tsx
@@ -76,6 +76,7 @@ const DraftContainer: React.FC<DraftContainerProps> = ({ dataset }) => {
   const [cookies] = useCookies()
   const profile = getUnexpiredProfile(cookies)
   const isAdmin = profile?.admin
+  const isReviewer = profile?.scopes?.includes('dataset:reviewer')
   const hasEdit =
     hasEditPermissions(dataset.permissions, profile?.sub) || isAdmin
   const hasDraftChanges =
@@ -94,15 +95,17 @@ const DraftContainer: React.FC<DraftContainerProps> = ({ dataset }) => {
           {description.Name} - {pageTitle}
         </title>
       </Helmet>
-      {dataset.snapshots && !hasEdit && (
-        <Navigate
-          to={`/datasets/${dataset.id}/versions/${
-            dataset.snapshots.length &&
-            dataset.snapshots[dataset.snapshots.length - 1].tag
-          }`}
-          replace
-        />
-      )}
+      {!isReviewer &&
+        dataset.snapshots.length &&
+        dataset.snapshots[dataset.snapshots.length - 1].tag &&
+        !hasEdit && (
+          <Navigate
+            to={`/datasets/${dataset.id}/versions/${
+              dataset.snapshots[dataset.snapshots.length - 1].tag
+            }`}
+            replace
+          />
+        )}
       <div
         className={`dataset dataset-draft dataset-page dataset-page-${modality?.toLowerCase()}`}>
         <DatasetHeader

--- a/packages/openneuro-app/src/scripts/dataset/routes/manage-anonymous-reviewers.tsx
+++ b/packages/openneuro-app/src/scripts/dataset/routes/manage-anonymous-reviewers.tsx
@@ -13,11 +13,13 @@ interface AnonymousReviewerProps {
     id: string
     expiration: Date
   }[]
+  hasSnapshot: boolean
 }
 
 export const AnonymousReviewer: FC<AnonymousReviewerProps> = ({
   datasetId,
   reviewers,
+  hasSnapshot,
 }) => {
   return (
     <div className="dataset-anonymous-form">
@@ -30,7 +32,13 @@ export const AnonymousReviewer: FC<AnonymousReviewerProps> = ({
             one year or until they are removed.
           </p>
         </div>
-        <CreateReviewLink datasetId={datasetId} />
+        {hasSnapshot ? (
+          <CreateReviewLink datasetId={datasetId} />
+        ) : (
+          <p className="text-danger">
+            Please create a dataset version before generating a reviewer link.
+          </p>
+        )}
         {reviewers.length ? (
           <div className="dataset-form-body">
             <h3>Previous Review Links: </h3>

--- a/packages/openneuro-app/src/scripts/dataset/routes/manage-permissions.jsx
+++ b/packages/openneuro-app/src/scripts/dataset/routes/manage-permissions.jsx
@@ -64,7 +64,7 @@ ShareTable.propTypes = {
   permissions: PropTypes.object,
 }
 
-const Share = ({ datasetId, permissions, reviewers }) => {
+const Share = ({ datasetId, permissions, reviewers, hasSnapshot }) => {
   const [userEmail, setUserEmail] = useState('')
   const [access, setAccess] = useState('ro')
 
@@ -127,7 +127,11 @@ const Share = ({ datasetId, permissions, reviewers }) => {
         </div>
       </div>
       <hr />
-      <AnonymousReviewer datasetId={datasetId} reviewers={reviewers} />
+      <AnonymousReviewer
+        datasetId={datasetId}
+        reviewers={reviewers}
+        hasSnapshot={hasSnapshot}
+      />
     </DatasetPageBorder>
   )
 }
@@ -135,6 +139,8 @@ const Share = ({ datasetId, permissions, reviewers }) => {
 Share.propTypes = {
   datasetId: PropTypes.string,
   permissions: PropTypes.object,
+  reviewers: PropTypes.array,
+  hasSnapshot: PropTypes.boolean,
 }
 
 export default Share

--- a/packages/openneuro-app/src/scripts/dataset/routes/tab-routes-draft.tsx
+++ b/packages/openneuro-app/src/scripts/dataset/routes/tab-routes-draft.tsx
@@ -55,6 +55,7 @@ export const TabRoutesDraft = ({ dataset, hasEdit }) => {
             datasetId={dataset.id}
             permissions={dataset.permissions}
             reviewers={dataset.reviewers}
+            hasSnapshot={dataset.snapshots.length}
           />
         }
       />


### PR DESCRIPTION
This disables the redirect to snapshot for reviewer users, allowing them to browse a draft. Also catches some rare cases where the redirect can trigger when snapshots are being created and avoids forcing a redirect before one exists by checking the tag value before attempting the redirect.