### PR TITLE
fix(cli): Explicitly close file read stream on request abort

### DIFF
--- a/packages/openneuro-cli/src/upload.js
+++ b/packages/openneuro-cli/src/upload.js
@@ -161,6 +161,7 @@ export const uploadFiles = async ({
       const fileStream = createReadStream(file.path)
       fileStream.on('error', err => {
         console.error(err)
+        fileStream.close()
         controller.abort()
       })
       fileStream.on('close', () => {


### PR DESCRIPTION
This prevents a warning thrown by the controller.abort() call closing this stream.

Fixes #2786 