### PR TITLE
feat(api): Resolve dynamic metadata at read instead of write

### DIFF
--- a/packages/openneuro-server/src/graphql/resolvers/metadata.js
+++ b/packages/openneuro-server/src/graphql/resolvers/metadata.js
@@ -1,12 +1,48 @@
+import Snapshot from '../../models/snapshot'
 import MetadataModel from '../../models/metadata'
+import { latestSnapshot } from './snapshots'
+import { permissions } from './permissions'
 
 /**
  * Summary resolver
+ *
+ * User modified fields are queried from the Metadata model and dynamic metadata is updated from the latest snapshot
  */
-export const metadata = dataset => {
-  return MetadataModel.findOne({
+export const metadata = async (dataset, _, { user }) => {
+  const record = await MetadataModel.findOne({
     datasetId: dataset.id,
+  }).lean()
+  // Replace dynamic fields with latest available
+  const snapshot = await latestSnapshot(dataset, null, user)
+  const description = await snapshot.description()
+  const summary = await snapshot.summary()
+  // Find the users with admin access
+  // TODO - This could be a user object that is resolved with the full type instead of just email
+  // Email matches the existing records however and the user object would require other changes
+  const adminUsers = []
+  const { userPermissions } = await permissions(dataset)
+  for (const user of userPermissions) {
+    adminUsers.push((await user.user).email)
+  }
+  const firstSnapshot = await Snapshot.find({ datasetId: dataset.id }).sort({
+    created: 1,
   })
+  const firstSnapshotCreatedAt = firstSnapshot.length
+    ? firstSnapshot[0].created
+    : null
+  return {
+    ...record,
+    datasetId: dataset.id,
+    datasetName: description.Name,
+    tasksCompleted: summary.tasks,
+    seniorAuthor: description.Authors[0],
+    adminUsers,
+    firstSnapshotCreatedAt,
+    latestSnapshotCreatedAt: snapshot.created,
+    subjectAges: summary.subjectMetadata.map(s => s.age),
+    modalities: summary.modalities,
+    dataProcessed: summary.dataProcessed,
+  }
 }
 
 /**

--- a/packages/openneuro-server/src/models/metadata.ts
+++ b/packages/openneuro-server/src/models/metadata.ts
@@ -3,6 +3,7 @@ import mongoose, { Document } from 'mongoose'
 const { Schema, model } = mongoose
 
 export interface MetadataDocument extends Document {
+  datasetId: string
   datasetName: string
   datasetUrl: string
   dataProcessed: boolean
@@ -10,7 +11,6 @@ export interface MetadataDocument extends Document {
   latestSnapshotCreatedAt: Date
   ages: number[]
   modalities: string[]
-  datasetId: string
   adminUsers: string[]
   dxStatus: string
   tasksCompleted: string[]
@@ -29,6 +29,7 @@ export interface MetadataDocument extends Document {
 }
 
 const metadataSchema = new Schema({
+  datasetId: { type: String, default: uuid.v4 }, // OpenNeuro id
   datasetName: String,
   datasetUrl: String, // @id type
   dataProcessed: Boolean, // 'true' | 'false' | 'user input string'
@@ -36,7 +37,6 @@ const metadataSchema = new Schema({
   latestSnapshotCreatedAt: Date,
   ages: [Number],
   modalities: [String],
-  datasetId: { type: String, default: uuid.v4 }, // OpenNeuro id
   adminUsers: [String], // email type (@id type?)
   dxStatus: String,
   tasksCompleted: [String],


### PR DESCRIPTION
Dataset metadata fields are currently written to the MongoDB Metadata model and not updated until the next time metadata is modified by a dataset admin. This can lead to stale data for any derived fields (those related to OpenNeuro or validator data). This change now always queries the dynamic fields when they are read.

See also #2814 