### PR TITLE
Metadata API fixes

### DIFF
--- a/packages/openneuro-server/src/graphql/resolvers/metadata.js
+++ b/packages/openneuro-server/src/graphql/resolvers/metadata.js
@@ -22,7 +22,10 @@ export const metadata = async (dataset, _, context) => {
   const adminUsers = []
   const { userPermissions } = await permissions(dataset)
   for (const user of userPermissions) {
-    adminUsers.push((await user.user).email)
+    if (user.level === 'admin') {
+      const userObj = await user.user
+      adminUsers.push(userObj.email)
+    }
   }
   const firstSnapshot = await Snapshot.find({ datasetId: dataset.id }).sort({
     created: 1,

--- a/packages/openneuro-server/src/graphql/resolvers/metadata.js
+++ b/packages/openneuro-server/src/graphql/resolvers/metadata.js
@@ -33,15 +33,17 @@ export const metadata = async (dataset, _, context) => {
   return {
     ...record,
     datasetId: dataset.id,
-    datasetName: description.Name,
-    tasksCompleted: summary.tasks,
-    seniorAuthor: description.Authors[description.Authors.length - 1],
+    datasetName: description?.Name,
+    tasksCompleted: summary?.tasks || [],
+    seniorAuthor: description?.Authors
+      ? description.Authors[description.Authors.length - 1]
+      : null,
     adminUsers,
     firstSnapshotCreatedAt,
     latestSnapshotCreatedAt: snapshot.created,
     subjectAges: summary.subjectMetadata.map(s => s.age),
-    modalities: summary.modalities,
-    dataProcessed: summary.dataProcessed,
+    modalities: summary?.modalities || [],
+    dataProcessed: summary?.dataProcessed || null,
   }
 }
 


### PR DESCRIPTION
Few improvements to the metadata API changes.

* Drops a bunch of unused client side code that can potentially conflict with the server representation.
* Handles the cases where summary or description are missing better. This will now just return empty array or null values in those cases.
* Fixes a bug where admin users had all users with access list.

Fixes #2831