### PR TITLE
fix(worker): Use stable sort order for tags during export

### DIFF
--- a/services/datalad/datalad_service/tasks/publish.py
+++ b/services/datalad/datalad_service/tasks/publish.py
@@ -71,7 +71,7 @@ def export_dataset(dataset_path, cookies=None, s3_export=s3_export, github_expor
     if is_git_annex_remote(dataset_path, get_s3_remote()):
         dataset_id = os.path.basename(dataset_path)
         repo = pygit2.Repository(dataset_path)
-        tags = git_tag(repo)
+        tags = sorted(git_tag(repo), key=lambda tag: tag.name)
         # Update configuration for the remote
         update_s3_sibling(dataset_path)
         # Push the most recent tag


### PR DESCRIPTION
This is the cause of some missing exports on recently published datasets (since db0d8939dd1e238133f538a5b950acd22b183aa1).