### PR TITLE
Revert "fix: Allow testing openneuro git-annex-remote-openneuro via yarn/npm"

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,5 +3,5 @@
   "packages": ["packages/*"],
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "version": "4.19.0"
+  "version": "4.19.1-alpha.0"
 }

--- a/packages/openneuro-app/package.json
+++ b/packages/openneuro-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openneuro/app",
-  "version": "4.19.0",
+  "version": "4.19.1-alpha.0",
   "description": "React JS web frontend for the OpenNeuro platform.",
   "license": "MIT",
   "main": "public/client.js",
@@ -20,8 +20,8 @@
     "@emotion/react": "11.6.0",
     "@emotion/styled": "11.6.0",
     "@niivue/niivue": "0.34.0",
-    "@openneuro/client": "^4.19.0",
-    "@openneuro/components": "^4.19.0",
+    "@openneuro/client": "^4.19.1-alpha.0",
+    "@openneuro/components": "^4.19.1-alpha.0",
     "bids-validator": "1.10.0",
     "bytes": "^3.0.0",
     "comlink": "^4.0.5",

--- a/packages/openneuro-cli/package.json
+++ b/packages/openneuro-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openneuro/cli",
-  "version": "4.19.0",
+  "version": "4.19.1-alpha.0",
   "description": "OpenNeuro command line uploader / editor.",
   "main": "index.js",
   "repository": "git@github.com:OpenNeuroOrg/openneuro.git",
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@apollo/client": "3.7.2",
-    "@openneuro/client": "^4.19.0",
+    "@openneuro/client": "^4.19.1-alpha.0",
     "bids-validator": "1.10.0",
     "cli-progress": "^3.8.2",
     "commander": "7.2.0",

--- a/packages/openneuro-cli/src/cli.js
+++ b/packages/openneuro-cli/src/cli.js
@@ -74,17 +74,12 @@ commander
   .option('-s, --snapshot [snapshotVersion]')
   .action(ls)
 
-const processName = process.argv[1].endsWith('index.js')
-  ? process.env.npm_lifecycle_event
-  : process.argv[1]
+commander.parse(process.argv)
 
-if (processName.endsWith('git-credential-openneuro')) {
+if (process.argv[1].endsWith('git-credential-openneuro')) {
   gitCredential()
-} else if (processName.endsWith('git-annex-remote-openneuro')) {
+} else if (process.argv[1].endsWith('git-annex-remote-openneuro')) {
   gitAnnexRemote()
-} else {
-  commander.parse(process.argv)
-  if (!process.argv.slice(2).length) {
-    commander.help()
-  }
+} else if (!process.argv.slice(2).length) {
+  commander.help()
 }

--- a/packages/openneuro-client/package.json
+++ b/packages/openneuro-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openneuro/client",
-  "version": "4.19.0",
+  "version": "4.19.1-alpha.0",
   "description": "OpenNeuro shared client library.",
   "main": "dist/index.js",
   "browser": "src/index.js",
@@ -27,7 +27,7 @@
   "devDependencies": {
     "@babel/preset-typescript": "^7.14.5",
     "@babel/runtime-corejs3": "^7.13.10",
-    "@openneuro/server": "^4.19.0",
+    "@openneuro/server": "^4.19.1-alpha.0",
     "apollo-server": "^2.23.0",
     "core-js": "^3.10.1",
     "vitest": "^0.25.2"

--- a/packages/openneuro-components/package.json
+++ b/packages/openneuro-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openneuro/components",
-  "version": "4.19.0",
+  "version": "4.19.1-alpha.0",
   "description": "OpenNeuro component library and Storybook configuration",
   "main": "dist/index.js",
   "browser": "src/index.js",

--- a/packages/openneuro-indexer/package.json
+++ b/packages/openneuro-indexer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openneuro/indexer",
-  "version": "4.19.0",
+  "version": "4.19.1-alpha.0",
   "description": "OpenNeuro elastic search indexing tool",
   "main": "./dist/index.js",
   "types": "./src/index.d.ts",
@@ -11,8 +11,8 @@
   "dependencies": {
     "@apollo/client": "3.7.2",
     "@elastic/elasticsearch": "7.15.0",
-    "@openneuro/client": "^4.19.0",
-    "@openneuro/search": "^4.19.0",
+    "@openneuro/client": "^4.19.1-alpha.0",
+    "@openneuro/search": "^4.19.1-alpha.0",
     "apollo-link-retry": "^2.2.16",
     "ts-node": "^9.1.1",
     "typescript": "4.5.4"

--- a/packages/openneuro-search/package.json
+++ b/packages/openneuro-search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openneuro/search",
-  "version": "4.19.0",
+  "version": "4.19.1-alpha.0",
   "description": "OpenNeuro search client functions.",
   "main": "dist/index.js",
   "browser": "src/index.ts",

--- a/packages/openneuro-server/package.json
+++ b/packages/openneuro-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openneuro/server",
-  "version": "4.19.0",
+  "version": "4.19.1-alpha.0",
   "description": "Core service for the OpenNeuro platform.",
   "license": "MIT",
   "main": "src/server.js",
@@ -17,7 +17,7 @@
   "dependencies": {
     "@apollo/client": "3.7.2",
     "@elastic/elasticsearch": "7.15.0",
-    "@openneuro/search": "^4.19.0",
+    "@openneuro/search": "^4.19.1-alpha.0",
     "@passport-next/passport-google-oauth2": "^1.0.0",
     "@sentry/node": "^4.5.3",
     "apollo-server": "2.25.4",


### PR DESCRIPTION
Fixes issues running the CLI on Windows, process.env.npm_lifecycle_event to test is no longer required with yarn v2 or recent npm. See #2838 

This reverts commit 044835d944b52286dce4e2fb24a39cf4c1260223.