### PR TITLE
Update to Vite 4.4.9

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -97,7 +97,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["tsc-watch", "virtual:dc3fc578bfa5e06182a4d2be39ede0bc5b74940b1ffe0d70c26892ab140a4699787750fba175dc306292e80b4aa2c8c5f68c2a821e69b2c37e360c0dff36ff66#npm:6.0.4"],\
             ["typescript", "patch:typescript@npm%3A5.1.6#~builtin<compat/typescript>::version=5.1.6&hash=5da071"],\
             ["vite", "virtual:dc3fc578bfa5e06182a4d2be39ede0bc5b74940b1ffe0d70c26892ab140a4699787750fba175dc306292e80b4aa2c8c5f68c2a821e69b2c37e360c0dff36ff66#npm:4.4.9"],\
-            ["vitest", "virtual:dc3fc578bfa5e06182a4d2be39ede0bc5b74940b1ffe0d70c26892ab140a4699787750fba175dc306292e80b4aa2c8c5f68c2a821e69b2c37e360c0dff36ff66#npm:0.33.0"],\
+            ["vitest", "virtual:dc3fc578bfa5e06182a4d2be39ede0bc5b74940b1ffe0d70c26892ab140a4699787750fba175dc306292e80b4aa2c8c5f68c2a821e69b2c37e360c0dff36ff66#npm:0.34.4"],\
             ["vitest-fetch-mock", "virtual:dc3fc578bfa5e06182a4d2be39ede0bc5b74940b1ffe0d70c26892ab140a4699787750fba175dc306292e80b4aa2c8c5f68c2a821e69b2c37e360c0dff36ff66#npm:0.2.2"],\
             ["vitest-mongodb", "npm:0.0.4"]\
           ],\
@@ -4884,7 +4884,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@openneuro/client", "workspace:packages/openneuro-client"],\
             ["@openneuro/components", "workspace:packages/openneuro-components"],\
             ["@tanstack/react-table", "virtual:4112afb9dad10978c159910bf10db9840b981b1333117623c8a4a8cf77481344a0a24735a5506e2920c18e3cfa2cc179489824b6a56c988bb070f4f60da40974#npm:8.9.3"],\
-            ["@testing-library/jest-dom", "virtual:4112afb9dad10978c159910bf10db9840b981b1333117623c8a4a8cf77481344a0a24735a5506e2920c18e3cfa2cc179489824b6a56c988bb070f4f60da40974#npm:6.1.3"],\
+            ["@testing-library/jest-dom", "virtual:dc3fc578bfa5e06182a4d2be39ede0bc5b74940b1ffe0d70c26892ab140a4699787750fba175dc306292e80b4aa2c8c5f68c2a821e69b2c37e360c0dff36ff66#npm:6.1.3"],\
             ["@testing-library/react", "virtual:4112afb9dad10978c159910bf10db9840b981b1333117623c8a4a8cf77481344a0a24735a5506e2920c18e3cfa2cc179489824b6a56c988bb070f4f60da40974#npm:11.2.7"],\
             ["@types/jsdom", "npm:16.2.13"],\
             ["@types/node", "npm:18.11.9"],\
@@ -4924,7 +4924,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["typescript", "patch:typescript@npm%3A5.1.6#~builtin<compat/typescript>::version=5.1.6&hash=5da071"],\
             ["universal-cookie", "npm:4.0.4"],\
             ["vite", "virtual:4112afb9dad10978c159910bf10db9840b981b1333117623c8a4a8cf77481344a0a24735a5506e2920c18e3cfa2cc179489824b6a56c988bb070f4f60da40974#npm:4.4.9"],\
-            ["vitest", "virtual:4112afb9dad10978c159910bf10db9840b981b1333117623c8a4a8cf77481344a0a24735a5506e2920c18e3cfa2cc179489824b6a56c988bb070f4f60da40974#npm:0.34.4"]\
+            ["vitest", "virtual:dc3fc578bfa5e06182a4d2be39ede0bc5b74940b1ffe0d70c26892ab140a4699787750fba175dc306292e80b4aa2c8c5f68c2a821e69b2c37e360c0dff36ff66#npm:0.34.4"]\
           ],\
           "linkType": "SOFT"\
         }]\
@@ -5598,35 +5598,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           ],\
           "linkType": "SOFT"\
         }],\
-        ["virtual:4112afb9dad10978c159910bf10db9840b981b1333117623c8a4a8cf77481344a0a24735a5506e2920c18e3cfa2cc179489824b6a56c988bb070f4f60da40974#npm:6.1.3", {\
-          "packageLocation": "./.yarn/__virtual__/@testing-library-jest-dom-virtual-22b22f5792/0/cache/@testing-library-jest-dom-npm-6.1.3-b27b065d9a-5bd14ba31f.zip/node_modules/@testing-library/jest-dom/",\
-          "packageDependencies": [\
-            ["@testing-library/jest-dom", "virtual:4112afb9dad10978c159910bf10db9840b981b1333117623c8a4a8cf77481344a0a24735a5506e2920c18e3cfa2cc179489824b6a56c988bb070f4f60da40974#npm:6.1.3"],\
-            ["@adobe/css-tools", "npm:4.3.1"],\
-            ["@babel/runtime", "npm:7.15.4"],\
-            ["@jest/globals", null],\
-            ["@types/jest", null],\
-            ["@types/jest__globals", null],\
-            ["@types/vitest", null],\
-            ["aria-query", "npm:5.1.3"],\
-            ["chalk", "npm:3.0.0"],\
-            ["css.escape", "npm:1.5.1"],\
-            ["dom-accessibility-api", "npm:0.5.7"],\
-            ["jest", null],\
-            ["lodash", "npm:4.17.21"],\
-            ["redent", "npm:3.0.0"],\
-            ["vitest", "virtual:4112afb9dad10978c159910bf10db9840b981b1333117623c8a4a8cf77481344a0a24735a5506e2920c18e3cfa2cc179489824b6a56c988bb070f4f60da40974#npm:0.34.4"]\
-          ],\
-          "packagePeers": [\
-            "@jest/globals",\
-            "@types/jest",\
-            "@types/jest__globals",\
-            "@types/vitest",\
-            "jest",\
-            "vitest"\
-          ],\
-          "linkType": "HARD"\
-        }],\
         ["virtual:bb4ed02b339ed801b02d2ec15b42a5aa7b1afdaf44119aefaab128a59d6e16cc6018880c169f24bf2107550e914562ee9e1780db01a12e1bc3c492ad0a049c36#npm:6.1.3", {\
           "packageLocation": "./.yarn/__virtual__/@testing-library-jest-dom-virtual-7943075c7d/0/cache/@testing-library-jest-dom-npm-6.1.3-b27b065d9a-5bd14ba31f.zip/node_modules/@testing-library/jest-dom/",\
           "packageDependencies": [\
@@ -5673,7 +5644,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["jest", null],\
             ["lodash", "npm:4.17.21"],\
             ["redent", "npm:3.0.0"],\
-            ["vitest", "virtual:dc3fc578bfa5e06182a4d2be39ede0bc5b74940b1ffe0d70c26892ab140a4699787750fba175dc306292e80b4aa2c8c5f68c2a821e69b2c37e360c0dff36ff66#npm:0.33.0"]\
+            ["vitest", "virtual:dc3fc578bfa5e06182a4d2be39ede0bc5b74940b1ffe0d70c26892ab140a4699787750fba175dc306292e80b4aa2c8c5f68c2a821e69b2c37e360c0dff36ff66#npm:0.34.4"]\
           ],\
           "packagePeers": [\
             "@jest/globals",\
@@ -6749,7 +6720,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["std-env", "npm:3.3.3"],\
             ["test-exclude", "npm:6.0.0"],\
             ["v8-to-istanbul", "npm:9.1.0"],\
-            ["vitest", "virtual:dc3fc578bfa5e06182a4d2be39ede0bc5b74940b1ffe0d70c26892ab140a4699787750fba175dc306292e80b4aa2c8c5f68c2a821e69b2c37e360c0dff36ff66#npm:0.33.0"]\
+            ["vitest", "virtual:dc3fc578bfa5e06182a4d2be39ede0bc5b74940b1ffe0d70c26892ab140a4699787750fba175dc306292e80b4aa2c8c5f68c2a821e69b2c37e360c0dff36ff66#npm:0.34.4"]\
           ],\
           "packagePeers": [\
             "@types/vitest",\
@@ -6759,16 +6730,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
         }]\
       ]],\
       ["@vitest/expect", [\
-        ["npm:0.33.0", {\
-          "packageLocation": "./.yarn/cache/@vitest-expect-npm-0.33.0-977ab93af1-da6bf8e4a4.zip/node_modules/@vitest/expect/",\
-          "packageDependencies": [\
-            ["@vitest/expect", "npm:0.33.0"],\
-            ["@vitest/spy", "npm:0.33.0"],\
-            ["@vitest/utils", "npm:0.33.0"],\
-            ["chai", "npm:4.3.7"]\
-          ],\
-          "linkType": "HARD"\
-        }],\
         ["npm:0.34.4", {\
           "packageLocation": "./.yarn/cache/@vitest-expect-npm-0.34.4-af0620ab6d-eb51e73f70.zip/node_modules/@vitest/expect/",\
           "packageDependencies": [\
@@ -6781,16 +6742,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
         }]\
       ]],\
       ["@vitest/runner", [\
-        ["npm:0.33.0", {\
-          "packageLocation": "./.yarn/cache/@vitest-runner-npm-0.33.0-66e3fd30a0-de731aa068.zip/node_modules/@vitest/runner/",\
-          "packageDependencies": [\
-            ["@vitest/runner", "npm:0.33.0"],\
-            ["@vitest/utils", "npm:0.33.0"],\
-            ["p-limit", "npm:4.0.0"],\
-            ["pathe", "npm:1.1.1"]\
-          ],\
-          "linkType": "HARD"\
-        }],\
         ["npm:0.34.4", {\
           "packageLocation": "./.yarn/cache/@vitest-runner-npm-0.34.4-310f6b0d10-b0188ea197.zip/node_modules/@vitest/runner/",\
           "packageDependencies": [\
@@ -6803,16 +6754,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
         }]\
       ]],\
       ["@vitest/snapshot", [\
-        ["npm:0.33.0", {\
-          "packageLocation": "./.yarn/cache/@vitest-snapshot-npm-0.33.0-b4e168423b-ff2604d5bf.zip/node_modules/@vitest/snapshot/",\
-          "packageDependencies": [\
-            ["@vitest/snapshot", "npm:0.33.0"],\
-            ["magic-string", "npm:0.30.1"],\
-            ["pathe", "npm:1.1.1"],\
-            ["pretty-format", "npm:29.6.2"]\
-          ],\
-          "linkType": "HARD"\
-        }],\
         ["npm:0.34.4", {\
           "packageLocation": "./.yarn/cache/@vitest-snapshot-npm-0.34.4-28f7eb1c29-3c9335bff7.zip/node_modules/@vitest/snapshot/",\
           "packageDependencies": [\
@@ -6825,14 +6766,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
         }]\
       ]],\
       ["@vitest/spy", [\
-        ["npm:0.33.0", {\
-          "packageLocation": "./.yarn/cache/@vitest-spy-npm-0.33.0-893d8058a6-501a704a10.zip/node_modules/@vitest/spy/",\
-          "packageDependencies": [\
-            ["@vitest/spy", "npm:0.33.0"],\
-            ["tinyspy", "npm:2.1.1"]\
-          ],\
-          "linkType": "HARD"\
-        }],\
         ["npm:0.34.4", {\
           "packageLocation": "./.yarn/cache/@vitest-spy-npm-0.34.4-9ae9d5c6f0-84e29920b5.zip/node_modules/@vitest/spy/",\
           "packageDependencies": [\
@@ -6843,16 +6776,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
         }]\
       ]],\
       ["@vitest/utils", [\
-        ["npm:0.33.0", {\
-          "packageLocation": "./.yarn/cache/@vitest-utils-npm-0.33.0-4a9e2c7435-8c5b381f55.zip/node_modules/@vitest/utils/",\
-          "packageDependencies": [\
-            ["@vitest/utils", "npm:0.33.0"],\
-            ["diff-sequences", "npm:29.4.3"],\
-            ["loupe", "npm:2.3.6"],\
-            ["pretty-format", "npm:29.6.2"]\
-          ],\
-          "linkType": "HARD"\
-        }],\
         ["npm:0.34.4", {\
           "packageLocation": "./.yarn/cache/@vitest-utils-npm-0.34.4-dd186e0507-5ec5e9d6de.zip/node_modules/@vitest/utils/",\
           "packageDependencies": [\
@@ -20126,7 +20049,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["tsc-watch", "virtual:dc3fc578bfa5e06182a4d2be39ede0bc5b74940b1ffe0d70c26892ab140a4699787750fba175dc306292e80b4aa2c8c5f68c2a821e69b2c37e360c0dff36ff66#npm:6.0.4"],\
             ["typescript", "patch:typescript@npm%3A5.1.6#~builtin<compat/typescript>::version=5.1.6&hash=5da071"],\
             ["vite", "virtual:dc3fc578bfa5e06182a4d2be39ede0bc5b74940b1ffe0d70c26892ab140a4699787750fba175dc306292e80b4aa2c8c5f68c2a821e69b2c37e360c0dff36ff66#npm:4.4.9"],\
-            ["vitest", "virtual:dc3fc578bfa5e06182a4d2be39ede0bc5b74940b1ffe0d70c26892ab140a4699787750fba175dc306292e80b4aa2c8c5f68c2a821e69b2c37e360c0dff36ff66#npm:0.33.0"],\
+            ["vitest", "virtual:dc3fc578bfa5e06182a4d2be39ede0bc5b74940b1ffe0d70c26892ab140a4699787750fba175dc306292e80b4aa2c8c5f68c2a821e69b2c37e360c0dff36ff66#npm:0.34.4"],\
             ["vitest-fetch-mock", "virtual:dc3fc578bfa5e06182a4d2be39ede0bc5b74940b1ffe0d70c26892ab140a4699787750fba175dc306292e80b4aa2c8c5f68c2a821e69b2c37e360c0dff36ff66#npm:0.2.2"],\
             ["vitest-mongodb", "npm:0.0.4"]\
           ],\
@@ -21851,13 +21774,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
         }]\
       ]],\
       ["tinypool", [\
-        ["npm:0.6.0", {\
-          "packageLocation": "./.yarn/cache/tinypool-npm-0.6.0-8397ce29b4-996bf3a922.zip/node_modules/tinypool/",\
-          "packageDependencies": [\
-            ["tinypool", "npm:0.6.0"]\
-          ],\
-          "linkType": "HARD"\
-        }],\
         ["npm:0.7.0", {\
           "packageLocation": "./.yarn/cache/tinypool-npm-0.7.0-725c438ec5-fdcccd5c75.zip/node_modules/tinypool/",\
           "packageDependencies": [\
@@ -22920,49 +22836,10 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           ],\
           "linkType": "SOFT"\
         }],\
-        ["virtual:185bd601e02ffe31741ebe5fd9185af7ea79dc6e098f6290e1bb0212a50aac69c474ab2f2089ce16e96ddfd2444b0860d9e3457861e243603a62f3be84b37977#npm:4.4.7", {\
-          "packageLocation": "./.yarn/__virtual__/vite-virtual-1995b6688e/0/cache/vite-npm-4.4.7-cdb8738fa5-787c4d891d.zip/node_modules/vite/",\
+        ["virtual:1bd263c7ada3e211930ef93b8cc1b620475ce61ffd4fa6e2e4d7cd05c348d038a78b293757b6e4a4693763fae6b21242c23b26b43f6521638b9122dd93b030e0#npm:5.0.0-beta.1", {\
+          "packageLocation": "./.yarn/__virtual__/vite-virtual-a714ad7520/0/cache/vite-npm-5.0.0-beta.1-38e49bfa78-428530b51b.zip/node_modules/vite/",\
           "packageDependencies": [\
-            ["vite", "virtual:185bd601e02ffe31741ebe5fd9185af7ea79dc6e098f6290e1bb0212a50aac69c474ab2f2089ce16e96ddfd2444b0860d9e3457861e243603a62f3be84b37977#npm:4.4.7"],\
-            ["@types/less", null],\
-            ["@types/lightningcss", null],\
-            ["@types/node", null],\
-            ["@types/sass", null],\
-            ["@types/stylus", null],\
-            ["@types/sugarss", null],\
-            ["@types/terser", null],\
-            ["esbuild", "npm:0.18.17"],\
-            ["fsevents", "patch:fsevents@npm%3A2.3.2#~builtin<compat/fsevents>::version=2.3.2&hash=df0bf1"],\
-            ["less", null],\
-            ["lightningcss", null],\
-            ["postcss", "npm:8.4.27"],\
-            ["rollup", "npm:3.26.3"],\
-            ["sass", null],\
-            ["stylus", null],\
-            ["sugarss", null],\
-            ["terser", null]\
-          ],\
-          "packagePeers": [\
-            "@types/less",\
-            "@types/lightningcss",\
-            "@types/node",\
-            "@types/sass",\
-            "@types/stylus",\
-            "@types/sugarss",\
-            "@types/terser",\
-            "less",\
-            "lightningcss",\
-            "sass",\
-            "stylus",\
-            "sugarss",\
-            "terser"\
-          ],\
-          "linkType": "HARD"\
-        }],\
-        ["virtual:376781791b24114abac37408781df52a2b558e2b667813ecca803e63c3d220c49686ddff7fd404076f9f6aa234aabe71f8d7358c8757fce8f801777441641332#npm:4.4.7", {\
-          "packageLocation": "./.yarn/__virtual__/vite-virtual-5538362618/0/cache/vite-npm-4.4.7-cdb8738fa5-787c4d891d.zip/node_modules/vite/",\
-          "packageDependencies": [\
-            ["vite", "virtual:376781791b24114abac37408781df52a2b558e2b667813ecca803e63c3d220c49686ddff7fd404076f9f6aa234aabe71f8d7358c8757fce8f801777441641332#npm:4.4.7"],\
+            ["vite", "virtual:1bd263c7ada3e211930ef93b8cc1b620475ce61ffd4fa6e2e4d7cd05c348d038a78b293757b6e4a4693763fae6b21242c23b26b43f6521638b9122dd93b030e0#npm:5.0.0-beta.1"],\
             ["@types/less", null],\
             ["@types/lightningcss", null],\
             ["@types/node", "npm:16.9.6"],\
@@ -22974,8 +22851,8 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["fsevents", "patch:fsevents@npm%3A2.3.2#~builtin<compat/fsevents>::version=2.3.2&hash=df0bf1"],\
             ["less", null],\
             ["lightningcss", null],\
-            ["postcss", "npm:8.4.27"],\
-            ["rollup", "npm:3.26.3"],\
+            ["postcss", "npm:8.4.29"],\
+            ["rollup", "npm:3.29.0"],\
             ["sass", null],\
             ["stylus", null],\
             ["sugarss", null],\
@@ -23076,13 +22953,13 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           ],\
           "linkType": "HARD"\
         }],\
-        ["virtual:fe1829478a443c21e0c5bdbe3c8594d6b9cf0560394d62eed4dc6ef352199a9a0bee8984fe407e1a7a97aafd33c47cbe04815be83c83f91b0db8774c8b88f69b#npm:5.0.0-beta.1", {\
-          "packageLocation": "./.yarn/__virtual__/vite-virtual-2c58c15e3f/0/cache/vite-npm-5.0.0-beta.1-38e49bfa78-428530b51b.zip/node_modules/vite/",\
+        ["virtual:df6dad177b2aa9c01db6c617da8de4d3559a6438651c3152aaa85f6f59569ee7cc47bbd88402c5a1f75d0679628a5d015a8690c0c481c11d8893844ba1fe5832#npm:4.4.7", {\
+          "packageLocation": "./.yarn/__virtual__/vite-virtual-8ed83f494a/0/cache/vite-npm-4.4.7-cdb8738fa5-787c4d891d.zip/node_modules/vite/",\
           "packageDependencies": [\
-            ["vite", "virtual:fe1829478a443c21e0c5bdbe3c8594d6b9cf0560394d62eed4dc6ef352199a9a0bee8984fe407e1a7a97aafd33c47cbe04815be83c83f91b0db8774c8b88f69b#npm:5.0.0-beta.1"],\
+            ["vite", "virtual:df6dad177b2aa9c01db6c617da8de4d3559a6438651c3152aaa85f6f59569ee7cc47bbd88402c5a1f75d0679628a5d015a8690c0c481c11d8893844ba1fe5832#npm:4.4.7"],\
             ["@types/less", null],\
             ["@types/lightningcss", null],\
-            ["@types/node", "npm:16.9.6"],\
+            ["@types/node", null],\
             ["@types/sass", null],\
             ["@types/stylus", null],\
             ["@types/sugarss", null],\
@@ -23091,8 +22968,8 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["fsevents", "patch:fsevents@npm%3A2.3.2#~builtin<compat/fsevents>::version=2.3.2&hash=df0bf1"],\
             ["less", null],\
             ["lightningcss", null],\
-            ["postcss", "npm:8.4.29"],\
-            ["rollup", "npm:3.29.0"],\
+            ["postcss", "npm:8.4.27"],\
+            ["rollup", "npm:3.26.3"],\
             ["sass", null],\
             ["stylus", null],\
             ["sugarss", null],\
@@ -23117,19 +22994,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
         }]\
       ]],\
       ["vite-node", [\
-        ["npm:0.33.0", {\
-          "packageLocation": "./.yarn/cache/vite-node-npm-0.33.0-185bd601e0-7c37911251.zip/node_modules/vite-node/",\
-          "packageDependencies": [\
-            ["vite-node", "npm:0.33.0"],\
-            ["cac", "npm:6.7.14"],\
-            ["debug", "virtual:58471071b1e0e7981e3318280660861b4dec874aaf0d60e144b70657cb5ce0af059ae16711a2af10f4d1ff0536527e350e6e47a8f79db2d8d37ff2ec84865bbc#npm:4.3.4"],\
-            ["mlly", "npm:1.4.0"],\
-            ["pathe", "npm:1.1.1"],\
-            ["picocolors", "npm:1.0.0"],\
-            ["vite", "virtual:185bd601e02ffe31741ebe5fd9185af7ea79dc6e098f6290e1bb0212a50aac69c474ab2f2089ce16e96ddfd2444b0860d9e3457861e243603a62f3be84b37977#npm:4.4.7"]\
-          ],\
-          "linkType": "HARD"\
-        }],\
         ["npm:0.34.4", {\
           "packageLocation": "./.yarn/cache/vite-node-npm-0.34.4-df6dad177b-bcbba2f920.zip/node_modules/vite-node/",\
           "packageDependencies": [\
@@ -23139,90 +23003,18 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["mlly", "npm:1.4.0"],\
             ["pathe", "npm:1.1.1"],\
             ["picocolors", "npm:1.0.0"],\
-            ["vite", "virtual:185bd601e02ffe31741ebe5fd9185af7ea79dc6e098f6290e1bb0212a50aac69c474ab2f2089ce16e96ddfd2444b0860d9e3457861e243603a62f3be84b37977#npm:4.4.7"]\
+            ["vite", "virtual:df6dad177b2aa9c01db6c617da8de4d3559a6438651c3152aaa85f6f59569ee7cc47bbd88402c5a1f75d0679628a5d015a8690c0c481c11d8893844ba1fe5832#npm:4.4.7"]\
           ],\
           "linkType": "HARD"\
         }]\
       ]],\
       ["vitest", [\
-        ["npm:0.33.0", {\
-          "packageLocation": "./.yarn/cache/vitest-npm-0.33.0-420f3c7c44-c1884b2a1a.zip/node_modules/vitest/",\
-          "packageDependencies": [\
-            ["vitest", "npm:0.33.0"]\
-          ],\
-          "linkType": "SOFT"\
-        }],\
         ["npm:0.34.4", {\
           "packageLocation": "./.yarn/cache/vitest-npm-0.34.4-59d4b8418b-7ac214cfeb.zip/node_modules/vitest/",\
           "packageDependencies": [\
             ["vitest", "npm:0.34.4"]\
           ],\
           "linkType": "SOFT"\
-        }],\
-        ["virtual:4112afb9dad10978c159910bf10db9840b981b1333117623c8a4a8cf77481344a0a24735a5506e2920c18e3cfa2cc179489824b6a56c988bb070f4f60da40974#npm:0.34.4", {\
-          "packageLocation": "./.yarn/__virtual__/vitest-virtual-06dc25330d/0/cache/vitest-npm-0.34.4-59d4b8418b-7ac214cfeb.zip/node_modules/vitest/",\
-          "packageDependencies": [\
-            ["vitest", "virtual:4112afb9dad10978c159910bf10db9840b981b1333117623c8a4a8cf77481344a0a24735a5506e2920c18e3cfa2cc179489824b6a56c988bb070f4f60da40974#npm:0.34.4"],\
-            ["@edge-runtime/vm", null],\
-            ["@types/chai", "npm:4.3.5"],\
-            ["@types/chai-subset", "npm:1.3.3"],\
-            ["@types/edge-runtime__vm", null],\
-            ["@types/happy-dom", null],\
-            ["@types/jsdom", "npm:16.2.13"],\
-            ["@types/node", "npm:16.9.6"],\
-            ["@types/playwright", null],\
-            ["@types/safaridriver", null],\
-            ["@types/vitest__browser", null],\
-            ["@types/vitest__ui", null],\
-            ["@types/webdriverio", null],\
-            ["@vitest/browser", null],\
-            ["@vitest/expect", "npm:0.34.4"],\
-            ["@vitest/runner", "npm:0.34.4"],\
-            ["@vitest/snapshot", "npm:0.34.4"],\
-            ["@vitest/spy", "npm:0.34.4"],\
-            ["@vitest/ui", null],\
-            ["@vitest/utils", "npm:0.34.4"],\
-            ["acorn", "npm:8.10.0"],\
-            ["acorn-walk", "npm:8.2.0"],\
-            ["cac", "npm:6.7.14"],\
-            ["chai", "npm:4.3.7"],\
-            ["debug", "virtual:58471071b1e0e7981e3318280660861b4dec874aaf0d60e144b70657cb5ce0af059ae16711a2af10f4d1ff0536527e350e6e47a8f79db2d8d37ff2ec84865bbc#npm:4.3.4"],\
-            ["happy-dom", null],\
-            ["jsdom", "virtual:dc3fc578bfa5e06182a4d2be39ede0bc5b74940b1ffe0d70c26892ab140a4699787750fba175dc306292e80b4aa2c8c5f68c2a821e69b2c37e360c0dff36ff66#npm:16.7.0"],\
-            ["local-pkg", "npm:0.4.3"],\
-            ["magic-string", "npm:0.30.1"],\
-            ["pathe", "npm:1.1.1"],\
-            ["picocolors", "npm:1.0.0"],\
-            ["playwright", null],\
-            ["safaridriver", null],\
-            ["std-env", "npm:3.3.3"],\
-            ["strip-literal", "npm:1.0.1"],\
-            ["tinybench", "npm:2.5.0"],\
-            ["tinypool", "npm:0.7.0"],\
-            ["vite", "virtual:fe1829478a443c21e0c5bdbe3c8594d6b9cf0560394d62eed4dc6ef352199a9a0bee8984fe407e1a7a97aafd33c47cbe04815be83c83f91b0db8774c8b88f69b#npm:5.0.0-beta.1"],\
-            ["vite-node", "npm:0.34.4"],\
-            ["webdriverio", null],\
-            ["why-is-node-running", "npm:2.2.2"]\
-          ],\
-          "packagePeers": [\
-            "@edge-runtime/vm",\
-            "@types/edge-runtime__vm",\
-            "@types/happy-dom",\
-            "@types/jsdom",\
-            "@types/playwright",\
-            "@types/safaridriver",\
-            "@types/vitest__browser",\
-            "@types/vitest__ui",\
-            "@types/webdriverio",\
-            "@vitest/browser",\
-            "@vitest/ui",\
-            "happy-dom",\
-            "jsdom",\
-            "playwright",\
-            "safaridriver",\
-            "webdriverio"\
-          ],\
-          "linkType": "HARD"\
         }],\
         ["virtual:6d9c0fee0b376eb0bb6824eb7a3246834ef21d870b31f75eebe59bb4d027e50f2607ba168fd29d446567f4e9c2a5cad2442c4741fa92c92e0b7e9145c3a3e3a7#npm:0.34.4", {\
           "packageLocation": "./.yarn/__virtual__/vitest-virtual-af669c7e8d/0/cache/vitest-npm-0.34.4-59d4b8418b-7ac214cfeb.zip/node_modules/vitest/",\
@@ -23264,7 +23056,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["strip-literal", "npm:1.0.1"],\
             ["tinybench", "npm:2.5.0"],\
             ["tinypool", "npm:0.7.0"],\
-            ["vite", "virtual:fe1829478a443c21e0c5bdbe3c8594d6b9cf0560394d62eed4dc6ef352199a9a0bee8984fe407e1a7a97aafd33c47cbe04815be83c83f91b0db8774c8b88f69b#npm:5.0.0-beta.1"],\
+            ["vite", "virtual:1bd263c7ada3e211930ef93b8cc1b620475ce61ffd4fa6e2e4d7cd05c348d038a78b293757b6e4a4693763fae6b21242c23b26b43f6521638b9122dd93b030e0#npm:5.0.0-beta.1"],\
             ["vite-node", "npm:0.34.4"],\
             ["webdriverio", null],\
             ["why-is-node-running", "npm:2.2.2"]\
@@ -23289,10 +23081,10 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           ],\
           "linkType": "HARD"\
         }],\
-        ["virtual:dc3fc578bfa5e06182a4d2be39ede0bc5b74940b1ffe0d70c26892ab140a4699787750fba175dc306292e80b4aa2c8c5f68c2a821e69b2c37e360c0dff36ff66#npm:0.33.0", {\
-          "packageLocation": "./.yarn/__virtual__/vitest-virtual-376781791b/0/cache/vitest-npm-0.33.0-420f3c7c44-c1884b2a1a.zip/node_modules/vitest/",\
+        ["virtual:dc3fc578bfa5e06182a4d2be39ede0bc5b74940b1ffe0d70c26892ab140a4699787750fba175dc306292e80b4aa2c8c5f68c2a821e69b2c37e360c0dff36ff66#npm:0.34.4", {\
+          "packageLocation": "./.yarn/__virtual__/vitest-virtual-1bd263c7ad/0/cache/vitest-npm-0.34.4-59d4b8418b-7ac214cfeb.zip/node_modules/vitest/",\
           "packageDependencies": [\
-            ["vitest", "virtual:dc3fc578bfa5e06182a4d2be39ede0bc5b74940b1ffe0d70c26892ab140a4699787750fba175dc306292e80b4aa2c8c5f68c2a821e69b2c37e360c0dff36ff66#npm:0.33.0"],\
+            ["vitest", "virtual:dc3fc578bfa5e06182a4d2be39ede0bc5b74940b1ffe0d70c26892ab140a4699787750fba175dc306292e80b4aa2c8c5f68c2a821e69b2c37e360c0dff36ff66#npm:0.34.4"],\
             ["@edge-runtime/vm", null],\
             ["@types/chai", "npm:4.3.5"],\
             ["@types/chai-subset", "npm:1.3.3"],\
@@ -23306,12 +23098,12 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@types/vitest__ui", null],\
             ["@types/webdriverio", null],\
             ["@vitest/browser", null],\
-            ["@vitest/expect", "npm:0.33.0"],\
-            ["@vitest/runner", "npm:0.33.0"],\
-            ["@vitest/snapshot", "npm:0.33.0"],\
-            ["@vitest/spy", "npm:0.33.0"],\
+            ["@vitest/expect", "npm:0.34.4"],\
+            ["@vitest/runner", "npm:0.34.4"],\
+            ["@vitest/snapshot", "npm:0.34.4"],\
+            ["@vitest/spy", "npm:0.34.4"],\
             ["@vitest/ui", null],\
-            ["@vitest/utils", "npm:0.33.0"],\
+            ["@vitest/utils", "npm:0.34.4"],\
             ["acorn", "npm:8.10.0"],\
             ["acorn-walk", "npm:8.2.0"],\
             ["cac", "npm:6.7.14"],\
@@ -23328,9 +23120,9 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["std-env", "npm:3.3.3"],\
             ["strip-literal", "npm:1.0.1"],\
             ["tinybench", "npm:2.5.0"],\
-            ["tinypool", "npm:0.6.0"],\
-            ["vite", "virtual:376781791b24114abac37408781df52a2b558e2b667813ecca803e63c3d220c49686ddff7fd404076f9f6aa234aabe71f8d7358c8757fce8f801777441641332#npm:4.4.7"],\
-            ["vite-node", "npm:0.33.0"],\
+            ["tinypool", "npm:0.7.0"],\
+            ["vite", "virtual:1bd263c7ada3e211930ef93b8cc1b620475ce61ffd4fa6e2e4d7cd05c348d038a78b293757b6e4a4693763fae6b21242c23b26b43f6521638b9122dd93b030e0#npm:5.0.0-beta.1"],\
+            ["vite-node", "npm:0.34.4"],\
             ["webdriverio", null],\
             ["why-is-node-running", "npm:2.2.2"]\
           ],\
@@ -23394,7 +23186,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["strip-literal", "npm:1.0.1"],\
             ["tinybench", "npm:2.5.0"],\
             ["tinypool", "npm:0.7.0"],\
-            ["vite", "virtual:fe1829478a443c21e0c5bdbe3c8594d6b9cf0560394d62eed4dc6ef352199a9a0bee8984fe407e1a7a97aafd33c47cbe04815be83c83f91b0db8774c8b88f69b#npm:5.0.0-beta.1"],\
+            ["vite", "virtual:1bd263c7ada3e211930ef93b8cc1b620475ce61ffd4fa6e2e4d7cd05c348d038a78b293757b6e4a4693763fae6b21242c23b26b43f6521638b9122dd93b030e0#npm:5.0.0-beta.1"],\
             ["vite-node", "npm:0.34.4"],\
             ["webdriverio", null],\
             ["why-is-node-running", "npm:2.2.2"]\
@@ -23448,7 +23240,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["vitest-fetch-mock", "virtual:dc3fc578bfa5e06182a4d2be39ede0bc5b74940b1ffe0d70c26892ab140a4699787750fba175dc306292e80b4aa2c8c5f68c2a821e69b2c37e360c0dff36ff66#npm:0.2.2"],\
             ["@types/vitest", null],\
             ["cross-fetch", "npm:3.1.4"],\
-            ["vitest", "virtual:dc3fc578bfa5e06182a4d2be39ede0bc5b74940b1ffe0d70c26892ab140a4699787750fba175dc306292e80b4aa2c8c5f68c2a821e69b2c37e360c0dff36ff66#npm:0.33.0"]\
+            ["vitest", "virtual:dc3fc578bfa5e06182a4d2be39ede0bc5b74940b1ffe0d70c26892ab140a4699787750fba175dc306292e80b4aa2c8c5f68c2a821e69b2c37e360c0dff36ff66#npm:0.34.4"]\
           ],\
           "packagePeers": [\
             "@types/vitest",\

--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -96,7 +96,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["sass", "npm:1.56.1"],\
             ["tsc-watch", "virtual:dc3fc578bfa5e06182a4d2be39ede0bc5b74940b1ffe0d70c26892ab140a4699787750fba175dc306292e80b4aa2c8c5f68c2a821e69b2c37e360c0dff36ff66#npm:6.0.4"],\
             ["typescript", "patch:typescript@npm%3A5.1.6#~builtin<compat/typescript>::version=5.1.6&hash=5da071"],\
-            ["vite", "virtual:dc3fc578bfa5e06182a4d2be39ede0bc5b74940b1ffe0d70c26892ab140a4699787750fba175dc306292e80b4aa2c8c5f68c2a821e69b2c37e360c0dff36ff66#npm:3.2.7"],\
+            ["vite", "virtual:dc3fc578bfa5e06182a4d2be39ede0bc5b74940b1ffe0d70c26892ab140a4699787750fba175dc306292e80b4aa2c8c5f68c2a821e69b2c37e360c0dff36ff66#npm:4.4.9"],\
             ["vitest", "virtual:dc3fc578bfa5e06182a4d2be39ede0bc5b74940b1ffe0d70c26892ab140a4699787750fba175dc306292e80b4aa2c8c5f68c2a821e69b2c37e360c0dff36ff66#npm:0.33.0"],\
             ["vitest-fetch-mock", "virtual:dc3fc578bfa5e06182a4d2be39ede0bc5b74940b1ffe0d70c26892ab140a4699787750fba175dc306292e80b4aa2c8c5f68c2a821e69b2c37e360c0dff36ff66#npm:0.2.2"],\
             ["vitest-mongodb", "npm:0.0.4"]\
@@ -3059,13 +3059,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
         }]\
       ]],\
       ["@esbuild/android-arm", [\
-        ["npm:0.15.13", {\
-          "packageLocation": "./.yarn/unplugged/@esbuild-android-arm-npm-0.15.13-090f132ac6/node_modules/@esbuild/android-arm/",\
-          "packageDependencies": [\
-            ["@esbuild/android-arm", "npm:0.15.13"]\
-          ],\
-          "linkType": "HARD"\
-        }],\
         ["npm:0.18.17", {\
           "packageLocation": "./.yarn/unplugged/@esbuild-android-arm-npm-0.18.17-aff912470a/node_modules/@esbuild/android-arm/",\
           "packageDependencies": [\
@@ -3156,13 +3149,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
         }]\
       ]],\
       ["@esbuild/linux-loong64", [\
-        ["npm:0.15.13", {\
-          "packageLocation": "./.yarn/unplugged/@esbuild-linux-loong64-npm-0.15.13-e51f4225c8/node_modules/@esbuild/linux-loong64/",\
-          "packageDependencies": [\
-            ["@esbuild/linux-loong64", "npm:0.15.13"]\
-          ],\
-          "linkType": "HARD"\
-        }],\
         ["npm:0.18.17", {\
           "packageLocation": "./.yarn/unplugged/@esbuild-linux-loong64-npm-0.18.17-7e66f39beb/node_modules/@esbuild/linux-loong64/",\
           "packageDependencies": [\
@@ -4937,7 +4923,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["subscriptions-transport-ws", "virtual:86720daff6fa91ef488bb305b0b2c8253fb3fabde470b409f92b17f3b1d6203e3f6631585a5dc2cd5ccefab01339e6676f430f53e0206b9354f687fcc9c70489#npm:0.11.0"],\
             ["typescript", "patch:typescript@npm%3A5.1.6#~builtin<compat/typescript>::version=5.1.6&hash=5da071"],\
             ["universal-cookie", "npm:4.0.4"],\
-            ["vite", "virtual:4112afb9dad10978c159910bf10db9840b981b1333117623c8a4a8cf77481344a0a24735a5506e2920c18e3cfa2cc179489824b6a56c988bb070f4f60da40974#npm:3.2.7"],\
+            ["vite", "virtual:4112afb9dad10978c159910bf10db9840b981b1333117623c8a4a8cf77481344a0a24735a5506e2920c18e3cfa2cc179489824b6a56c988bb070f4f60da40974#npm:4.4.9"],\
             ["vitest", "virtual:4112afb9dad10978c159910bf10db9840b981b1333117623c8a4a8cf77481344a0a24735a5506e2920c18e3cfa2cc179489824b6a56c988bb070f4f60da40974#npm:0.34.4"]\
           ],\
           "linkType": "SOFT"\
@@ -10874,35 +10860,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
         }]\
       ]],\
       ["esbuild", [\
-        ["npm:0.15.13", {\
-          "packageLocation": "./.yarn/unplugged/esbuild-npm-0.15.13-7db36c1caa/node_modules/esbuild/",\
-          "packageDependencies": [\
-            ["esbuild", "npm:0.15.13"],\
-            ["@esbuild/android-arm", "npm:0.15.13"],\
-            ["@esbuild/linux-loong64", "npm:0.15.13"],\
-            ["esbuild-android-64", "npm:0.15.13"],\
-            ["esbuild-android-arm64", "npm:0.15.13"],\
-            ["esbuild-darwin-64", "npm:0.15.13"],\
-            ["esbuild-darwin-arm64", "npm:0.15.13"],\
-            ["esbuild-freebsd-64", "npm:0.15.13"],\
-            ["esbuild-freebsd-arm64", "npm:0.15.13"],\
-            ["esbuild-linux-32", "npm:0.15.13"],\
-            ["esbuild-linux-64", "npm:0.15.13"],\
-            ["esbuild-linux-arm", "npm:0.15.13"],\
-            ["esbuild-linux-arm64", "npm:0.15.13"],\
-            ["esbuild-linux-mips64le", "npm:0.15.13"],\
-            ["esbuild-linux-ppc64le", "npm:0.15.13"],\
-            ["esbuild-linux-riscv64", "npm:0.15.13"],\
-            ["esbuild-linux-s390x", "npm:0.15.13"],\
-            ["esbuild-netbsd-64", "npm:0.15.13"],\
-            ["esbuild-openbsd-64", "npm:0.15.13"],\
-            ["esbuild-sunos-64", "npm:0.15.13"],\
-            ["esbuild-windows-32", "npm:0.15.13"],\
-            ["esbuild-windows-64", "npm:0.15.13"],\
-            ["esbuild-windows-arm64", "npm:0.15.13"]\
-          ],\
-          "linkType": "HARD"\
-        }],\
         ["npm:0.18.17", {\
           "packageLocation": "./.yarn/unplugged/esbuild-npm-0.18.17-384f2c63dc/node_modules/esbuild/",\
           "packageDependencies": [\
@@ -10933,191 +10890,11 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "linkType": "HARD"\
         }]\
       ]],\
-      ["esbuild-android-64", [\
-        ["npm:0.15.13", {\
-          "packageLocation": "./.yarn/unplugged/esbuild-android-64-npm-0.15.13-64a149e066/node_modules/esbuild-android-64/",\
-          "packageDependencies": [\
-            ["esbuild-android-64", "npm:0.15.13"]\
-          ],\
-          "linkType": "HARD"\
-        }]\
-      ]],\
-      ["esbuild-android-arm64", [\
-        ["npm:0.15.13", {\
-          "packageLocation": "./.yarn/unplugged/esbuild-android-arm64-npm-0.15.13-92be621047/node_modules/esbuild-android-arm64/",\
-          "packageDependencies": [\
-            ["esbuild-android-arm64", "npm:0.15.13"]\
-          ],\
-          "linkType": "HARD"\
-        }]\
-      ]],\
-      ["esbuild-darwin-64", [\
-        ["npm:0.15.13", {\
-          "packageLocation": "./.yarn/unplugged/esbuild-darwin-64-npm-0.15.13-cd6d2aa5ba/node_modules/esbuild-darwin-64/",\
-          "packageDependencies": [\
-            ["esbuild-darwin-64", "npm:0.15.13"]\
-          ],\
-          "linkType": "HARD"\
-        }]\
-      ]],\
-      ["esbuild-darwin-arm64", [\
-        ["npm:0.15.13", {\
-          "packageLocation": "./.yarn/unplugged/esbuild-darwin-arm64-npm-0.15.13-1f1d7601b0/node_modules/esbuild-darwin-arm64/",\
-          "packageDependencies": [\
-            ["esbuild-darwin-arm64", "npm:0.15.13"]\
-          ],\
-          "linkType": "HARD"\
-        }]\
-      ]],\
-      ["esbuild-freebsd-64", [\
-        ["npm:0.15.13", {\
-          "packageLocation": "./.yarn/unplugged/esbuild-freebsd-64-npm-0.15.13-93d7e9e575/node_modules/esbuild-freebsd-64/",\
-          "packageDependencies": [\
-            ["esbuild-freebsd-64", "npm:0.15.13"]\
-          ],\
-          "linkType": "HARD"\
-        }]\
-      ]],\
-      ["esbuild-freebsd-arm64", [\
-        ["npm:0.15.13", {\
-          "packageLocation": "./.yarn/unplugged/esbuild-freebsd-arm64-npm-0.15.13-98160ae84d/node_modules/esbuild-freebsd-arm64/",\
-          "packageDependencies": [\
-            ["esbuild-freebsd-arm64", "npm:0.15.13"]\
-          ],\
-          "linkType": "HARD"\
-        }]\
-      ]],\
-      ["esbuild-linux-32", [\
-        ["npm:0.15.13", {\
-          "packageLocation": "./.yarn/unplugged/esbuild-linux-32-npm-0.15.13-0bec1c7d3e/node_modules/esbuild-linux-32/",\
-          "packageDependencies": [\
-            ["esbuild-linux-32", "npm:0.15.13"]\
-          ],\
-          "linkType": "HARD"\
-        }]\
-      ]],\
-      ["esbuild-linux-64", [\
-        ["npm:0.15.13", {\
-          "packageLocation": "./.yarn/unplugged/esbuild-linux-64-npm-0.15.13-e3cb5ce303/node_modules/esbuild-linux-64/",\
-          "packageDependencies": [\
-            ["esbuild-linux-64", "npm:0.15.13"]\
-          ],\
-          "linkType": "HARD"\
-        }]\
-      ]],\
-      ["esbuild-linux-arm", [\
-        ["npm:0.15.13", {\
-          "packageLocation": "./.yarn/unplugged/esbuild-linux-arm-npm-0.15.13-9ca88fae87/node_modules/esbuild-linux-arm/",\
-          "packageDependencies": [\
-            ["esbuild-linux-arm", "npm:0.15.13"]\
-          ],\
-          "linkType": "HARD"\
-        }]\
-      ]],\
-      ["esbuild-linux-arm64", [\
-        ["npm:0.15.13", {\
-          "packageLocation": "./.yarn/unplugged/esbuild-linux-arm64-npm-0.15.13-87db89c02a/node_modules/esbuild-linux-arm64/",\
-          "packageDependencies": [\
-            ["esbuild-linux-arm64", "npm:0.15.13"]\
-          ],\
-          "linkType": "HARD"\
-        }]\
-      ]],\
-      ["esbuild-linux-mips64le", [\
-        ["npm:0.15.13", {\
-          "packageLocation": "./.yarn/unplugged/esbuild-linux-mips64le-npm-0.15.13-6d31bd35df/node_modules/esbuild-linux-mips64le/",\
-          "packageDependencies": [\
-            ["esbuild-linux-mips64le", "npm:0.15.13"]\
-          ],\
-          "linkType": "HARD"\
-        }]\
-      ]],\
-      ["esbuild-linux-ppc64le", [\
-        ["npm:0.15.13", {\
-          "packageLocation": "./.yarn/unplugged/esbuild-linux-ppc64le-npm-0.15.13-be1c175b09/node_modules/esbuild-linux-ppc64le/",\
-          "packageDependencies": [\
-            ["esbuild-linux-ppc64le", "npm:0.15.13"]\
-          ],\
-          "linkType": "HARD"\
-        }]\
-      ]],\
-      ["esbuild-linux-riscv64", [\
-        ["npm:0.15.13", {\
-          "packageLocation": "./.yarn/unplugged/esbuild-linux-riscv64-npm-0.15.13-d72af9a7fb/node_modules/esbuild-linux-riscv64/",\
-          "packageDependencies": [\
-            ["esbuild-linux-riscv64", "npm:0.15.13"]\
-          ],\
-          "linkType": "HARD"\
-        }]\
-      ]],\
-      ["esbuild-linux-s390x", [\
-        ["npm:0.15.13", {\
-          "packageLocation": "./.yarn/unplugged/esbuild-linux-s390x-npm-0.15.13-1e037c1465/node_modules/esbuild-linux-s390x/",\
-          "packageDependencies": [\
-            ["esbuild-linux-s390x", "npm:0.15.13"]\
-          ],\
-          "linkType": "HARD"\
-        }]\
-      ]],\
-      ["esbuild-netbsd-64", [\
-        ["npm:0.15.13", {\
-          "packageLocation": "./.yarn/unplugged/esbuild-netbsd-64-npm-0.15.13-62b29b354b/node_modules/esbuild-netbsd-64/",\
-          "packageDependencies": [\
-            ["esbuild-netbsd-64", "npm:0.15.13"]\
-          ],\
-          "linkType": "HARD"\
-        }]\
-      ]],\
-      ["esbuild-openbsd-64", [\
-        ["npm:0.15.13", {\
-          "packageLocation": "./.yarn/unplugged/esbuild-openbsd-64-npm-0.15.13-b50bd3a55b/node_modules/esbuild-openbsd-64/",\
-          "packageDependencies": [\
-            ["esbuild-openbsd-64", "npm:0.15.13"]\
-          ],\
-          "linkType": "HARD"\
-        }]\
-      ]],\
       ["esbuild-plugin-globals", [\
         ["npm:0.1.1", {\
           "packageLocation": "./.yarn/cache/esbuild-plugin-globals-npm-0.1.1-bdd72e97d3-07460a4551.zip/node_modules/esbuild-plugin-globals/",\
           "packageDependencies": [\
             ["esbuild-plugin-globals", "npm:0.1.1"]\
-          ],\
-          "linkType": "HARD"\
-        }]\
-      ]],\
-      ["esbuild-sunos-64", [\
-        ["npm:0.15.13", {\
-          "packageLocation": "./.yarn/unplugged/esbuild-sunos-64-npm-0.15.13-3fe373c1c4/node_modules/esbuild-sunos-64/",\
-          "packageDependencies": [\
-            ["esbuild-sunos-64", "npm:0.15.13"]\
-          ],\
-          "linkType": "HARD"\
-        }]\
-      ]],\
-      ["esbuild-windows-32", [\
-        ["npm:0.15.13", {\
-          "packageLocation": "./.yarn/unplugged/esbuild-windows-32-npm-0.15.13-23635b24bd/node_modules/esbuild-windows-32/",\
-          "packageDependencies": [\
-            ["esbuild-windows-32", "npm:0.15.13"]\
-          ],\
-          "linkType": "HARD"\
-        }]\
-      ]],\
-      ["esbuild-windows-64", [\
-        ["npm:0.15.13", {\
-          "packageLocation": "./.yarn/unplugged/esbuild-windows-64-npm-0.15.13-39d5cedd74/node_modules/esbuild-windows-64/",\
-          "packageDependencies": [\
-            ["esbuild-windows-64", "npm:0.15.13"]\
-          ],\
-          "linkType": "HARD"\
-        }]\
-      ]],\
-      ["esbuild-windows-arm64", [\
-        ["npm:0.15.13", {\
-          "packageLocation": "./.yarn/unplugged/esbuild-windows-arm64-npm-0.15.13-0735b77049/node_modules/esbuild-windows-arm64/",\
-          "packageDependencies": [\
-            ["esbuild-windows-arm64", "npm:0.15.13"]\
           ],\
           "linkType": "HARD"\
         }]\
@@ -16838,13 +16615,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
         }]\
       ]],\
       ["nanoid", [\
-        ["npm:3.3.4", {\
-          "packageLocation": "./.yarn/cache/nanoid-npm-3.3.4-3d250377d6-2fddd6dee9.zip/node_modules/nanoid/",\
-          "packageDependencies": [\
-            ["nanoid", "npm:3.3.4"]\
-          ],\
-          "linkType": "HARD"\
-        }],\
         ["npm:3.3.6", {\
           "packageLocation": "./.yarn/cache/nanoid-npm-3.3.6-e6d6ae7e71-7d0eda6570.zip/node_modules/nanoid/",\
           "packageDependencies": [\
@@ -18521,16 +18291,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
         }]\
       ]],\
       ["postcss", [\
-        ["npm:8.4.19", {\
-          "packageLocation": "./.yarn/cache/postcss-npm-8.4.19-164042496a-62782723a3.zip/node_modules/postcss/",\
-          "packageDependencies": [\
-            ["postcss", "npm:8.4.19"],\
-            ["nanoid", "npm:3.3.4"],\
-            ["picocolors", "npm:1.0.0"],\
-            ["source-map-js", "npm:1.0.2"]\
-          ],\
-          "linkType": "HARD"\
-        }],\
         ["npm:8.4.27", {\
           "packageLocation": "./.yarn/cache/postcss-npm-8.4.27-2a9f5f8f40-1cdd0c2988.zip/node_modules/postcss/",\
           "packageDependencies": [\
@@ -20279,14 +20039,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
         }]\
       ]],\
       ["rollup", [\
-        ["npm:2.79.1", {\
-          "packageLocation": "./.yarn/cache/rollup-npm-2.79.1-94e707a9a3-6a2bf167b3.zip/node_modules/rollup/",\
-          "packageDependencies": [\
-            ["rollup", "npm:2.79.1"],\
-            ["fsevents", "patch:fsevents@npm%3A2.3.2#~builtin<compat/fsevents>::version=2.3.2&hash=df0bf1"]\
-          ],\
-          "linkType": "HARD"\
-        }],\
         ["npm:3.26.3", {\
           "packageLocation": "./.yarn/cache/rollup-npm-3.26.3-072c90700e-e6a765b2b7.zip/node_modules/rollup/",\
           "packageDependencies": [\
@@ -20299,6 +20051,14 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "packageLocation": "./.yarn/cache/rollup-npm-3.29.0-b39b056857-77124a606f.zip/node_modules/rollup/",\
           "packageDependencies": [\
             ["rollup", "npm:3.29.0"],\
+            ["fsevents", "patch:fsevents@npm%3A2.3.2#~builtin<compat/fsevents>::version=2.3.2&hash=df0bf1"]\
+          ],\
+          "linkType": "HARD"\
+        }],\
+        ["npm:3.29.1", {\
+          "packageLocation": "./.yarn/cache/rollup-npm-3.29.1-c6f1191ba8-eb92dbb838.zip/node_modules/rollup/",\
+          "packageDependencies": [\
+            ["rollup", "npm:3.29.1"],\
             ["fsevents", "patch:fsevents@npm%3A2.3.2#~builtin<compat/fsevents>::version=2.3.2&hash=df0bf1"]\
           ],\
           "linkType": "HARD"\
@@ -20365,7 +20125,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["sass", "npm:1.56.1"],\
             ["tsc-watch", "virtual:dc3fc578bfa5e06182a4d2be39ede0bc5b74940b1ffe0d70c26892ab140a4699787750fba175dc306292e80b4aa2c8c5f68c2a821e69b2c37e360c0dff36ff66#npm:6.0.4"],\
             ["typescript", "patch:typescript@npm%3A5.1.6#~builtin<compat/typescript>::version=5.1.6&hash=5da071"],\
-            ["vite", "virtual:dc3fc578bfa5e06182a4d2be39ede0bc5b74940b1ffe0d70c26892ab140a4699787750fba175dc306292e80b4aa2c8c5f68c2a821e69b2c37e360c0dff36ff66#npm:3.2.7"],\
+            ["vite", "virtual:dc3fc578bfa5e06182a4d2be39ede0bc5b74940b1ffe0d70c26892ab140a4699787750fba175dc306292e80b4aa2c8c5f68c2a821e69b2c37e360c0dff36ff66#npm:4.4.9"],\
             ["vitest", "virtual:dc3fc578bfa5e06182a4d2be39ede0bc5b74940b1ffe0d70c26892ab140a4699787750fba175dc306292e80b4aa2c8c5f68c2a821e69b2c37e360c0dff36ff66#npm:0.33.0"],\
             ["vitest-fetch-mock", "virtual:dc3fc578bfa5e06182a4d2be39ede0bc5b74940b1ffe0d70c26892ab140a4699787750fba175dc306292e80b4aa2c8c5f68c2a821e69b2c37e360c0dff36ff66#npm:0.2.2"],\
             ["vitest-mongodb", "npm:0.0.4"]\
@@ -23139,17 +22899,17 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
         }]\
       ]],\
       ["vite", [\
-        ["npm:3.2.7", {\
-          "packageLocation": "./.yarn/cache/vite-npm-3.2.7-dc0dc30c5d-4c5883b721.zip/node_modules/vite/",\
-          "packageDependencies": [\
-            ["vite", "npm:3.2.7"]\
-          ],\
-          "linkType": "SOFT"\
-        }],\
         ["npm:4.4.7", {\
           "packageLocation": "./.yarn/cache/vite-npm-4.4.7-cdb8738fa5-787c4d891d.zip/node_modules/vite/",\
           "packageDependencies": [\
             ["vite", "npm:4.4.7"]\
+          ],\
+          "linkType": "SOFT"\
+        }],\
+        ["npm:4.4.9", {\
+          "packageLocation": "./.yarn/cache/vite-npm-4.4.9-e845c1bbf8-c511024cea.zip/node_modules/vite/",\
+          "packageDependencies": [\
+            ["vite", "npm:4.4.9"]\
           ],\
           "linkType": "SOFT"\
         }],\
@@ -23238,22 +22998,23 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           ],\
           "linkType": "HARD"\
         }],\
-        ["virtual:4112afb9dad10978c159910bf10db9840b981b1333117623c8a4a8cf77481344a0a24735a5506e2920c18e3cfa2cc179489824b6a56c988bb070f4f60da40974#npm:3.2.7", {\
-          "packageLocation": "./.yarn/__virtual__/vite-virtual-03625f3a00/0/cache/vite-npm-3.2.7-dc0dc30c5d-4c5883b721.zip/node_modules/vite/",\
+        ["virtual:4112afb9dad10978c159910bf10db9840b981b1333117623c8a4a8cf77481344a0a24735a5506e2920c18e3cfa2cc179489824b6a56c988bb070f4f60da40974#npm:4.4.9", {\
+          "packageLocation": "./.yarn/__virtual__/vite-virtual-7d339e0792/0/cache/vite-npm-4.4.9-e845c1bbf8-c511024cea.zip/node_modules/vite/",\
           "packageDependencies": [\
-            ["vite", "virtual:4112afb9dad10978c159910bf10db9840b981b1333117623c8a4a8cf77481344a0a24735a5506e2920c18e3cfa2cc179489824b6a56c988bb070f4f60da40974#npm:3.2.7"],\
+            ["vite", "virtual:4112afb9dad10978c159910bf10db9840b981b1333117623c8a4a8cf77481344a0a24735a5506e2920c18e3cfa2cc179489824b6a56c988bb070f4f60da40974#npm:4.4.9"],\
             ["@types/less", null],\
+            ["@types/lightningcss", null],\
             ["@types/node", "npm:18.11.9"],\
             ["@types/sass", null],\
             ["@types/stylus", null],\
             ["@types/sugarss", null],\
             ["@types/terser", null],\
-            ["esbuild", "npm:0.15.13"],\
+            ["esbuild", "npm:0.18.17"],\
             ["fsevents", "patch:fsevents@npm%3A2.3.2#~builtin<compat/fsevents>::version=2.3.2&hash=df0bf1"],\
             ["less", null],\
-            ["postcss", "npm:8.4.19"],\
-            ["resolve", "patch:resolve@npm%3A1.22.1#~builtin<compat/resolve>::version=1.22.1&hash=c3c19d"],\
-            ["rollup", "npm:2.79.1"],\
+            ["lightningcss", null],\
+            ["postcss", "npm:8.4.29"],\
+            ["rollup", "npm:3.29.1"],\
             ["sass", "npm:1.42.1"],\
             ["stylus", null],\
             ["sugarss", null],\
@@ -23261,12 +23022,14 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           ],\
           "packagePeers": [\
             "@types/less",\
+            "@types/lightningcss",\
             "@types/node",\
             "@types/sass",\
             "@types/stylus",\
             "@types/sugarss",\
             "@types/terser",\
             "less",\
+            "lightningcss",\
             "sass",\
             "stylus",\
             "sugarss",\
@@ -23274,22 +23037,23 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           ],\
           "linkType": "HARD"\
         }],\
-        ["virtual:dc3fc578bfa5e06182a4d2be39ede0bc5b74940b1ffe0d70c26892ab140a4699787750fba175dc306292e80b4aa2c8c5f68c2a821e69b2c37e360c0dff36ff66#npm:3.2.7", {\
-          "packageLocation": "./.yarn/__virtual__/vite-virtual-b854c1b626/0/cache/vite-npm-3.2.7-dc0dc30c5d-4c5883b721.zip/node_modules/vite/",\
+        ["virtual:dc3fc578bfa5e06182a4d2be39ede0bc5b74940b1ffe0d70c26892ab140a4699787750fba175dc306292e80b4aa2c8c5f68c2a821e69b2c37e360c0dff36ff66#npm:4.4.9", {\
+          "packageLocation": "./.yarn/__virtual__/vite-virtual-81c46be283/0/cache/vite-npm-4.4.9-e845c1bbf8-c511024cea.zip/node_modules/vite/",\
           "packageDependencies": [\
-            ["vite", "virtual:dc3fc578bfa5e06182a4d2be39ede0bc5b74940b1ffe0d70c26892ab140a4699787750fba175dc306292e80b4aa2c8c5f68c2a821e69b2c37e360c0dff36ff66#npm:3.2.7"],\
+            ["vite", "virtual:dc3fc578bfa5e06182a4d2be39ede0bc5b74940b1ffe0d70c26892ab140a4699787750fba175dc306292e80b4aa2c8c5f68c2a821e69b2c37e360c0dff36ff66#npm:4.4.9"],\
             ["@types/less", null],\
+            ["@types/lightningcss", null],\
             ["@types/node", null],\
             ["@types/sass", null],\
             ["@types/stylus", null],\
             ["@types/sugarss", null],\
             ["@types/terser", null],\
-            ["esbuild", "npm:0.15.13"],\
+            ["esbuild", "npm:0.18.17"],\
             ["fsevents", "patch:fsevents@npm%3A2.3.2#~builtin<compat/fsevents>::version=2.3.2&hash=df0bf1"],\
             ["less", null],\
-            ["postcss", "npm:8.4.19"],\
-            ["resolve", "patch:resolve@npm%3A1.22.1#~builtin<compat/resolve>::version=1.22.1&hash=c3c19d"],\
-            ["rollup", "npm:2.79.1"],\
+            ["lightningcss", null],\
+            ["postcss", "npm:8.4.29"],\
+            ["rollup", "npm:3.29.1"],\
             ["sass", "npm:1.56.1"],\
             ["stylus", null],\
             ["sugarss", null],\
@@ -23297,12 +23061,14 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           ],\
           "packagePeers": [\
             "@types/less",\
+            "@types/lightningcss",\
             "@types/node",\
             "@types/sass",\
             "@types/stylus",\
             "@types/sugarss",\
             "@types/terser",\
             "less",\
+            "lightningcss",\
             "sass",\
             "stylus",\
             "sugarss",\

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "tsc-watch": "6.0.4",
     "typescript": "5.1.6",
     "vite": "4.4.9",
-    "vitest": "0.33.0",
+    "vitest": "0.34.4",
     "vitest-fetch-mock": "0.2.2",
     "vitest-mongodb": "^0.0.4"
   },

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "sass": "^1.56.1",
     "tsc-watch": "6.0.4",
     "typescript": "5.1.6",
-    "vite": "3.2.7",
+    "vite": "4.4.9",
     "vitest": "0.33.0",
     "vitest-fetch-mock": "0.2.2",
     "vitest-mongodb": "^0.0.4"

--- a/packages/openneuro-app/package.json
+++ b/packages/openneuro-app/package.json
@@ -64,7 +64,7 @@
     "sass": "^1.32.8",
     "stream-browserify": "^3.0.0",
     "typescript": "5.1.6",
-    "vite": "^3.2.7",
+    "vite": "4.4.9",
     "vitest": "0.34.4"
   },
   "publishConfig": {

--- a/packages/openneuro-app/src/scripts/dataset/__tests__/snapshot-container.spec.tsx
+++ b/packages/openneuro-app/src/scripts/dataset/__tests__/snapshot-container.spec.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import { render } from '@testing-library/react'
 import Helmet from 'react-helmet'
-import '@testing-library/jest-dom/extend-expect'
 import { SnapshotContainer } from '../snapshot-container'
 import { MockAppWrapper } from '../../fixtures/mock-app-wrapper'
 import { dataset, snapshot } from '../../fixtures/dataset-query'

--- a/packages/openneuro-app/src/scripts/dataset/download/__tests__/download-command-line.spec.jsx
+++ b/packages/openneuro-app/src/scripts/dataset/download/__tests__/download-command-line.spec.jsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import { render, screen } from '@testing-library/react'
-import '@testing-library/jest-dom/extend-expect'
 import { DownloadSampleCommand } from '../download-command-line.jsx'
 
 const defProps = { datasetId: 'ds000001' }

--- a/packages/openneuro-app/src/scripts/dataset/fragments/__tests__/dataset-alert-draft.spec.tsx
+++ b/packages/openneuro-app/src/scripts/dataset/fragments/__tests__/dataset-alert-draft.spec.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import { render, screen } from '@testing-library/react'
-import '@testing-library/jest-dom/extend-expect'
 import { MemoryRouter } from 'react-router-dom'
 import { DatasetAlertDraft } from '../dataset-alert-draft'
 

--- a/packages/openneuro-app/src/scripts/search/__tests__/search-params-ctx.spec.tsx
+++ b/packages/openneuro-app/src/scripts/search/__tests__/search-params-ctx.spec.tsx
@@ -4,7 +4,6 @@ import { SearchParamsProvider, SearchParamsCtx } from '../search-params-ctx'
 import AuthorInput from '../inputs/author-input'
 import initialSearchParams from '../initial-search-params'
 import { MemoryRouter } from 'react-router-dom'
-import '@testing-library/jest-dom'
 
 describe('SearchParamsProvider', () => {
   it('restores URL searchParams state', () => {

--- a/packages/openneuro-cli/src/download.js
+++ b/packages/openneuro-cli/src/download.js
@@ -5,6 +5,9 @@ import cliProgress from 'cli-progress'
 import { getToken } from './config.js'
 import { downloadDataset } from './datasets'
 import fetch from 'node-fetch'
+import nodeFetch, { Request, Response } from 'node-fetch'
+
+Object.assign(global, { fetch: nodeFetch, Request, Response })
 
 export const checkDestination = destination => {
   if (fs.existsSync(destination)) {

--- a/packages/openneuro-components/src/accordion/__tests__/AccordionTab.spec.tsx
+++ b/packages/openneuro-components/src/accordion/__tests__/AccordionTab.spec.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import '@testing-library/jest-dom/extend-expect'
 import { render, screen } from '@testing-library/react'
 import { AccordionTab } from '../AccordionTab'
 

--- a/packages/openneuro-components/src/count-toggle/__tests__/CountToggle.spec.tsx
+++ b/packages/openneuro-components/src/count-toggle/__tests__/CountToggle.spec.tsx
@@ -2,7 +2,6 @@ import { vi } from 'vitest'
 import React from 'react'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { CountToggle } from '../CountToggle'
-import '@testing-library/jest-dom/extend-expect'
 
 export const datasetType_available = [
   { label: 'All Public', value: 'All Public' },

--- a/packages/openneuro-components/src/dataset/__tests__/DatasetAlert.spec.tsx
+++ b/packages/openneuro-components/src/dataset/__tests__/DatasetAlert.spec.tsx
@@ -1,8 +1,6 @@
 import React from 'react'
 import { render, screen } from '@testing-library/react'
-import { MemoryRouter } from 'react-router-dom'
 import { DatasetAlert } from '../DatasetAlert'
-import '@testing-library/jest-dom/extend-expect'
 
 describe('DatasetAlert component', () => {
   it('all props are rendered', () => {

--- a/packages/openneuro-components/src/dataset/__tests__/DatasetHeaders.spec.tsx
+++ b/packages/openneuro-components/src/dataset/__tests__/DatasetHeaders.spec.tsx
@@ -2,7 +2,6 @@ import React from 'react'
 import { render, screen } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { DatasetHeader } from '../DatasetHeader'
-import '@testing-library/jest-dom/extend-expect'
 
 describe('DatasetHeader component', () => {
   it('renders with an undefined modality', () => {

--- a/packages/openneuro-components/src/dataset/__tests__/DatasetTools.spec.tsx
+++ b/packages/openneuro-components/src/dataset/__tests__/DatasetTools.spec.tsx
@@ -2,7 +2,6 @@ import React from 'react'
 import { render, screen } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { DatasetTools } from '../DatasetTools'
-import '@testing-library/jest-dom/extend-expect'
 
 describe('DatasetTools component', () => {
   it('provides expected tools for a draft (admin)', () => {

--- a/packages/openneuro-components/src/icon/__tests__/Icon.spec.tsx
+++ b/packages/openneuro-components/src/icon/__tests__/Icon.spec.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import '@testing-library/jest-dom/extend-expect'
 import { render, screen } from '@testing-library/react'
 import { Icon } from '../Icon'
 

--- a/packages/openneuro-components/src/loading/__tests__/Loading.spec.tsx
+++ b/packages/openneuro-components/src/loading/__tests__/Loading.spec.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import { render, screen } from '@testing-library/react'
 import { Loading } from '../Loading'
-import '@testing-library/jest-dom/extend-expect'
 
 describe('Loading component', () => {
   it('loading animation is labeled alert and aria-busy', async () => {

--- a/packages/openneuro-components/src/logo/__tests__/Logo.spec.tsx
+++ b/packages/openneuro-components/src/logo/__tests__/Logo.spec.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import { render, screen } from '@testing-library/react'
 import { Logo } from '../Logo'
-import '@testing-library/jest-dom/extend-expect'
 
 describe('Logo component', () => {
   it('renders dark/horizontal', async () => {

--- a/packages/openneuro-components/src/radio/__tests__/RadioGroup.spec.tsx
+++ b/packages/openneuro-components/src/radio/__tests__/RadioGroup.spec.tsx
@@ -2,7 +2,6 @@ import { vi } from 'vitest'
 import React from 'react'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { RadioGroup } from '../RadioGroup'
-import '@testing-library/jest-dom/extend-expect'
 
 export const datasetType_available = [
   { label: 'All Public', value: 'All Public' },

--- a/packages/openneuro-components/src/range/__tests__/TwoHandleRange.spec.tsx
+++ b/packages/openneuro-components/src/range/__tests__/TwoHandleRange.spec.tsx
@@ -2,7 +2,6 @@ import { vi } from 'vitest'
 import React from 'react'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { TwoHandleRange } from '../TwoHandleRange'
-import '@testing-library/jest-dom/extend-expect'
 
 import { stepping } from '../TwoHandleRange'
 

--- a/packages/openneuro-components/src/read-more/__tests__/ReadMore.spec.tsx
+++ b/packages/openneuro-components/src/read-more/__tests__/ReadMore.spec.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import { render, screen } from '@testing-library/react'
 import { ReadMore } from '../ReadMore'
-import '@testing-library/jest-dom/extend-expect'
 
 describe('ReadMore component', () => {
   it('renders children', async () => {

--- a/packages/openneuro-components/src/select/__tests__/SelectGroup.spec.tsx
+++ b/packages/openneuro-components/src/select/__tests__/SelectGroup.spec.tsx
@@ -2,7 +2,6 @@ import { vi } from 'vitest'
 import React from 'react'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { SelectGroup } from '../SelectGroup'
-import '@testing-library/jest-dom/extend-expect'
 
 const SelectContent = [
   { label: '--Select--', value: '' },

--- a/packages/openneuro-components/src/textarea/__tests__/Textarea.spec.tsx
+++ b/packages/openneuro-components/src/textarea/__tests__/Textarea.spec.tsx
@@ -2,7 +2,6 @@ import { vi } from 'vitest'
 import React from 'react'
 import { render, screen } from '@testing-library/react'
 import { Textarea } from '../Textarea'
-import '@testing-library/jest-dom/extend-expect'
 
 describe('Textarea component', () => {
   it('supports inline type', () => {

--- a/packages/openneuro-components/src/tooltip/__tests__/Tooltip.spec.tsx
+++ b/packages/openneuro-components/src/tooltip/__tests__/Tooltip.spec.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import { render, screen } from '@testing-library/react'
 import { Tooltip } from '../Tooltip'
-import '@testing-library/jest-dom/extend-expect'
 
 describe('Tooltip component', () => {
   it('renders children', async () => {

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -3,7 +3,6 @@ import createFetchMock from 'vitest-fetch-mock'
 import { vi, afterAll } from 'vitest'
 import { setup, teardown } from 'vitest-mongodb'
 
-// @ts-expect-error vitest-fetch-mock has out of date typing but still works
 const fetchMock = createFetchMock(vi)
 
 // sets globalThis.fetch and globalThis.fetchMock to our mocked version

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
     environment: 'jsdom',
     setupFiles: './test/setup.ts',
     clearMocks: true,
-    maxConcurrency: 24,
+    maxConcurrency: 16,
     isolate: true,
   },
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -2492,13 +2492,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/android-arm@npm:0.15.13":
-  version: 0.15.13
-  resolution: "@esbuild/android-arm@npm:0.15.13"
-  conditions: os=android & cpu=arm
-  languageName: node
-  linkType: hard
-
 "@esbuild/android-arm@npm:0.18.17":
   version: 0.18.17
   resolution: "@esbuild/android-arm@npm:0.18.17"
@@ -2559,13 +2552,6 @@ __metadata:
   version: 0.18.17
   resolution: "@esbuild/linux-ia32@npm:0.18.17"
   conditions: os=linux & cpu=ia32
-  languageName: node
-  linkType: hard
-
-"@esbuild/linux-loong64@npm:0.15.13":
-  version: 0.15.13
-  resolution: "@esbuild/linux-loong64@npm:0.15.13"
-  conditions: os=linux & cpu=loong64
   languageName: node
   linkType: hard
 
@@ -4099,7 +4085,7 @@ __metadata:
     subscriptions-transport-ws: 0.11.0
     typescript: 5.1.6
     universal-cookie: ^4.0.4
-    vite: ^3.2.7
+    vite: 4.4.9
     vitest: 0.34.4
   languageName: unknown
   linkType: soft
@@ -9087,227 +9073,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild-android-64@npm:0.15.13":
-  version: 0.15.13
-  resolution: "esbuild-android-64@npm:0.15.13"
-  conditions: os=android & cpu=x64
-  languageName: node
-  linkType: hard
-
-"esbuild-android-arm64@npm:0.15.13":
-  version: 0.15.13
-  resolution: "esbuild-android-arm64@npm:0.15.13"
-  conditions: os=android & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"esbuild-darwin-64@npm:0.15.13":
-  version: 0.15.13
-  resolution: "esbuild-darwin-64@npm:0.15.13"
-  conditions: os=darwin & cpu=x64
-  languageName: node
-  linkType: hard
-
-"esbuild-darwin-arm64@npm:0.15.13":
-  version: 0.15.13
-  resolution: "esbuild-darwin-arm64@npm:0.15.13"
-  conditions: os=darwin & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"esbuild-freebsd-64@npm:0.15.13":
-  version: 0.15.13
-  resolution: "esbuild-freebsd-64@npm:0.15.13"
-  conditions: os=freebsd & cpu=x64
-  languageName: node
-  linkType: hard
-
-"esbuild-freebsd-arm64@npm:0.15.13":
-  version: 0.15.13
-  resolution: "esbuild-freebsd-arm64@npm:0.15.13"
-  conditions: os=freebsd & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"esbuild-linux-32@npm:0.15.13":
-  version: 0.15.13
-  resolution: "esbuild-linux-32@npm:0.15.13"
-  conditions: os=linux & cpu=ia32
-  languageName: node
-  linkType: hard
-
-"esbuild-linux-64@npm:0.15.13":
-  version: 0.15.13
-  resolution: "esbuild-linux-64@npm:0.15.13"
-  conditions: os=linux & cpu=x64
-  languageName: node
-  linkType: hard
-
-"esbuild-linux-arm64@npm:0.15.13":
-  version: 0.15.13
-  resolution: "esbuild-linux-arm64@npm:0.15.13"
-  conditions: os=linux & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"esbuild-linux-arm@npm:0.15.13":
-  version: 0.15.13
-  resolution: "esbuild-linux-arm@npm:0.15.13"
-  conditions: os=linux & cpu=arm
-  languageName: node
-  linkType: hard
-
-"esbuild-linux-mips64le@npm:0.15.13":
-  version: 0.15.13
-  resolution: "esbuild-linux-mips64le@npm:0.15.13"
-  conditions: os=linux & cpu=mips64el
-  languageName: node
-  linkType: hard
-
-"esbuild-linux-ppc64le@npm:0.15.13":
-  version: 0.15.13
-  resolution: "esbuild-linux-ppc64le@npm:0.15.13"
-  conditions: os=linux & cpu=ppc64
-  languageName: node
-  linkType: hard
-
-"esbuild-linux-riscv64@npm:0.15.13":
-  version: 0.15.13
-  resolution: "esbuild-linux-riscv64@npm:0.15.13"
-  conditions: os=linux & cpu=riscv64
-  languageName: node
-  linkType: hard
-
-"esbuild-linux-s390x@npm:0.15.13":
-  version: 0.15.13
-  resolution: "esbuild-linux-s390x@npm:0.15.13"
-  conditions: os=linux & cpu=s390x
-  languageName: node
-  linkType: hard
-
-"esbuild-netbsd-64@npm:0.15.13":
-  version: 0.15.13
-  resolution: "esbuild-netbsd-64@npm:0.15.13"
-  conditions: os=netbsd & cpu=x64
-  languageName: node
-  linkType: hard
-
-"esbuild-openbsd-64@npm:0.15.13":
-  version: 0.15.13
-  resolution: "esbuild-openbsd-64@npm:0.15.13"
-  conditions: os=openbsd & cpu=x64
-  languageName: node
-  linkType: hard
-
 "esbuild-plugin-globals@npm:^0.1.1":
   version: 0.1.1
   resolution: "esbuild-plugin-globals@npm:0.1.1"
   checksum: 07460a455174e280829e172096b70422a945bcaba0efbe2e71a88ccdcc194e0251c7a7cdc27fd5dda3420777dc6f7ee6312e1e3167af2627a67a39be7d7c373d
-  languageName: node
-  linkType: hard
-
-"esbuild-sunos-64@npm:0.15.13":
-  version: 0.15.13
-  resolution: "esbuild-sunos-64@npm:0.15.13"
-  conditions: os=sunos & cpu=x64
-  languageName: node
-  linkType: hard
-
-"esbuild-windows-32@npm:0.15.13":
-  version: 0.15.13
-  resolution: "esbuild-windows-32@npm:0.15.13"
-  conditions: os=win32 & cpu=ia32
-  languageName: node
-  linkType: hard
-
-"esbuild-windows-64@npm:0.15.13":
-  version: 0.15.13
-  resolution: "esbuild-windows-64@npm:0.15.13"
-  conditions: os=win32 & cpu=x64
-  languageName: node
-  linkType: hard
-
-"esbuild-windows-arm64@npm:0.15.13":
-  version: 0.15.13
-  resolution: "esbuild-windows-arm64@npm:0.15.13"
-  conditions: os=win32 & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"esbuild@npm:^0.15.9":
-  version: 0.15.13
-  resolution: "esbuild@npm:0.15.13"
-  dependencies:
-    "@esbuild/android-arm": 0.15.13
-    "@esbuild/linux-loong64": 0.15.13
-    esbuild-android-64: 0.15.13
-    esbuild-android-arm64: 0.15.13
-    esbuild-darwin-64: 0.15.13
-    esbuild-darwin-arm64: 0.15.13
-    esbuild-freebsd-64: 0.15.13
-    esbuild-freebsd-arm64: 0.15.13
-    esbuild-linux-32: 0.15.13
-    esbuild-linux-64: 0.15.13
-    esbuild-linux-arm: 0.15.13
-    esbuild-linux-arm64: 0.15.13
-    esbuild-linux-mips64le: 0.15.13
-    esbuild-linux-ppc64le: 0.15.13
-    esbuild-linux-riscv64: 0.15.13
-    esbuild-linux-s390x: 0.15.13
-    esbuild-netbsd-64: 0.15.13
-    esbuild-openbsd-64: 0.15.13
-    esbuild-sunos-64: 0.15.13
-    esbuild-windows-32: 0.15.13
-    esbuild-windows-64: 0.15.13
-    esbuild-windows-arm64: 0.15.13
-  dependenciesMeta:
-    "@esbuild/android-arm":
-      optional: true
-    "@esbuild/linux-loong64":
-      optional: true
-    esbuild-android-64:
-      optional: true
-    esbuild-android-arm64:
-      optional: true
-    esbuild-darwin-64:
-      optional: true
-    esbuild-darwin-arm64:
-      optional: true
-    esbuild-freebsd-64:
-      optional: true
-    esbuild-freebsd-arm64:
-      optional: true
-    esbuild-linux-32:
-      optional: true
-    esbuild-linux-64:
-      optional: true
-    esbuild-linux-arm:
-      optional: true
-    esbuild-linux-arm64:
-      optional: true
-    esbuild-linux-mips64le:
-      optional: true
-    esbuild-linux-ppc64le:
-      optional: true
-    esbuild-linux-riscv64:
-      optional: true
-    esbuild-linux-s390x:
-      optional: true
-    esbuild-netbsd-64:
-      optional: true
-    esbuild-openbsd-64:
-      optional: true
-    esbuild-sunos-64:
-      optional: true
-    esbuild-windows-32:
-      optional: true
-    esbuild-windows-64:
-      optional: true
-    esbuild-windows-arm64:
-      optional: true
-  bin:
-    esbuild: bin/esbuild
-  checksum: ef5f339fae7e2abc4ec5484d4b301efdf40f580e043cbf8a66e19d6c91df82368a810abec61fd5e5db226f0c354f49c36616c9ea04c5412a142a050c10239bf7
   languageName: node
   linkType: hard
 
@@ -14395,15 +14164,6 @@ fsevents@~2.3.2:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.3.4":
-  version: 3.3.4
-  resolution: "nanoid@npm:3.3.4"
-  bin:
-    nanoid: bin/nanoid.cjs
-  checksum: 2fddd6dee994b7676f008d3ffa4ab16035a754f4bb586c61df5a22cf8c8c94017aadd360368f47d653829e0569a92b129979152ff97af23a558331e47e37cd9c
-  languageName: node
-  linkType: hard
-
 "nanoid@npm:^3.3.6":
   version: 3.3.6
   resolution: "nanoid@npm:3.3.6"
@@ -15922,17 +15682,6 @@ fsevents@~2.3.2:
   languageName: node
   linkType: hard
 
-"postcss@npm:^8.4.18":
-  version: 8.4.19
-  resolution: "postcss@npm:8.4.19"
-  dependencies:
-    nanoid: ^3.3.4
-    picocolors: ^1.0.0
-    source-map-js: ^1.0.2
-  checksum: 62782723a385f92b7525f66d29614624de7c5643855423db3a5efd9287e677650300192749adddbbb6734cea9b1d5f5fd4f6ea00ca3f9a95dbbb88f835f5ca64
-  languageName: node
-  linkType: hard
-
 "postcss@npm:^8.4.26":
   version: 8.4.27
   resolution: "postcss@npm:8.4.27"
@@ -17352,20 +17101,6 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"rollup@npm:^2.79.1":
-  version: 2.79.1
-  resolution: "rollup@npm:2.79.1"
-  dependencies:
-    fsevents: ~2.3.2
-  dependenciesMeta:
-    fsevents:
-      optional: true
-  bin:
-    rollup: dist/bin/rollup
-  checksum: 6a2bf167b3587d4df709b37d149ad0300692cc5deb510f89ac7bdc77c8738c9546ae3de9322b0968e1ed2b0e984571f5f55aae28fa7de4cfcb1bc5402a4e2be6
-  languageName: node
-  linkType: hard
-
 "rollup@npm:^3.25.2":
   version: 3.26.3
   resolution: "rollup@npm:3.26.3"
@@ -17377,6 +17112,20 @@ resolve@^2.0.0-next.3:
   bin:
     rollup: dist/bin/rollup
   checksum: e6a765b2b7af709170344cc804392936613e06b6bdab46a04d264368d154bdadaaaf77de39e6e656bf728a060d7b4867d81e2464d791c0f37dd5b21aa9c7a6df
+  languageName: node
+  linkType: hard
+
+"rollup@npm:^3.27.1":
+  version: 3.29.1
+  resolution: "rollup@npm:3.29.1"
+  dependencies:
+    fsevents: ~2.3.2
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  bin:
+    rollup: dist/bin/rollup
+  checksum: eb92dbb83842f46782257c93e864dd12e9eef72eb98485a70a08026e50f7b557cfff7da71f677a4bd62906e597cc99284bf152b876f814a95b61f5a618a0f43e
   languageName: node
   linkType: hard
 
@@ -17431,7 +17180,7 @@ resolve@^2.0.0-next.3:
     sass: ^1.56.1
     tsc-watch: 6.0.4
     typescript: 5.1.6
-    vite: 3.2.7
+    vite: 4.4.9
     vitest: 0.33.0
     vitest-fetch-mock: 0.2.2
     vitest-mongodb: ^0.0.4
@@ -19947,18 +19696,18 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"vite@npm:3.2.7, vite@npm:^3.2.7":
-  version: 3.2.7
-  resolution: "vite@npm:3.2.7"
+"vite@npm:4.4.9":
+  version: 4.4.9
+  resolution: "vite@npm:4.4.9"
   dependencies:
-    esbuild: ^0.15.9
+    esbuild: ^0.18.10
     fsevents: ~2.3.2
-    postcss: ^8.4.18
-    resolve: ^1.22.1
-    rollup: ^2.79.1
+    postcss: ^8.4.27
+    rollup: ^3.27.1
   peerDependencies:
     "@types/node": ">= 14"
     less: "*"
+    lightningcss: ^1.21.0
     sass: "*"
     stylus: "*"
     sugarss: "*"
@@ -19971,6 +19720,8 @@ resolve@^2.0.0-next.3:
       optional: true
     less:
       optional: true
+    lightningcss:
+      optional: true
     sass:
       optional: true
     stylus:
@@ -19981,7 +19732,7 @@ resolve@^2.0.0-next.3:
       optional: true
   bin:
     vite: bin/vite.js
-  checksum: 4c5883b721b6ec406419e61d0b3fae8528e80f8c2eb20c087c7b1b76daec3665a0a49c83cd8ac7fdda6089625094b70c6a132daa5edc650c515ddc9f5eed44f0
+  checksum: c511024ceae39c68c7dbf2ac4381ee655cd7bb62cf43867a14798bc835d3320b8fa7867a336143c30825c191c1fb4e9aa3348fce831ab617e96203080d3d2908
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5506,17 +5506,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vitest/expect@npm:0.33.0":
-  version: 0.33.0
-  resolution: "@vitest/expect@npm:0.33.0"
-  dependencies:
-    "@vitest/spy": 0.33.0
-    "@vitest/utils": 0.33.0
-    chai: ^4.3.7
-  checksum: da6bf8e4a4f23218088b4e7dcdf6eb9f8d92e82a98a674edf8be2f333625179da6802936a948e7a60e0918da53e7ec548183d1d9d42f0e1c4e2d3f66fd63e11f
-  languageName: node
-  linkType: hard
-
 "@vitest/expect@npm:0.34.4":
   version: 0.34.4
   resolution: "@vitest/expect@npm:0.34.4"
@@ -5525,17 +5514,6 @@ __metadata:
     "@vitest/utils": 0.34.4
     chai: ^4.3.7
   checksum: eb51e73f703ed6a916516ab45068a8c44d715d4eabb8bbae7bfe1d3707131d5ac62c9e70130d5075ad7d0a19da0a0e8e994bc8579e185d229f6e8adaf1235f6f
-  languageName: node
-  linkType: hard
-
-"@vitest/runner@npm:0.33.0":
-  version: 0.33.0
-  resolution: "@vitest/runner@npm:0.33.0"
-  dependencies:
-    "@vitest/utils": 0.33.0
-    p-limit: ^4.0.0
-    pathe: ^1.1.1
-  checksum: de731aa0687cf15f141e81fb11027ff52860292f6d8957678c9fcd307502e4f9fd679bcaff93b53d29eeeb694d403d6aa52d49d341f998ec2b794e7abe061572
   languageName: node
   linkType: hard
 
@@ -5550,17 +5528,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vitest/snapshot@npm:0.33.0":
-  version: 0.33.0
-  resolution: "@vitest/snapshot@npm:0.33.0"
-  dependencies:
-    magic-string: ^0.30.1
-    pathe: ^1.1.1
-    pretty-format: ^29.5.0
-  checksum: ff2604d5bf09342eab45109df06f4e2e9e78698bf26b0eed1f4871d7757312e43de90ead938698be3e03e9873d4081ebeb69c94928b8065c53d1e9f28742185e
-  languageName: node
-  linkType: hard
-
 "@vitest/snapshot@npm:0.34.4":
   version: 0.34.4
   resolution: "@vitest/snapshot@npm:0.34.4"
@@ -5572,32 +5539,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vitest/spy@npm:0.33.0":
-  version: 0.33.0
-  resolution: "@vitest/spy@npm:0.33.0"
-  dependencies:
-    tinyspy: ^2.1.1
-  checksum: 501a704a10b411f407fbcedeaf1f469e6fcac4894af11fa89c74e6f64bf3eebbcd006cf86377ae379708c0b8c860243db504f5d4e90d382419aa666458b76800
-  languageName: node
-  linkType: hard
-
 "@vitest/spy@npm:0.34.4":
   version: 0.34.4
   resolution: "@vitest/spy@npm:0.34.4"
   dependencies:
     tinyspy: ^2.1.1
   checksum: 84e29920b5ecfd4623bb1a644872fcfdc6ce23e3e25e46a5932599880f179b85ffb5d5e84c39b820c26717ccb4038a9e311e5ab2376f2da28308d7062b1a15fc
-  languageName: node
-  linkType: hard
-
-"@vitest/utils@npm:0.33.0":
-  version: 0.33.0
-  resolution: "@vitest/utils@npm:0.33.0"
-  dependencies:
-    diff-sequences: ^29.4.3
-    loupe: ^2.3.6
-    pretty-format: ^29.5.0
-  checksum: 8c5b381f5599ca517bedd0e46805e91b1150564473d37b2b80ef45aa9c16cb59d296513dd34bc2171904beb28be73b89e5333056539d49a0ba9d513ae7672a0a
   languageName: node
   linkType: hard
 
@@ -17181,7 +17128,7 @@ resolve@^2.0.0-next.3:
     tsc-watch: 6.0.4
     typescript: 5.1.6
     vite: 4.4.9
-    vitest: 0.33.0
+    vitest: 0.34.4
     vitest-fetch-mock: 0.2.2
     vitest-mongodb: ^0.0.4
   dependenciesMeta:
@@ -18758,13 +18705,6 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"tinypool@npm:^0.6.0":
-  version: 0.6.0
-  resolution: "tinypool@npm:0.6.0"
-  checksum: 996bf3a922993cec568d6b6ddc72531700b2a8aea24623ed6946a8929557b0f17629955d20defda09cb3b12fc94087159f14cb8e06570adce7d1b7d2eef00a91
-  languageName: node
-  linkType: hard
-
 "tinypool@npm:^0.7.0":
   version: 0.7.0
   resolution: "tinypool@npm:0.7.0"
@@ -19664,22 +19604,6 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"vite-node@npm:0.33.0":
-  version: 0.33.0
-  resolution: "vite-node@npm:0.33.0"
-  dependencies:
-    cac: ^6.7.14
-    debug: ^4.3.4
-    mlly: ^1.4.0
-    pathe: ^1.1.1
-    picocolors: ^1.0.0
-    vite: ^3.0.0 || ^4.0.0
-  bin:
-    vite-node: vite-node.mjs
-  checksum: 7c37911251d3e318fe4ad6b4093207498336ce190a58afb43a9ae701eee7f110ef80920b79061710cf6abcc6335ce58f6ca412ee6b268f25fe10f278c94cc264
-  languageName: node
-  linkType: hard
-
 "vite-node@npm:0.34.4":
   version: 0.34.4
   resolution: "vite-node@npm:0.34.4"
@@ -19834,66 +19758,6 @@ resolve@^2.0.0-next.3:
     debug: ^4.3.4
     mongodb-memory-server: ^8.8.0
   checksum: 072a5acee0048f22d968531e37628613bdc5a6221fab0478d7e79e71b9922c1227c4a1414133143c1de9071f4c2a60cc852ad95bb7f10f0eb924d0f759c7445f
-  languageName: node
-  linkType: hard
-
-"vitest@npm:0.33.0":
-  version: 0.33.0
-  resolution: "vitest@npm:0.33.0"
-  dependencies:
-    "@types/chai": ^4.3.5
-    "@types/chai-subset": ^1.3.3
-    "@types/node": "*"
-    "@vitest/expect": 0.33.0
-    "@vitest/runner": 0.33.0
-    "@vitest/snapshot": 0.33.0
-    "@vitest/spy": 0.33.0
-    "@vitest/utils": 0.33.0
-    acorn: ^8.9.0
-    acorn-walk: ^8.2.0
-    cac: ^6.7.14
-    chai: ^4.3.7
-    debug: ^4.3.4
-    local-pkg: ^0.4.3
-    magic-string: ^0.30.1
-    pathe: ^1.1.1
-    picocolors: ^1.0.0
-    std-env: ^3.3.3
-    strip-literal: ^1.0.1
-    tinybench: ^2.5.0
-    tinypool: ^0.6.0
-    vite: ^3.0.0 || ^4.0.0
-    vite-node: 0.33.0
-    why-is-node-running: ^2.2.2
-  peerDependencies:
-    "@edge-runtime/vm": "*"
-    "@vitest/browser": "*"
-    "@vitest/ui": "*"
-    happy-dom: "*"
-    jsdom: "*"
-    playwright: "*"
-    safaridriver: "*"
-    webdriverio: "*"
-  peerDependenciesMeta:
-    "@edge-runtime/vm":
-      optional: true
-    "@vitest/browser":
-      optional: true
-    "@vitest/ui":
-      optional: true
-    happy-dom:
-      optional: true
-    jsdom:
-      optional: true
-    playwright:
-      optional: true
-    safaridriver:
-      optional: true
-    webdriverio:
-      optional: true
-  bin:
-    vitest: vitest.mjs
-  checksum: c1884b2a1a41af81ee54c86a986a32b6a4c69ec3b3f7d2322f92c8fad5532d6a12160e7efb7927e4c53d95806ef4ede9549bdd82c66604e281c71056212f56e7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This includes fixes mainly for the test environment and brings Vite up to date with upstream.