### PR TITLE
fix: Revert Node.js containers to bullseye (libssl fixes)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18.17.1 as dependencies
+FROM node:18.17.1-bullseye as dependencies
 
 WORKDIR /srv
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,7 @@ volumes:
 services:
   # This dummy service provides shared configuration for all Node deps
   node:
-    image: node:18.17.1
+    image: node:18.17.1-bullseye
     env_file: ./config.env
     working_dir: /srv
     command: bash -c 'yarn install && yarn pnpify tsc-watch -b --onSuccess "touch /watch/done"'


### PR DESCRIPTION
Fixes missing `libcrypto.so.1.1` in Node.js tests. 