### PR TITLE
Enable schema validator for worker validation

### DIFF
--- a/packages/openneuro-server/src/graphql/schema.js
+++ b/packages/openneuro-server/src/graphql/schema.js
@@ -221,7 +221,9 @@ export const typeDefs = `
 
   # BIDS Validator metadata
   input ValidatorMetadata {
-    type: String
+    # Unique string identifying the type of BIDS validator software
+    validator: String
+    # Semantic versioning string for the version of the validation software
     version: String
   }
 
@@ -239,7 +241,10 @@ export const typeDefs = `
     totalFiles: Int!
     dataProcessed: Boolean
     pet: SummaryPetInput
+    # Metadata for validation software used
     validatorMetadata: ValidatorMetadata
+    # BIDS Specification schema version
+    schemaVersion: String
   }
 
   input SubjectMetadataInput {
@@ -606,6 +611,8 @@ export const typeDefs = `
     totalFiles: Int!
     dataProcessed: Boolean
     pet: SummaryPetFields
+    # BIDS Specification schema version
+    schemaVersion: String
   }
 
   type SummaryPetFields {
@@ -671,6 +678,8 @@ export const typeDefs = `
   }
 
   type ValidationIssueFile {
+    name: String
+    path: String
     key: String!
     code: Int
     file: ValidationIssueFileDetail
@@ -683,6 +692,8 @@ export const typeDefs = `
   }
 
   input ValidationIssueFileInput {
+    name: String
+    path: String
     key: String
     code: Int
     file: ValidationIssueFileDetailInput
@@ -692,6 +703,8 @@ export const typeDefs = `
     severity: Severity
     reason: String
     helpUrl: String
+    # Temporary field for compatibility (remove after bids-validator@1.13.0)
+    _datasetAbsPath: String
   }
 
   type ValidationIssueFileDetail {

--- a/packages/openneuro-server/src/graphql/schema.js
+++ b/packages/openneuro-server/src/graphql/schema.js
@@ -683,13 +683,13 @@ export const typeDefs = `
   }
 
   input ValidationIssueFileInput {
-    key: String!
+    key: String
     code: Int
     file: ValidationIssueFileDetailInput
     evidence: String
     line: Int
     character: Int
-    severity: Severity!
+    severity: Severity
     reason: String
     helpUrl: String
   }

--- a/packages/openneuro-server/src/graphql/schema.js
+++ b/packages/openneuro-server/src/graphql/schema.js
@@ -219,6 +219,12 @@ export const typeDefs = `
     TracerRadionuclide: [String]
   }
 
+  # BIDS Validator metadata
+  input ValidatorMetadata {
+    type: String
+    version: String
+  }
+
   input SummaryInput {
     id: ID! # Git reference for this summary
     datasetId: ID!
@@ -233,6 +239,7 @@ export const typeDefs = `
     totalFiles: Int!
     dataProcessed: Boolean
     pet: SummaryPetInput
+    validatorMetadata: ValidatorMetadata
   }
 
   input SubjectMetadataInput {
@@ -246,6 +253,7 @@ export const typeDefs = `
     id: ID! # Git reference for this validation
     datasetId: ID!
     issues: [ValidationIssueInput]!
+    validatorMetadata: ValidatorMetadata
   }
 
   # Dataset Metadata

--- a/packages/openneuro-server/src/graphql/schema.js
+++ b/packages/openneuro-server/src/graphql/schema.js
@@ -653,7 +653,7 @@ export const typeDefs = `
   type ValidationIssue {
     severity: Severity!
     key: String!
-    code: Int!
+    code: Int
     reason: String!
     files: [ValidationIssueFile]
     additionalFileCount: Int
@@ -663,7 +663,7 @@ export const typeDefs = `
   input ValidationIssueInput {
     severity: Severity!
     key: String!
-    code: Int!
+    code: Int
     reason: String!
     files: [ValidationIssueFileInput]
     additionalFileCount: Int
@@ -672,7 +672,7 @@ export const typeDefs = `
 
   type ValidationIssueFile {
     key: String!
-    code: Int!
+    code: Int
     file: ValidationIssueFileDetail
     evidence: String
     line: Int
@@ -684,7 +684,7 @@ export const typeDefs = `
 
   input ValidationIssueFileInput {
     key: String!
-    code: Int!
+    code: Int
     file: ValidationIssueFileDetailInput
     evidence: String
     line: Int

--- a/packages/openneuro-server/src/models/issue.ts
+++ b/packages/openneuro-server/src/models/issue.ts
@@ -6,7 +6,7 @@ export interface IssueDocument extends Document {
   datasetId: string
   issues: object
   validatorMetadata: {
-    type: string
+    validator: string
     version: string
   }
 }
@@ -16,7 +16,7 @@ const issueSchema = new Schema({
   datasetId: { type: String, required: true },
   issues: Object,
   validatorMetadata: {
-    type: String,
+    validator: String,
     version: String,
   },
 })

--- a/packages/openneuro-server/src/models/issue.ts
+++ b/packages/openneuro-server/src/models/issue.ts
@@ -5,12 +5,20 @@ export interface IssueDocument extends Document {
   id: string
   datasetId: string
   issues: object
+  validatorMetadata: {
+    type: string
+    version: string
+  }
 }
 
 const issueSchema = new Schema({
   id: { type: String, required: true },
   datasetId: { type: String, required: true },
   issues: Object,
+  validatorMetadata: {
+    type: String,
+    version: String,
+  },
 })
 
 const Issue = model<IssueDocument>('Issue', issueSchema)

--- a/packages/openneuro-server/src/models/summary.ts
+++ b/packages/openneuro-server/src/models/summary.ts
@@ -24,6 +24,10 @@ export interface SummaryDocument extends Document {
   size: number
   dataProcessed: boolean
   pet: SummaryPetField
+  validatorMetadata: {
+    type: string
+    version: string
+  }
 }
 
 const summarySchema = new Schema({
@@ -46,6 +50,10 @@ const summarySchema = new Schema({
     ScannerManufacturersModelName: [String],
     TracerName: [String],
     TracerRadionuclide: [String],
+  },
+  validatorMetadata: {
+    type: String,
+    version: String,
   },
 })
 

--- a/packages/openneuro-server/src/models/summary.ts
+++ b/packages/openneuro-server/src/models/summary.ts
@@ -25,7 +25,7 @@ export interface SummaryDocument extends Document {
   dataProcessed: boolean
   pet: SummaryPetField
   validatorMetadata: {
-    type: string
+    validator: string
     version: string
   }
 }
@@ -52,7 +52,7 @@ const summarySchema = new Schema({
     TracerRadionuclide: [String],
   },
   validatorMetadata: {
-    type: String,
+    validator: String,
     version: String,
   },
 })

--- a/services/datalad/Dockerfile
+++ b/services/datalad/Dockerfile
@@ -1,3 +1,4 @@
+FROM denoland/deno:bin-1.33.1 AS deno
 FROM python:3.11-slim as production
 
 WORKDIR /srv
@@ -10,8 +11,9 @@ COPY datalad_service /srv/datalad_service
 COPY get_docker_scale.py /get_docker_scale.py
 COPY ./ssh_config /root/.ssh/config
 COPY tests /srv/tests
-# Install node the Dockery-but-hacky-way
+# Install node and Deno the Dockery-but-hacky-way
 COPY --from=node:18.17.1-buster /usr/local/bin/node /usr/local/bin/node
+COPY --from=deno /deno /usr/local/bin/deno
 
 RUN apt-get update \
   && node --version \

--- a/services/datalad/datalad_service/tasks/validator.py
+++ b/services/datalad/datalad_service/tasks/validator.py
@@ -12,7 +12,7 @@ from datalad_service.common.elasticsearch import ValidationLogger
 
 LEGACY_VALIDATOR_VERSION = json.load(
     open('/srv/package.json'))['dependencies']['bids-validator']
-DENO_VALIDATOR_VERSION = 'd1202edf63a866bfee7b6bc55a3b5158cadae14b'
+DENO_VALIDATOR_VERSION = 'v1.12.0'
 
 LEGACY_METADATA = {
     'type': 'legacy',
@@ -58,18 +58,11 @@ def validate_dataset_deno_sync(dataset_path, ref, esLogger):
 
     Runs the bids-validator process and installs node dependencies if needed.
     """
-
-    process = gevent.subprocess.run(
-        ['deno', 'run', '-A',
-         f'https://raw.githubusercontent.com/bids-standard/bids-validator/{DENO_VALIDATOR_VERSION}/bids-validator.js',
-         '--json', dataset_path], stdout=subprocess.PIPE, timeout=300)
-    print('stdout', process.stdout)
-    return json.loads(process.stdout)
     try:
         process = gevent.subprocess.run(
             ['deno', 'run', '-A',
-             f'https://raw.githubusercontent.com/bids-standard/bids-validator/{DENO_VALIDATOR_VERSION}/bids-validator.js',
-             '--json', dataset_path], stdout=subprocess.PIPE, timeout=300)
+            f'https://deno.land/x/bids_validator@{DENO_VALIDATOR_VERSION}/bids-validator.ts',
+            '--json', dataset_path], stdout=subprocess.PIPE, timeout=300)
         return json.loads(escape_ansi(process.stdout.decode('utf-8')))
     except subprocess.TimeoutExpired as err:
         esLogger.log(process.stdout, process.stderr, err)

--- a/services/datalad/datalad_service/tasks/validator.py
+++ b/services/datalad/datalad_service/tasks/validator.py
@@ -12,14 +12,14 @@ from datalad_service.common.elasticsearch import ValidationLogger
 
 LEGACY_VALIDATOR_VERSION = json.load(
     open('/srv/package.json'))['dependencies']['bids-validator']
-DENO_VALIDATOR_VERSION = 'v1.12.0'
+DENO_VALIDATOR_VERSION = 'v1.13.0'
 
 LEGACY_METADATA = {
-    'type': 'legacy',
+    'validator': 'legacy',
     'version': LEGACY_VALIDATOR_VERSION
 }
 DENO_METADATA = {
-    'type': 'schema',
+    'validator': 'schema',
     'version': DENO_VALIDATOR_VERSION
 }
 
@@ -124,12 +124,12 @@ def _validate_dataset_eventlet(dataset_id, dataset_path, ref, cookies=None, user
         if 'issues' in validator_output:
             r = requests.post(
                 url=GRAPHQL_ENDPOINT, json=issues_mutation(dataset_id, ref, all_issues, LEGACY_METADATA), cookies=cookies)
-            if r.status_code != 200:
+            if r.status_code != 200 or 'errors' in r.json():
                 raise Exception(r.text)
         if 'summary' in validator_output:
             r = requests.post(
                 url=GRAPHQL_ENDPOINT, json=summary_mutation(dataset_id, ref, validator_output, LEGACY_METADATA), cookies=cookies)
-            if r.status_code != 200:
+            if r.status_code != 200 or 'errors' in r.json():
                 raise Exception(r.text)
     else:
         raise Exception('Validation failed unexpectedly')
@@ -142,12 +142,12 @@ def _validate_dataset_eventlet(dataset_id, dataset_path, ref, cookies=None, user
         if 'issues' in validator_output_deno:
             r = requests.post(
                 url=GRAPHQL_ENDPOINT, json=issues_mutation(dataset_id, ref, validator_output_deno['issues'], DENO_METADATA), cookies=cookies)
-            if r.status_code != 200:
+            if r.status_code != 200 or 'errors' in r.json():
                 raise Exception(r.text)
         if 'summary' in validator_output_deno:
             r = requests.post(
                 url=GRAPHQL_ENDPOINT, json=summary_mutation(dataset_id, ref, validator_output_deno, DENO_METADATA), cookies=cookies)
-            if r.status_code != 200:
+            if r.status_code != 200 or 'errors' in r.json():
                 raise Exception(r.text)
 
 

--- a/services/datalad/datalad_service/tasks/validator.py
+++ b/services/datalad/datalad_service/tasks/validator.py
@@ -119,7 +119,6 @@ def _validate_dataset_eventlet(dataset_id, dataset_path, ref, cookies=None, user
     validator_output = validate_dataset_sync(dataset_path, ref, esLogger)
     all_issues = validator_output['issues']['warnings'] + \
         validator_output['issues']['errors']
-    print('LEGACY', all_issues)
     if validator_output:
         if 'issues' in validator_output:
             r = requests.post(
@@ -137,7 +136,6 @@ def _validate_dataset_eventlet(dataset_id, dataset_path, ref, cookies=None, user
     # New schema validator second in case of issues
     validator_output_deno = validate_dataset_deno_sync(
         dataset_path, ref, esLogger)
-    print('DENO', validator_output_deno['issues'])
     if validator_output_deno:
         if 'issues' in validator_output_deno:
             r = requests.post(

--- a/services/datalad/datalad_service/tasks/validator.py
+++ b/services/datalad/datalad_service/tasks/validator.py
@@ -1,12 +1,32 @@
 import json
 import os
 import requests
+import re
 
 import gevent
 from gevent import subprocess
 
 from datalad_service.config import GRAPHQL_ENDPOINT
 from datalad_service.common.elasticsearch import ValidationLogger
+
+
+LEGACY_VALIDATOR_VERSION = json.load(
+    open('/srv/package.json'))['dependencies']['bids-validator']
+DENO_VALIDATOR_VERSION = 'd1202edf63a866bfee7b6bc55a3b5158cadae14b'
+
+LEGACY_METADATA = {
+    'type': 'legacy',
+    'version': LEGACY_VALIDATOR_VERSION
+}
+DENO_METADATA = {
+    'type': 'schema',
+    'version': DENO_VALIDATOR_VERSION
+}
+
+
+def escape_ansi(text):
+    ansi_escape = re.compile(r'(?:\x1B[@-_]|[\x80-\x9F])[0-?]*[ -/]*[@-~]')
+    return ansi_escape.sub('', text)
 
 
 def setup_validator():
@@ -32,7 +52,32 @@ def validate_dataset_sync(dataset_path, ref, esLogger):
         esLogger.log(process.stdout, process.stderr, err)
 
 
-def summary_mutation(dataset_id, ref, validator_output):
+def validate_dataset_deno_sync(dataset_path, ref, esLogger):
+    """
+    Synchronous dataset validation.
+
+    Runs the bids-validator process and installs node dependencies if needed.
+    """
+
+    process = gevent.subprocess.run(
+        ['deno', 'run', '-A',
+         f'https://raw.githubusercontent.com/bids-standard/bids-validator/{DENO_VALIDATOR_VERSION}/bids-validator.js',
+         '--json', dataset_path], stdout=subprocess.PIPE, timeout=300)
+    print('stdout', process.stdout)
+    return json.loads(process.stdout)
+    try:
+        process = gevent.subprocess.run(
+            ['deno', 'run', '-A',
+             f'https://raw.githubusercontent.com/bids-standard/bids-validator/{DENO_VALIDATOR_VERSION}/bids-validator.js',
+             '--json', dataset_path], stdout=subprocess.PIPE, timeout=300)
+        return json.loads(escape_ansi(process.stdout.decode('utf-8')))
+    except subprocess.TimeoutExpired as err:
+        esLogger.log(process.stdout, process.stderr, err)
+    except json.decoder.JSONDecodeError as err:
+        esLogger.log(process.stdout, process.stderr, err)
+
+
+def summary_mutation(dataset_id, ref, validator_output, validator_metadata):
     """
     Return the OpenNeuro mutation to update a dataset summary.
     """
@@ -40,22 +85,21 @@ def summary_mutation(dataset_id, ref, validator_output):
     summary['datasetId'] = dataset_id
     # Set the object id to the git sha256 ref
     summary['id'] = ref
+    summary['validatorMetadata'] = validator_metadata
     return {
         'query': 'mutation ($summaryInput: SummaryInput!) { updateSummary(summary: $summaryInput) { id } }',
         'variables':
             {
-                'summaryInput': summary
+                'summaryInput': summary,
             }
     }
 
 
-def issues_mutation(dataset_id, ref, validator_output):
+def issues_mutation(dataset_id, ref, issues, validator_metadata):
     """
     Return the OpenNeuro mutation to update any validation issues.
     """
-    all_issues = validator_output['issues']['warnings'] + \
-        validator_output['issues']['errors']
-    for issue in all_issues:
+    for issue in issues:
         # Remove extra stats to keep collection size down
         if 'files' in issue:
             for f in issue['files']:
@@ -65,13 +109,14 @@ def issues_mutation(dataset_id, ref, validator_output):
     issues = {
         'datasetId': dataset_id,
         'id': ref,
-        'issues': all_issues
+        'issues': issues,
+        'validatorMetadata': validator_metadata
     }
     return {
         'query': 'mutation ($issues: ValidationInput!) { updateValidation(validation: $issues) }',
         'variables':
             {
-                'issues': issues
+                'issues': issues,
             }
     }
 
@@ -79,19 +124,38 @@ def issues_mutation(dataset_id, ref, validator_output):
 def _validate_dataset_eventlet(dataset_id, dataset_path, ref, cookies=None, user=''):
     esLogger = ValidationLogger(dataset_id, user)
     validator_output = validate_dataset_sync(dataset_path, ref, esLogger)
+    all_issues = validator_output['issues']['warnings'] + \
+        validator_output['issues']['errors']
+    print('LEGACY', all_issues)
     if validator_output:
         if 'issues' in validator_output:
             r = requests.post(
-                url=GRAPHQL_ENDPOINT, json=issues_mutation(dataset_id, ref, validator_output), cookies=cookies)
+                url=GRAPHQL_ENDPOINT, json=issues_mutation(dataset_id, ref, all_issues, LEGACY_METADATA), cookies=cookies)
             if r.status_code != 200:
                 raise Exception(r.text)
         if 'summary' in validator_output:
             r = requests.post(
-                url=GRAPHQL_ENDPOINT, json=summary_mutation(dataset_id, ref, validator_output), cookies=cookies)
+                url=GRAPHQL_ENDPOINT, json=summary_mutation(dataset_id, ref, validator_output, LEGACY_METADATA), cookies=cookies)
             if r.status_code != 200:
                 raise Exception(r.text)
     else:
         raise Exception('Validation failed unexpectedly')
+
+    # New schema validator second in case of issues
+    validator_output_deno = validate_dataset_deno_sync(
+        dataset_path, ref, esLogger)
+    print('DENO', validator_output_deno['issues'])
+    if validator_output_deno:
+        if 'issues' in validator_output_deno:
+            r = requests.post(
+                url=GRAPHQL_ENDPOINT, json=issues_mutation(dataset_id, ref, validator_output_deno['issues'], DENO_METADATA), cookies=cookies)
+            if r.status_code != 200:
+                raise Exception(r.text)
+        if 'summary' in validator_output_deno:
+            r = requests.post(
+                url=GRAPHQL_ENDPOINT, json=summary_mutation(dataset_id, ref, validator_output_deno, DENO_METADATA), cookies=cookies)
+            if r.status_code != 200:
+                raise Exception(r.text)
 
 
 def validate_dataset(dataset_id, dataset_path, ref, cookies=None, user=''):


### PR DESCRIPTION
This enables running both validators on dataset changes. Validator metadata identifies which validator is used. The schema validator provides a superset of the fields for issues and summary allowing for existing OpenNeuro components to render these outputs without changes.