### PR TITLE
feat(api): Return schema validator output for derivative datasets

### DIFF
--- a/packages/openneuro-server/src/graphql/resolvers/datasetType.ts
+++ b/packages/openneuro-server/src/graphql/resolvers/datasetType.ts
@@ -1,0 +1,6 @@
+import { description } from './description.js'
+
+export async function datasetType(dsOrSnapshot): Promise<'schema' | 'legacy'> {
+  const dsDescription = await description(dsOrSnapshot)
+  return dsDescription.DatasetType === 'derivative' ? 'schema' : 'legacy'
+}

--- a/packages/openneuro-server/src/graphql/resolvers/issues.js
+++ b/packages/openneuro-server/src/graphql/resolvers/issues.js
@@ -1,13 +1,19 @@
 import Issue from '../../models/issue'
+import { datasetType } from './datasetType'
 import { revalidate } from './validation.js'
 
 /**
  * Issues resolver
  */
-export const issues = (dataset, _, { userInfo }) => {
+export const issues = async (dataset, _, { userInfo }) => {
   return Issue.findOne({
     id: dataset.revision,
     datasetId: dataset.id,
+    // Match if we have no validatorMetadata or the correct 'legacy' / 'schema' value if we do
+    $or: [
+      { 'validatorMetadata.validator': await datasetType(dataset) },
+      { validatorMetadata: { $exists: false } },
+    ],
   })
     .exec()
     .then(data => {
@@ -26,11 +32,16 @@ export const issues = (dataset, _, { userInfo }) => {
 /**
  * Snapshot issues resolver
  */
-export const snapshotIssues = snapshot => {
+export const snapshotIssues = async snapshot => {
   const datasetId = snapshot.id.split(':')[0]
   return Issue.findOne({
     id: snapshot.hexsha,
     datasetId,
+    // Match if we have no validatorMetadata or the correct 'legacy' / 'schema' value if we do
+    $or: [
+      { 'validatorMetadata.validator': await datasetType(snapshot) },
+      { validatorMetadata: { $exists: false } },
+    ],
   })
     .exec()
     .then(data => (data ? data.issues : null))

--- a/packages/openneuro-server/src/graphql/resolvers/validation.js
+++ b/packages/openneuro-server/src/graphql/resolvers/validation.js
@@ -12,7 +12,11 @@ import { redlock } from '../../libs/redis.js'
  */
 export const updateValidation = (obj, args) => {
   return Issue.updateOne(
-    { id: args.validation.id, datasetId: args.validation.datasetId },
+    {
+      id: args.validation.id,
+      datasetId: args.validation.datasetId,
+      validatorMetadata: args.validation.validatorMetadata,
+    },
     args.validation,
     {
       upsert: true,


### PR DESCRIPTION
This automatically maps the API requests for validator output based on whether the dataset at a given commit or version is a derivative in dataset_description.json.