### PR TITLE
fix(worker): Return 404 for missing datasets on draft or snapshot API calls

### DIFF
--- a/services/datalad/datalad_service/handlers/draft.py
+++ b/services/datalad/datalad_service/handlers/draft.py
@@ -1,3 +1,5 @@
+import os
+
 import falcon
 import pygit2
 
@@ -13,9 +15,8 @@ class DraftResource(object):
         """
         Return draft state (other than files).
         """
-        if dataset:
-            # Maybe turn this into status?
-            dataset_path = self.store.get_dataset_path(dataset)
+        dataset_path = self.store.get_dataset_path(dataset)
+        if dataset and os.path.exists(dataset_path):
             repo = pygit2.Repository(dataset_path)
             commit = repo.revparse_single('HEAD')
             resp.media = {'hexsha': commit.hex,

--- a/services/datalad/datalad_service/handlers/snapshots.py
+++ b/services/datalad/datalad_service/handlers/snapshots.py
@@ -1,3 +1,4 @@
+import os
 import logging
 
 import gevent
@@ -19,7 +20,9 @@ class SnapshotResource(object):
 
     def on_get(self, req, resp, dataset, snapshot=None):
         """Get the tree of files for a snapshot."""
-        if snapshot:
+        if not os.path.exists(self.store.get_dataset_path(dataset)):
+            resp.status = falcon.HTTP_NOT_FOUND
+        elif snapshot:
             files = get_tree(self.store, dataset, snapshot)
             response = get_snapshot(self.store, dataset, snapshot)
             response['files'] = files

--- a/services/datalad/datalad_service/tasks/validator.py
+++ b/services/datalad/datalad_service/tasks/validator.py
@@ -11,7 +11,7 @@ from datalad_service.common.elasticsearch import ValidationLogger
 
 
 LEGACY_VALIDATOR_VERSION = json.load(
-    open('/srv/package.json'))['dependencies']['bids-validator']
+    open('package.json'))['dependencies']['bids-validator']
 DENO_VALIDATOR_VERSION = 'v1.13.0'
 
 LEGACY_METADATA = {


### PR DESCRIPTION
This avoids an unhandled exception opening the pygit2 repo in these two cases.