### PR TITLE
fix(worker): Don't throw KeyError when auth token is missing 'name' field

### DIFF
--- a/services/datalad/datalad_service/common/user.py
+++ b/services/datalad/datalad_service/common/user.py
@@ -4,6 +4,8 @@ def get_user_info(req):
     email = None
     if 'user' in req.context and req.context['user']:
         user = req.context['user']
-        name = user['name']
-        email = user['email']
+        if 'name' in user:
+            name = user['name']
+        if 'email' in user:
+            email = user['email']
     return name, email

--- a/services/datalad/datalad_service/handlers/validation.py
+++ b/services/datalad/datalad_service/handlers/validation.py
@@ -13,10 +13,6 @@ class ValidationResource(object):
         if dataset and hexsha:
             # Record if this was done on behalf of a user
             name, email = get_user_info(req)
-            media_dict = {}
-            if name and email:
-                media_dict['name'] = name
-                media_dict['email'] = email
             try:
                 dataset_path = self.store.get_dataset_path(dataset)
                 # Run the validator but don't block on the request


### PR DESCRIPTION
There are valid tokens that don't contain a name or email (service tokens) and this avoids the exception in that case.