### PR TITLE
Fixes search by sex not catching 'M' and 'F' in participants.tsv

### DIFF
--- a/packages/openneuro-app/src/scripts/search/es-query-builders.ts
+++ b/packages/openneuro-app/src/scripts/search/es-query-builders.ts
@@ -50,6 +50,22 @@ export const matchQuery = (
   },
 })
 
+export const multiMatchQuery = (
+  field: string,
+  queryStrings: string[],
+  fuzziness?: string,
+  operator?: string,
+) => {
+  return {
+    bool: {
+      should: queryStrings.map(queryString =>
+        matchQuery(field, queryString, fuzziness, operator),
+      ),
+      minimum_should_match: 1,
+    },
+  }
+}
+
 export const rangeQuery = (
   field,
   gte?: number | string,

--- a/packages/openneuro-app/src/scripts/search/use-search-results.tsx
+++ b/packages/openneuro-app/src/scripts/search/use-search-results.tsx
@@ -6,6 +6,7 @@ import {
   BoolQuery,
   simpleQueryString,
   matchQuery,
+  multiMatchQuery,
   rangeQuery,
   rangeListLengthQuery,
   sqsJoinWithAND,
@@ -239,11 +240,23 @@ export const useSearchResults = () => {
         '3',
       ),
     )
-  if (sex_selected !== 'All')
+  if (sex_selected !== 'All') {
+    // Possible values for this field are specified here:
+    // https://bids-specification.readthedocs.io/en/stable/glossary.html#objects.columns.sex
+    let queryStrings = []
+    if (sex_selected == 'Male') {
+      queryStrings = ['male', 'm', 'M', 'MALE', 'Male']
+    } else if (sex_selected == 'Female') {
+      queryStrings = ['female', 'f', 'F', 'FEMALE', 'Female']
+    }
     boolQuery.addClause(
       'filter',
-      matchQuery('latestSnapshot.summary.subjectMetadata.sex', sex_selected),
+      multiMatchQuery(
+        'latestSnapshot.summary.subjectMetadata.sex',
+        queryStrings,
+      ),
     )
+  }
   if (date_selected !== 'All Time') {
     let d: number
     if (date_selected === 'Last 30 days') {


### PR DESCRIPTION
This PR resolves the open issue [here](https://github.com/OpenNeuroOrg/openneuro/issues/2921). It adds a multiMatchQuery to search for returning all possible valid strings per BIDS.  I tested this locally on a few datasets and it seems to work fine.