### PR TITLE
fix(cli): Prevent commander parsing from overriding git-annex-remote-openneuro

### DIFF
--- a/packages/openneuro-cli/src/cli.js
+++ b/packages/openneuro-cli/src/cli.js
@@ -74,12 +74,16 @@ commander
   .option('-s, --snapshot [snapshotVersion]')
   .action(ls)
 
-commander.parse(process.argv)
-
-if (process.argv[1].endsWith('git-credential-openneuro')) {
-  gitCredential()
-} else if (process.argv[1].endsWith('git-annex-remote-openneuro')) {
-  gitAnnexRemote()
-} else if (!process.argv.slice(2).length) {
-  commander.help()
+function main(argv) {
+  if (argv.endsWith('git-credential-openneuro')) {
+    gitCredential()
+  } else if (argv.endsWith('git-annex-remote-openneuro')) {
+    gitAnnexRemote()
+  } else if (!process.argv.slice(2).length) {
+    commander.help()
+  } else {
+    commander.parse(process.argv)
+  }
 }
+
+main(process.argv)


### PR DESCRIPTION
Fixes #2924