### PR TITLE
feat(dataset): Annex TSV files in phenotype directory

### DIFF
--- a/docs/git.md
+++ b/docs/git.md
@@ -18,14 +18,18 @@ OpenNeuro validates the size of regular git (non-annexed) files and a subset of 
 A recommended `.gitattributes` configuration for git-annex to automate annexing the correct files when using `git add` or `datalad save`
 
 ```
-* annex.largefiles=largerthan=1mb
+* annex.backend=SHA256E
+**/.git* annex.largefiles=nothing
 *.bval annex.largefiles=nothing
 *.bvec annex.largefiles=nothing
-*.json annex.largefiles=nothing
-*.tsv annex.largefiles=nothing
+*.json annex.largefiles=largerthan=1mb
+phenotype/*.tsv annex.largefiles=anything
+*.tsv annex.largefiles=largerthan=1mb
+dataset_description.json annex.largefiles=nothing
 .bidsignore annex.largefiles=nothing
 CHANGES annex.largefiles=nothing
-README annex.largefiles=nothing
+README* annex.largefiles=nothing
+LICENSE annex.largefiles=nothing
 ```
 
 ## Credential Helper

--- a/services/datalad/datalad_service/tasks/dataset.py
+++ b/services/datalad/datalad_service/tasks/dataset.py
@@ -18,6 +18,7 @@ GIT_ATTRIBUTES = """* annex.backend=SHA256E
 *.bval annex.largefiles=nothing
 *.bvec annex.largefiles=nothing
 *.json annex.largefiles=largerthan=1mb
+phenotype/*.tsv annex.largefiles=anything
 *.tsv annex.largefiles=largerthan=1mb
 dataset_description.json annex.largefiles=nothing
 .bidsignore annex.largefiles=nothing

--- a/services/datalad/hooks/pre-receive
+++ b/services/datalad/hooks/pre-receive
@@ -20,6 +20,7 @@ readonly GIT_ATTRIBUTES="* annex.backend=SHA256E
 *.bval annex.largefiles=nothing
 *.bvec annex.largefiles=nothing
 *.json annex.largefiles=largerthan=1mb
+phenotype/*.tsv annex.largefiles=anything
 *.tsv annex.largefiles=largerthan=1mb
 dataset_description.json annex.largefiles=nothing
 .bidsignore annex.largefiles=nothing


### PR DESCRIPTION
This adds `phenotype/*.tsv` to the annex by default.

Should we (and how should we) inject this into legacy datasets?

I couldn't find a place where we test that expected files get annexed or not. If a test is needed, I'll need a little guidance of what to use as a model.