### PR TITLE
Support podman for local dev environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ dist
 !.yarn/sdks
 !.yarn/versions
 .*.sw[po]
+.venv/

--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -10247,6 +10247,14 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["debug", "virtual:428f325a939c2653ad822eb3d75efb02ac311523dd0d4f9645afc39ea00bd86eceac35a9d59c9b6977d76b670a4ef0ae057ea572338a44729aa592711a8c05a3#npm:4.3.2"]\
           ],\
           "linkType": "HARD"\
+        }],\
+        ["npm:7.1.0", {\
+          "packageLocation": "./.yarn/cache/agent-base-npm-7.1.0-4b12ba5111-f7828f9914.zip/node_modules/agent-base/",\
+          "packageDependencies": [\
+            ["agent-base", "npm:7.1.0"],\
+            ["debug", "virtual:58471071b1e0e7981e3318280660861b4dec874aaf0d60e144b70657cb5ce0af059ae16711a2af10f4d1ff0536527e350e6e47a8f79db2d8d37ff2ec84865bbc#npm:4.3.4"]\
+          ],\
+          "linkType": "HARD"\
         }]\
       ]],\
       ["agentkeepalive", [\
@@ -10817,11 +10825,11 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
         }]\
       ]],\
       ["async-mutex", [\
-        ["npm:0.3.2", {\
-          "packageLocation": "./.yarn/cache/async-mutex-npm-0.3.2-600f6c46a1-620b771dfd.zip/node_modules/async-mutex/",\
+        ["npm:0.4.0", {\
+          "packageLocation": "./.yarn/cache/async-mutex-npm-0.4.0-f5a25d4255-813a71728b.zip/node_modules/async-mutex/",\
           "packageDependencies": [\
-            ["async-mutex", "npm:0.3.2"],\
-            ["tslib", "npm:2.4.1"]\
+            ["async-mutex", "npm:0.4.0"],\
+            ["tslib", "npm:2.6.1"]\
           ],\
           "linkType": "HARD"\
         }]\
@@ -10926,6 +10934,15 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["follow-redirects", "virtual:35a845e191d5a8a7376e256c81e9e855732385142c5dc9e26f0b8393c2fb4673b81fed201d5f2c5ab96fb727142683ac03329eab760f2c4870779d4bda6abe8f#npm:1.15.2"],\
             ["form-data", "npm:4.0.0"],\
             ["proxy-from-env", "npm:1.1.0"]\
+          ],\
+          "linkType": "HARD"\
+        }]\
+      ]],\
+      ["b4a", [\
+        ["npm:1.6.4", {\
+          "packageLocation": "./.yarn/cache/b4a-npm-1.6.4-080bcba845-81b086f9af.zip/node_modules/b4a/",\
+          "packageDependencies": [\
+            ["b4a", "npm:1.6.4"]\
           ],\
           "linkType": "HARD"\
         }]\
@@ -11445,6 +11462,13 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "packageDependencies": [\
             ["bson", "npm:4.7.2"],\
             ["buffer", "npm:5.7.1"]\
+          ],\
+          "linkType": "HARD"\
+        }],\
+        ["npm:5.5.1", {\
+          "packageLocation": "./.yarn/cache/bson-npm-5.5.1-d8774a4337-f49730504e.zip/node_modules/bson/",\
+          "packageDependencies": [\
+            ["bson", "npm:5.5.1"]\
           ],\
           "linkType": "HARD"\
         }]\
@@ -15314,6 +15338,15 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "linkType": "HARD"\
         }]\
       ]],\
+      ["fast-fifo", [\
+        ["npm:1.3.2", {\
+          "packageLocation": "./.yarn/cache/fast-fifo-npm-1.3.2-391cc25df4-6bfcba3e4d.zip/node_modules/fast-fifo/",\
+          "packageDependencies": [\
+            ["fast-fifo", "npm:1.3.2"]\
+          ],\
+          "linkType": "HARD"\
+        }]\
+      ]],\
       ["fast-glob", [\
         ["npm:2.2.7", {\
           "packageLocation": "./.yarn/cache/fast-glob-npm-2.2.7-f211fb26f4-304ccff1d4.zip/node_modules/fast-glob/",\
@@ -15771,18 +15804,12 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           ],\
           "linkType": "SOFT"\
         }],\
-        ["virtual:0f2c58533d5ae53fe8d3b1cb5e5cb8e43e3e2d7669343628c0e0e3ec650e92c188661a07c62bd0e049a683d03ad0f5f7911a33a29316bd3959b8724b5aeada68#npm:1.15.2", {\
-          "packageLocation": "./.yarn/__virtual__/follow-redirects-virtual-9f20bb700a/0/cache/follow-redirects-npm-1.15.2-1ec1dd82be-faa66059b6.zip/node_modules/follow-redirects/",\
+        ["npm:1.15.3", {\
+          "packageLocation": "./.yarn/cache/follow-redirects-npm-1.15.3-ca69c47b72-584da22ec5.zip/node_modules/follow-redirects/",\
           "packageDependencies": [\
-            ["follow-redirects", "virtual:0f2c58533d5ae53fe8d3b1cb5e5cb8e43e3e2d7669343628c0e0e3ec650e92c188661a07c62bd0e049a683d03ad0f5f7911a33a29316bd3959b8724b5aeada68#npm:1.15.2"],\
-            ["@types/debug", null],\
-            ["debug", "virtual:58471071b1e0e7981e3318280660861b4dec874aaf0d60e144b70657cb5ce0af059ae16711a2af10f4d1ff0536527e350e6e47a8f79db2d8d37ff2ec84865bbc#npm:4.3.4"]\
+            ["follow-redirects", "npm:1.15.3"]\
           ],\
-          "packagePeers": [\
-            "@types/debug",\
-            "debug"\
-          ],\
-          "linkType": "HARD"\
+          "linkType": "SOFT"\
         }],\
         ["virtual:35a845e191d5a8a7376e256c81e9e855732385142c5dc9e26f0b8393c2fb4673b81fed201d5f2c5ab96fb727142683ac03329eab760f2c4870779d4bda6abe8f#npm:1.15.2", {\
           "packageLocation": "./.yarn/__virtual__/follow-redirects-virtual-2e83874824/0/cache/follow-redirects-npm-1.15.2-1ec1dd82be-faa66059b6.zip/node_modules/follow-redirects/",\
@@ -15790,6 +15817,19 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["follow-redirects", "virtual:35a845e191d5a8a7376e256c81e9e855732385142c5dc9e26f0b8393c2fb4673b81fed201d5f2c5ab96fb727142683ac03329eab760f2c4870779d4bda6abe8f#npm:1.15.2"],\
             ["@types/debug", null],\
             ["debug", null]\
+          ],\
+          "packagePeers": [\
+            "@types/debug",\
+            "debug"\
+          ],\
+          "linkType": "HARD"\
+        }],\
+        ["virtual:6f48908c3af8c754fea38f10057cfc0081ca24b9ec51933d35d3ad791bb3860f2b56d8b63b6851dbeaa8a9ef39ad5034c7710c92d6dad744acf332331717e74b#npm:1.15.3", {\
+          "packageLocation": "./.yarn/__virtual__/follow-redirects-virtual-12c73923b5/0/cache/follow-redirects-npm-1.15.3-ca69c47b72-584da22ec5.zip/node_modules/follow-redirects/",\
+          "packageDependencies": [\
+            ["follow-redirects", "virtual:6f48908c3af8c754fea38f10057cfc0081ca24b9ec51933d35d3ad791bb3860f2b56d8b63b6851dbeaa8a9ef39ad5034c7710c92d6dad744acf332331717e74b#npm:1.15.3"],\
+            ["@types/debug", null],\
+            ["debug", "virtual:58471071b1e0e7981e3318280660861b4dec874aaf0d60e144b70657cb5ce0af059ae16711a2af10f4d1ff0536527e350e6e47a8f79db2d8d37ff2ec84865bbc#npm:4.3.4"]\
           ],\
           "packagePeers": [\
             "@types/debug",\
@@ -17344,11 +17384,11 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           ],\
           "linkType": "HARD"\
         }],\
-        ["npm:5.0.1", {\
-          "packageLocation": "./.yarn/cache/https-proxy-agent-npm-5.0.1-42d65f358e-571fccdf38.zip/node_modules/https-proxy-agent/",\
+        ["npm:7.0.2", {\
+          "packageLocation": "./.yarn/cache/https-proxy-agent-npm-7.0.2-83ea6a5d42-088969a0dd.zip/node_modules/https-proxy-agent/",\
           "packageDependencies": [\
-            ["https-proxy-agent", "npm:5.0.1"],\
-            ["agent-base", "npm:6.0.2"],\
+            ["https-proxy-agent", "npm:7.0.2"],\
+            ["agent-base", "npm:7.1.0"],\
             ["debug", "virtual:428f325a939c2653ad822eb3d75efb02ac311523dd0d4f9645afc39ea00bd86eceac35a9d59c9b6977d76b670a4ef0ae057ea572338a44729aa592711a8c05a3#npm:4.3.2"]\
           ],\
           "linkType": "HARD"\
@@ -20787,15 +20827,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "linkType": "HARD"\
         }]\
       ]],\
-      ["md5-file", [\
-        ["npm:5.0.0", {\
-          "packageLocation": "./.yarn/cache/md5-file-npm-5.0.0-e5f59abc62-c606a00ff5.zip/node_modules/md5-file/",\
-          "packageDependencies": [\
-            ["md5-file", "npm:5.0.0"]\
-          ],\
-          "linkType": "HARD"\
-        }]\
-      ]],\
       ["measured-core", [\
         ["npm:1.51.1", {\
           "packageLocation": "./.yarn/cache/measured-core-npm-1.51.1-3a43a565f1-b8c7cd5495.zip/node_modules/measured-core/",\
@@ -21391,15 +21422,43 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           ],\
           "linkType": "HARD"\
         }],\
-        ["npm:4.17.1", {\
-          "packageLocation": "./.yarn/cache/mongodb-npm-4.17.1-a2fe811ff1-e7f280570d.zip/node_modules/mongodb/",\
+        ["npm:5.9.1", {\
+          "packageLocation": "./.yarn/cache/mongodb-npm-5.9.1-7e427c6de3-a827937120.zip/node_modules/mongodb/",\
           "packageDependencies": [\
-            ["mongodb", "npm:4.17.1"],\
-            ["@aws-sdk/credential-providers", "npm:3.212.0"],\
+            ["mongodb", "npm:5.9.1"]\
+          ],\
+          "linkType": "SOFT"\
+        }],\
+        ["virtual:6f48908c3af8c754fea38f10057cfc0081ca24b9ec51933d35d3ad791bb3860f2b56d8b63b6851dbeaa8a9ef39ad5034c7710c92d6dad744acf332331717e74b#npm:5.9.1", {\
+          "packageLocation": "./.yarn/__virtual__/mongodb-virtual-01716b6021/0/cache/mongodb-npm-5.9.1-7e427c6de3-a827937120.zip/node_modules/mongodb/",\
+          "packageDependencies": [\
+            ["mongodb", "virtual:6f48908c3af8c754fea38f10057cfc0081ca24b9ec51933d35d3ad791bb3860f2b56d8b63b6851dbeaa8a9ef39ad5034c7710c92d6dad744acf332331717e74b#npm:5.9.1"],\
+            ["@aws-sdk/credential-providers", null],\
             ["@mongodb-js/saslprep", "npm:1.1.0"],\
-            ["bson", "npm:4.7.2"],\
+            ["@mongodb-js/zstd", null],\
+            ["@types/aws-sdk__credential-providers", null],\
+            ["@types/kerberos", null],\
+            ["@types/mongodb-client-encryption", null],\
+            ["@types/mongodb-js__zstd", null],\
+            ["@types/snappy", null],\
+            ["bson", "npm:5.5.1"],\
+            ["kerberos", null],\
+            ["mongodb-client-encryption", null],\
             ["mongodb-connection-string-url", "npm:2.6.0"],\
+            ["snappy", null],\
             ["socks", "npm:2.7.1"]\
+          ],\
+          "packagePeers": [\
+            "@aws-sdk/credential-providers",\
+            "@mongodb-js/zstd",\
+            "@types/aws-sdk__credential-providers",\
+            "@types/kerberos",\
+            "@types/mongodb-client-encryption",\
+            "@types/mongodb-js__zstd",\
+            "@types/snappy",\
+            "kerberos",\
+            "mongodb-client-encryption",\
+            "snappy"\
           ],\
           "linkType": "HARD"\
         }]\
@@ -21425,35 +21484,32 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
         }]\
       ]],\
       ["mongodb-memory-server", [\
-        ["npm:8.15.1", {\
-          "packageLocation": "./.yarn/unplugged/mongodb-memory-server-npm-8.15.1-52153cb2c7/node_modules/mongodb-memory-server/",\
+        ["npm:9.0.1", {\
+          "packageLocation": "./.yarn/unplugged/mongodb-memory-server-npm-9.0.1-cf910b6df5/node_modules/mongodb-memory-server/",\
           "packageDependencies": [\
-            ["mongodb-memory-server", "npm:8.15.1"],\
-            ["mongodb-memory-server-core", "npm:8.15.1"],\
+            ["mongodb-memory-server", "npm:9.0.1"],\
+            ["mongodb-memory-server-core", "npm:9.0.1"],\
             ["tslib", "npm:2.6.2"]\
           ],\
           "linkType": "HARD"\
         }]\
       ]],\
       ["mongodb-memory-server-core", [\
-        ["npm:8.15.1", {\
-          "packageLocation": "./.yarn/cache/mongodb-memory-server-core-npm-8.15.1-0f2c58533d-2e47663a65.zip/node_modules/mongodb-memory-server-core/",\
+        ["npm:9.0.1", {\
+          "packageLocation": "./.yarn/cache/mongodb-memory-server-core-npm-9.0.1-6f48908c3a-41ed9b1c6c.zip/node_modules/mongodb-memory-server-core/",\
           "packageDependencies": [\
-            ["mongodb-memory-server-core", "npm:8.15.1"],\
-            ["async-mutex", "npm:0.3.2"],\
+            ["mongodb-memory-server-core", "npm:9.0.1"],\
+            ["async-mutex", "npm:0.4.0"],\
             ["camelcase", "npm:6.3.0"],\
             ["debug", "virtual:58471071b1e0e7981e3318280660861b4dec874aaf0d60e144b70657cb5ce0af059ae16711a2af10f4d1ff0536527e350e6e47a8f79db2d8d37ff2ec84865bbc#npm:4.3.4"],\
             ["find-cache-dir", "npm:3.3.2"],\
-            ["follow-redirects", "virtual:0f2c58533d5ae53fe8d3b1cb5e5cb8e43e3e2d7669343628c0e0e3ec650e92c188661a07c62bd0e049a683d03ad0f5f7911a33a29316bd3959b8724b5aeada68#npm:1.15.2"],\
-            ["get-port", "npm:5.1.1"],\
-            ["https-proxy-agent", "npm:5.0.1"],\
-            ["md5-file", "npm:5.0.0"],\
-            ["mongodb", "npm:4.17.1"],\
+            ["follow-redirects", "virtual:6f48908c3af8c754fea38f10057cfc0081ca24b9ec51933d35d3ad791bb3860f2b56d8b63b6851dbeaa8a9ef39ad5034c7710c92d6dad744acf332331717e74b#npm:1.15.3"],\
+            ["https-proxy-agent", "npm:7.0.2"],\
+            ["mongodb", "virtual:6f48908c3af8c754fea38f10057cfc0081ca24b9ec51933d35d3ad791bb3860f2b56d8b63b6851dbeaa8a9ef39ad5034c7710c92d6dad744acf332331717e74b#npm:5.9.1"],\
             ["new-find-package-json", "npm:2.0.0"],\
             ["semver", "npm:7.5.4"],\
-            ["tar-stream", "npm:2.2.0"],\
+            ["tar-stream", "npm:3.1.6"],\
             ["tslib", "npm:2.6.2"],\
-            ["uuid", "npm:9.0.0"],\
             ["yauzl", "npm:2.10.0"]\
           ],\
           "linkType": "HARD"\
@@ -24349,6 +24405,15 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "linkType": "HARD"\
         }]\
       ]],\
+      ["queue-tick", [\
+        ["npm:1.0.1", {\
+          "packageLocation": "./.yarn/cache/queue-tick-npm-1.0.1-10bd6eaf3d-57c3292814.zip/node_modules/queue-tick/",\
+          "packageDependencies": [\
+            ["queue-tick", "npm:1.0.1"]\
+          ],\
+          "linkType": "HARD"\
+        }]\
+      ]],\
       ["quick-format-unescaped", [\
         ["npm:4.0.4", {\
           "packageLocation": "./.yarn/cache/quick-format-unescaped-npm-4.0.4-7e22c9b7dc-7bc32b9935.zip/node_modules/quick-format-unescaped/",\
@@ -26857,6 +26922,17 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "linkType": "HARD"\
         }]\
       ]],\
+      ["streamx", [\
+        ["npm:2.15.5", {\
+          "packageLocation": "./.yarn/cache/streamx-npm-2.15.5-08568dca5b-52e0ec9402.zip/node_modules/streamx/",\
+          "packageDependencies": [\
+            ["streamx", "npm:2.15.5"],\
+            ["fast-fifo", "npm:1.3.2"],\
+            ["queue-tick", "npm:1.0.1"]\
+          ],\
+          "linkType": "HARD"\
+        }]\
+      ]],\
       ["strict-uri-encode", [\
         ["npm:2.0.0", {\
           "packageLocation": "./.yarn/cache/strict-uri-encode-npm-2.0.0-1ec3189376-eaac4cf978.zip/node_modules/strict-uri-encode/",\
@@ -27493,6 +27569,16 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["fs-constants", "npm:1.0.0"],\
             ["inherits", "npm:2.0.4"],\
             ["readable-stream", "npm:3.6.0"]\
+          ],\
+          "linkType": "HARD"\
+        }],\
+        ["npm:3.1.6", {\
+          "packageLocation": "./.yarn/cache/tar-stream-npm-3.1.6-ce3ac17e49-f3627f9185.zip/node_modules/tar-stream/",\
+          "packageDependencies": [\
+            ["tar-stream", "npm:3.1.6"],\
+            ["b4a", "npm:1.6.4"],\
+            ["fast-fifo", "npm:1.3.2"],\
+            ["streamx", "npm:2.15.5"]\
           ],\
           "linkType": "HARD"\
         }]\
@@ -29269,7 +29355,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "packageDependencies": [\
             ["vitest-mongodb", "npm:0.0.5"],\
             ["debug", "virtual:58471071b1e0e7981e3318280660861b4dec874aaf0d60e144b70657cb5ce0af059ae16711a2af10f4d1ff0536527e350e6e47a8f79db2d8d37ff2ec84865bbc#npm:4.3.4"],\
-            ["mongodb-memory-server", "npm:8.15.1"]\
+            ["mongodb-memory-server", "npm:9.0.1"]\
           ],\
           "linkType": "HARD"\
         }]\

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18.17.1-bullseye as dependencies
+FROM docker.io/library/node:18.17.1-bullseye as dependencies
 
 WORKDIR /srv
 

--- a/README.md
+++ b/README.md
@@ -31,14 +31,14 @@ GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
 ```
 
-[docker-compose](https://docs.docker.com/compose/overview/) is used to run a local copy of all required services together.
+[podman-compose](https://github.com/containers/podman-compose) is used to run a local copy of all required services together.
 
 ```shell
-# This will run docker-compose in the background (-d flag is --detach)
-docker-compose up -d
+# This will run podman-compose in the background (-d flag is --detach)
+podman-compose up -d
 ```
 
-For example, you can restart the server container with `docker-compose restart server` or view logs with `docker-compose logs -f --tail=10 server`.
+For example, you can restart the server container with `podman-compose restart server` or view logs with `podman-compose logs -f --tail=10 server`.
 
 ## Major Components
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,48 +1,10 @@
 # docker compose versions
 version: '2.3'
 
-volumes:
-  node_deps:
-  dist:
-    driver_opts:
-      type: tmpfs
-      device: tmpfs
-  dist_app:
-    driver_opts:
-      type: tmpfs
-      device: tmpfs
-  dist_client:
-    driver_opts:
-      type: tmpfs
-      device: tmpfs
-  dist_cli:
-    driver_opts:
-      type: tmpfs
-      device: tmpfs
-  dist_components:
-    driver_opts:
-      type: tmpfs
-      device: tmpfs
-  dist_indexer:
-    driver_opts:
-      type: tmpfs
-      device: tmpfs
-  dist_server:
-    driver_opts:
-      type: tmpfs
-      device: tmpfs
-  dist_search:
-    driver_opts:
-      type: tmpfs
-      device: tmpfs
-  typescript_build_cache:
-  node_modules_app:
-  node_modules_components:
-
 services:
   # This dummy service provides shared configuration for all Node deps
   node:
-    image: node:18.17.1-bullseye
+    image: docker.io/library/node:18.17.1-bullseye
     env_file: ./config.env
     working_dir: /srv
     command: bash -c 'yarn install && yarn pnpify tsc-watch -b --onSuccess "touch /watch/done"'
@@ -52,23 +14,10 @@ services:
       retries: 60
     tmpfs:
       - /watch
-      - /srv/.build-cache
     volumes:
-      - ./:/srv
-      - node_deps:/srv/.yarn
-      - ./.yarn/cache:/srv/.yarn/cache:ro
-      - ./.yarn/releases:/srv/.yarn/releases:cached
-      - ./.yarn/plugins:/srv/.yarn/plugins:cached
-      - dist:/srv/dist
-      - dist_app:/srv/packages/openneuro-app/dist
-      - dist_cli:/srv/packages/openneuro-cli/dist
-      - dist_client:/srv/packages/openneuro-client/dist
-      - dist_components:/srv/packages/openneuro-components/dist
-      - dist_search:/srv/packages/openneuro-search/dist
-      - dist_indexer:/srv/packages/openneuro-indexer/dist
-      - dist_server:/srv/packages/openneuro-server/dist
-      - node_modules_app:/srv/packages/openneuro-app/node_modules
-      - node_modules_components:/srv/packages/openneuro-components/node_modules
+      - ./:/srv:rw,z
+      - /srv/dist
+      - /srv/.build-cache
 
   # web app bundle build
   app:
@@ -126,13 +75,13 @@ services:
 
   # mongodb
   mongo:
-    image: mongo:5.0
+    image: docker.io/library/mongo:5.0
     volumes:
       - ${PERSISTENT_DIR}/mongo:/data/db:delegated
 
   # Redis
   redis:
-    image: redis:alpine
+    image: docker.io/library/redis:alpine
 
   # datalad Python backend
   datalad:
@@ -169,11 +118,10 @@ services:
 
   # nginx + app
   web:
-    image: nginx:1.16.1
+    image: docker.io/library/nginx:1.16.1
     volumes:
       - ./nginx/nginx.dev.conf:/etc/nginx/conf.d/default.conf:ro
     ports:
-      - '80:80'
       - '8110:8110'
       - '9876:80'
     depends_on:
@@ -197,11 +145,3 @@ services:
       - '9200:9200'
       - '9300:9300'
 
-# comment out `x-disabled` to enable kibana service
-x-disabled:
-  kibana:
-    image: kibana:7.10.1
-    depends_on:
-      - elasticsearch
-    ports:
-      - '5601:5601'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,7 +77,7 @@ services:
   mongo:
     image: docker.io/library/mongo:5.0
     volumes:
-      - ${PERSISTENT_DIR}/mongo:/data/db:delegated
+      - ${PERSISTENT_DIR}/mongo:/data/db:z
 
   # Redis
   redis:
@@ -88,7 +88,7 @@ services:
     build:
       context: services/datalad
     volumes:
-      - ${PERSISTENT_DIR}/datalad:/datalad:delegated
+      - ${PERSISTENT_DIR}/datalad:/datalad:z
       - ./services/datalad/datalad_service:/srv/datalad_service
     env_file: ./config.env
     init: true

--- a/nginx/nginx.dev.conf
+++ b/nginx/nginx.dev.conf
@@ -1,17 +1,9 @@
-# Override docker-compose 600s TTL
-resolver 127.0.0.11 valid=10s;
-
 server {
     listen 80;
 
     gzip on;
     gzip_proxied any;
     gzip_types text/html application/json text/css;
-
-    # Use a variable to allow for IP changes when a new container starts
-    # https://www.nginx.com/blog/dns-service-discovery-nginx-plus/#domain-name-proxy_pass
-    set $openneuro_server server;
-    set $datalad_service datalad;
 
     location /uploads {
         client_max_body_size 0;
@@ -20,7 +12,7 @@ server {
         proxy_set_header Connection "";
         proxy_http_version 1.1;
         proxy_request_buffering off;
-        proxy_pass http://$datalad_service:80;
+        proxy_pass http://datalad:80;
     }
 
     location /git {
@@ -30,7 +22,7 @@ server {
         proxy_set_header Connection "";
         proxy_http_version 1.1;
         proxy_request_buffering off;
-        proxy_pass http://$datalad_service:80;
+        proxy_pass http://datalad:80;
     }
 
     # crn-server proxy
@@ -41,7 +33,7 @@ server {
         proxy_set_header Connection "";
         proxy_http_version 1.1;
         proxy_request_buffering off;
-        proxy_pass http://$openneuro_server:8111;
+        proxy_pass http://server:8111;
     }
 
     # Sitemap path
@@ -52,11 +44,11 @@ server {
         proxy_set_header Connection "";
         proxy_http_version 1.1;
         proxy_request_buffering off;
-        proxy_pass http://$openneuro_server:8111/crn/sitemap;
+        proxy_pass http://server:8111/crn/sitemap;
     }
 
     location /graphql-subscriptions {
-        proxy_pass http://$openneuro_server:8111/graphql-subscriptions;
+        proxy_pass http://server:8111/graphql-subscriptions;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";

--- a/package.json
+++ b/package.json
@@ -66,7 +66,8 @@
     }
   },
   "resolutions": {
-    "react-router-dom": "6.3.0"
+    "react-router-dom": "6.3.0",
+    "mongodb-memory-server": "9.0.1"
   },
   "packageManager": "yarn@3.6.3",
   "dependencies": {

--- a/packages/openneuro-app/src/scripts/dataset/__tests__/__snapshots__/snapshot-container.spec.tsx.snap
+++ b/packages/openneuro-app/src/scripts/dataset/__tests__/__snapshots__/snapshot-container.spec.tsx.snap
@@ -258,7 +258,7 @@ exports[`SnapshotContainer component > renders successfully 1`] = `
                                         >
                                           <span>
                                             <label>
-                                              Location: 
+                                              Location:
                                             </label>
                                             <p>
                                               /participants.tsv
@@ -269,7 +269,7 @@ exports[`SnapshotContainer component > renders successfully 1`] = `
                                           class="e-meta"
                                         >
                                           <label>
-                                            Reason: 
+                                            Reason:
                                           </label>
                                           <p>
                                             Tabular file contains custom columns not described in a data dictionary

--- a/packages/openneuro-app/src/scripts/dataset/files/viewers/__tests__/__snapshots__/file-viewer-json.spec.jsx.snap
+++ b/packages/openneuro-app/src/scripts/dataset/files/viewers/__tests__/__snapshots__/file-viewer-json.spec.jsx.snap
@@ -1,29 +1,5 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`File Viewer - JSON > renders with invalid JSON 1`] = `
-<DocumentFragment>
-  <h3>
-    Tree
-  </h3>
-  <hr />
-  <p>
-    JSON failed to parse
-  </p>
-  <pre>
-    Unexpected token ; in JSON at position 4
-  </pre>
-  <h3>
-    Raw
-  </h3>
-  <hr />
-  <pre
-    class="css-ffm88e"
-  >
-    1234;
-  </pre>
-</DocumentFragment>
-`;
-
 exports[`File Viewer - JSON > renders with valid JSON 1`] = `
 <DocumentFragment>
   <h3>

--- a/packages/openneuro-app/src/scripts/pages/metadata/dataset-metadata.tsx
+++ b/packages/openneuro-app/src/scripts/pages/metadata/dataset-metadata.tsx
@@ -80,8 +80,7 @@ export function DatasetMetadata(): React.ReactElement {
             "affirmedDefaced",
             "affirmedConsent",
           ]}
-        >
-        </DataTable>
+        />
       </MetadataPageStyle>
     )
   }

--- a/packages/openneuro-server/src/libs/authentication/__tests__/jwt.spec.ts
+++ b/packages/openneuro-server/src/libs/authentication/__tests__/jwt.spec.ts
@@ -16,7 +16,7 @@ describe("jwt auth", () => {
           },
         },
       }
-      const user = User({ email: "test@example.com" })
+      const user = new User({ email: "test@example.com" })
       const obj = addJWT(config)(user)
       expect(obj).toHaveProperty("token")
     })

--- a/services/datalad/Dockerfile
+++ b/services/datalad/Dockerfile
@@ -1,5 +1,5 @@
-FROM denoland/deno:bin-1.33.1 AS deno
-FROM python:3.11-slim as production
+FROM docker.io/denoland/deno:bin-1.33.1 AS deno
+FROM docker.io/library/python:3.11-slim as production
 
 WORKDIR /srv
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8439,6 +8439,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"agent-base@npm:^7.0.2":
+  version: 7.1.0
+  resolution: "agent-base@npm:7.1.0"
+  dependencies:
+    debug: ^4.3.4
+  checksum: f7828f991470a0cc22cb579c86a18cbae83d8a3cbed39992ab34fc7217c4d126017f1c74d0ab66be87f71455318a8ea3e757d6a37881b8d0f2a2c6aa55e5418f
+  languageName: node
+  linkType: hard
+
 "agent-base@npm:~4.2.1":
   version: 4.2.1
   resolution: "agent-base@npm:4.2.1"
@@ -8948,12 +8957,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"async-mutex@npm:^0.3.2":
-  version: 0.3.2
-  resolution: "async-mutex@npm:0.3.2"
+"async-mutex@npm:^0.4.0":
+  version: 0.4.0
+  resolution: "async-mutex@npm:0.4.0"
   dependencies:
-    tslib: ^2.3.1
-  checksum: 620b771dfdea1cad0a6b712915c31a1e3ca880a8cf1eae92b4590f435995e0260929c6ebaae0b9126b1456790ea498064b5bb9a506948cda760f48d3d0dcc4c8
+    tslib: ^2.4.0
+  checksum: 813a71728b35a4fbfd64dba719f04726d9133c67b577fcd951b7028c4a675a13ee34e69beb82d621f87bf81f5d4f135c4c44be0448550c7db728547244ef71fc
   languageName: node
   linkType: hard
 
@@ -9048,6 +9057,13 @@ __metadata:
     form-data: ^4.0.0
     proxy-from-env: ^1.1.0
   checksum: e7405a5dbbea97760d0e6cd58fecba311b0401ddb4a8efbc4108f5537da9b3f278bde566deb777935a960beec4fa18e7b8353881f2f465e4f2c0e949fead35be
+  languageName: node
+  linkType: hard
+
+"b4a@npm:^1.6.4":
+  version: 1.6.4
+  resolution: "b4a@npm:1.6.4"
+  checksum: 81b086f9af1f8845fbef4476307236bda3d660c158c201db976f19cdce05f41f93110ab6b12fd7a2696602a490cc43d5410ee36a56d6eef93afb0d6ca69ac3b2
   languageName: node
   linkType: hard
 
@@ -9480,6 +9496,13 @@ __metadata:
   dependencies:
     buffer: ^5.6.0
   checksum: f357d12c5679c8eb029a62e410ad40fb862b7b91f0fc12a3399fb3668e14aecaa63205ffeeee48735a01d393171743607dcd527eb8c058b6f2bd294079ee4125
+  languageName: node
+  linkType: hard
+
+"bson@npm:^5.5.0":
+  version: 5.5.1
+  resolution: "bson@npm:5.5.1"
+  checksum: f49730504e8362e2c8d1eb0c272e5e125392c41fb7196fc35ccbc39718ee62569a1d197bd2342c3334cd420073d3fd5dc7dea764a7f219dcd79e0ce473dd2772
   languageName: node
   linkType: hard
 
@@ -12839,6 +12862,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fast-fifo@npm:^1.1.0, fast-fifo@npm:^1.2.0":
+  version: 1.3.2
+  resolution: "fast-fifo@npm:1.3.2"
+  checksum: 6bfcba3e4df5af7be3332703b69a7898a8ed7020837ec4395bb341bd96cc3a6d86c3f6071dd98da289618cf2234c70d84b2a6f09a33dd6f988b1ff60d8e54275
+  languageName: node
+  linkType: hard
+
 "fast-glob@npm:3.2.7, fast-glob@npm:^3.1.1, fast-glob@npm:^3.2.2":
   version: 3.2.7
   resolution: "fast-glob@npm:3.2.7"
@@ -13243,13 +13273,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"follow-redirects@npm:^1.15.0, follow-redirects@npm:^1.15.2":
+"follow-redirects@npm:^1.15.0":
   version: 1.15.2
   resolution: "follow-redirects@npm:1.15.2"
   peerDependenciesMeta:
     debug:
       optional: true
   checksum: faa66059b66358ba65c234c2f2a37fcec029dc22775f35d9ad6abac56003268baf41e55f9ee645957b32c7d9f62baf1f0b906e68267276f54ec4b4c597c2b190
+  languageName: node
+  linkType: hard
+
+"follow-redirects@npm:^1.15.3":
+  version: 1.15.3
+  resolution: "follow-redirects@npm:1.15.3"
+  peerDependenciesMeta:
+    debug:
+      optional: true
+  checksum: 584da22ec5420c837bd096559ebfb8fe69d82512d5585004e36a3b4a6ef6d5905780e0c74508c7b72f907d1fa2b7bd339e613859e9c304d0dc96af2027fd0231
   languageName: node
   linkType: hard
 
@@ -13674,7 +13714,7 @@ fsevents@~2.3.2:
   languageName: node
   linkType: hard
 
-"get-port@npm:5.1.1, get-port@npm:^5.1.1":
+"get-port@npm:5.1.1":
   version: 5.1.1
   resolution: "get-port@npm:5.1.1"
   checksum: 0162663ffe5c09e748cd79d97b74cd70e5a5c84b760a475ce5767b357fb2a57cb821cee412d646aa8a156ed39b78aab88974eddaa9e5ee926173c036c0713787
@@ -14675,13 +14715,13 @@ fsevents@~2.3.2:
   languageName: node
   linkType: hard
 
-"https-proxy-agent@npm:^5.0.1":
-  version: 5.0.1
-  resolution: "https-proxy-agent@npm:5.0.1"
+"https-proxy-agent@npm:^7.0.2":
+  version: 7.0.2
+  resolution: "https-proxy-agent@npm:7.0.2"
   dependencies:
-    agent-base: 6
+    agent-base: ^7.0.2
     debug: 4
-  checksum: 571fccdf38184f05943e12d37d6ce38197becdd69e58d03f43637f7fa1269cf303a7d228aa27e5b27bbd3af8f09fd938e1c91dcfefff2df7ba77c20ed8dfc765
+  checksum: 088969a0dd476ea7a0ed0a2cf1283013682b08f874c3bc6696c83fa061d2c157d29ef0ad3eb70a2046010bb7665573b2388d10fdcb3e410a66995e5248444292
   languageName: node
   linkType: hard
 
@@ -17750,15 +17790,6 @@ fsevents@~2.3.2:
   languageName: node
   linkType: hard
 
-"md5-file@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "md5-file@npm:5.0.0"
-  bin:
-    md5-file: cli.js
-  checksum: c606a00ff58adf5428e8e2f36d86e5d3c7029f9688126faca302cd83b5e92cac183a62e1d1f05fae7c2614e80f993326fd0a8d6a3a913c41ec7ea0eefc25aa76
-  languageName: node
-  linkType: hard
-
 "measured-core@npm:^1.51.1":
   version: 1.51.1
   resolution: "measured-core@npm:1.51.1"
@@ -18334,36 +18365,33 @@ fsevents@~2.3.2:
   languageName: node
   linkType: hard
 
-"mongodb-memory-server-core@npm:8.15.1":
-  version: 8.15.1
-  resolution: "mongodb-memory-server-core@npm:8.15.1"
+"mongodb-memory-server-core@npm:9.0.1":
+  version: 9.0.1
+  resolution: "mongodb-memory-server-core@npm:9.0.1"
   dependencies:
-    async-mutex: ^0.3.2
+    async-mutex: ^0.4.0
     camelcase: ^6.3.0
     debug: ^4.3.4
     find-cache-dir: ^3.3.2
-    follow-redirects: ^1.15.2
-    get-port: ^5.1.1
-    https-proxy-agent: ^5.0.1
-    md5-file: ^5.0.0
-    mongodb: ^4.16.0
+    follow-redirects: ^1.15.3
+    https-proxy-agent: ^7.0.2
+    mongodb: ^5.9.0
     new-find-package-json: ^2.0.0
     semver: ^7.5.4
-    tar-stream: ^2.1.4
-    tslib: ^2.6.1
-    uuid: ^9.0.0
+    tar-stream: ^3.0.0
+    tslib: ^2.6.2
     yauzl: ^2.10.0
-  checksum: 2e47663a65575f4d067f8acf47a00aa7f2cfd8040854034f72e2ca35ab3d708fbe45feff556eff9d9d8fce5a9618a57c4d01c8a9c267b810470962fd5e126823
+  checksum: 41ed9b1c6c3d56e637594e250ccd151cdf2b958b77551e9e8616f39f1d4ceb22376def390f3bbedff5417b3b448ec235a108e9022da1ab88458719baaf11d8c6
   languageName: node
   linkType: hard
 
-"mongodb-memory-server@npm:^8.12.0":
-  version: 8.15.1
-  resolution: "mongodb-memory-server@npm:8.15.1"
+"mongodb-memory-server@npm:9.0.1":
+  version: 9.0.1
+  resolution: "mongodb-memory-server@npm:9.0.1"
   dependencies:
-    mongodb-memory-server-core: 8.15.1
-    tslib: ^2.6.1
-  checksum: ad1f1cba52925556274786414c9267056dac6a7463789a13ebb3722a840fdbe45131a50d964ec5ee215460518dc0966050c8f118b70ea97d8de5d4276da44c6b
+    mongodb-memory-server-core: 9.0.1
+    tslib: ^2.6.2
+  checksum: 0f54d26edde117a6e87423461445be094a6af6e7d87d3bf2c98607683c41bed4f2e5a0175dfa8ffd9b6d0bf6fcea11bf3a18aaf66f5ccc619a0a6a4417ebdfce
   languageName: node
   linkType: hard
 
@@ -18385,21 +18413,35 @@ fsevents@~2.3.2:
   languageName: node
   linkType: hard
 
-"mongodb@npm:^4.16.0":
-  version: 4.17.1
-  resolution: "mongodb@npm:4.17.1"
+"mongodb@npm:^5.9.0":
+  version: 5.9.1
+  resolution: "mongodb@npm:5.9.1"
   dependencies:
-    "@aws-sdk/credential-providers": ^3.186.0
     "@mongodb-js/saslprep": ^1.1.0
-    bson: ^4.7.2
+    bson: ^5.5.0
     mongodb-connection-string-url: ^2.6.0
     socks: ^2.7.1
+  peerDependencies:
+    "@aws-sdk/credential-providers": ^3.188.0
+    "@mongodb-js/zstd": ^1.0.0
+    kerberos: ^1.0.0 || ^2.0.0
+    mongodb-client-encryption: ">=2.3.0 <3"
+    snappy: ^7.2.2
   dependenciesMeta:
-    "@aws-sdk/credential-providers":
-      optional: true
     "@mongodb-js/saslprep":
       optional: true
-  checksum: e7f280570d0f23d60c308b2a484ed55762ec8e523946c0de1a0b3b398f24efcf1916a745e5407f32cd1c105b2f19d8ac75474c92f73cdf651affe3430a963f54
+  peerDependenciesMeta:
+    "@aws-sdk/credential-providers":
+      optional: true
+    "@mongodb-js/zstd":
+      optional: true
+    kerberos:
+      optional: true
+    mongodb-client-encryption:
+      optional: true
+    snappy:
+      optional: true
+  checksum: a827937120cd7eecafc0ad5657b40536774f0b09582a9363db0a192149ba20eae80a33fccf573f5ce69a20aca6759c40b4961d9d1d4de2a350c543030055e0f6
   languageName: node
   linkType: hard
 
@@ -21063,6 +21105,13 @@ fsevents@~2.3.2:
   languageName: node
   linkType: hard
 
+"queue-tick@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "queue-tick@npm:1.0.1"
+  checksum: 57c3292814b297f87f792fbeb99ce982813e4e54d7a8bdff65cf53d5c084113913289d4a48ec8bbc964927a74b847554f9f4579df43c969a6c8e0f026457ad01
+  languageName: node
+  linkType: hard
+
 "quick-format-unescaped@npm:^4.0.3":
   version: 4.0.4
   resolution: "quick-format-unescaped@npm:4.0.4"
@@ -23231,6 +23280,16 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
+"streamx@npm:^2.15.0":
+  version: 2.15.5
+  resolution: "streamx@npm:2.15.5"
+  dependencies:
+    fast-fifo: ^1.1.0
+    queue-tick: ^1.0.1
+  checksum: 52e0ec94026d67c9e2e2e1090f05e5b138c2f2822462d9a8ef4a4805625a31d103e55ea5267fcd9bfe041374926424e42aec2dda28a85cb9de42c2a16d416d94
+  languageName: node
+  linkType: hard
+
 "strict-uri-encode@npm:^2.0.0":
   version: 2.0.0
   resolution: "strict-uri-encode@npm:2.0.0"
@@ -23758,7 +23817,18 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"tar-stream@npm:^2.1.4, tar-stream@npm:~2.2.0":
+"tar-stream@npm:^3.0.0":
+  version: 3.1.6
+  resolution: "tar-stream@npm:3.1.6"
+  dependencies:
+    b4a: ^1.6.4
+    fast-fifo: ^1.2.0
+    streamx: ^2.15.0
+  checksum: f3627f918581976e954ff03cb8d370551053796b82564f8c7ca8fac84c48e4d042026d0854fc222171a34ff9c682b72fae91be9c9b0a112d4c54f9e4f443e9c5
+  languageName: node
+  linkType: hard
+
+"tar-stream@npm:~2.2.0":
   version: 2.2.0
   resolution: "tar-stream@npm:2.2.0"
   dependencies:
@@ -24342,7 +24412,7 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"tslib@npm:^2.5.0, tslib@npm:^2.6.1":
+"tslib@npm:^2.5.0, tslib@npm:^2.6.2":
   version: 2.6.2
   resolution: "tslib@npm:2.6.2"
   checksum: 329ea56123005922f39642318e3d1f0f8265d1e7fcb92c633e0809521da75eeaca28d2cf96d7248229deb40e5c19adf408259f4b9640afd20d13aecc1430f3ad


### PR DESCRIPTION
This includes some general simplification of the dev environment, reducing the need to maintain as many docker volumes. This also allows OpenNeuro to run in a dev environment where the user running it may not have root access (such as nested within a flatpak or on a multiuser server) assuming the system is otherwise compatible with rootless docker or podman.

I updated documentation to point at podman-compose but docker-compose v1 should continue to work. Usage is identical to docker-compose. ```podman-compose up -d```