### PR TITLE
fix(server): Allow /api in addition to /crn for API requests

### DIFF
--- a/nginx/nginx.dev.conf
+++ b/nginx/nginx.dev.conf
@@ -36,6 +36,16 @@ server {
         proxy_pass http://server:8111;
     }
 
+    location /api {
+        client_max_body_size 0;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header Connection "";
+        proxy_http_version 1.1;
+        proxy_request_buffering off;
+        proxy_pass http://server:8111;
+    }
+
     # Sitemap path
     location /sitemap.xml {
         client_max_body_size 0;

--- a/packages/openneuro-server/src/app.ts
+++ b/packages/openneuro-server/src/app.ts
@@ -58,6 +58,7 @@ export async function expressApolloSetup() {
   // routing ---------------------------------------------------------
   app.use("/sitemap.xml", sitemapHandler)
   app.use(config.apiPrefix, routes)
+  app.use("/api/", routes)
 
   const httpServer = createServer(app)
 
@@ -98,7 +99,7 @@ export async function expressApolloSetup() {
 
   // Setup GraphQL middleware
   app.use(
-    ["/graphql", "/crn/graphql"],
+    ["/graphql", "/crn/graphql", "/api/graphql"],
     cors<cors.CorsRequest>(),
     jwt.authenticate,
     auth.optional,


### PR DESCRIPTION
Minor change to allow /api to replace /crn to make it clearer what this prefix does.