### PR TITLE
fix(server): Allow authorization bearer token header for API access

### DIFF
--- a/packages/openneuro-server/src/libs/authentication/__tests__/jwt.spec.ts
+++ b/packages/openneuro-server/src/libs/authentication/__tests__/jwt.spec.ts
@@ -1,6 +1,6 @@
 import { vi } from "vitest"
 import User from "../../../models/user"
-import { addJWT } from "../jwt"
+import { addJWT, jwtFromRequest } from "../jwt"
 
 vi.mock("ioredis")
 vi.mock("../../../config.ts")
@@ -19,6 +19,41 @@ describe("jwt auth", () => {
       const user = new User({ email: "test@example.com" })
       const obj = addJWT(config)(user)
       expect(obj).toHaveProperty("token")
+    })
+  })
+  describe("jwtFromRequest()", () => {
+    it("handles both cookie and authorization headers", () => {
+      const cookieToken = "1234"
+      const headersToken = "Bearer 5678"
+      const cookieRequest = {
+        cookies: {
+          accessToken: cookieToken,
+        },
+      }
+      const headersRequest = {
+        headers: {
+          authorization: headersToken,
+        },
+      }
+      expect(jwtFromRequest(cookieRequest)).toEqual(cookieToken)
+      expect(jwtFromRequest(headersRequest)).toEqual("5678")
+    })
+    it("prefers authorization header when cookies are present", () => {
+      const req = {
+        cookies: {
+          accessToken: "1234",
+        },
+        headers: {
+          authorization: "Bearer 5678",
+        },
+      }
+      expect(jwtFromRequest(req)).toEqual("5678")
+    })
+    it("returns null when authorization header is missing", () => {
+      const req = {
+        headers: {},
+      }
+      expect(jwtFromRequest(req)).toEqual(null)
     })
   })
 })

--- a/packages/openneuro-server/src/libs/authentication/jwt.ts
+++ b/packages/openneuro-server/src/libs/authentication/jwt.ts
@@ -120,7 +120,16 @@ const requestNewAccessToken = (jwtProvider, refreshToken) =>
  * @param {Object} req
  */
 export const jwtFromRequest = (req) => {
-  if (req.cookies && req.cookies.accessToken) {
+  if (req.headers?.authorization) {
+    try {
+      return req.headers.authorization.substring(
+        7,
+        req.headers.authorization.length,
+      )
+    } catch (_err) {
+      return null
+    }
+  } else if (req.cookies && req.cookies.accessToken) {
     return req.cookies.accessToken
   } else {
     return null


### PR DESCRIPTION
Originally reported by @jbwexler - this fix is also needed for deferred auth used with new upload features.