### PR TITLE
Fix git-annex access issues for CLI

### DIFF
--- a/packages/openneuro-cli/src/transferKey.js
+++ b/packages/openneuro-cli/src/transferKey.js
@@ -12,13 +12,15 @@ import fetch, { Request } from "node-fetch"
  * @returns {Request} Configured fetch Request object
  */
 export function keyRequest(state, key, options) {
-  const headers = new Headers()
+  const headers = new Headers(
+    "headers" in options && options.headers || undefined,
+  )
   headers.set(
     "Authorization",
     "Basic " + Buffer.from(`openneuro-cli:${state.token}`).toString("base64"),
   )
   const requestUrl = `${state.url}/annex/${key}`
-  return new Request(requestUrl, { headers, ...options })
+  return new Request(requestUrl, { ...options, headers })
 }
 
 /**

--- a/packages/openneuro-cli/src/transferKey.js
+++ b/packages/openneuro-cli/src/transferKey.js
@@ -64,9 +64,8 @@ export async function retrieveKey(state, key, file) {
     const response = await fetch(request)
     if (response.status === 200) {
       const writable = createWriteStream(file)
-      const readable = await response.readable()
-      readable.pipe(writable)
-      await once(readable, "close")
+      response.body.pipe(writable)
+      await once(response.body, "close")
       return true
     } else {
       return false

--- a/packages/openneuro-cli/src/transferKey.js
+++ b/packages/openneuro-cli/src/transferKey.js
@@ -1,3 +1,4 @@
+import { stat } from "fs/promises"
 import { createReadStream, createWriteStream } from "fs"
 import { once } from "events"
 import fetch, { Request } from "node-fetch"
@@ -32,9 +33,13 @@ export function keyRequest(state, key, options) {
  * @param {string} file File path
  */
 export async function storeKey(state, key, file) {
+  const fileStat = await stat(file)
   const body = createReadStream(file)
   const requestOptions = {
     method: "POST",
+    headers: {
+      "Content-Length": fileStat.size,
+    },
   }
   const request = keyRequest(state, key, requestOptions)
   const response = await fetch(request, { body })

--- a/packages/openneuro-cli/src/transferKey.js
+++ b/packages/openneuro-cli/src/transferKey.js
@@ -32,11 +32,10 @@ export function keyRequest(state, key, options) {
 export async function storeKey(state, key, file) {
   const body = createReadStream(file)
   const requestOptions = {
-    body,
     method: "POST",
   }
   const request = keyRequest(state, key, requestOptions)
-  const response = await fetch(request)
+  const response = await fetch(request, { body })
   if (response.status === 200) {
     return true
   } else {


### PR DESCRIPTION
This fixes a bug in retrieveKey where the wrong streaming API was used preventing download of keys and improves performance/reliability (especially on Node 19 or later) where storeKey requests would sometimes hang.

One small change to allow tranferKey providers to override headers without losing the authorization header.