### PR TITLE
Helm configuration fixes for ElasticSearch 8.0

### DIFF
--- a/helm/openneuro/templates/secret.yaml
+++ b/helm/openneuro/templates/secret.yaml
@@ -40,3 +40,4 @@ stringData:
   ELASTICSEARCH_CLOUD_ID: {{ .Values.secrets.elasticsearch.ELASTICSEARCH_CLOUD_ID | quote }}
   ELASTICSEARCH_CLOUD_AUTH: {{ .Values.secrets.elasticsearch.ELASTICSEARCH_CLOUD_AUTH | quote }}
   ELASTIC_APM_SECRET_TOKEN: {{ .Values.secrets.elasticsearch.ELASTIC_APM_SECRET_TOKEN | quote }}
+  ELASTIC_APM_API_KEY: {{ .Values.secrets.elasticsearch.ELASTIC_APM_API_KEY | quote }}

--- a/helm/openneuro/values.yaml
+++ b/helm/openneuro/values.yaml
@@ -29,7 +29,7 @@ apiReplicas: 2
 webReplicas: 2
 
 # Elastic APM path
-apmServerUrl: https://b33224e4ded44efabb74f65de2f84f2e.apm.us-east-1.aws.found.io
+apmServerUrl: https://openneuro-staging.apm.us-west-2.aws.found.io
 
 # API resource configuration
 apiCpuRequests: 0.5


### PR DESCRIPTION
Add the ELASTIC_APM_API_KEY environment variable required in ElasticSearch 8.0.