### PR TITLE
Fix API crash caused by socket closed errors

### DIFF
--- a/packages/openneuro-server/src/handlers/datalad.ts
+++ b/packages/openneuro-server/src/handlers/datalad.ts
@@ -44,12 +44,13 @@ export const getFile = async (req, res) => {
       .then((r) => {
         // Set the content length (allow clients to catch HTTP issues better)
         res.setHeader("Content-Length", Number(r.headers.get("content-length")))
-        return r.body
+        if (r.status === 404) {
+          res.status(404).send("Requested dataset or file cannot be found")
+        } else {
+          // @ts-expect-error
+          Readable.fromWeb(r.body, { highWaterMark: 4194304 }).pipe(res)
+        }
       })
-      .then((stream) =>
-        // @ts-expect-error
-        Readable.fromWeb(stream, { highWaterMark: 4194304 }).pipe(res)
-      )
       .catch((err) => {
         console.error(err)
         res.status(500).send("Internal error transferring requested file")

--- a/services/datalad/datalad_service/handlers/tree.py
+++ b/services/datalad/datalad_service/handlers/tree.py
@@ -15,6 +15,11 @@ class TreeResource(object):
         # Request for index of files
         # Return a list of file objects
         # {name, path, size}
-        files = get_tree(self.store, dataset, tree)
-        files.sort(key=dataset_sort)
-        resp.media = {'files': files}
+        try:
+            files = get_tree(self.store, dataset, tree)
+            files.sort(key=dataset_sort)
+            resp.status = falcon.HTTP_OK
+            resp.media = {'files': files}
+        except FileNotFoundError:
+            resp.status = falcon.HTTP_NOT_FOUND
+            resp.media = {'error': 'Dataset does not exist'}


### PR DESCRIPTION
A request for a deleted dataset tree object could cause a crash due to unhandled errors opening the repository. This changes both the worker and the API to handle this situation better and return more sensible HTTP 404 errors when requesting trees or datasets that do not exist.