### PR TITLE
Improve handling of file requests during worker restarts

### DIFF
--- a/packages/openneuro-server/src/datalad/files.ts
+++ b/packages/openneuro-server/src/datalad/files.ts
@@ -92,11 +92,16 @@ export const getFiles = (datasetId, treeish): Promise<[DatasetFile?]> => {
   ])
   return cache.get(
     async (doNotCache): Promise<[DatasetFile?]> => {
-      const response = await fetch(`http://${
-        getDatasetWorker(
-          datasetId,
-        )
-      }/datasets/${datasetId}/tree/${treeish}`)
+      const response = await fetch(
+        `http://${
+          getDatasetWorker(
+            datasetId,
+          )
+        }/datasets/${datasetId}/tree/${treeish}`,
+        {
+          signal: AbortSignal.timeout(10000),
+        },
+      )
       const body = await response.json()
       const files = body?.files
       if (files) {


### PR DESCRIPTION
This avoids an API crash and returns an error the clients can handle if a worker is temporarily unavailable (took more than 10 seconds begin responding to the file request). Timeout might be a little tight here for some datasets but raising it too much leads to stacking up these errors while a worker restarts.

Handling the timeout error here in both the standard way and the Node.js way to keep this portable for Deno.