### PR TITLE
fix(api): Prevent crash when tree is requested with no children

### DIFF
--- a/packages/openneuro-server/src/handlers/datalad.ts
+++ b/packages/openneuro-server/src/handlers/datalad.ts
@@ -29,7 +29,10 @@ export const getFile = async (req, res) => {
       if (level == pathComponents.slice(-1)) {
         file = files.find((f) => !f.directory && f.filename === level)
       } else {
-        tree = files.find((f) => f.directory && f.filename === level).id
+        // This tree may exist but have no children
+        if (files) {
+          tree = files.find((f) => f.directory && f.filename === level).id
+        }
       }
     } catch (err) {
       // ConnectTimeoutError is Node/Undici and TimeoutError is the standard DOMException name


### PR DESCRIPTION
This is a rare crash but found in APM data for serving datasets where a request was made for a deleted tree mainly.