### PR TITLE
Add codespell: workflow, config + get more typos fixed

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,6 +1,6 @@
 # Ref: https://github.com/codespell-project/codespell#using-a-config-file
 [codespell]
-skip = .git,*.pdf,*.svg,go.sum,*.lock,.codespellrc
+skip = .git,*.pdf,*.svg,go.sum,*.lock,.codespellrc,.yarn,node_modules
 check-hidden = true
-# ignore-regex = 
+ignore-regex = ^.{300,}$
 # ignore-words-list =

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,6 +1,6 @@
 # Ref: https://github.com/codespell-project/codespell#using-a-config-file
 [codespell]
-skip = .git,*.pdf,*.svg,go.sum,*.lock,.codespellrc,.yarn,node_modules,schema-validator.js
+skip = .git,*.pdf,*.svg,go.sum,*.lock,.codespellrc,.yarn,node_modules,schema-validator.js,.pnp.cjs
 check-hidden = true
 ignore-regex = ^.{300,}$|/((.*\|){4,}.*\))|\b(afterAll)\b
 ignore-words-list = chack

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,6 +1,6 @@
 # Ref: https://github.com/codespell-project/codespell#using-a-config-file
 [codespell]
-skip = .git,*.pdf,*.svg,go.sum,*.lock,.codespellrc,.yarn,node_modules
+skip = .git,*.pdf,*.svg,go.sum,*.lock,.codespellrc,.yarn,node_modules,schema-validator.js
 check-hidden = true
-ignore-regex = ^.{300,}$
-# ignore-words-list =
+ignore-regex = ^.{300,}$|/((.*\|){4,}.*\))|\b(afterAll)\b
+ignore-words-list = chack

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,6 @@
+# Ref: https://github.com/codespell-project/codespell#using-a-config-file
+[codespell]
+skip = .git,*.pdf,*.svg,go.sum,*.lock,.codespellrc
+check-hidden = true
+# ignore-regex = 
+# ignore-words-list =

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,23 @@
+# Codespell configuration is within .codespellrc
+---
+name: Codespell
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+permissions:
+  contents: read
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Codespell
+        uses: codespell-project/actions-codespell@v2

--- a/packages/openneuro-app/src/scripts/dataset/mutations/create-anonymous-reviewer.tsx
+++ b/packages/openneuro-app/src/scripts/dataset/mutations/create-anonymous-reviewer.tsx
@@ -30,7 +30,7 @@ export const CreateReviewLink: FC<CreateReviewLinkProps> = ({ datasetId }) => {
       <div className="share-form-controls">
         {error
           ? (
-            "An Error Occured"
+            "An Error Occurred"
           )
           : data
           ? (

--- a/services/datalad/datalad_service/common/git.py
+++ b/services/datalad/datalad_service/common/git.py
@@ -14,9 +14,9 @@ class OpenNeuroGitError(Exception):
     """OpenNeuro git repo states that should not arise under normal use but may be a valid git operation in other contexts."""
 
 
-def git_show(path, commitish, obj):
+def git_show(path, committish, obj):
     repo = pygit2.Repository(path)
-    commit, _ = repo.resolve_refish(commitish)
+    commit, _ = repo.resolve_refish(committish)
     data_bytes = (commit.tree / obj).read_raw()
     encoding = chardet.detect(data_bytes[0:4096])["encoding"] or 'utf-8'
     return data_bytes.decode(encoding)


### PR DESCRIPTION
In the past there were just PRs with results of applying codespell, not to use it in CI.