### PR TITLE
FIX: Display metadata lists as unordered lists

### DIFF
--- a/packages/openneuro-app/src/scripts/dataset/__tests__/__snapshots__/snapshot-container.spec.tsx.snap
+++ b/packages/openneuro-app/src/scripts/dataset/__tests__/__snapshots__/snapshot-container.spec.tsx.snap
@@ -1279,6 +1279,7 @@ OCI-1131441 (R. Poldrack, PI) in any publications.
             >
               Funding
             </h2>
+            <ul />
           </div>
           <div
             class="dataset-meta-block dmb-list"
@@ -1288,6 +1289,7 @@ OCI-1131441 (R. Poldrack, PI) in any publications.
             >
               References and Links
             </h2>
+            <ul />
           </div>
           <div
             class="dataset-meta-block dmb-list"
@@ -1297,6 +1299,7 @@ OCI-1131441 (R. Poldrack, PI) in any publications.
             >
               Ethics Approvals
             </h2>
+            <ul />
           </div>
         </div>
       </div>

--- a/packages/openneuro-app/src/scripts/dataset/components/MetaDataListBlock.tsx
+++ b/packages/openneuro-app/src/scripts/dataset/components/MetaDataListBlock.tsx
@@ -17,7 +17,13 @@ export const MetaDataListBlock = ({
   return (
     <div className={"dataset-meta-block " + className}>
       <h2 className="dmb-heading">{heading}</h2>
-      {fieldContent}
+      <ul>
+        {fieldContent.map((item, index) => (
+          <li key={index}>
+            <Markdown>{item}</Markdown>
+          </li>
+        ))}
+      </ul>
     </div>
   )
 }

--- a/packages/openneuro-app/src/scripts/dataset/components/MetaDataListBlock.tsx
+++ b/packages/openneuro-app/src/scripts/dataset/components/MetaDataListBlock.tsx
@@ -1,4 +1,5 @@
 import React from "react"
+import { Markdown } from "../../utils/markdown"
 
 export interface MetaDataListBlockProps {
   heading: string
@@ -18,11 +19,13 @@ export const MetaDataListBlock = ({
     <div className={"dataset-meta-block " + className}>
       <h2 className="dmb-heading">{heading}</h2>
       <ul>
-        {fieldContent.map((item, index) => (
-          <li key={index}>
-            <Markdown>{item}</Markdown>
-          </li>
-        ))}
+        {Array.isArray(fieldContent)
+          ? fieldContent.map((item, index) => (
+            <li key={index}>
+              <Markdown>{item}</Markdown>
+            </li>
+          ))
+          : item}
       </ul>
     </div>
   )

--- a/packages/openneuro-app/src/scripts/dataset/snapshot-container.tsx
+++ b/packages/openneuro-app/src/scripts/dataset/snapshot-container.tsx
@@ -17,6 +17,7 @@ import { DatasetGitAccess } from "./components/DatasetGitAccess"
 import { DatasetHeader } from "./components/DatasetHeader"
 import { DatasetTools } from "./components/DatasetTools"
 import { MetaDataBlock } from "./components/MetaDataBlock"
+import { MetaDataListBlock } from "./components/MetaDataListBlock"
 import { ModalitiesMetaDataBlock } from "./components/ModalitiesMetaDataBlock"
 import { ValidationBlock } from "./components/ValidationBlock"
 import { VersionList } from "./components/VersionList"
@@ -316,19 +317,19 @@ export const SnapshotContainer: React.FC<SnapshotContainerProps> = ({
                 heading="How to Acknowledge"
                 item={description.HowToAcknowledge}
               />
-              <MetaDataBlock
+              <MetaDataListBlock
                 heading="Funding"
                 item={description.Funding}
                 className="dmb-list"
               />
 
-              <MetaDataBlock
+              <MetaDataListBlock
                 heading="References and Links"
                 item={description.ReferencesAndLinks}
                 className="dmb-list"
               />
 
-              <MetaDataBlock
+              <MetaDataListBlock
                 heading="Ethics Approvals"
                 item={description.EthicsApprovals}
                 className="dmb-list"


### PR DESCRIPTION
Fixes #2984. Needs tests, but I think this is about what we want, pulling what I could find from `packages/openneuro-app/src/scripts/dataset/fragments/edit-description-list.jsx`.

I haven't got a local build working, so I'm not sure if this is quite right.