### PR TITLE
feat(app): Add a quick shortcut for accession number -> dataset page to homepage

### DIFF
--- a/packages/openneuro-app/src/scripts/common/containers/header.tsx
+++ b/packages/openneuro-app/src/scripts/common/containers/header.tsx
@@ -31,11 +31,18 @@ export const HeaderContainer: FC = () => {
   const [newKeyword, setNewKeyword, newKeywordRef] = useState("")
 
   const handleSubmit = () => {
-    const query = JSON.stringify({
+    const newQuery = {
       keywords: newKeywordRef.current ? [newKeywordRef.current] : [],
-    })
+    }
+    const query = JSON.stringify(newQuery)
     setNewKeyword("")
-    navigate(`/search?query=${query}`)
+    if (
+      newQuery?.keywords?.length && newQuery.keywords[0].match(/^ds[0-9]{6,6}$/)
+    ) {
+      navigate(`/datasets/${newQuery.keywords[0]}`)
+    } else {
+      navigate(`/search?query=${query}`)
+    }
   }
 
   const toggleLoginModal = (): void => {


### PR DESCRIPTION
This only affects the front page. On the search page, the plan to improve this is to tune the weights to include the accession number index so it's still possible to search for related datasets including the accession number.

See #2671