### PR TITLE
fix(app): Raise preference for exact matches of accession numbers when searching for keywords above other fields

### DIFF
--- a/packages/openneuro-app/src/scripts/search/use-search-results.tsx
+++ b/packages/openneuro-app/src/scripts/search/use-search-results.tsx
@@ -157,7 +157,7 @@ export const useSearchResults = () => {
     boolQuery.addClause(
       "must",
       simpleQueryString(sqsJoinWithAND(keywords), [
-        "id^6",
+        "id^20",
         "latestSnapshot.readme",
         "latestSnapshot.description.Name^6",
         "latestSnapshot.description.Authors^3",


### PR DESCRIPTION
Tested this with a few example queries (such ds000224 which was an obviously bad example) and 20 consistently returns the accession number match as the #1 result.

See #2671