### PR TITLE
feat(app): Disable derivatives tab if ToS not accepted

### DIFF
--- a/packages/openneuro-app/src/scripts/dataset/components/DatasetTools.tsx
+++ b/packages/openneuro-app/src/scripts/dataset/components/DatasetTools.tsx
@@ -115,6 +115,7 @@ export const DatasetTools = ({
             : `/datasets/${datasetId}/derivatives`}
           icon="fa-cubes"
           label="Derivatives"
+          disable={!agree}
         />
       )}
       <DatasetToolButton

--- a/packages/openneuro-app/src/scripts/dataset/routes/derivatives.tsx
+++ b/packages/openneuro-app/src/scripts/dataset/routes/derivatives.tsx
@@ -1,8 +1,10 @@
 import React from "react"
+import { Navigate, useParams } from "react-router-dom"
 import DownloadS3Derivative from "../download/download-derivative-s3"
 import DownloadDataLadDerivative from "../download/download-derivative-datalad"
 import { DatasetPageBorder } from "./styles/dataset-page-border"
 import { HeaderRow3 } from "./styles/header-row"
+import { useAgreement } from "../../components/agreement"
 
 interface DerivativeElementProps {
   name: string
@@ -38,6 +40,12 @@ interface DerivativesProps {
 }
 
 const Derivatives = ({ derivatives }: DerivativesProps): JSX.Element => {
+  const { datasetId, tag: snapshotTag } = useParams()
+  const [agreed] = useAgreement()
+  // If the derivatives page is directly visited without the agreement, return to the dataset page
+  if (!agreed) {
+    return <Navigate to={`/datasets/${datasetId}`} replace={true} />
+  }
   return (
     <DatasetPageBorder>
       <HeaderRow3>Available Derivatives</HeaderRow3>


### PR DESCRIPTION
It seems somewhat inconsistent that we tell people how to get derivatives but not raw data if they haven't agreed not to attempt to reidentify participants.

![image](https://github.com/OpenNeuroOrg/openneuro/assets/83442/659833d0-0f21-439d-b9d9-3c4b9c4e9aa7)

I think this is as simple as my proposed change. Open to arguments if you think this doesn't matter as much.