### PR TITLE
fix(app): Show file metadata for schema validator issues

### DIFF
--- a/packages/openneuro-app/src/scripts/validation/validation-results.issues.issue.jsx
+++ b/packages/openneuro-app/src/scripts/validation/validation-results.issues.issue.jsx
@@ -73,7 +73,7 @@ class Issue extends React.Component {
         <span className="e-meta">
           <label>File Metadata:</label>
           <p>
-            {file.size / 1000} KB | {file.type}
+            {file.size / 1000} KB {file.type ? ` | ${file.type}` : ""}
           </p>
         </span>
       )

--- a/packages/openneuro-app/src/scripts/validation/validation-results.issues.jsx
+++ b/packages/openneuro-app/src/scripts/validation/validation-results.issues.jsx
@@ -31,23 +31,28 @@ class Issues extends React.Component {
         </span>
       )
 
-      // issue sub-errors
-      const subErrors = Array.from(issue.files).map((error, index2) => {
-        // Schema validator returns multiple files here
+      let subErrors = []
+      if (issue.files instanceof Map) {
+        // Schema validator returns multiple files here as a map
         // map those to the old sub-issue model to display them
-        if (error?.length) {
-          return error.filter(Boolean).map((i, index3) => {
-            return (
-              <Issue
-                type={this.props.issueType}
-                file={i.file}
-                error={i}
-                index={index3}
-                key={index3}
-              />
-            )
-          })
-        } else {
+        let index = 0
+        for (const [path, fObj] of issue.files) {
+          const error = {
+            reason: path,
+            file: fObj,
+          }
+          subErrors.push(
+            (<Issue
+              type={this.props.issueType}
+              error={error}
+              index={index}
+              key={index}
+            />),
+          )
+          index += 1
+        }
+      } else {
+        subErrors = Array.from(issue.files).map((error, index2) => {
           return error
             ? (
               <Issue
@@ -59,8 +64,8 @@ class Issues extends React.Component {
               />
             )
             : null
-        }
-      })
+        })
+      }
 
       if (issue.additionalFileCount > 0) {
         subErrors.push(


### PR DESCRIPTION
Main issue is the map was being iterated over so keys and values were being displayed here. This iterates over the schema validator file issues and handles file metadata better.

Fixes #2995