### PR TITLE
Add 30 second timeout to dataset resolver

### DIFF
--- a/packages/openneuro-server/src/graphql/resolvers/dataset.ts
+++ b/packages/openneuro-server/src/graphql/resolvers/dataset.ts
@@ -20,11 +20,12 @@ import { getDatasetWorker } from "../../libs/datalad-service"
 import { getFileName } from "../../datalad/files"
 import { onBrainlife } from "./brainlife"
 import { derivatives } from "./derivatives"
+import { promiseTimeout } from "../../utils/promiseTimeout"
 import semver from "semver"
 
 export const dataset = async (obj, { id }, { user, userInfo }) => {
   await checkDatasetRead(id, user, userInfo)
-  return datalad.getDataset(id)
+  return promiseTimeout(datalad.getDataset(id), 30000)
 }
 
 export const datasets = (parent, args, { user, userInfo }) => {

--- a/packages/openneuro-server/src/types/promiseTimeoutError.ts
+++ b/packages/openneuro-server/src/types/promiseTimeoutError.ts
@@ -1,0 +1,6 @@
+export class PromiseTimeoutError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = "PromiseTimeoutError"
+  }
+}

--- a/packages/openneuro-server/src/utils/__tests__/promiseTimeout.spec.ts
+++ b/packages/openneuro-server/src/utils/__tests__/promiseTimeout.spec.ts
@@ -1,0 +1,16 @@
+import { promiseTimeout } from "../promiseTimeout"
+
+describe("withTimeout", () => {
+  it("rejects with null when the promise exceeds timeout milliseconds", async () => {
+    const slowPromise = new Promise((resolve) =>
+      setTimeout(() => resolve("Slow Result"), 500)
+    )
+    expect(await promiseTimeout(slowPromise, 100)).toBeNull()
+  })
+  it("resolves when the promise returns before timeout", async () => {
+    const slowPromise = new Promise((resolve) =>
+      setTimeout(() => resolve("Fast Result"), 10)
+    )
+    expect(await promiseTimeout(slowPromise, 500)).toBe("Fast Result")
+  })
+})

--- a/packages/openneuro-server/src/utils/promiseTimeout.ts
+++ b/packages/openneuro-server/src/utils/promiseTimeout.ts
@@ -1,0 +1,31 @@
+import { PromiseTimeoutError } from "../types/promiseTimeoutError.ts"
+
+/**
+ * Add a timeout to a promise and return null if timeout occurs before the promise resolves
+ * @param promise Promise to timeout
+ * @param timeout Timeout in milliseconds
+ */
+export async function promiseTimeout<T>(
+  promise: Promise<T>,
+  timeout: number,
+): Promise<T | null> {
+  try {
+    const result = await Promise.race([
+      promise,
+      new Promise((_, reject) =>
+        setTimeout(
+          () => reject(new PromiseTimeoutError("Operation timed out")),
+          timeout,
+        )
+      ),
+    ])
+
+    return result
+  } catch (error) {
+    if (error instanceof PromiseTimeoutError) {
+      return null
+    } else {
+      throw error // Re-throw other errors
+    }
+  }
+}


### PR DESCRIPTION
This avoids aggregate queries (search) from hanging forever if one result cannot be loaded in the 30 second deadline.