### PR TITLE
DOC: Recommend "provider = generic" in .gitconfig

### DIFF
--- a/docs/git.md
+++ b/docs/git.md
@@ -60,6 +60,7 @@ To enable for all OpenNeuro repositories add this to your [git configuration fil
 ```cfg
 [credential "https://openneuro.org"]
   useHttpPath = true
+  provider = generic
   helper = "/path/to/openneuro git-credential"
 ```
 

--- a/docs/git.md
+++ b/docs/git.md
@@ -60,6 +60,14 @@ To enable for all OpenNeuro repositories add this to your [git configuration fil
 ```cfg
 [credential "https://openneuro.org"]
   useHttpPath = true
+  helper = "/path/to/openneuro git-credential"
+```
+
+If you are using [Git Credential Manager](https://github.com/git-ecosystem/git-credential-manager) add the provider entry to avoid duplicating entries.
+
+```cfg
+[credential "https://openneuro.org"]
+  useHttpPath = true
   provider = generic
   helper = "/path/to/openneuro git-credential"
 ```


### PR DESCRIPTION
At least when credential.credentialStore == secretservice, failing to include this produces a large number of sections like:

```cfg
[credential "https://openneuro.org/git/0/ds002278"]
provider = generic
```

Adding this prevents that duplication. I am not positive that this has no knock-on effects.