### PR TITLE
Add search indexing for dataset_description DatasetType field

### DIFF
--- a/packages/openneuro-search/src/mappings/datasets-mapping.json
+++ b/packages/openneuro-search/src/mappings/datasets-mapping.json
@@ -60,7 +60,8 @@
           "properties": {
             "Name": { "type": "text" },
             "Authors": { "type": "text" },
-            "SeniorAuthor": { "type": "text" }
+            "SeniorAuthor": { "type": "text" },
+            "DatasetType": { "type": "keyword" }
           }
         },
         "readme": {

--- a/packages/openneuro-search/src/query.ts
+++ b/packages/openneuro-search/src/query.ts
@@ -43,6 +43,7 @@ export const INDEX_DATASET_FRAGMENT = gql`
         Name
         Authors
         SeniorAuthor
+        DatasetType
       }
       summary {
         tasks

--- a/packages/openneuro-server/src/datalad/description.ts
+++ b/packages/openneuro-server/src/datalad/description.ts
@@ -88,6 +88,12 @@ export const repairDescriptionTypes = (description) => {
     newDescription.HowToAcknowledge =
       JSON.stringify(description.HowToAcknowledge) || ""
   }
+  if (
+    description.hasOwnProperty("DatasetType") &&
+    typeof description.DatasetType !== "string"
+  ) {
+    newDescription.DatasetType = "raw"
+  }
   return newDescription
 }
 

--- a/packages/openneuro-server/src/graphql/schema.ts
+++ b/packages/openneuro-server/src/graphql/schema.ts
@@ -571,7 +571,7 @@ export const typeDefs = `
     ReferencesAndLinks: [String]
     # The Document Object Identifier of the dataset (not the corresponding paper).
     DatasetDOI: String
-    # The BIDS DatasetType defines as "raw" or "derivative"
+    # The BIDS DatasetType field defined as "raw" or "derivative"
     DatasetType: String
     # List of ethics committee approvals of the research protocols and/or protocol identifiers.
     EthicsApprovals: [String]

--- a/packages/openneuro-server/src/graphql/schema.ts
+++ b/packages/openneuro-server/src/graphql/schema.ts
@@ -571,6 +571,8 @@ export const typeDefs = `
     ReferencesAndLinks: [String]
     # The Document Object Identifier of the dataset (not the corresponding paper).
     DatasetDOI: String
+    # The BIDS DatasetType defines as "raw" or "derivative"
+    DatasetType: String
     # List of ethics committee approvals of the research protocols and/or protocol identifiers.
     EthicsApprovals: [String]
   }


### PR DESCRIPTION
Defaults to raw if unspecified by the dataset. Any string is allowed here for future BEPS extending this field if needed.