### PR TITLE
fix(app): Apply default search parameters on any initial render

### DIFF
--- a/packages/openneuro-app/src/scripts/search/search-container.tsx
+++ b/packages/openneuro-app/src/scripts/search/search-container.tsx
@@ -102,14 +102,12 @@ const SearchContainer: FC<SearchContainerProps> = ({ portalContent }) => {
 
   const { searchParams, setSearchParams } = useContext(SearchParamsCtx)
   const modality = portalContent?.modality || null
-  useEffect(() => {
-    setDefaultSearch(
-      modality,
-      searchParams,
-      setSearchParams,
-      new URLSearchParams(location.search),
-    )
-  }, [modality, searchParams.modality_selected, setSearchParams, location])
+  setDefaultSearch(
+    modality,
+    searchParams,
+    setSearchParams,
+    new URLSearchParams(location.search),
+  )
 
   const { loading, data, fetchMore, refetch, variables, error } =
     useSearchResults()


### PR DESCRIPTION
Fixes an issue where the portal pages would not have any search parameters applied. The search container itself is only recreated when changing modalities (since this remounts the component), so otherwise parameters are maintained without the useEffect call.

See #3043 