### PR TITLE
fix(datalad): Separate validator process construction from wait, allowing error logging

### DIFF
--- a/services/datalad/tests/test_validator.py
+++ b/services/datalad/tests/test_validator.py
@@ -21,8 +21,12 @@ def test_validator_error(new_dataset):
 @pytest.fixture
 def mock_validator_crash(monkeypatch):
     def return_bad_json(*args, **kwargs):
-        return SimpleNamespace(stdout='{invalidJson', stderr='')
-    monkeypatch.setattr(subprocess, 'run', return_bad_json)
+        return SimpleNamespace(
+            wait=lambda timeout=None: None,
+            kill=lambda: None,
+            communicate=lambda: (b'{invalidJson', b'')
+        )
+    monkeypatch.setattr(subprocess, 'Popen', return_bad_json)
 
 
 def test_validator_bad_json(new_dataset, mock_validator_crash):


### PR DESCRIPTION
We were having an `UnboundLocalError` show up in the logs:

![image](https://github.com/OpenNeuroOrg/openneuro/assets/83442/eddcfd3c-31ac-4830-bd65-890aac875f13)

This resulted from trying to read from `process.stdout` and `process.stderr` during a timeout.

This refactors `subprocess.run()` so that we can access the stdout/stderr in the event of a timeout. We then use the same code for both validators.
