### PR TITLE
chore(style): Run pyupgrade --py311-plus to modernize idioms

### DIFF
--- a/services/datalad/Pipfile
+++ b/services/datalad/Pipfile
@@ -7,7 +7,6 @@ verify_ssl = true
 datalad = "==1.0.2"
 pytest = "*"
 coverage = "*"
-mock = "*"
 pytest-cov = "*"
 pytest-xdist = "*"
 exceptiongroup = "*"

--- a/services/datalad/Pipfile.lock
+++ b/services/datalad/Pipfile.lock
@@ -1205,15 +1205,6 @@
             "markers": "python_version >= '3'",
             "version": "==1.3.0"
         },
-        "mock": {
-            "hashes": [
-                "sha256:18c694e5ae8a208cdb3d2c20a993ca1a7b0efa258c247a1e565150f477f83744",
-                "sha256:5e96aad5ccda4718e0a229ed94b2024df75cc2d55575ba5762d31f5767b8767d"
-            ],
-            "index": "pypi",
-            "markers": "python_version >= '3.6'",
-            "version": "==5.1.0"
-        },
         "more-itertools": {
             "hashes": [
                 "sha256:686b06abe565edfab151cb8fd385a05651e1fdf8f0a14191e4439283421f8684",

--- a/services/datalad/datalad_service/common/annex.py
+++ b/services/datalad/datalad_service/common/annex.py
@@ -20,7 +20,7 @@ def init_annex(dataset_path):
 
 def compute_git_hash(path, size):
     """Given a path and size, generate the git blob hash for a file."""
-    git_obj_header = 'blob {}'.format(size).encode() + b'\x00'
+    git_obj_header = f'blob {size}'.encode() + b'\x00'
     blob_hash = hashlib.sha1()
     blob_hash.update(git_obj_header)
     # If size is zero, skip opening and mmap
@@ -35,7 +35,7 @@ def compute_git_hash(path, size):
 
 def compute_file_hash(git_hash, path):
     """Computes a unique hash for a given git path, based on the git hash and path values."""
-    return hashlib.sha1('{}:{}'.format(git_hash, path).encode()).hexdigest()
+    return hashlib.sha1(f'{git_hash}:{path}'.encode()).hexdigest()
 
 
 def parse_ls_tree_line(gitTreeLine):
@@ -79,11 +79,11 @@ def read_ls_tree_line(gitTreeLine, files, symlinkFilenames, symlinkObjects):
 def compute_rmet(key, legacy=False):
     if len(key) == 40:
         if legacy:
-            key = 'SHA1--{}'.format(key)
+            key = f'SHA1--{key}'
         else:
-            key = 'GIT--{}'.format(key)
+            key = f'GIT--{key}'
     keyHash = hashlib.md5(key.encode()).hexdigest()
-    return '{}/{}/{}.log.rmet'.format(keyHash[0:3], keyHash[3:6], key)
+    return f'{keyHash[0:3]}/{keyHash[3:6]}/{key}.log.rmet'
 
 
 def parse_remote_line(remoteLine,
@@ -161,7 +161,7 @@ def get_repo_urls(path, files):
     gitObjects = rmetObjects['remote.log'] + '\n' + \
         '\n'.join(rmetObjects[rmetPath] for rmetPath in rmetPaths)
     catFileProcess = subprocess.run(['git', 'cat-file', '--batch=:::%(objectname)', '--buffer'],
-                                    cwd=path, stdout=subprocess.PIPE, input=gitObjects, encoding='utf-8', bufsize=0, universal_newlines=True)
+                                    cwd=path, stdout=subprocess.PIPE, input=gitObjects, encoding='utf-8', bufsize=0, text=True)
     catFile = io.StringIO(catFileProcess.stdout)
     # Read in remote.log first
     remoteLogMetadata = catFile.readline().rstrip()

--- a/services/datalad/datalad_service/common/s3.py
+++ b/services/datalad/datalad_service/common/s3.py
@@ -21,14 +21,14 @@ def generate_s3_annex_options(dataset_path):
     dataset_id = os.path.basename(dataset_path)
     annex_options = [
         'type=S3',
-        'bucket={}'.format(get_s3_bucket()),
+        f'bucket={get_s3_bucket()}',
         'exporttree=yes',
         'versioning=yes',
         'partsize=1GiB',
         'encryption=none',
-        'fileprefix={}/'.format(dataset_id),
+        f'fileprefix={dataset_id}/',
         'autoenable=true',
-        'publicurl=https://s3.amazonaws.com/{}'.format(get_s3_bucket()),
+        f'publicurl=https://s3.amazonaws.com/{get_s3_bucket()}',
         'public=no',
     ]
     return annex_options

--- a/services/datalad/datalad_service/datalad.py
+++ b/services/datalad/datalad_service/datalad.py
@@ -1,6 +1,6 @@
 from os import path
 
-class DataladStore(object):
+class DataladStore:
     """Store for Datalad state accessed by resource handlers."""
 
     def __init__(self, annex_path):

--- a/services/datalad/datalad_service/handlers/annex.py
+++ b/services/datalad/datalad_service/handlers/annex.py
@@ -17,14 +17,14 @@ def hashdirmixed(key):
     first_word = struct.unpack('<I', digest[:4])[0]
     nums = [first_word >> (6 * x) & 31 for x in range(4)]
     letters = ["0123456789zqjxkmvwgpfZQJXKMVWGPF"[i] for i in nums]
-    return ("{0:s}{1:s}".format(letters[1], letters[0]), "{0:s}{1:s}".format(letters[3], letters[2]))
+    return (f"{letters[1]:s}{letters[0]:s}", f"{letters[3]:s}{letters[2]:s}")
 
 
 def key_to_path(key):
     return os.path.join('.git', 'annex', 'objects', *hashdirmixed(key), key, key)
 
 
-class GitAnnexResource(object):
+class GitAnnexResource:
     """{worker}/{dataset}/annex/{key} serves git-annex object requests
 
     This allows OpenNeuro to act as a special remote, adding or removing objects from .git/annex/objects/

--- a/services/datalad/datalad_service/handlers/annex_objects.py
+++ b/services/datalad/datalad_service/handlers/annex_objects.py
@@ -5,7 +5,7 @@ import falcon
 from datalad_service.tasks.files import remove_annex_object
 
 
-class AnnexObjectsResource(object):
+class AnnexObjectsResource:
 
     def __init__(self, store):
         self.store = store

--- a/services/datalad/datalad_service/handlers/dataset.py
+++ b/services/datalad/datalad_service/handlers/dataset.py
@@ -10,7 +10,7 @@ from datalad_service.tasks.dataset import delete_dataset
 from datalad_service.tasks.publish import delete_siblings
 
 
-class DatasetResource(object):
+class DatasetResource:
 
     """A Falcon API wrapper around underlying datalad/git-annex datasets."""
 

--- a/services/datalad/datalad_service/handlers/description.py
+++ b/services/datalad/datalad_service/handlers/description.py
@@ -4,7 +4,7 @@ import os
 from datalad_service.tasks.description import update_description
 
 
-class DescriptionResource(object):
+class DescriptionResource:
     def __init__(self, store):
         self.store = store
 

--- a/services/datalad/datalad_service/handlers/draft.py
+++ b/services/datalad/datalad_service/handlers/draft.py
@@ -7,7 +7,7 @@ from datalad_service.common.user import get_user_info
 from datalad_service.common.git import git_commit
 
 
-class DraftResource(object):
+class DraftResource:
     def __init__(self, store):
         self.store = store
 

--- a/services/datalad/datalad_service/handlers/files.py
+++ b/services/datalad/datalad_service/handlers/files.py
@@ -10,7 +10,7 @@ from datalad_service.common.stream import update_file
 from datalad_service.tasks.files import remove_files
 
 
-class FilesResource(object):
+class FilesResource:
 
     def __init__(self, store):
         self.store = store
@@ -44,7 +44,7 @@ class FilesResource(object):
             # File is not present in tree
             resp.media = {'error': 'file not found in git tree'}
             resp.status = falcon.HTTP_NOT_FOUND
-        except IOError:
+        except OSError:
             # File is not kept locally
             resp.media = {'error': 'file not found'}
             resp.status = falcon.HTTP_NOT_FOUND
@@ -54,7 +54,7 @@ class FilesResource(object):
                 'error': 'an unknown error occurred accessing this file'}
             resp.status = falcon.HTTP_INTERNAL_SERVER_ERROR
             self.logger.exception(
-                'An unknown error processing file "{}"'.format(filename))
+                f'An unknown error processing file "{filename}"')
 
     def on_post(self, req, resp, dataset, filename):
         """Post will create new files and adds them to the annex if they do not exist, else update existing files."""

--- a/services/datalad/datalad_service/handlers/git.py
+++ b/services/datalad/datalad_service/handlers/git.py
@@ -28,14 +28,14 @@ def _handle_failed_access(req, resp):
     user = 'user' in req.context and req.context['user'] or None
     # No user = unauthorized, otherwise token is present with the wrong scope/grant
     if user == None:
-        resp.data = 'Authentication required for git access'.encode()
+        resp.data = b'Authentication required for git access'
         resp.status = falcon.HTTP_UNAUTHORIZED
     else:
-        resp.data = 'You do not have permission to access this dataset'.encode()
+        resp.data = b'You do not have permission to access this dataset'
         resp.status = falcon.HTTP_FORBIDDEN
 
 
-class GitRefsResource(object):
+class GitRefsResource:
     """/info/refs returns current state for either git-receive-pack or git-upload-pack"""
 
     def __init__(self, store):
@@ -70,7 +70,7 @@ class GitRefsResource(object):
             resp.status = falcon.HTTP_UNPROCESSABLE_ENTITY
 
 
-class GitReceiveResource(object):
+class GitReceiveResource:
     """/git-receive-pack is used to receive pushes"""
 
     def __init__(self, store):
@@ -100,7 +100,7 @@ class GitReceiveResource(object):
             resp.status = falcon.HTTP_UNPROCESSABLE_ENTITY
 
 
-class GitUploadResource(object):
+class GitUploadResource:
     """/git-upload-pack serves git fetch requests"""
 
     def __init__(self, store):

--- a/services/datalad/datalad_service/handlers/heartbeat.py
+++ b/services/datalad/datalad_service/handlers/heartbeat.py
@@ -1,7 +1,7 @@
 import falcon
 
 
-class HeartbeatResource(object):
+class HeartbeatResource:
 
     def on_get(self, req, resp):
         resp.media = {

--- a/services/datalad/datalad_service/handlers/history.py
+++ b/services/datalad/datalad_service/handlers/history.py
@@ -4,7 +4,7 @@ import pygit2
 from datalad_service.common.git import git_tag
 
 
-class HistoryResource(object):
+class HistoryResource:
     def __init__(self, store):
         self.store = store
 

--- a/services/datalad/datalad_service/handlers/objects.py
+++ b/services/datalad/datalad_service/handlers/objects.py
@@ -5,7 +5,7 @@ import falcon
 from datalad_service.common.git import git_show_object
 
 
-class ObjectsResource(object):
+class ObjectsResource:
 
     def __init__(self, store):
         self.store = store
@@ -31,4 +31,4 @@ class ObjectsResource(object):
                 'error': 'an unknown error occurred accessing this file'}
             resp.status = falcon.HTTP_INTERNAL_SERVER_ERROR
             self.logger.exception(
-                'An unknown error processing object "{}"'.format(obj))
+                f'An unknown error processing object "{obj}"')

--- a/services/datalad/datalad_service/handlers/publish.py
+++ b/services/datalad/datalad_service/handlers/publish.py
@@ -4,7 +4,7 @@ import gevent
 from datalad_service.tasks.publish import create_remotes_and_export
 
 
-class PublishResource(object):
+class PublishResource:
 
     """A Falcon API wrapper around underlying datalad/git-annex datasets."""
 

--- a/services/datalad/datalad_service/handlers/reexporter.py
+++ b/services/datalad/datalad_service/handlers/reexporter.py
@@ -5,7 +5,7 @@ import gevent
 from datalad_service.tasks.publish import export_dataset
 
 
-class ReexporterResource(object):
+class ReexporterResource:
     def __init__(self, store):
         self.store = store
         self.logger = logging.getLogger('datalad_service.' + __name__)

--- a/services/datalad/datalad_service/handlers/remote_import.py
+++ b/services/datalad/datalad_service/handlers/remote_import.py
@@ -6,7 +6,7 @@ from datalad_service.tasks.remote_import import remote_import
 from datalad_service.common.user import get_user_info
 
 
-class RemoteImportResource(object):
+class RemoteImportResource:
     def __init__(self, store):
         self.store = store
         self.logger = logging.getLogger('datalad_service.' + __name__)

--- a/services/datalad/datalad_service/handlers/reset.py
+++ b/services/datalad/datalad_service/handlers/reset.py
@@ -5,7 +5,7 @@ from datalad_service.common.user import get_user_info
 from datalad_service.tasks.files import commit_files
 
 
-class ResetResource(object):
+class ResetResource:
     def __init__(self, store):
         self.store = store
 

--- a/services/datalad/datalad_service/handlers/snapshots.py
+++ b/services/datalad/datalad_service/handlers/snapshots.py
@@ -10,7 +10,7 @@ from datalad_service.tasks.publish import export_dataset, monitor_remote_configs
 from datalad_service.common.git import delete_tag
 
 
-class SnapshotResource(object):
+class SnapshotResource:
 
     """Snapshots on top of DataLad datasets."""
 

--- a/services/datalad/datalad_service/handlers/tree.py
+++ b/services/datalad/datalad_service/handlers/tree.py
@@ -6,7 +6,7 @@ from datalad_service.common.bids import dataset_sort
 from datalad_service.tasks.files import get_tree
 
 
-class TreeResource(object):
+class TreeResource:
     def __init__(self, store):
         self.store = store
         self.logger = logging.getLogger('datalad_service.' + __name__)

--- a/services/datalad/datalad_service/handlers/upload.py
+++ b/services/datalad/datalad_service/handlers/upload.py
@@ -34,7 +34,7 @@ def move_files_into_repo(dataset_id, dataset_path, upload_path, name, email, coo
     update_head(dataset_id, dataset_path, hexsha, cookies)
 
 
-class UploadResource(object):
+class UploadResource:
     def __init__(self, store):
         self.store = store
         self.logger = logging.getLogger('datalad_service.' + __name__)

--- a/services/datalad/datalad_service/handlers/validation.py
+++ b/services/datalad/datalad_service/handlers/validation.py
@@ -4,7 +4,7 @@ from datalad_service.common.user import get_user_info
 from datalad_service.tasks.validator import validate_dataset
 
 
-class ValidationResource(object):
+class ValidationResource:
     def __init__(self, store):
         self.store = store
 

--- a/services/datalad/datalad_service/middleware/auth.py
+++ b/services/datalad/datalad_service/middleware/auth.py
@@ -18,7 +18,7 @@ def parse_authorization_header(authorization):
         return None
 
 
-class AuthenticateMiddleware(object):
+class AuthenticateMiddleware:
     def process_request(self, req, resp):
         """Process the request before routing it for authentication.
 

--- a/services/datalad/datalad_service/tasks/audit.py
+++ b/services/datalad/datalad_service/tasks/audit.py
@@ -13,7 +13,7 @@ def audit_datasets(store):
 def fsck_remote(dataset_path, remote):
     """Run fsck for one dataset remote"""
     # Run at most once per month per dataset
-    annex_command = ("git-annex", "fsck", "--all", "--from={}".format(remote), "--fast", "--json",
+    annex_command = ("git-annex", "fsck", "--all", f"--from={remote}", "--fast", "--json",
                      "--json-error-messages", "--incremental", "--incremental-schedule=30d", "--time-limit=15m")
     annex_process = subprocess.Popen(
         annex_command, cwd=dataset_path, stdout=subprocess.PIPE, encoding='utf-8')

--- a/services/datalad/datalad_service/tasks/snapshots.py
+++ b/services/datalad/datalad_service/tasks/snapshots.py
@@ -27,14 +27,14 @@ def get_snapshot(store, dataset, snapshot):
     hexsha = commit.hex
     created = commit.commit_time
     tree = commit.tree_id.hex
-    return {'id': '{}:{}'.format(dataset, snapshot), 'tag': snapshot, 'hexsha': hexsha, 'created': created, 'tree': tree}
+    return {'id': f'{dataset}:{snapshot}', 'tag': snapshot, 'hexsha': hexsha, 'created': created, 'tree': tree}
 
 
 def get_snapshots(store, dataset):
     path = store.get_dataset_path(dataset)
     repo_tags = git_tag(pygit2.Repository(path))
     # Include an extra id field to uniquely identify snapshots
-    tags = [{'id': '{}:{}'.format(dataset, tag.shorthand), 'tag': tag.shorthand, 'hexsha': tag.target.hex, 'created': tag.peel().commit_time}
+    tags = [{'id': f'{dataset}:{tag.shorthand}', 'tag': tag.shorthand, 'hexsha': tag.target.hex, 'created': tag.peel().commit_time}
             for tag in repo_tags]
     return tags
 
@@ -131,7 +131,7 @@ def validate_snapshot_name(store, dataset, snapshot):
     tagged = [tag for tag in tags if tag.name == snapshot]
     if tagged:
         raise SnapshotExistsException(
-            'Tag "{}" already exists, name conflict'.format(snapshot))
+            f'Tag "{snapshot}" already exists, name conflict')
 
 
 def validate_datalad_config(store, dataset):

--- a/services/datalad/tests/test_annex_handler.py
+++ b/services/datalad/tests/test_annex_handler.py
@@ -20,7 +20,7 @@ def test_key_add_remove(client):
     ds_id = 'ds000001'
     key = "MD5E-s24--e04bb0391ed06622b018aac26c736870.nii"
     random_value = b"ooQuieshaz4of2Aip3Niec2e"
-    url = '/git/0/{}/annex/{}'.format(ds_id, key)
+    url = f'/git/0/{ds_id}/annex/{key}'
     response = client.simulate_post(
         url, headers={"authorization": test_auth}, body=random_value)
     assert response.status == falcon.HTTP_OK
@@ -33,7 +33,7 @@ def test_key_get_head(client):
     ds_id = 'ds000001'
     key = "MD5E-s24--00e7097e83570b24b69cc509fc8f3cbf.nii"
     random_value = b"soo2aid1po5teiJoowufah4i"
-    url = '/git/0/{}/annex/{}'.format(ds_id, key)
+    url = f'/git/0/{ds_id}/annex/{key}'
     # Test failure first
     response = client.simulate_head(url, headers={"authorization": test_auth})
     assert response.status == falcon.HTTP_NOT_FOUND

--- a/services/datalad/tests/test_auth.py
+++ b/services/datalad/tests/test_auth.py
@@ -10,9 +10,9 @@ basic_token = base64.urlsafe_b64encode(
 
 def test_parse_authorization_header():
     assert parse_authorization_header(
-        'Basic {}'.format(basic_token)) == raw_token
+        f'Basic {basic_token}') == raw_token
     assert parse_authorization_header(
-        'Bearer {}'.format(raw_token)) == raw_token
+        f'Bearer {raw_token}') == raw_token
 
 
 def test_auth_middleware_bearer():
@@ -25,7 +25,7 @@ def test_auth_middleware_bearer():
         'SCRIPT_NAME': '',
         'PATH_INFO': '',
         'SERVER_PROTOCOL': 'HTTP/1.1',
-        'HTTP_AUTHORIZATION': 'Bearer {}'.format(raw_token)
+        'HTTP_AUTHORIZATION': f'Bearer {raw_token}'
     })
 
     resp = Response()
@@ -49,7 +49,7 @@ def test_auth_middleware_basic():
         'SCRIPT_NAME': '',
         'PATH_INFO': '',
         'SERVER_PROTOCOL': 'HTTP/1.1',
-        'HTTP_AUTHORIZATION': 'Basic {}'.format(basic_token)
+        'HTTP_AUTHORIZATION': f'Basic {basic_token}'
     })
 
     resp = Response()

--- a/services/datalad/tests/test_datalad.py
+++ b/services/datalad/tests/test_datalad.py
@@ -1,6 +1,6 @@
 """Test DataLad tasks."""
 import os
-from mock import patch
+from unittest.mock import patch
 import uuid
 
 import pytest

--- a/services/datalad/tests/test_dataset.py
+++ b/services/datalad/tests/test_dataset.py
@@ -23,7 +23,7 @@ def test_get_dataset_404(client):
 
 def test_create_dataset_duplicate(client, datalad_store):
     ds_id = 'ds000003'
-    first_response = client.simulate_post('/datasets/{}'.format(ds_id))
+    first_response = client.simulate_post(f'/datasets/{ds_id}')
     assert first_response.status == falcon.HTTP_OK
-    second_response = client.simulate_post('/datasets/{}'.format(ds_id))
+    second_response = client.simulate_post(f'/datasets/{ds_id}')
     assert second_response.status == falcon.HTTP_CONFLICT

--- a/services/datalad/tests/test_description.py
+++ b/services/datalad/tests/test_description.py
@@ -15,14 +15,14 @@ def test_update(client, new_dataset):
 
     ds_id = os.path.basename(new_dataset.path)
     update_response = client.simulate_post(
-        '/datasets/{}/description'.format(ds_id), body=body)
+        f'/datasets/{ds_id}/description', body=body)
     assert update_response.status == falcon.HTTP_OK
     updated_ds = json.loads(
         update_response.content) if update_response.content else None
     assert updated_ds is not None
 
     check_response = client.simulate_get(
-        '/datasets/{}/files/dataset_description.json'.format(ds_id))
+        f'/datasets/{ds_id}/files/dataset_description.json')
     assert check_response.status == falcon.HTTP_OK
     ds_description = json.loads(check_response.content)
     assert ds_description[key] == value
@@ -37,22 +37,22 @@ def post_and_check_description(client, new_dataset, base_description, key="Name"
 
     ds_id = os.path.basename(new_dataset.path)
     update_response = client.simulate_post(
-        '/datasets/{}/files/dataset_description.json'.format(ds_id), body=base_description)
+        f'/datasets/{ds_id}/files/dataset_description.json', body=base_description)
     assert update_response.status == falcon.HTTP_OK
     # Commit files
     response = client.simulate_post(
-        '/datasets/{}/draft'.format(ds_id), params={"validate": "false"})
+        f'/datasets/{ds_id}/draft', params={"validate": "false"})
     assert response.status == falcon.HTTP_OK
 
     update_response = client.simulate_post(
-        '/datasets/{}/description'.format(ds_id), body=body)
+        f'/datasets/{ds_id}/description', body=body)
     assert update_response.status == falcon.HTTP_OK
     updated_ds = json.loads(
         update_response.content) if update_response.content else None
     assert updated_ds is not None
 
     check_response = client.simulate_get(
-        '/datasets/{}/files/dataset_description.json'.format(ds_id))
+        f'/datasets/{ds_id}/files/dataset_description.json')
     assert check_response.status == falcon.HTTP_OK
     return check_response.content
 
@@ -114,14 +114,14 @@ def test_description_formatting(client, new_dataset):
 
     ds_id = os.path.basename(new_dataset.path)
     update_response = client.simulate_post(
-        '/datasets/{}/description'.format(ds_id), body=body)
+        f'/datasets/{ds_id}/description', body=body)
     assert update_response.status == falcon.HTTP_OK
     updated_ds = json.loads(
         update_response.content) if update_response.content else None
     assert updated_ds is not None
 
     check_response = client.simulate_get(
-        '/datasets/{}/files/dataset_description.json'.format(ds_id))
+        f'/datasets/{ds_id}/files/dataset_description.json')
     assert check_response.status == falcon.HTTP_OK
     decoded_response = check_response.content.decode('utf-8')
     # Verify the 4 space indent in the encoded file

--- a/services/datalad/tests/test_draft.py
+++ b/services/datalad/tests/test_draft.py
@@ -19,15 +19,15 @@ def test_add_commit_info(client):
     jwt_secret = 'shhhhh'
     os.environ['JWT_SECRET'] = jwt_secret
     access_token = jwt.encode(user, jwt_secret)
-    cookie = 'accessToken={}'.format(access_token)
+    cookie = f'accessToken={access_token}'
     headers = {
         'Cookie': cookie
     }
     response = client.simulate_post(
-        '/datasets/{}/files/USER_ADDED_FILE'.format(ds_id), body=file_data, headers=headers)
+        f'/datasets/{ds_id}/files/USER_ADDED_FILE', body=file_data, headers=headers)
     assert response.status == falcon.HTTP_OK
     response = client.simulate_post(
-        '/datasets/{}/draft'.format(ds_id), body=file_data, headers=headers)
+        f'/datasets/{ds_id}/draft', body=file_data, headers=headers)
     assert response.status == falcon.HTTP_OK
     response_content = json.loads(response.content)
     assert response_content['name'] == name
@@ -38,6 +38,6 @@ def test_get_draft(client, new_dataset):
     ds_id = os.path.basename(new_dataset.path)
     # Check if new_dataset is not dirty
     response = client.simulate_get(
-        '/datasets/{}/draft'.format(ds_id))
+        f'/datasets/{ds_id}/draft')
     assert response.status == falcon.HTTP_OK
     assert len(json.loads(response.content)['hexsha']) == 40

--- a/services/datalad/tests/test_git.py
+++ b/services/datalad/tests/test_git.py
@@ -54,7 +54,7 @@ dataset_description_4096 = """{
         "National Institute of Health grant (P41EB027061)",
         "European Research Council (ERC) under the European Union’s Horizon 2020 research and innovation programme (grant agreement No. 101001270)"
     ]
-}""".encode('utf-8')
+}""".encode()
 
 def test_git_show_unicode_after_4096(new_dataset):
     ds = Dataset(new_dataset.path)
@@ -78,7 +78,7 @@ def test_git_tag(new_dataset):
 def test_git_refs_resource(client):
     ds_id = 'ds000001'
     response = client.simulate_get(
-        '/git/0/{}/info/refs?service=git-receive-pack'.format(ds_id), headers={"authorization": test_auth})
+        f'/git/0/{ds_id}/info/refs?service=git-receive-pack', headers={"authorization": test_auth})
     assert response.status == falcon.HTTP_OK
     # A basic check for the terminator sequence at the end
     assert b'0000' == response.content[-4:]
@@ -96,7 +96,7 @@ def test_git_refs_resource(client):
 def test_git_upload_resource(client):
     ds_id = 'ds000001'
     get_response = client.simulate_get(
-        '/git/0/{}/info/refs?service=git-upload-pack'.format(ds_id), headers={"authorization": test_auth})
+        f'/git/0/{ds_id}/info/refs?service=git-upload-pack', headers={"authorization": test_auth})
     lines = get_response.content.decode().split('\n')
     # Grab two refs to ask for
     annex = lines[2][4:44]
@@ -105,7 +105,7 @@ def test_git_upload_resource(client):
         head, annex)
     # Ask for them
     response = client.simulate_post(
-        '/git/0/{}/git-upload-pack'.format(ds_id), headers={"authorization": test_auth}, body=upload_pack_input)
+        f'/git/0/{ds_id}/git-upload-pack', headers={"authorization": test_auth}, body=upload_pack_input)
     assert response.status == falcon.HTTP_OK
     # Just look for the start of a pack stream
     assert response.content[0:12] == b'0008NAK\nPACK'
@@ -114,12 +114,12 @@ def test_git_upload_resource(client):
 def test_git_receive_resource(client):
     ds_id = 'ds000001'
     get_response = client.simulate_get(
-        '/git/0/{}/info/refs?service=git-upload-pack'.format(ds_id), headers={"authorization": test_auth})
+        f'/git/0/{ds_id}/info/refs?service=git-upload-pack', headers={"authorization": test_auth})
     lines = get_response.content.decode().split('\n')
     # Just try a noop push to avoid changing the test dataset
     receive_pack_input = '0000'
     response = client.simulate_post(
-        '/git/0/{}/git-receive-pack'.format(ds_id), headers={"authorization": test_auth}, body=receive_pack_input)
+        f'/git/0/{ds_id}/git-receive-pack', headers={"authorization": test_auth}, body=receive_pack_input)
     assert response.status == falcon.HTTP_OK
 
 

--- a/services/datalad/tests/test_history.py
+++ b/services/datalad/tests/test_history.py
@@ -10,7 +10,7 @@ from datalad_service.handlers.history import HistoryResource
 def test_history(client, new_dataset):
     ds_id = os.path.basename(new_dataset.path)
     response = client.simulate_get(
-        '/datasets/{}/history'.format(ds_id))
+        f'/datasets/{ds_id}/history')
     assert response.status == falcon.HTTP_OK
     history = json.loads(
         response.content) if response.content else None

--- a/services/datalad/tests/test_publish.py
+++ b/services/datalad/tests/test_publish.py
@@ -34,7 +34,7 @@ def test_export_snapshots(no_init_remote, client, new_dataset):
         "Authors": ["Test Authors", "Please Ignore"],
     }, indent=4)
     response = client.simulate_post(
-        '/datasets/{}/files/dataset_description.json'.format(ds_id), body=file_data)
+        f'/datasets/{ds_id}/files/dataset_description.json', body=file_data)
     assert response.status == falcon.HTTP_OK
     # Create 2.0.0
     response = client.simulate_post(

--- a/services/datalad/tests/test_snapshots.py
+++ b/services/datalad/tests/test_snapshots.py
@@ -37,7 +37,7 @@ def test_create_snapshot(client, new_dataset):
     ds_id = os.path.basename(new_dataset.path)
     snapshot_id = '1'
     response = client.simulate_post(
-        '/datasets/{}/snapshots/{}'.format(ds_id, snapshot_id), body="")
+        f'/datasets/{ds_id}/snapshots/{snapshot_id}', body="")
     assert response.status == falcon.HTTP_OK
 
 
@@ -56,7 +56,7 @@ def test_create_snapshot_no_config(datalad_store, client, new_dataset):
     ds.close()
     # Try to snapshot now
     response = client.simulate_post(
-        '/datasets/{}/snapshots/{}'.format(ds_id, snapshot_id), body="")
+        f'/datasets/{ds_id}/snapshots/{snapshot_id}', body="")
     assert response.status == falcon.HTTP_OK
     # Verify the dataset now has an ID
     ds = Dataset(os.path.join(datalad_store.annex_path, ds_id))
@@ -77,16 +77,16 @@ def test_pre_snapshot_edit(client, new_dataset):
     }, indent=4)
     # Update a file
     response = client.simulate_post(
-        '/datasets/{}/files/dataset_description.json'.format(ds_id), body=file_data)
+        f'/datasets/{ds_id}/files/dataset_description.json', body=file_data)
     assert response.status == falcon.HTTP_OK
     # Commit changes
     response = client.simulate_post(
-        '/datasets/{}/draft'.format(ds_id), params={"validate": "false"})
+        f'/datasets/{ds_id}/draft', params={"validate": "false"})
     assert response.status == falcon.HTTP_OK
     commit_ref = response.json['ref']
     # Make a snapshot
     response = client.simulate_post(
-        '/datasets/{}/snapshots/{}'.format(ds_id, snapshot_id), json={'skip_publishing': True})
+        f'/datasets/{ds_id}/snapshots/{snapshot_id}', json={'skip_publishing': True})
     assert response.status == falcon.HTTP_OK
     # Validate that create_snapshot has not moved main commit
     with open(os.path.join(new_dataset.path, '.git/refs/heads/main')) as fd:
@@ -101,11 +101,11 @@ def test_duplicate_snapshot(client, new_dataset):
     #     'snapshot_changes': ['test']
     # })
     response = client.simulate_post(
-        '/datasets/{}/snapshots/{}'.format(ds_id, snapshot_id))
+        f'/datasets/{ds_id}/snapshots/{snapshot_id}')
     assert response.status == falcon.HTTP_OK
     try:
         response = client.simulate_post(
-            '/datasets/{}/snapshots/{}'.format(ds_id, snapshot_id))
+            f'/datasets/{ds_id}/snapshots/{snapshot_id}')
         assert response.status == falcon.HTTP_CONFLICT
     except:
         # In eager mode, eat the exception
@@ -124,7 +124,7 @@ def test_get_snapshots(client, new_dataset):
         '/datasets/{}/snapshots/{}'.format(ds_id, 'v2.0.0'))
     assert response.status == falcon.HTTP_OK
     response = client.simulate_get(
-        '/datasets/{}/snapshots'.format(ds_id))
+        f'/datasets/{ds_id}/snapshots')
     result_doc = json.loads(response.content)
     assert response.status == falcon.HTTP_OK
     assert result_doc['snapshots'][0]['hexsha'] == result_doc['snapshots'][1]['hexsha']
@@ -152,7 +152,7 @@ def test_description_update(client, new_dataset):
     assert update_response.status == falcon.HTTP_OK
 
     check_response = client.simulate_get(
-        '/datasets/{}/files/dataset_description.json'.format(ds_id))
+        f'/datasets/{ds_id}/files/dataset_description.json')
     assert check_response.status == falcon.HTTP_OK
     ds_description = json.loads(check_response.content)
     assert ds_description[key] == value

--- a/services/datalad/tests/test_upload.py
+++ b/services/datalad/tests/test_upload.py
@@ -13,7 +13,7 @@ def test_upload_file_no_auth(client):
     upload_id = '5da16a13-6028-4a53-808e-e828f5f280e5'
     file_data = 'Test dataset README'
     response = client.simulate_post(
-        '/uploads/1/{}/{}/README'.format(ds_id, upload_id), body=file_data)
+        f'/uploads/1/{ds_id}/{upload_id}/README', body=file_data)
     assert response.status == falcon.HTTP_UNAUTHORIZED
 
 
@@ -22,7 +22,7 @@ def test_upload_file(client, datalad_store):
     upload_id = '5da16a13-6028-4a53-808e-e828f5f280e5'
     file_data = 'Test dataset README for new upload'
     response = client.simulate_post(
-        '/uploads/1/{}/{}/README'.format(ds_id, upload_id), body=file_data, headers={'cookie': 'accessToken=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJmZDQ0ZjVjNS1iMjFiLTQyMGItOTU1NS1hZjg1NmVmYzk0NTIiLCJlbWFpbCI6Im5lbGxAc3F1aXNoeW1lZGlhLmNvbSIsInByb3ZpZGVyIjoiZ29vZ2xlIiwibmFtZSI6Ik5lbGwgSGFyZGNhc3RsZSIsImFkbWluIjp0cnVlLCJzY29wZXMiOlsiZGF0YXNldDp1cGxvYWQiXSwiZGF0YXNldCI6ImRzMDAyMDc0IiwiaWF0IjoxNTk3MTgzMDk5LCJleHAiOjEyNDI1NzI3ODA3fQ.1fsa6rZfAOGTmbQ3FJsGZD61tZddqIRAIFpRrAe2Tao'})
+        f'/uploads/1/{ds_id}/{upload_id}/README', body=file_data, headers={'cookie': 'accessToken=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJmZDQ0ZjVjNS1iMjFiLTQyMGItOTU1NS1hZjg1NmVmYzk0NTIiLCJlbWFpbCI6Im5lbGxAc3F1aXNoeW1lZGlhLmNvbSIsInByb3ZpZGVyIjoiZ29vZ2xlIiwibmFtZSI6Ik5lbGwgSGFyZGNhc3RsZSIsImFkbWluIjp0cnVlLCJzY29wZXMiOlsiZGF0YXNldDp1cGxvYWQiXSwiZGF0YXNldCI6ImRzMDAyMDc0IiwiaWF0IjoxNTk3MTgzMDk5LCJleHAiOjEyNDI1NzI3ODA3fQ.1fsa6rZfAOGTmbQ3FJsGZD61tZddqIRAIFpRrAe2Tao'})
     assert response.status == falcon.HTTP_OK
     readme_path = os.path.join(
         datalad_store.get_upload_path(ds_id, upload_id), 'README')


### PR DESCRIPTION
[pyupgrade](https://github.com/asottile/pyupgrade) is a tool that automatically adopts newer syntax when available without changing the results. The semantics might change slightly (e.g. f-strings have different bytecode than the equivalent `string.format(...)`) but it's very good about not breaking things, so it's pretty safe.