### PR TITLE
Bust cache for draft files when file exists on S3

### DIFF
--- a/packages/openneuro-server/src/cache/types.ts
+++ b/packages/openneuro-server/src/cache/types.ts
@@ -12,4 +12,5 @@ export enum CacheType {
   snapshotIndex = "snapshotIndex",
   participantCount = "participantCount",
   snapshotDownload = "download",
+  draftRevision = "revision",
 }

--- a/packages/openneuro-server/src/datalad/draft.ts
+++ b/packages/openneuro-server/src/datalad/draft.ts
@@ -4,16 +4,21 @@
 import request from "superagent"
 import Dataset from "../models/dataset"
 import { getDatasetWorker } from "../libs/datalad-service"
+import CacheItem, { CacheType } from "../cache/item"
+import { redis } from "../libs/redis"
 
 export const getDraftRevision = async (datasetId) => {
-  const draftUrl = `http://${
-    getDatasetWorker(
-      datasetId,
-    )
-  }/datasets/${datasetId}/draft`
-  const response = await fetch(draftUrl)
-  const { hexsha } = await response.json()
-  return hexsha
+  const cache = new CacheItem(redis, CacheType.draftRevision, [datasetId], 10)
+  return cache.get(async (_doNotCache): Promise<string> => {
+    const draftUrl = `http://${
+      getDatasetWorker(
+        datasetId,
+      )
+    }/datasets/${datasetId}/draft`
+    const response = await fetch(draftUrl)
+    const { hexsha } = await response.json()
+    return hexsha
+  })
 }
 
 export const updateDatasetRevision = (datasetId, gitRef) => {

--- a/packages/openneuro-server/src/handlers/datalad.ts
+++ b/packages/openneuro-server/src/handlers/datalad.ts
@@ -3,6 +3,7 @@ import { Readable } from "node:stream"
 import mime from "mime-types"
 import { getFiles } from "../datalad/files"
 import { getDatasetWorker } from "../libs/datalad-service"
+import { getDraftRevision } from "../datalad/draft"
 
 /**
  * Handlers for datalad dataset manipulation
@@ -21,7 +22,9 @@ export const getFile = async (req, res) => {
   const worker = getDatasetWorker(datasetId)
   // Find the right tree
   const pathComponents = filename.split(":")
-  let tree = snapshotId || "HEAD"
+  // Get the draft commit for cache busting
+  const draftCommit = await getDraftRevision(datasetId)
+  let tree = snapshotId || draftCommit
   let file
   for (const level of pathComponents) {
     try {


### PR DESCRIPTION
Fixes #3047. This cache was created with the key "HEAD" and the cached value would be returned if the file existed on S3. Instead this caches the draft with the commit hash. This does mean an extra worker API call for each file during a download, so added a short lived cache to avoid bulk file requests from repeating this request to the worker.