### PR TITLE
deps: Update to bids-validator 1.14.6

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 /* eslint-disable */
+// @ts-nocheck
 "use strict";
 
 const RAW_RUNTIME_STATE =
@@ -993,125 +994,67 @@ const RAW_RUNTIME_STATE =
       }]\
     ]],\
     ["@aws-sdk/client-s3", [\
-      ["npm:3.412.0", {\
-        "packageLocation": "./.yarn/cache/@aws-sdk-client-s3-npm-3.412.0-898d9707a9-71fa2c9f4c.zip/node_modules/@aws-sdk/client-s3/",\
+      ["npm:3.575.0", {\
+        "packageLocation": "./.yarn/cache/@aws-sdk-client-s3-npm-3.575.0-9bd6a5266c-d44c44fd7b.zip/node_modules/@aws-sdk/client-s3/",\
         "packageDependencies": [\
-          ["@aws-sdk/client-s3", "npm:3.412.0"],\
+          ["@aws-sdk/client-s3", "npm:3.575.0"],\
           ["@aws-crypto/sha1-browser", "npm:3.0.0"],\
           ["@aws-crypto/sha256-browser", "npm:3.0.0"],\
           ["@aws-crypto/sha256-js", "npm:3.0.0"],\
-          ["@aws-sdk/client-sts", "npm:3.410.0"],\
-          ["@aws-sdk/credential-provider-node", "npm:3.410.0"],\
-          ["@aws-sdk/middleware-bucket-endpoint", "npm:3.410.0"],\
-          ["@aws-sdk/middleware-expect-continue", "npm:3.410.0"],\
-          ["@aws-sdk/middleware-flexible-checksums", "npm:3.410.0"],\
-          ["@aws-sdk/middleware-host-header", "npm:3.410.0"],\
-          ["@aws-sdk/middleware-location-constraint", "npm:3.410.0"],\
-          ["@aws-sdk/middleware-logger", "npm:3.410.0"],\
-          ["@aws-sdk/middleware-recursion-detection", "npm:3.410.0"],\
-          ["@aws-sdk/middleware-sdk-s3", "npm:3.410.0"],\
-          ["@aws-sdk/middleware-signing", "npm:3.410.0"],\
-          ["@aws-sdk/middleware-ssec", "npm:3.410.0"],\
-          ["@aws-sdk/middleware-user-agent", "npm:3.410.0"],\
-          ["@aws-sdk/signature-v4-multi-region", "npm:3.412.0"],\
-          ["@aws-sdk/types", "npm:3.410.0"],\
-          ["@aws-sdk/util-endpoints", "npm:3.410.0"],\
-          ["@aws-sdk/util-user-agent-browser", "npm:3.410.0"],\
-          ["@aws-sdk/util-user-agent-node", "virtual:c7975f58467d1dba56c127268c561e37a9aeb3e8ff2db4488146ca26449caeb14e77c14d9661786bb33164386650d156f363ae901de2f0c228f8100fa963f5d2#npm:3.410.0"],\
-          ["@aws-sdk/xml-builder", "npm:3.310.0"],\
-          ["@smithy/config-resolver", "npm:2.0.8"],\
-          ["@smithy/eventstream-serde-browser", "npm:2.0.7"],\
-          ["@smithy/eventstream-serde-config-resolver", "npm:2.0.7"],\
-          ["@smithy/eventstream-serde-node", "npm:2.0.7"],\
-          ["@smithy/fetch-http-handler", "npm:2.1.3"],\
-          ["@smithy/hash-blob-browser", "npm:2.0.7"],\
-          ["@smithy/hash-node", "npm:2.0.7"],\
-          ["@smithy/hash-stream-node", "npm:2.0.7"],\
-          ["@smithy/invalid-dependency", "npm:2.0.7"],\
-          ["@smithy/md5-js", "npm:2.0.7"],\
-          ["@smithy/middleware-content-length", "npm:2.0.9"],\
-          ["@smithy/middleware-endpoint", "npm:2.0.7"],\
-          ["@smithy/middleware-retry", "npm:2.0.10"],\
-          ["@smithy/middleware-serde", "npm:2.0.7"],\
-          ["@smithy/middleware-stack", "npm:2.0.0"],\
-          ["@smithy/node-config-provider", "npm:2.0.10"],\
-          ["@smithy/node-http-handler", "npm:2.1.3"],\
-          ["@smithy/protocol-http", "npm:3.0.3"],\
-          ["@smithy/smithy-client", "npm:2.1.4"],\
-          ["@smithy/types", "npm:2.3.1"],\
-          ["@smithy/url-parser", "npm:2.0.7"],\
-          ["@smithy/util-base64", "npm:2.0.0"],\
-          ["@smithy/util-body-length-browser", "npm:2.0.0"],\
-          ["@smithy/util-body-length-node", "npm:2.1.0"],\
-          ["@smithy/util-defaults-mode-browser", "npm:2.0.8"],\
-          ["@smithy/util-defaults-mode-node", "npm:2.0.10"],\
-          ["@smithy/util-retry", "npm:2.0.0"],\
-          ["@smithy/util-stream", "npm:2.0.10"],\
-          ["@smithy/util-utf8", "npm:2.0.0"],\
-          ["@smithy/util-waiter", "npm:2.0.7"],\
-          ["fast-xml-parser", "npm:4.2.5"],\
-          ["tslib", "npm:2.6.2"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["npm:3.418.0", {\
-        "packageLocation": "./.yarn/cache/@aws-sdk-client-s3-npm-3.418.0-0a9bcc534c-30f81d680a.zip/node_modules/@aws-sdk/client-s3/",\
-        "packageDependencies": [\
-          ["@aws-sdk/client-s3", "npm:3.418.0"],\
-          ["@aws-crypto/sha1-browser", "npm:3.0.0"],\
-          ["@aws-crypto/sha256-browser", "npm:3.0.0"],\
-          ["@aws-crypto/sha256-js", "npm:3.0.0"],\
-          ["@aws-sdk/client-sts", "npm:3.418.0"],\
-          ["@aws-sdk/credential-provider-node", "npm:3.418.0"],\
-          ["@aws-sdk/middleware-bucket-endpoint", "npm:3.418.0"],\
-          ["@aws-sdk/middleware-expect-continue", "npm:3.418.0"],\
-          ["@aws-sdk/middleware-flexible-checksums", "npm:3.418.0"],\
-          ["@aws-sdk/middleware-host-header", "npm:3.418.0"],\
-          ["@aws-sdk/middleware-location-constraint", "npm:3.418.0"],\
-          ["@aws-sdk/middleware-logger", "npm:3.418.0"],\
-          ["@aws-sdk/middleware-recursion-detection", "npm:3.418.0"],\
-          ["@aws-sdk/middleware-sdk-s3", "npm:3.418.0"],\
-          ["@aws-sdk/middleware-signing", "npm:3.418.0"],\
-          ["@aws-sdk/middleware-ssec", "npm:3.418.0"],\
-          ["@aws-sdk/middleware-user-agent", "npm:3.418.0"],\
-          ["@aws-sdk/region-config-resolver", "npm:3.418.0"],\
-          ["@aws-sdk/signature-v4-multi-region", "npm:3.418.0"],\
-          ["@aws-sdk/types", "npm:3.418.0"],\
-          ["@aws-sdk/util-endpoints", "npm:3.418.0"],\
-          ["@aws-sdk/util-user-agent-browser", "npm:3.418.0"],\
-          ["@aws-sdk/util-user-agent-node", "virtual:237879ce01b3ff848a2895d7d2678bbddd9a88004cc756cf719f41780198bfd8d3b25aeafa3735ef24f38db5a5ea403a1197167bd689c00be82f590eabdb0d0a#npm:3.418.0"],\
-          ["@aws-sdk/xml-builder", "npm:3.310.0"],\
-          ["@smithy/config-resolver", "npm:2.0.10"],\
-          ["@smithy/eventstream-serde-browser", "npm:2.0.9"],\
-          ["@smithy/eventstream-serde-config-resolver", "npm:2.0.9"],\
-          ["@smithy/eventstream-serde-node", "npm:2.0.9"],\
-          ["@smithy/fetch-http-handler", "npm:2.1.5"],\
-          ["@smithy/hash-blob-browser", "npm:2.0.9"],\
-          ["@smithy/hash-node", "npm:2.0.9"],\
-          ["@smithy/hash-stream-node", "npm:2.0.9"],\
-          ["@smithy/invalid-dependency", "npm:2.0.9"],\
-          ["@smithy/md5-js", "npm:2.0.9"],\
-          ["@smithy/middleware-content-length", "npm:2.0.11"],\
-          ["@smithy/middleware-endpoint", "npm:2.0.9"],\
-          ["@smithy/middleware-retry", "npm:2.0.12"],\
-          ["@smithy/middleware-serde", "npm:2.0.9"],\
-          ["@smithy/middleware-stack", "npm:2.0.3"],\
-          ["@smithy/node-config-provider", "npm:2.0.12"],\
-          ["@smithy/node-http-handler", "npm:2.1.5"],\
-          ["@smithy/protocol-http", "npm:3.0.5"],\
-          ["@smithy/smithy-client", "npm:2.1.7"],\
-          ["@smithy/types", "npm:2.3.3"],\
-          ["@smithy/url-parser", "npm:2.0.9"],\
-          ["@smithy/util-base64", "npm:2.0.0"],\
-          ["@smithy/util-body-length-browser", "npm:2.0.0"],\
-          ["@smithy/util-body-length-node", "npm:2.1.0"],\
-          ["@smithy/util-defaults-mode-browser", "npm:2.0.11"],\
-          ["@smithy/util-defaults-mode-node", "npm:2.0.13"],\
-          ["@smithy/util-retry", "npm:2.0.2"],\
-          ["@smithy/util-stream", "npm:2.0.12"],\
-          ["@smithy/util-utf8", "npm:2.0.0"],\
-          ["@smithy/util-waiter", "npm:2.0.9"],\
-          ["fast-xml-parser", "npm:4.2.5"],\
+          ["@aws-sdk/client-sso-oidc", "npm:3.575.0"],\
+          ["@aws-sdk/client-sts", "npm:3.575.0"],\
+          ["@aws-sdk/core", "npm:3.575.0"],\
+          ["@aws-sdk/credential-provider-node", "npm:3.575.0"],\
+          ["@aws-sdk/middleware-bucket-endpoint", "npm:3.575.0"],\
+          ["@aws-sdk/middleware-expect-continue", "npm:3.575.0"],\
+          ["@aws-sdk/middleware-flexible-checksums", "npm:3.575.0"],\
+          ["@aws-sdk/middleware-host-header", "npm:3.575.0"],\
+          ["@aws-sdk/middleware-location-constraint", "npm:3.575.0"],\
+          ["@aws-sdk/middleware-logger", "npm:3.575.0"],\
+          ["@aws-sdk/middleware-recursion-detection", "npm:3.575.0"],\
+          ["@aws-sdk/middleware-sdk-s3", "npm:3.575.0"],\
+          ["@aws-sdk/middleware-signing", "npm:3.575.0"],\
+          ["@aws-sdk/middleware-ssec", "npm:3.575.0"],\
+          ["@aws-sdk/middleware-user-agent", "npm:3.575.0"],\
+          ["@aws-sdk/region-config-resolver", "npm:3.575.0"],\
+          ["@aws-sdk/signature-v4-multi-region", "npm:3.575.0"],\
+          ["@aws-sdk/types", "npm:3.575.0"],\
+          ["@aws-sdk/util-endpoints", "npm:3.575.0"],\
+          ["@aws-sdk/util-user-agent-browser", "npm:3.575.0"],\
+          ["@aws-sdk/util-user-agent-node", "virtual:e040dbdfd8c517cb5d8a409346f35e678a3acb76496a0d9281895be98ff787119fbf283008021c4dcf1b6d48be6af86b553dee0f028567f0a199ea55e4659b36#npm:3.575.0"],\
+          ["@aws-sdk/xml-builder", "npm:3.575.0"],\
+          ["@smithy/config-resolver", "npm:3.0.0"],\
+          ["@smithy/core", "npm:2.0.0"],\
+          ["@smithy/eventstream-serde-browser", "npm:3.0.0"],\
+          ["@smithy/eventstream-serde-config-resolver", "npm:3.0.0"],\
+          ["@smithy/eventstream-serde-node", "npm:3.0.0"],\
+          ["@smithy/fetch-http-handler", "npm:3.0.0"],\
+          ["@smithy/hash-blob-browser", "npm:3.0.0"],\
+          ["@smithy/hash-node", "npm:3.0.0"],\
+          ["@smithy/hash-stream-node", "npm:3.0.0"],\
+          ["@smithy/invalid-dependency", "npm:3.0.0"],\
+          ["@smithy/md5-js", "npm:3.0.0"],\
+          ["@smithy/middleware-content-length", "npm:3.0.0"],\
+          ["@smithy/middleware-endpoint", "npm:3.0.0"],\
+          ["@smithy/middleware-retry", "npm:3.0.0"],\
+          ["@smithy/middleware-serde", "npm:3.0.0"],\
+          ["@smithy/middleware-stack", "npm:3.0.0"],\
+          ["@smithy/node-config-provider", "npm:3.0.0"],\
+          ["@smithy/node-http-handler", "npm:3.0.0"],\
+          ["@smithy/protocol-http", "npm:4.0.0"],\
+          ["@smithy/smithy-client", "npm:3.0.0"],\
+          ["@smithy/types", "npm:3.0.0"],\
+          ["@smithy/url-parser", "npm:3.0.0"],\
+          ["@smithy/util-base64", "npm:3.0.0"],\
+          ["@smithy/util-body-length-browser", "npm:3.0.0"],\
+          ["@smithy/util-body-length-node", "npm:3.0.0"],\
+          ["@smithy/util-defaults-mode-browser", "npm:3.0.0"],\
+          ["@smithy/util-defaults-mode-node", "npm:3.0.0"],\
+          ["@smithy/util-endpoints", "npm:2.0.0"],\
+          ["@smithy/util-retry", "npm:3.0.0"],\
+          ["@smithy/util-stream", "npm:3.0.0"],\
+          ["@smithy/util-utf8", "npm:3.0.0"],\
+          ["@smithy/util-waiter", "npm:3.0.0"],\
           ["tslib", "npm:2.6.2"]\
         ],\
         "linkType": "HARD"\
@@ -1157,83 +1100,47 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "HARD"\
       }],\
-      ["npm:3.410.0", {\
-        "packageLocation": "./.yarn/cache/@aws-sdk-client-sso-npm-3.410.0-c7975f5846-176d7700dd.zip/node_modules/@aws-sdk/client-sso/",\
+      ["npm:3.575.0", {\
+        "packageLocation": "./.yarn/cache/@aws-sdk-client-sso-npm-3.575.0-e040dbdfd8-38957b3cac.zip/node_modules/@aws-sdk/client-sso/",\
         "packageDependencies": [\
-          ["@aws-sdk/client-sso", "npm:3.410.0"],\
+          ["@aws-sdk/client-sso", "npm:3.575.0"],\
           ["@aws-crypto/sha256-browser", "npm:3.0.0"],\
           ["@aws-crypto/sha256-js", "npm:3.0.0"],\
-          ["@aws-sdk/middleware-host-header", "npm:3.410.0"],\
-          ["@aws-sdk/middleware-logger", "npm:3.410.0"],\
-          ["@aws-sdk/middleware-recursion-detection", "npm:3.410.0"],\
-          ["@aws-sdk/middleware-user-agent", "npm:3.410.0"],\
-          ["@aws-sdk/types", "npm:3.410.0"],\
-          ["@aws-sdk/util-endpoints", "npm:3.410.0"],\
-          ["@aws-sdk/util-user-agent-browser", "npm:3.410.0"],\
-          ["@aws-sdk/util-user-agent-node", "virtual:c7975f58467d1dba56c127268c561e37a9aeb3e8ff2db4488146ca26449caeb14e77c14d9661786bb33164386650d156f363ae901de2f0c228f8100fa963f5d2#npm:3.410.0"],\
-          ["@smithy/config-resolver", "npm:2.0.8"],\
-          ["@smithy/fetch-http-handler", "npm:2.1.3"],\
-          ["@smithy/hash-node", "npm:2.0.7"],\
-          ["@smithy/invalid-dependency", "npm:2.0.7"],\
-          ["@smithy/middleware-content-length", "npm:2.0.9"],\
-          ["@smithy/middleware-endpoint", "npm:2.0.7"],\
-          ["@smithy/middleware-retry", "npm:2.0.10"],\
-          ["@smithy/middleware-serde", "npm:2.0.7"],\
-          ["@smithy/middleware-stack", "npm:2.0.0"],\
-          ["@smithy/node-config-provider", "npm:2.0.10"],\
-          ["@smithy/node-http-handler", "npm:2.1.3"],\
-          ["@smithy/protocol-http", "npm:3.0.3"],\
-          ["@smithy/smithy-client", "npm:2.1.4"],\
-          ["@smithy/types", "npm:2.3.1"],\
-          ["@smithy/url-parser", "npm:2.0.7"],\
-          ["@smithy/util-base64", "npm:2.0.0"],\
-          ["@smithy/util-body-length-browser", "npm:2.0.0"],\
-          ["@smithy/util-body-length-node", "npm:2.1.0"],\
-          ["@smithy/util-defaults-mode-browser", "npm:2.0.8"],\
-          ["@smithy/util-defaults-mode-node", "npm:2.0.10"],\
-          ["@smithy/util-retry", "npm:2.0.0"],\
-          ["@smithy/util-utf8", "npm:2.0.0"],\
-          ["tslib", "npm:2.6.2"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["npm:3.418.0", {\
-        "packageLocation": "./.yarn/cache/@aws-sdk-client-sso-npm-3.418.0-237879ce01-14a046232c.zip/node_modules/@aws-sdk/client-sso/",\
-        "packageDependencies": [\
-          ["@aws-sdk/client-sso", "npm:3.418.0"],\
-          ["@aws-crypto/sha256-browser", "npm:3.0.0"],\
-          ["@aws-crypto/sha256-js", "npm:3.0.0"],\
-          ["@aws-sdk/middleware-host-header", "npm:3.418.0"],\
-          ["@aws-sdk/middleware-logger", "npm:3.418.0"],\
-          ["@aws-sdk/middleware-recursion-detection", "npm:3.418.0"],\
-          ["@aws-sdk/middleware-user-agent", "npm:3.418.0"],\
-          ["@aws-sdk/region-config-resolver", "npm:3.418.0"],\
-          ["@aws-sdk/types", "npm:3.418.0"],\
-          ["@aws-sdk/util-endpoints", "npm:3.418.0"],\
-          ["@aws-sdk/util-user-agent-browser", "npm:3.418.0"],\
-          ["@aws-sdk/util-user-agent-node", "virtual:237879ce01b3ff848a2895d7d2678bbddd9a88004cc756cf719f41780198bfd8d3b25aeafa3735ef24f38db5a5ea403a1197167bd689c00be82f590eabdb0d0a#npm:3.418.0"],\
-          ["@smithy/config-resolver", "npm:2.0.10"],\
-          ["@smithy/fetch-http-handler", "npm:2.1.5"],\
-          ["@smithy/hash-node", "npm:2.0.9"],\
-          ["@smithy/invalid-dependency", "npm:2.0.9"],\
-          ["@smithy/middleware-content-length", "npm:2.0.11"],\
-          ["@smithy/middleware-endpoint", "npm:2.0.9"],\
-          ["@smithy/middleware-retry", "npm:2.0.12"],\
-          ["@smithy/middleware-serde", "npm:2.0.9"],\
-          ["@smithy/middleware-stack", "npm:2.0.3"],\
-          ["@smithy/node-config-provider", "npm:2.0.12"],\
-          ["@smithy/node-http-handler", "npm:2.1.5"],\
-          ["@smithy/protocol-http", "npm:3.0.5"],\
-          ["@smithy/smithy-client", "npm:2.1.7"],\
-          ["@smithy/types", "npm:2.3.3"],\
-          ["@smithy/url-parser", "npm:2.0.9"],\
-          ["@smithy/util-base64", "npm:2.0.0"],\
-          ["@smithy/util-body-length-browser", "npm:2.0.0"],\
-          ["@smithy/util-body-length-node", "npm:2.1.0"],\
-          ["@smithy/util-defaults-mode-browser", "npm:2.0.11"],\
-          ["@smithy/util-defaults-mode-node", "npm:2.0.13"],\
-          ["@smithy/util-retry", "npm:2.0.2"],\
-          ["@smithy/util-utf8", "npm:2.0.0"],\
+          ["@aws-sdk/core", "npm:3.575.0"],\
+          ["@aws-sdk/middleware-host-header", "npm:3.575.0"],\
+          ["@aws-sdk/middleware-logger", "npm:3.575.0"],\
+          ["@aws-sdk/middleware-recursion-detection", "npm:3.575.0"],\
+          ["@aws-sdk/middleware-user-agent", "npm:3.575.0"],\
+          ["@aws-sdk/region-config-resolver", "npm:3.575.0"],\
+          ["@aws-sdk/types", "npm:3.575.0"],\
+          ["@aws-sdk/util-endpoints", "npm:3.575.0"],\
+          ["@aws-sdk/util-user-agent-browser", "npm:3.575.0"],\
+          ["@aws-sdk/util-user-agent-node", "virtual:e040dbdfd8c517cb5d8a409346f35e678a3acb76496a0d9281895be98ff787119fbf283008021c4dcf1b6d48be6af86b553dee0f028567f0a199ea55e4659b36#npm:3.575.0"],\
+          ["@smithy/config-resolver", "npm:3.0.0"],\
+          ["@smithy/core", "npm:2.0.0"],\
+          ["@smithy/fetch-http-handler", "npm:3.0.0"],\
+          ["@smithy/hash-node", "npm:3.0.0"],\
+          ["@smithy/invalid-dependency", "npm:3.0.0"],\
+          ["@smithy/middleware-content-length", "npm:3.0.0"],\
+          ["@smithy/middleware-endpoint", "npm:3.0.0"],\
+          ["@smithy/middleware-retry", "npm:3.0.0"],\
+          ["@smithy/middleware-serde", "npm:3.0.0"],\
+          ["@smithy/middleware-stack", "npm:3.0.0"],\
+          ["@smithy/node-config-provider", "npm:3.0.0"],\
+          ["@smithy/node-http-handler", "npm:3.0.0"],\
+          ["@smithy/protocol-http", "npm:4.0.0"],\
+          ["@smithy/smithy-client", "npm:3.0.0"],\
+          ["@smithy/types", "npm:3.0.0"],\
+          ["@smithy/url-parser", "npm:3.0.0"],\
+          ["@smithy/util-base64", "npm:3.0.0"],\
+          ["@smithy/util-body-length-browser", "npm:3.0.0"],\
+          ["@smithy/util-body-length-node", "npm:3.0.0"],\
+          ["@smithy/util-defaults-mode-browser", "npm:3.0.0"],\
+          ["@smithy/util-defaults-mode-node", "npm:3.0.0"],\
+          ["@smithy/util-endpoints", "npm:2.0.0"],\
+          ["@smithy/util-middleware", "npm:3.0.0"],\
+          ["@smithy/util-retry", "npm:3.0.0"],\
+          ["@smithy/util-utf8", "npm:3.0.0"],\
           ["tslib", "npm:2.6.2"]\
         ],\
         "linkType": "HARD"\
@@ -1276,6 +1183,53 @@ const RAW_RUNTIME_STATE =
           ["@aws-sdk/util-utf8-browser", "npm:3.188.0"],\
           ["@aws-sdk/util-utf8-node", "npm:3.208.0"],\
           ["tslib", "npm:2.4.1"]\
+        ],\
+        "linkType": "HARD"\
+      }],\
+      ["npm:3.575.0", {\
+        "packageLocation": "./.yarn/cache/@aws-sdk-client-sso-oidc-npm-3.575.0-899296fcf2-98cc6f5718.zip/node_modules/@aws-sdk/client-sso-oidc/",\
+        "packageDependencies": [\
+          ["@aws-sdk/client-sso-oidc", "npm:3.575.0"],\
+          ["@aws-crypto/sha256-browser", "npm:3.0.0"],\
+          ["@aws-crypto/sha256-js", "npm:3.0.0"],\
+          ["@aws-sdk/client-sts", "npm:3.575.0"],\
+          ["@aws-sdk/core", "npm:3.575.0"],\
+          ["@aws-sdk/credential-provider-node", "npm:3.575.0"],\
+          ["@aws-sdk/middleware-host-header", "npm:3.575.0"],\
+          ["@aws-sdk/middleware-logger", "npm:3.575.0"],\
+          ["@aws-sdk/middleware-recursion-detection", "npm:3.575.0"],\
+          ["@aws-sdk/middleware-user-agent", "npm:3.575.0"],\
+          ["@aws-sdk/region-config-resolver", "npm:3.575.0"],\
+          ["@aws-sdk/types", "npm:3.575.0"],\
+          ["@aws-sdk/util-endpoints", "npm:3.575.0"],\
+          ["@aws-sdk/util-user-agent-browser", "npm:3.575.0"],\
+          ["@aws-sdk/util-user-agent-node", "virtual:e040dbdfd8c517cb5d8a409346f35e678a3acb76496a0d9281895be98ff787119fbf283008021c4dcf1b6d48be6af86b553dee0f028567f0a199ea55e4659b36#npm:3.575.0"],\
+          ["@smithy/config-resolver", "npm:3.0.0"],\
+          ["@smithy/core", "npm:2.0.0"],\
+          ["@smithy/fetch-http-handler", "npm:3.0.0"],\
+          ["@smithy/hash-node", "npm:3.0.0"],\
+          ["@smithy/invalid-dependency", "npm:3.0.0"],\
+          ["@smithy/middleware-content-length", "npm:3.0.0"],\
+          ["@smithy/middleware-endpoint", "npm:3.0.0"],\
+          ["@smithy/middleware-retry", "npm:3.0.0"],\
+          ["@smithy/middleware-serde", "npm:3.0.0"],\
+          ["@smithy/middleware-stack", "npm:3.0.0"],\
+          ["@smithy/node-config-provider", "npm:3.0.0"],\
+          ["@smithy/node-http-handler", "npm:3.0.0"],\
+          ["@smithy/protocol-http", "npm:4.0.0"],\
+          ["@smithy/smithy-client", "npm:3.0.0"],\
+          ["@smithy/types", "npm:3.0.0"],\
+          ["@smithy/url-parser", "npm:3.0.0"],\
+          ["@smithy/util-base64", "npm:3.0.0"],\
+          ["@smithy/util-body-length-browser", "npm:3.0.0"],\
+          ["@smithy/util-body-length-node", "npm:3.0.0"],\
+          ["@smithy/util-defaults-mode-browser", "npm:3.0.0"],\
+          ["@smithy/util-defaults-mode-node", "npm:3.0.0"],\
+          ["@smithy/util-endpoints", "npm:2.0.0"],\
+          ["@smithy/util-middleware", "npm:3.0.0"],\
+          ["@smithy/util-retry", "npm:3.0.0"],\
+          ["@smithy/util-utf8", "npm:3.0.0"],\
+          ["tslib", "npm:2.6.2"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -1324,91 +1278,49 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "HARD"\
       }],\
-      ["npm:3.410.0", {\
-        "packageLocation": "./.yarn/cache/@aws-sdk-client-sts-npm-3.410.0-38012af9d7-b82d6a6a14.zip/node_modules/@aws-sdk/client-sts/",\
+      ["npm:3.575.0", {\
+        "packageLocation": "./.yarn/cache/@aws-sdk-client-sts-npm-3.575.0-1685c18ede-d37e4ac232.zip/node_modules/@aws-sdk/client-sts/",\
         "packageDependencies": [\
-          ["@aws-sdk/client-sts", "npm:3.410.0"],\
+          ["@aws-sdk/client-sts", "npm:3.575.0"],\
           ["@aws-crypto/sha256-browser", "npm:3.0.0"],\
           ["@aws-crypto/sha256-js", "npm:3.0.0"],\
-          ["@aws-sdk/credential-provider-node", "npm:3.410.0"],\
-          ["@aws-sdk/middleware-host-header", "npm:3.410.0"],\
-          ["@aws-sdk/middleware-logger", "npm:3.410.0"],\
-          ["@aws-sdk/middleware-recursion-detection", "npm:3.410.0"],\
-          ["@aws-sdk/middleware-sdk-sts", "npm:3.410.0"],\
-          ["@aws-sdk/middleware-signing", "npm:3.410.0"],\
-          ["@aws-sdk/middleware-user-agent", "npm:3.410.0"],\
-          ["@aws-sdk/types", "npm:3.410.0"],\
-          ["@aws-sdk/util-endpoints", "npm:3.410.0"],\
-          ["@aws-sdk/util-user-agent-browser", "npm:3.410.0"],\
-          ["@aws-sdk/util-user-agent-node", "virtual:c7975f58467d1dba56c127268c561e37a9aeb3e8ff2db4488146ca26449caeb14e77c14d9661786bb33164386650d156f363ae901de2f0c228f8100fa963f5d2#npm:3.410.0"],\
-          ["@smithy/config-resolver", "npm:2.0.8"],\
-          ["@smithy/fetch-http-handler", "npm:2.1.3"],\
-          ["@smithy/hash-node", "npm:2.0.7"],\
-          ["@smithy/invalid-dependency", "npm:2.0.7"],\
-          ["@smithy/middleware-content-length", "npm:2.0.9"],\
-          ["@smithy/middleware-endpoint", "npm:2.0.7"],\
-          ["@smithy/middleware-retry", "npm:2.0.10"],\
-          ["@smithy/middleware-serde", "npm:2.0.7"],\
-          ["@smithy/middleware-stack", "npm:2.0.0"],\
-          ["@smithy/node-config-provider", "npm:2.0.10"],\
-          ["@smithy/node-http-handler", "npm:2.1.3"],\
-          ["@smithy/protocol-http", "npm:3.0.3"],\
-          ["@smithy/smithy-client", "npm:2.1.4"],\
-          ["@smithy/types", "npm:2.3.1"],\
-          ["@smithy/url-parser", "npm:2.0.7"],\
-          ["@smithy/util-base64", "npm:2.0.0"],\
-          ["@smithy/util-body-length-browser", "npm:2.0.0"],\
-          ["@smithy/util-body-length-node", "npm:2.1.0"],\
-          ["@smithy/util-defaults-mode-browser", "npm:2.0.8"],\
-          ["@smithy/util-defaults-mode-node", "npm:2.0.10"],\
-          ["@smithy/util-retry", "npm:2.0.0"],\
-          ["@smithy/util-utf8", "npm:2.0.0"],\
-          ["fast-xml-parser", "npm:4.2.5"],\
-          ["tslib", "npm:2.6.2"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["npm:3.418.0", {\
-        "packageLocation": "./.yarn/cache/@aws-sdk-client-sts-npm-3.418.0-7e790c3805-87841ff5a8.zip/node_modules/@aws-sdk/client-sts/",\
-        "packageDependencies": [\
-          ["@aws-sdk/client-sts", "npm:3.418.0"],\
-          ["@aws-crypto/sha256-browser", "npm:3.0.0"],\
-          ["@aws-crypto/sha256-js", "npm:3.0.0"],\
-          ["@aws-sdk/credential-provider-node", "npm:3.418.0"],\
-          ["@aws-sdk/middleware-host-header", "npm:3.418.0"],\
-          ["@aws-sdk/middleware-logger", "npm:3.418.0"],\
-          ["@aws-sdk/middleware-recursion-detection", "npm:3.418.0"],\
-          ["@aws-sdk/middleware-sdk-sts", "npm:3.418.0"],\
-          ["@aws-sdk/middleware-signing", "npm:3.418.0"],\
-          ["@aws-sdk/middleware-user-agent", "npm:3.418.0"],\
-          ["@aws-sdk/region-config-resolver", "npm:3.418.0"],\
-          ["@aws-sdk/types", "npm:3.418.0"],\
-          ["@aws-sdk/util-endpoints", "npm:3.418.0"],\
-          ["@aws-sdk/util-user-agent-browser", "npm:3.418.0"],\
-          ["@aws-sdk/util-user-agent-node", "virtual:237879ce01b3ff848a2895d7d2678bbddd9a88004cc756cf719f41780198bfd8d3b25aeafa3735ef24f38db5a5ea403a1197167bd689c00be82f590eabdb0d0a#npm:3.418.0"],\
-          ["@smithy/config-resolver", "npm:2.0.10"],\
-          ["@smithy/fetch-http-handler", "npm:2.1.5"],\
-          ["@smithy/hash-node", "npm:2.0.9"],\
-          ["@smithy/invalid-dependency", "npm:2.0.9"],\
-          ["@smithy/middleware-content-length", "npm:2.0.11"],\
-          ["@smithy/middleware-endpoint", "npm:2.0.9"],\
-          ["@smithy/middleware-retry", "npm:2.0.12"],\
-          ["@smithy/middleware-serde", "npm:2.0.9"],\
-          ["@smithy/middleware-stack", "npm:2.0.3"],\
-          ["@smithy/node-config-provider", "npm:2.0.12"],\
-          ["@smithy/node-http-handler", "npm:2.1.5"],\
-          ["@smithy/protocol-http", "npm:3.0.5"],\
-          ["@smithy/smithy-client", "npm:2.1.7"],\
-          ["@smithy/types", "npm:2.3.3"],\
-          ["@smithy/url-parser", "npm:2.0.9"],\
-          ["@smithy/util-base64", "npm:2.0.0"],\
-          ["@smithy/util-body-length-browser", "npm:2.0.0"],\
-          ["@smithy/util-body-length-node", "npm:2.1.0"],\
-          ["@smithy/util-defaults-mode-browser", "npm:2.0.11"],\
-          ["@smithy/util-defaults-mode-node", "npm:2.0.13"],\
-          ["@smithy/util-retry", "npm:2.0.2"],\
-          ["@smithy/util-utf8", "npm:2.0.0"],\
-          ["fast-xml-parser", "npm:4.2.5"],\
+          ["@aws-sdk/client-sso-oidc", "npm:3.575.0"],\
+          ["@aws-sdk/core", "npm:3.575.0"],\
+          ["@aws-sdk/credential-provider-node", "npm:3.575.0"],\
+          ["@aws-sdk/middleware-host-header", "npm:3.575.0"],\
+          ["@aws-sdk/middleware-logger", "npm:3.575.0"],\
+          ["@aws-sdk/middleware-recursion-detection", "npm:3.575.0"],\
+          ["@aws-sdk/middleware-user-agent", "npm:3.575.0"],\
+          ["@aws-sdk/region-config-resolver", "npm:3.575.0"],\
+          ["@aws-sdk/types", "npm:3.575.0"],\
+          ["@aws-sdk/util-endpoints", "npm:3.575.0"],\
+          ["@aws-sdk/util-user-agent-browser", "npm:3.575.0"],\
+          ["@aws-sdk/util-user-agent-node", "virtual:e040dbdfd8c517cb5d8a409346f35e678a3acb76496a0d9281895be98ff787119fbf283008021c4dcf1b6d48be6af86b553dee0f028567f0a199ea55e4659b36#npm:3.575.0"],\
+          ["@smithy/config-resolver", "npm:3.0.0"],\
+          ["@smithy/core", "npm:2.0.0"],\
+          ["@smithy/fetch-http-handler", "npm:3.0.0"],\
+          ["@smithy/hash-node", "npm:3.0.0"],\
+          ["@smithy/invalid-dependency", "npm:3.0.0"],\
+          ["@smithy/middleware-content-length", "npm:3.0.0"],\
+          ["@smithy/middleware-endpoint", "npm:3.0.0"],\
+          ["@smithy/middleware-retry", "npm:3.0.0"],\
+          ["@smithy/middleware-serde", "npm:3.0.0"],\
+          ["@smithy/middleware-stack", "npm:3.0.0"],\
+          ["@smithy/node-config-provider", "npm:3.0.0"],\
+          ["@smithy/node-http-handler", "npm:3.0.0"],\
+          ["@smithy/protocol-http", "npm:4.0.0"],\
+          ["@smithy/smithy-client", "npm:3.0.0"],\
+          ["@smithy/types", "npm:3.0.0"],\
+          ["@smithy/url-parser", "npm:3.0.0"],\
+          ["@smithy/util-base64", "npm:3.0.0"],\
+          ["@smithy/util-body-length-browser", "npm:3.0.0"],\
+          ["@smithy/util-body-length-node", "npm:3.0.0"],\
+          ["@smithy/util-defaults-mode-browser", "npm:3.0.0"],\
+          ["@smithy/util-defaults-mode-node", "npm:3.0.0"],\
+          ["@smithy/util-endpoints", "npm:2.0.0"],\
+          ["@smithy/util-middleware", "npm:3.0.0"],\
+          ["@smithy/util-retry", "npm:3.0.0"],\
+          ["@smithy/util-utf8", "npm:3.0.0"],\
           ["tslib", "npm:2.6.2"]\
         ],\
         "linkType": "HARD"\
@@ -1424,6 +1336,22 @@ const RAW_RUNTIME_STATE =
           ["@aws-sdk/util-config-provider", "npm:3.208.0"],\
           ["@aws-sdk/util-middleware", "npm:3.212.0"],\
           ["tslib", "npm:2.4.1"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["@aws-sdk/core", [\
+      ["npm:3.575.0", {\
+        "packageLocation": "./.yarn/cache/@aws-sdk-core-npm-3.575.0-106da9d18b-9458760ba7.zip/node_modules/@aws-sdk/core/",\
+        "packageDependencies": [\
+          ["@aws-sdk/core", "npm:3.575.0"],\
+          ["@smithy/core", "npm:2.0.0"],\
+          ["@smithy/protocol-http", "npm:4.0.0"],\
+          ["@smithy/signature-v4", "npm:3.0.0"],\
+          ["@smithy/smithy-client", "npm:3.0.0"],\
+          ["@smithy/types", "npm:3.0.0"],\
+          ["fast-xml-parser", "npm:4.2.5"],\
+          ["tslib", "npm:2.6.2"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -1452,24 +1380,31 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "HARD"\
       }],\
-      ["npm:3.410.0", {\
-        "packageLocation": "./.yarn/cache/@aws-sdk-credential-provider-env-npm-3.410.0-b548839dcd-3ce240be3e.zip/node_modules/@aws-sdk/credential-provider-env/",\
+      ["npm:3.575.0", {\
+        "packageLocation": "./.yarn/cache/@aws-sdk-credential-provider-env-npm-3.575.0-1cb6730e26-9301c3dc80.zip/node_modules/@aws-sdk/credential-provider-env/",\
         "packageDependencies": [\
-          ["@aws-sdk/credential-provider-env", "npm:3.410.0"],\
-          ["@aws-sdk/types", "npm:3.410.0"],\
-          ["@smithy/property-provider", "npm:2.0.8"],\
-          ["@smithy/types", "npm:2.3.1"],\
+          ["@aws-sdk/credential-provider-env", "npm:3.575.0"],\
+          ["@aws-sdk/types", "npm:3.575.0"],\
+          ["@smithy/property-provider", "npm:3.0.0"],\
+          ["@smithy/types", "npm:3.0.0"],\
           ["tslib", "npm:2.6.2"]\
         ],\
         "linkType": "HARD"\
-      }],\
-      ["npm:3.418.0", {\
-        "packageLocation": "./.yarn/cache/@aws-sdk-credential-provider-env-npm-3.418.0-bbb1a24af7-84e0a2395d.zip/node_modules/@aws-sdk/credential-provider-env/",\
+      }]\
+    ]],\
+    ["@aws-sdk/credential-provider-http", [\
+      ["npm:3.575.0", {\
+        "packageLocation": "./.yarn/cache/@aws-sdk-credential-provider-http-npm-3.575.0-3dd3866b65-fec90a520c.zip/node_modules/@aws-sdk/credential-provider-http/",\
         "packageDependencies": [\
-          ["@aws-sdk/credential-provider-env", "npm:3.418.0"],\
-          ["@aws-sdk/types", "npm:3.418.0"],\
-          ["@smithy/property-provider", "npm:2.0.8"],\
-          ["@smithy/types", "npm:2.3.3"],\
+          ["@aws-sdk/credential-provider-http", "npm:3.575.0"],\
+          ["@aws-sdk/types", "npm:3.575.0"],\
+          ["@smithy/fetch-http-handler", "npm:3.0.0"],\
+          ["@smithy/node-http-handler", "npm:3.0.0"],\
+          ["@smithy/property-provider", "npm:3.0.0"],\
+          ["@smithy/protocol-http", "npm:4.0.0"],\
+          ["@smithy/smithy-client", "npm:3.0.0"],\
+          ["@smithy/types", "npm:3.0.0"],\
+          ["@smithy/util-stream", "npm:3.0.0"],\
           ["tslib", "npm:2.6.2"]\
         ],\
         "linkType": "HARD"\
@@ -1505,37 +1440,33 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "HARD"\
       }],\
-      ["npm:3.410.0", {\
-        "packageLocation": "./.yarn/cache/@aws-sdk-credential-provider-ini-npm-3.410.0-597b095657-0f02c6ddc4.zip/node_modules/@aws-sdk/credential-provider-ini/",\
+      ["npm:3.575.0", {\
+        "packageLocation": "./.yarn/cache/@aws-sdk-credential-provider-ini-npm-3.575.0-46b5f7fe35-d86df0977a.zip/node_modules/@aws-sdk/credential-provider-ini/",\
         "packageDependencies": [\
-          ["@aws-sdk/credential-provider-ini", "npm:3.410.0"],\
-          ["@aws-sdk/credential-provider-env", "npm:3.410.0"],\
-          ["@aws-sdk/credential-provider-process", "npm:3.410.0"],\
-          ["@aws-sdk/credential-provider-sso", "npm:3.410.0"],\
-          ["@aws-sdk/credential-provider-web-identity", "npm:3.410.0"],\
-          ["@aws-sdk/types", "npm:3.410.0"],\
-          ["@smithy/credential-provider-imds", "npm:2.0.10"],\
-          ["@smithy/property-provider", "npm:2.0.8"],\
-          ["@smithy/shared-ini-file-loader", "npm:2.0.9"],\
-          ["@smithy/types", "npm:2.3.1"],\
+          ["@aws-sdk/credential-provider-ini", "npm:3.575.0"]\
+        ],\
+        "linkType": "SOFT"\
+      }],\
+      ["virtual:1d11b4b476c820528ca080242c9b6c937b82c8ffcde42840716faadf62ab859495c7eb364c112c8848958819c2ae2a516e528ad7dcdf8d8e28ab5f9622723aa5#npm:3.575.0", {\
+        "packageLocation": "./.yarn/__virtual__/@aws-sdk-credential-provider-ini-virtual-34b2d8b8cd/0/cache/@aws-sdk-credential-provider-ini-npm-3.575.0-46b5f7fe35-d86df0977a.zip/node_modules/@aws-sdk/credential-provider-ini/",\
+        "packageDependencies": [\
+          ["@aws-sdk/credential-provider-ini", "virtual:1d11b4b476c820528ca080242c9b6c937b82c8ffcde42840716faadf62ab859495c7eb364c112c8848958819c2ae2a516e528ad7dcdf8d8e28ab5f9622723aa5#npm:3.575.0"],\
+          ["@aws-sdk/client-sts", null],\
+          ["@aws-sdk/credential-provider-env", "npm:3.575.0"],\
+          ["@aws-sdk/credential-provider-process", "npm:3.575.0"],\
+          ["@aws-sdk/credential-provider-sso", "npm:3.575.0"],\
+          ["@aws-sdk/credential-provider-web-identity", "virtual:1d11b4b476c820528ca080242c9b6c937b82c8ffcde42840716faadf62ab859495c7eb364c112c8848958819c2ae2a516e528ad7dcdf8d8e28ab5f9622723aa5#npm:3.575.0"],\
+          ["@aws-sdk/types", "npm:3.575.0"],\
+          ["@smithy/credential-provider-imds", "npm:3.0.0"],\
+          ["@smithy/property-provider", "npm:3.0.0"],\
+          ["@smithy/shared-ini-file-loader", "npm:3.0.0"],\
+          ["@smithy/types", "npm:3.0.0"],\
+          ["@types/aws-sdk__client-sts", null],\
           ["tslib", "npm:2.6.2"]\
         ],\
-        "linkType": "HARD"\
-      }],\
-      ["npm:3.418.0", {\
-        "packageLocation": "./.yarn/cache/@aws-sdk-credential-provider-ini-npm-3.418.0-1d91afc9cf-9fd7070a99.zip/node_modules/@aws-sdk/credential-provider-ini/",\
-        "packageDependencies": [\
-          ["@aws-sdk/credential-provider-ini", "npm:3.418.0"],\
-          ["@aws-sdk/credential-provider-env", "npm:3.418.0"],\
-          ["@aws-sdk/credential-provider-process", "npm:3.418.0"],\
-          ["@aws-sdk/credential-provider-sso", "npm:3.418.0"],\
-          ["@aws-sdk/credential-provider-web-identity", "npm:3.418.0"],\
-          ["@aws-sdk/types", "npm:3.418.0"],\
-          ["@smithy/credential-provider-imds", "npm:2.0.10"],\
-          ["@smithy/property-provider", "npm:2.0.8"],\
-          ["@smithy/shared-ini-file-loader", "npm:2.0.9"],\
-          ["@smithy/types", "npm:2.3.3"],\
-          ["tslib", "npm:2.6.2"]\
+        "packagePeers": [\
+          "@aws-sdk/client-sts",\
+          "@types/aws-sdk__client-sts"\
         ],\
         "linkType": "HARD"\
       }]\
@@ -1558,38 +1489,21 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "HARD"\
       }],\
-      ["npm:3.410.0", {\
-        "packageLocation": "./.yarn/cache/@aws-sdk-credential-provider-node-npm-3.410.0-28988550f5-5a11d53533.zip/node_modules/@aws-sdk/credential-provider-node/",\
+      ["npm:3.575.0", {\
+        "packageLocation": "./.yarn/cache/@aws-sdk-credential-provider-node-npm-3.575.0-1d11b4b476-91f06aff0d.zip/node_modules/@aws-sdk/credential-provider-node/",\
         "packageDependencies": [\
-          ["@aws-sdk/credential-provider-node", "npm:3.410.0"],\
-          ["@aws-sdk/credential-provider-env", "npm:3.410.0"],\
-          ["@aws-sdk/credential-provider-ini", "npm:3.410.0"],\
-          ["@aws-sdk/credential-provider-process", "npm:3.410.0"],\
-          ["@aws-sdk/credential-provider-sso", "npm:3.410.0"],\
-          ["@aws-sdk/credential-provider-web-identity", "npm:3.410.0"],\
-          ["@aws-sdk/types", "npm:3.410.0"],\
-          ["@smithy/credential-provider-imds", "npm:2.0.10"],\
-          ["@smithy/property-provider", "npm:2.0.8"],\
-          ["@smithy/shared-ini-file-loader", "npm:2.0.9"],\
-          ["@smithy/types", "npm:2.3.1"],\
-          ["tslib", "npm:2.6.2"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["npm:3.418.0", {\
-        "packageLocation": "./.yarn/cache/@aws-sdk-credential-provider-node-npm-3.418.0-438c0f824f-1efbd7b580.zip/node_modules/@aws-sdk/credential-provider-node/",\
-        "packageDependencies": [\
-          ["@aws-sdk/credential-provider-node", "npm:3.418.0"],\
-          ["@aws-sdk/credential-provider-env", "npm:3.418.0"],\
-          ["@aws-sdk/credential-provider-ini", "npm:3.418.0"],\
-          ["@aws-sdk/credential-provider-process", "npm:3.418.0"],\
-          ["@aws-sdk/credential-provider-sso", "npm:3.418.0"],\
-          ["@aws-sdk/credential-provider-web-identity", "npm:3.418.0"],\
-          ["@aws-sdk/types", "npm:3.418.0"],\
-          ["@smithy/credential-provider-imds", "npm:2.0.10"],\
-          ["@smithy/property-provider", "npm:2.0.8"],\
-          ["@smithy/shared-ini-file-loader", "npm:2.0.9"],\
-          ["@smithy/types", "npm:2.3.3"],\
+          ["@aws-sdk/credential-provider-node", "npm:3.575.0"],\
+          ["@aws-sdk/credential-provider-env", "npm:3.575.0"],\
+          ["@aws-sdk/credential-provider-http", "npm:3.575.0"],\
+          ["@aws-sdk/credential-provider-ini", "virtual:1d11b4b476c820528ca080242c9b6c937b82c8ffcde42840716faadf62ab859495c7eb364c112c8848958819c2ae2a516e528ad7dcdf8d8e28ab5f9622723aa5#npm:3.575.0"],\
+          ["@aws-sdk/credential-provider-process", "npm:3.575.0"],\
+          ["@aws-sdk/credential-provider-sso", "npm:3.575.0"],\
+          ["@aws-sdk/credential-provider-web-identity", "virtual:1d11b4b476c820528ca080242c9b6c937b82c8ffcde42840716faadf62ab859495c7eb364c112c8848958819c2ae2a516e528ad7dcdf8d8e28ab5f9622723aa5#npm:3.575.0"],\
+          ["@aws-sdk/types", "npm:3.575.0"],\
+          ["@smithy/credential-provider-imds", "npm:3.0.0"],\
+          ["@smithy/property-provider", "npm:3.0.0"],\
+          ["@smithy/shared-ini-file-loader", "npm:3.0.0"],\
+          ["@smithy/types", "npm:3.0.0"],\
           ["tslib", "npm:2.6.2"]\
         ],\
         "linkType": "HARD"\
@@ -1607,26 +1521,14 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "HARD"\
       }],\
-      ["npm:3.410.0", {\
-        "packageLocation": "./.yarn/cache/@aws-sdk-credential-provider-process-npm-3.410.0-ab59719f02-ba3759f43f.zip/node_modules/@aws-sdk/credential-provider-process/",\
+      ["npm:3.575.0", {\
+        "packageLocation": "./.yarn/cache/@aws-sdk-credential-provider-process-npm-3.575.0-dab50efe0a-a32fcc6f82.zip/node_modules/@aws-sdk/credential-provider-process/",\
         "packageDependencies": [\
-          ["@aws-sdk/credential-provider-process", "npm:3.410.0"],\
-          ["@aws-sdk/types", "npm:3.410.0"],\
-          ["@smithy/property-provider", "npm:2.0.8"],\
-          ["@smithy/shared-ini-file-loader", "npm:2.0.9"],\
-          ["@smithy/types", "npm:2.3.1"],\
-          ["tslib", "npm:2.6.2"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["npm:3.418.0", {\
-        "packageLocation": "./.yarn/cache/@aws-sdk-credential-provider-process-npm-3.418.0-78c74d0265-d9aa1d8865.zip/node_modules/@aws-sdk/credential-provider-process/",\
-        "packageDependencies": [\
-          ["@aws-sdk/credential-provider-process", "npm:3.418.0"],\
-          ["@aws-sdk/types", "npm:3.418.0"],\
-          ["@smithy/property-provider", "npm:2.0.8"],\
-          ["@smithy/shared-ini-file-loader", "npm:2.0.9"],\
-          ["@smithy/types", "npm:2.3.3"],\
+          ["@aws-sdk/credential-provider-process", "npm:3.575.0"],\
+          ["@aws-sdk/types", "npm:3.575.0"],\
+          ["@smithy/property-provider", "npm:3.0.0"],\
+          ["@smithy/shared-ini-file-loader", "npm:3.0.0"],\
+          ["@smithy/types", "npm:3.0.0"],\
           ["tslib", "npm:2.6.2"]\
         ],\
         "linkType": "HARD"\
@@ -1646,30 +1548,16 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "HARD"\
       }],\
-      ["npm:3.410.0", {\
-        "packageLocation": "./.yarn/cache/@aws-sdk-credential-provider-sso-npm-3.410.0-b43ec440ec-450fc30e64.zip/node_modules/@aws-sdk/credential-provider-sso/",\
+      ["npm:3.575.0", {\
+        "packageLocation": "./.yarn/cache/@aws-sdk-credential-provider-sso-npm-3.575.0-11cd4c9d92-e9197693fc.zip/node_modules/@aws-sdk/credential-provider-sso/",\
         "packageDependencies": [\
-          ["@aws-sdk/credential-provider-sso", "npm:3.410.0"],\
-          ["@aws-sdk/client-sso", "npm:3.410.0"],\
-          ["@aws-sdk/token-providers", "npm:3.410.0"],\
-          ["@aws-sdk/types", "npm:3.410.0"],\
-          ["@smithy/property-provider", "npm:2.0.8"],\
-          ["@smithy/shared-ini-file-loader", "npm:2.0.9"],\
-          ["@smithy/types", "npm:2.3.1"],\
-          ["tslib", "npm:2.6.2"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["npm:3.418.0", {\
-        "packageLocation": "./.yarn/cache/@aws-sdk-credential-provider-sso-npm-3.418.0-8d8563a16b-030e2208a9.zip/node_modules/@aws-sdk/credential-provider-sso/",\
-        "packageDependencies": [\
-          ["@aws-sdk/credential-provider-sso", "npm:3.418.0"],\
-          ["@aws-sdk/client-sso", "npm:3.418.0"],\
-          ["@aws-sdk/token-providers", "npm:3.418.0"],\
-          ["@aws-sdk/types", "npm:3.418.0"],\
-          ["@smithy/property-provider", "npm:2.0.8"],\
-          ["@smithy/shared-ini-file-loader", "npm:2.0.9"],\
-          ["@smithy/types", "npm:2.3.3"],\
+          ["@aws-sdk/credential-provider-sso", "npm:3.575.0"],\
+          ["@aws-sdk/client-sso", "npm:3.575.0"],\
+          ["@aws-sdk/token-providers", "virtual:11cd4c9d92793aad42f42cb55bb5aff1e0ca0f7c2f94aabc839146c98ddafc158af7fdf2bad3b0e96cde730847b0c7e91273d50d5870d5573bffa5b705938cd3#npm:3.575.0"],\
+          ["@aws-sdk/types", "npm:3.575.0"],\
+          ["@smithy/property-provider", "npm:3.0.0"],\
+          ["@smithy/shared-ini-file-loader", "npm:3.0.0"],\
+          ["@smithy/types", "npm:3.0.0"],\
           ["tslib", "npm:2.6.2"]\
         ],\
         "linkType": "HARD"\
@@ -1686,25 +1574,27 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "HARD"\
       }],\
-      ["npm:3.410.0", {\
-        "packageLocation": "./.yarn/cache/@aws-sdk-credential-provider-web-identity-npm-3.410.0-73cb26e825-6df9fc1eb5.zip/node_modules/@aws-sdk/credential-provider-web-identity/",\
+      ["npm:3.575.0", {\
+        "packageLocation": "./.yarn/cache/@aws-sdk-credential-provider-web-identity-npm-3.575.0-0d2a4bd43b-05088f325d.zip/node_modules/@aws-sdk/credential-provider-web-identity/",\
         "packageDependencies": [\
-          ["@aws-sdk/credential-provider-web-identity", "npm:3.410.0"],\
-          ["@aws-sdk/types", "npm:3.410.0"],\
-          ["@smithy/property-provider", "npm:2.0.8"],\
-          ["@smithy/types", "npm:2.3.1"],\
+          ["@aws-sdk/credential-provider-web-identity", "npm:3.575.0"]\
+        ],\
+        "linkType": "SOFT"\
+      }],\
+      ["virtual:1d11b4b476c820528ca080242c9b6c937b82c8ffcde42840716faadf62ab859495c7eb364c112c8848958819c2ae2a516e528ad7dcdf8d8e28ab5f9622723aa5#npm:3.575.0", {\
+        "packageLocation": "./.yarn/__virtual__/@aws-sdk-credential-provider-web-identity-virtual-6e18a70a6c/0/cache/@aws-sdk-credential-provider-web-identity-npm-3.575.0-0d2a4bd43b-05088f325d.zip/node_modules/@aws-sdk/credential-provider-web-identity/",\
+        "packageDependencies": [\
+          ["@aws-sdk/credential-provider-web-identity", "virtual:1d11b4b476c820528ca080242c9b6c937b82c8ffcde42840716faadf62ab859495c7eb364c112c8848958819c2ae2a516e528ad7dcdf8d8e28ab5f9622723aa5#npm:3.575.0"],\
+          ["@aws-sdk/client-sts", null],\
+          ["@aws-sdk/types", "npm:3.575.0"],\
+          ["@smithy/property-provider", "npm:3.0.0"],\
+          ["@smithy/types", "npm:3.0.0"],\
+          ["@types/aws-sdk__client-sts", null],\
           ["tslib", "npm:2.6.2"]\
         ],\
-        "linkType": "HARD"\
-      }],\
-      ["npm:3.418.0", {\
-        "packageLocation": "./.yarn/cache/@aws-sdk-credential-provider-web-identity-npm-3.418.0-cedc85393a-cc53d6c2da.zip/node_modules/@aws-sdk/credential-provider-web-identity/",\
-        "packageDependencies": [\
-          ["@aws-sdk/credential-provider-web-identity", "npm:3.418.0"],\
-          ["@aws-sdk/types", "npm:3.418.0"],\
-          ["@smithy/property-provider", "npm:2.0.8"],\
-          ["@smithy/types", "npm:2.3.3"],\
-          ["tslib", "npm:2.6.2"]\
+        "packagePeers": [\
+          "@aws-sdk/client-sts",\
+          "@types/aws-sdk__client-sts"\
         ],\
         "linkType": "HARD"\
       }]\
@@ -1781,30 +1671,16 @@ const RAW_RUNTIME_STATE =
       }]\
     ]],\
     ["@aws-sdk/middleware-bucket-endpoint", [\
-      ["npm:3.410.0", {\
-        "packageLocation": "./.yarn/cache/@aws-sdk-middleware-bucket-endpoint-npm-3.410.0-a292c5c9dd-8f04fc1f64.zip/node_modules/@aws-sdk/middleware-bucket-endpoint/",\
+      ["npm:3.575.0", {\
+        "packageLocation": "./.yarn/cache/@aws-sdk-middleware-bucket-endpoint-npm-3.575.0-e735e8e0e0-8e41eba73b.zip/node_modules/@aws-sdk/middleware-bucket-endpoint/",\
         "packageDependencies": [\
-          ["@aws-sdk/middleware-bucket-endpoint", "npm:3.410.0"],\
-          ["@aws-sdk/types", "npm:3.410.0"],\
-          ["@aws-sdk/util-arn-parser", "npm:3.310.0"],\
-          ["@smithy/node-config-provider", "npm:2.0.10"],\
-          ["@smithy/protocol-http", "npm:3.0.3"],\
-          ["@smithy/types", "npm:2.3.1"],\
-          ["@smithy/util-config-provider", "npm:2.0.0"],\
-          ["tslib", "npm:2.6.2"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["npm:3.418.0", {\
-        "packageLocation": "./.yarn/cache/@aws-sdk-middleware-bucket-endpoint-npm-3.418.0-8a0b9afbf9-be70a317ba.zip/node_modules/@aws-sdk/middleware-bucket-endpoint/",\
-        "packageDependencies": [\
-          ["@aws-sdk/middleware-bucket-endpoint", "npm:3.418.0"],\
-          ["@aws-sdk/types", "npm:3.418.0"],\
-          ["@aws-sdk/util-arn-parser", "npm:3.310.0"],\
-          ["@smithy/node-config-provider", "npm:2.0.12"],\
-          ["@smithy/protocol-http", "npm:3.0.5"],\
-          ["@smithy/types", "npm:2.3.3"],\
-          ["@smithy/util-config-provider", "npm:2.0.0"],\
+          ["@aws-sdk/middleware-bucket-endpoint", "npm:3.575.0"],\
+          ["@aws-sdk/types", "npm:3.575.0"],\
+          ["@aws-sdk/util-arn-parser", "npm:3.568.0"],\
+          ["@smithy/node-config-provider", "npm:3.0.0"],\
+          ["@smithy/protocol-http", "npm:4.0.0"],\
+          ["@smithy/types", "npm:3.0.0"],\
+          ["@smithy/util-config-provider", "npm:3.0.0"],\
           ["tslib", "npm:2.6.2"]\
         ],\
         "linkType": "HARD"\
@@ -1840,56 +1716,30 @@ const RAW_RUNTIME_STATE =
       }]\
     ]],\
     ["@aws-sdk/middleware-expect-continue", [\
-      ["npm:3.410.0", {\
-        "packageLocation": "./.yarn/cache/@aws-sdk-middleware-expect-continue-npm-3.410.0-e4547f4f59-b4facc2588.zip/node_modules/@aws-sdk/middleware-expect-continue/",\
+      ["npm:3.575.0", {\
+        "packageLocation": "./.yarn/cache/@aws-sdk-middleware-expect-continue-npm-3.575.0-3cd1f730c9-8836b2c9c8.zip/node_modules/@aws-sdk/middleware-expect-continue/",\
         "packageDependencies": [\
-          ["@aws-sdk/middleware-expect-continue", "npm:3.410.0"],\
-          ["@aws-sdk/types", "npm:3.410.0"],\
-          ["@smithy/protocol-http", "npm:3.0.3"],\
-          ["@smithy/types", "npm:2.3.1"],\
-          ["tslib", "npm:2.6.2"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["npm:3.418.0", {\
-        "packageLocation": "./.yarn/cache/@aws-sdk-middleware-expect-continue-npm-3.418.0-a0383f95d5-0d0cc77de8.zip/node_modules/@aws-sdk/middleware-expect-continue/",\
-        "packageDependencies": [\
-          ["@aws-sdk/middleware-expect-continue", "npm:3.418.0"],\
-          ["@aws-sdk/types", "npm:3.418.0"],\
-          ["@smithy/protocol-http", "npm:3.0.5"],\
-          ["@smithy/types", "npm:2.3.3"],\
+          ["@aws-sdk/middleware-expect-continue", "npm:3.575.0"],\
+          ["@aws-sdk/types", "npm:3.575.0"],\
+          ["@smithy/protocol-http", "npm:4.0.0"],\
+          ["@smithy/types", "npm:3.0.0"],\
           ["tslib", "npm:2.6.2"]\
         ],\
         "linkType": "HARD"\
       }]\
     ]],\
     ["@aws-sdk/middleware-flexible-checksums", [\
-      ["npm:3.410.0", {\
-        "packageLocation": "./.yarn/cache/@aws-sdk-middleware-flexible-checksums-npm-3.410.0-a56c1d4f54-e95c67dc48.zip/node_modules/@aws-sdk/middleware-flexible-checksums/",\
+      ["npm:3.575.0", {\
+        "packageLocation": "./.yarn/cache/@aws-sdk-middleware-flexible-checksums-npm-3.575.0-b9ce9890e9-eb30799caa.zip/node_modules/@aws-sdk/middleware-flexible-checksums/",\
         "packageDependencies": [\
-          ["@aws-sdk/middleware-flexible-checksums", "npm:3.410.0"],\
+          ["@aws-sdk/middleware-flexible-checksums", "npm:3.575.0"],\
           ["@aws-crypto/crc32", "npm:3.0.0"],\
           ["@aws-crypto/crc32c", "npm:3.0.0"],\
-          ["@aws-sdk/types", "npm:3.410.0"],\
-          ["@smithy/is-array-buffer", "npm:2.0.0"],\
-          ["@smithy/protocol-http", "npm:3.0.3"],\
-          ["@smithy/types", "npm:2.3.1"],\
-          ["@smithy/util-utf8", "npm:2.0.0"],\
-          ["tslib", "npm:2.6.2"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["npm:3.418.0", {\
-        "packageLocation": "./.yarn/cache/@aws-sdk-middleware-flexible-checksums-npm-3.418.0-afc9bb02ed-ab1c6675a6.zip/node_modules/@aws-sdk/middleware-flexible-checksums/",\
-        "packageDependencies": [\
-          ["@aws-sdk/middleware-flexible-checksums", "npm:3.418.0"],\
-          ["@aws-crypto/crc32", "npm:3.0.0"],\
-          ["@aws-crypto/crc32c", "npm:3.0.0"],\
-          ["@aws-sdk/types", "npm:3.418.0"],\
-          ["@smithy/is-array-buffer", "npm:2.0.0"],\
-          ["@smithy/protocol-http", "npm:3.0.5"],\
-          ["@smithy/types", "npm:2.3.3"],\
-          ["@smithy/util-utf8", "npm:2.0.0"],\
+          ["@aws-sdk/types", "npm:3.575.0"],\
+          ["@smithy/is-array-buffer", "npm:3.0.0"],\
+          ["@smithy/protocol-http", "npm:4.0.0"],\
+          ["@smithy/types", "npm:3.0.0"],\
+          ["@smithy/util-utf8", "npm:3.0.0"],\
           ["tslib", "npm:2.6.2"]\
         ],\
         "linkType": "HARD"\
@@ -1906,46 +1756,25 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "HARD"\
       }],\
-      ["npm:3.410.0", {\
-        "packageLocation": "./.yarn/cache/@aws-sdk-middleware-host-header-npm-3.410.0-303774f290-63ac263f39.zip/node_modules/@aws-sdk/middleware-host-header/",\
+      ["npm:3.575.0", {\
+        "packageLocation": "./.yarn/cache/@aws-sdk-middleware-host-header-npm-3.575.0-941c42e58a-8c5478db6b.zip/node_modules/@aws-sdk/middleware-host-header/",\
         "packageDependencies": [\
-          ["@aws-sdk/middleware-host-header", "npm:3.410.0"],\
-          ["@aws-sdk/types", "npm:3.410.0"],\
-          ["@smithy/protocol-http", "npm:3.0.3"],\
-          ["@smithy/types", "npm:2.3.1"],\
-          ["tslib", "npm:2.6.2"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["npm:3.418.0", {\
-        "packageLocation": "./.yarn/cache/@aws-sdk-middleware-host-header-npm-3.418.0-2d47b307fb-5cdfa1d725.zip/node_modules/@aws-sdk/middleware-host-header/",\
-        "packageDependencies": [\
-          ["@aws-sdk/middleware-host-header", "npm:3.418.0"],\
-          ["@aws-sdk/types", "npm:3.418.0"],\
-          ["@smithy/protocol-http", "npm:3.0.5"],\
-          ["@smithy/types", "npm:2.3.3"],\
+          ["@aws-sdk/middleware-host-header", "npm:3.575.0"],\
+          ["@aws-sdk/types", "npm:3.575.0"],\
+          ["@smithy/protocol-http", "npm:4.0.0"],\
+          ["@smithy/types", "npm:3.0.0"],\
           ["tslib", "npm:2.6.2"]\
         ],\
         "linkType": "HARD"\
       }]\
     ]],\
     ["@aws-sdk/middleware-location-constraint", [\
-      ["npm:3.410.0", {\
-        "packageLocation": "./.yarn/cache/@aws-sdk-middleware-location-constraint-npm-3.410.0-b37e886d4b-4735e6598f.zip/node_modules/@aws-sdk/middleware-location-constraint/",\
+      ["npm:3.575.0", {\
+        "packageLocation": "./.yarn/cache/@aws-sdk-middleware-location-constraint-npm-3.575.0-82c6da5226-690c362827.zip/node_modules/@aws-sdk/middleware-location-constraint/",\
         "packageDependencies": [\
-          ["@aws-sdk/middleware-location-constraint", "npm:3.410.0"],\
-          ["@aws-sdk/types", "npm:3.410.0"],\
-          ["@smithy/types", "npm:2.3.1"],\
-          ["tslib", "npm:2.6.2"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["npm:3.418.0", {\
-        "packageLocation": "./.yarn/cache/@aws-sdk-middleware-location-constraint-npm-3.418.0-455edc1633-8cdd394c5a.zip/node_modules/@aws-sdk/middleware-location-constraint/",\
-        "packageDependencies": [\
-          ["@aws-sdk/middleware-location-constraint", "npm:3.418.0"],\
-          ["@aws-sdk/types", "npm:3.418.0"],\
-          ["@smithy/types", "npm:2.3.3"],\
+          ["@aws-sdk/middleware-location-constraint", "npm:3.575.0"],\
+          ["@aws-sdk/types", "npm:3.575.0"],\
+          ["@smithy/types", "npm:3.0.0"],\
           ["tslib", "npm:2.6.2"]\
         ],\
         "linkType": "HARD"\
@@ -1961,22 +1790,12 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "HARD"\
       }],\
-      ["npm:3.410.0", {\
-        "packageLocation": "./.yarn/cache/@aws-sdk-middleware-logger-npm-3.410.0-a6c30bba87-56e30b3a16.zip/node_modules/@aws-sdk/middleware-logger/",\
+      ["npm:3.575.0", {\
+        "packageLocation": "./.yarn/cache/@aws-sdk-middleware-logger-npm-3.575.0-ea61b23068-30b6b986d6.zip/node_modules/@aws-sdk/middleware-logger/",\
         "packageDependencies": [\
-          ["@aws-sdk/middleware-logger", "npm:3.410.0"],\
-          ["@aws-sdk/types", "npm:3.410.0"],\
-          ["@smithy/types", "npm:2.3.1"],\
-          ["tslib", "npm:2.6.2"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["npm:3.418.0", {\
-        "packageLocation": "./.yarn/cache/@aws-sdk-middleware-logger-npm-3.418.0-a72b537495-5733dc9b96.zip/node_modules/@aws-sdk/middleware-logger/",\
-        "packageDependencies": [\
-          ["@aws-sdk/middleware-logger", "npm:3.418.0"],\
-          ["@aws-sdk/types", "npm:3.418.0"],\
-          ["@smithy/types", "npm:2.3.3"],\
+          ["@aws-sdk/middleware-logger", "npm:3.575.0"],\
+          ["@aws-sdk/types", "npm:3.575.0"],\
+          ["@smithy/types", "npm:3.0.0"],\
           ["tslib", "npm:2.6.2"]\
         ],\
         "linkType": "HARD"\
@@ -1993,24 +1812,13 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "HARD"\
       }],\
-      ["npm:3.410.0", {\
-        "packageLocation": "./.yarn/cache/@aws-sdk-middleware-recursion-detection-npm-3.410.0-52b9d6c467-464c729db2.zip/node_modules/@aws-sdk/middleware-recursion-detection/",\
+      ["npm:3.575.0", {\
+        "packageLocation": "./.yarn/cache/@aws-sdk-middleware-recursion-detection-npm-3.575.0-138091bf5d-a80a3b7aec.zip/node_modules/@aws-sdk/middleware-recursion-detection/",\
         "packageDependencies": [\
-          ["@aws-sdk/middleware-recursion-detection", "npm:3.410.0"],\
-          ["@aws-sdk/types", "npm:3.410.0"],\
-          ["@smithy/protocol-http", "npm:3.0.3"],\
-          ["@smithy/types", "npm:2.3.1"],\
-          ["tslib", "npm:2.6.2"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["npm:3.418.0", {\
-        "packageLocation": "./.yarn/cache/@aws-sdk-middleware-recursion-detection-npm-3.418.0-27643236df-cb49765812.zip/node_modules/@aws-sdk/middleware-recursion-detection/",\
-        "packageDependencies": [\
-          ["@aws-sdk/middleware-recursion-detection", "npm:3.418.0"],\
-          ["@aws-sdk/types", "npm:3.418.0"],\
-          ["@smithy/protocol-http", "npm:3.0.5"],\
-          ["@smithy/types", "npm:2.3.3"],\
+          ["@aws-sdk/middleware-recursion-detection", "npm:3.575.0"],\
+          ["@aws-sdk/types", "npm:3.575.0"],\
+          ["@smithy/protocol-http", "npm:4.0.0"],\
+          ["@smithy/types", "npm:3.0.0"],\
           ["tslib", "npm:2.6.2"]\
         ],\
         "linkType": "HARD"\
@@ -2032,27 +1840,18 @@ const RAW_RUNTIME_STATE =
       }]\
     ]],\
     ["@aws-sdk/middleware-sdk-s3", [\
-      ["npm:3.410.0", {\
-        "packageLocation": "./.yarn/cache/@aws-sdk-middleware-sdk-s3-npm-3.410.0-1a6132c802-9200c14d4d.zip/node_modules/@aws-sdk/middleware-sdk-s3/",\
+      ["npm:3.575.0", {\
+        "packageLocation": "./.yarn/cache/@aws-sdk-middleware-sdk-s3-npm-3.575.0-f0bcac9dad-52c666f794.zip/node_modules/@aws-sdk/middleware-sdk-s3/",\
         "packageDependencies": [\
-          ["@aws-sdk/middleware-sdk-s3", "npm:3.410.0"],\
-          ["@aws-sdk/types", "npm:3.410.0"],\
-          ["@aws-sdk/util-arn-parser", "npm:3.310.0"],\
-          ["@smithy/protocol-http", "npm:3.0.3"],\
-          ["@smithy/types", "npm:2.3.1"],\
-          ["tslib", "npm:2.6.2"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["npm:3.418.0", {\
-        "packageLocation": "./.yarn/cache/@aws-sdk-middleware-sdk-s3-npm-3.418.0-6084b7d238-205dd2399a.zip/node_modules/@aws-sdk/middleware-sdk-s3/",\
-        "packageDependencies": [\
-          ["@aws-sdk/middleware-sdk-s3", "npm:3.418.0"],\
-          ["@aws-sdk/types", "npm:3.418.0"],\
-          ["@aws-sdk/util-arn-parser", "npm:3.310.0"],\
-          ["@smithy/protocol-http", "npm:3.0.5"],\
-          ["@smithy/smithy-client", "npm:2.1.7"],\
-          ["@smithy/types", "npm:2.3.3"],\
+          ["@aws-sdk/middleware-sdk-s3", "npm:3.575.0"],\
+          ["@aws-sdk/types", "npm:3.575.0"],\
+          ["@aws-sdk/util-arn-parser", "npm:3.568.0"],\
+          ["@smithy/node-config-provider", "npm:3.0.0"],\
+          ["@smithy/protocol-http", "npm:4.0.0"],\
+          ["@smithy/signature-v4", "npm:3.0.0"],\
+          ["@smithy/smithy-client", "npm:3.0.0"],\
+          ["@smithy/types", "npm:3.0.0"],\
+          ["@smithy/util-config-provider", "npm:3.0.0"],\
           ["tslib", "npm:2.6.2"]\
         ],\
         "linkType": "HARD"\
@@ -2069,28 +1868,6 @@ const RAW_RUNTIME_STATE =
           ["@aws-sdk/signature-v4", "npm:3.212.0"],\
           ["@aws-sdk/types", "npm:3.212.0"],\
           ["tslib", "npm:2.4.1"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["npm:3.410.0", {\
-        "packageLocation": "./.yarn/cache/@aws-sdk-middleware-sdk-sts-npm-3.410.0-130115817e-b426e50ede.zip/node_modules/@aws-sdk/middleware-sdk-sts/",\
-        "packageDependencies": [\
-          ["@aws-sdk/middleware-sdk-sts", "npm:3.410.0"],\
-          ["@aws-sdk/middleware-signing", "npm:3.410.0"],\
-          ["@aws-sdk/types", "npm:3.410.0"],\
-          ["@smithy/types", "npm:2.3.1"],\
-          ["tslib", "npm:2.6.2"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["npm:3.418.0", {\
-        "packageLocation": "./.yarn/cache/@aws-sdk-middleware-sdk-sts-npm-3.418.0-8f2b21c5b7-6b57124820.zip/node_modules/@aws-sdk/middleware-sdk-sts/",\
-        "packageDependencies": [\
-          ["@aws-sdk/middleware-sdk-sts", "npm:3.418.0"],\
-          ["@aws-sdk/middleware-signing", "npm:3.418.0"],\
-          ["@aws-sdk/types", "npm:3.418.0"],\
-          ["@smithy/types", "npm:2.3.3"],\
-          ["tslib", "npm:2.6.2"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -2120,52 +1897,28 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "HARD"\
       }],\
-      ["npm:3.410.0", {\
-        "packageLocation": "./.yarn/cache/@aws-sdk-middleware-signing-npm-3.410.0-4e22d88a04-479dfe7ece.zip/node_modules/@aws-sdk/middleware-signing/",\
+      ["npm:3.575.0", {\
+        "packageLocation": "./.yarn/cache/@aws-sdk-middleware-signing-npm-3.575.0-dd2e8049cb-d7adaafbc2.zip/node_modules/@aws-sdk/middleware-signing/",\
         "packageDependencies": [\
-          ["@aws-sdk/middleware-signing", "npm:3.410.0"],\
-          ["@aws-sdk/types", "npm:3.410.0"],\
-          ["@smithy/property-provider", "npm:2.0.8"],\
-          ["@smithy/protocol-http", "npm:3.0.3"],\
-          ["@smithy/signature-v4", "npm:2.0.7"],\
-          ["@smithy/types", "npm:2.3.1"],\
-          ["@smithy/util-middleware", "npm:2.0.0"],\
-          ["tslib", "npm:2.6.2"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["npm:3.418.0", {\
-        "packageLocation": "./.yarn/cache/@aws-sdk-middleware-signing-npm-3.418.0-421231a608-bbfcac0f93.zip/node_modules/@aws-sdk/middleware-signing/",\
-        "packageDependencies": [\
-          ["@aws-sdk/middleware-signing", "npm:3.418.0"],\
-          ["@aws-sdk/types", "npm:3.418.0"],\
-          ["@smithy/property-provider", "npm:2.0.8"],\
-          ["@smithy/protocol-http", "npm:3.0.5"],\
-          ["@smithy/signature-v4", "npm:2.0.7"],\
-          ["@smithy/types", "npm:2.3.3"],\
-          ["@smithy/util-middleware", "npm:2.0.2"],\
+          ["@aws-sdk/middleware-signing", "npm:3.575.0"],\
+          ["@aws-sdk/types", "npm:3.575.0"],\
+          ["@smithy/property-provider", "npm:3.0.0"],\
+          ["@smithy/protocol-http", "npm:4.0.0"],\
+          ["@smithy/signature-v4", "npm:3.0.0"],\
+          ["@smithy/types", "npm:3.0.0"],\
+          ["@smithy/util-middleware", "npm:3.0.0"],\
           ["tslib", "npm:2.6.2"]\
         ],\
         "linkType": "HARD"\
       }]\
     ]],\
     ["@aws-sdk/middleware-ssec", [\
-      ["npm:3.410.0", {\
-        "packageLocation": "./.yarn/cache/@aws-sdk-middleware-ssec-npm-3.410.0-8b2bfabf87-1f9b37da90.zip/node_modules/@aws-sdk/middleware-ssec/",\
+      ["npm:3.575.0", {\
+        "packageLocation": "./.yarn/cache/@aws-sdk-middleware-ssec-npm-3.575.0-0a2ca403fe-ec7a0dd5fe.zip/node_modules/@aws-sdk/middleware-ssec/",\
         "packageDependencies": [\
-          ["@aws-sdk/middleware-ssec", "npm:3.410.0"],\
-          ["@aws-sdk/types", "npm:3.410.0"],\
-          ["@smithy/types", "npm:2.3.1"],\
-          ["tslib", "npm:2.6.2"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["npm:3.418.0", {\
-        "packageLocation": "./.yarn/cache/@aws-sdk-middleware-ssec-npm-3.418.0-881cecdcfa-31d45ed605.zip/node_modules/@aws-sdk/middleware-ssec/",\
-        "packageDependencies": [\
-          ["@aws-sdk/middleware-ssec", "npm:3.418.0"],\
-          ["@aws-sdk/types", "npm:3.418.0"],\
-          ["@smithy/types", "npm:2.3.3"],\
+          ["@aws-sdk/middleware-ssec", "npm:3.575.0"],\
+          ["@aws-sdk/types", "npm:3.575.0"],\
+          ["@smithy/types", "npm:3.0.0"],\
           ["tslib", "npm:2.6.2"]\
         ],\
         "linkType": "HARD"\
@@ -2192,26 +1945,14 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "HARD"\
       }],\
-      ["npm:3.410.0", {\
-        "packageLocation": "./.yarn/cache/@aws-sdk-middleware-user-agent-npm-3.410.0-e3d572ff23-cd631597b5.zip/node_modules/@aws-sdk/middleware-user-agent/",\
+      ["npm:3.575.0", {\
+        "packageLocation": "./.yarn/cache/@aws-sdk-middleware-user-agent-npm-3.575.0-bb45bea32d-2c2b9b840a.zip/node_modules/@aws-sdk/middleware-user-agent/",\
         "packageDependencies": [\
-          ["@aws-sdk/middleware-user-agent", "npm:3.410.0"],\
-          ["@aws-sdk/types", "npm:3.410.0"],\
-          ["@aws-sdk/util-endpoints", "npm:3.410.0"],\
-          ["@smithy/protocol-http", "npm:3.0.3"],\
-          ["@smithy/types", "npm:2.3.1"],\
-          ["tslib", "npm:2.6.2"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["npm:3.418.0", {\
-        "packageLocation": "./.yarn/cache/@aws-sdk-middleware-user-agent-npm-3.418.0-02c82a6281-992229cfb7.zip/node_modules/@aws-sdk/middleware-user-agent/",\
-        "packageDependencies": [\
-          ["@aws-sdk/middleware-user-agent", "npm:3.418.0"],\
-          ["@aws-sdk/types", "npm:3.418.0"],\
-          ["@aws-sdk/util-endpoints", "npm:3.418.0"],\
-          ["@smithy/protocol-http", "npm:3.0.5"],\
-          ["@smithy/types", "npm:2.3.3"],\
+          ["@aws-sdk/middleware-user-agent", "npm:3.575.0"],\
+          ["@aws-sdk/types", "npm:3.575.0"],\
+          ["@aws-sdk/util-endpoints", "npm:3.575.0"],\
+          ["@smithy/protocol-http", "npm:4.0.0"],\
+          ["@smithy/types", "npm:3.0.0"],\
           ["tslib", "npm:2.6.2"]\
         ],\
         "linkType": "HARD"\
@@ -2290,14 +2031,15 @@ const RAW_RUNTIME_STATE =
       }]\
     ]],\
     ["@aws-sdk/region-config-resolver", [\
-      ["npm:3.418.0", {\
-        "packageLocation": "./.yarn/cache/@aws-sdk-region-config-resolver-npm-3.418.0-6e43b346d0-48e0334158.zip/node_modules/@aws-sdk/region-config-resolver/",\
+      ["npm:3.575.0", {\
+        "packageLocation": "./.yarn/cache/@aws-sdk-region-config-resolver-npm-3.575.0-0034c0ea70-92c4550fd5.zip/node_modules/@aws-sdk/region-config-resolver/",\
         "packageDependencies": [\
-          ["@aws-sdk/region-config-resolver", "npm:3.418.0"],\
-          ["@smithy/node-config-provider", "npm:2.0.12"],\
-          ["@smithy/types", "npm:2.3.3"],\
-          ["@smithy/util-config-provider", "npm:2.0.0"],\
-          ["@smithy/util-middleware", "npm:2.0.2"],\
+          ["@aws-sdk/region-config-resolver", "npm:3.575.0"],\
+          ["@aws-sdk/types", "npm:3.575.0"],\
+          ["@smithy/node-config-provider", "npm:3.0.0"],\
+          ["@smithy/types", "npm:3.0.0"],\
+          ["@smithy/util-config-provider", "npm:3.0.0"],\
+          ["@smithy/util-middleware", "npm:3.0.0"],\
           ["tslib", "npm:2.6.2"]\
         ],\
         "linkType": "HARD"\
@@ -2339,26 +2081,15 @@ const RAW_RUNTIME_STATE =
       }]\
     ]],\
     ["@aws-sdk/signature-v4-multi-region", [\
-      ["npm:3.412.0", {\
-        "packageLocation": "./.yarn/cache/@aws-sdk-signature-v4-multi-region-npm-3.412.0-019c57a954-ecdbecf029.zip/node_modules/@aws-sdk/signature-v4-multi-region/",\
+      ["npm:3.575.0", {\
+        "packageLocation": "./.yarn/cache/@aws-sdk-signature-v4-multi-region-npm-3.575.0-08ee2ffdc7-c41791cdb2.zip/node_modules/@aws-sdk/signature-v4-multi-region/",\
         "packageDependencies": [\
-          ["@aws-sdk/signature-v4-multi-region", "npm:3.412.0"],\
-          ["@aws-sdk/types", "npm:3.410.0"],\
-          ["@smithy/protocol-http", "npm:3.0.3"],\
-          ["@smithy/signature-v4", "npm:2.0.7"],\
-          ["@smithy/types", "npm:2.3.1"],\
-          ["tslib", "npm:2.6.2"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["npm:3.418.0", {\
-        "packageLocation": "./.yarn/cache/@aws-sdk-signature-v4-multi-region-npm-3.418.0-b9fa1a0edb-133e5d71f4.zip/node_modules/@aws-sdk/signature-v4-multi-region/",\
-        "packageDependencies": [\
-          ["@aws-sdk/signature-v4-multi-region", "npm:3.418.0"],\
-          ["@aws-sdk/types", "npm:3.418.0"],\
-          ["@smithy/protocol-http", "npm:3.0.5"],\
-          ["@smithy/signature-v4", "npm:2.0.7"],\
-          ["@smithy/types", "npm:2.3.3"],\
+          ["@aws-sdk/signature-v4-multi-region", "npm:3.575.0"],\
+          ["@aws-sdk/middleware-sdk-s3", "npm:3.575.0"],\
+          ["@aws-sdk/types", "npm:3.575.0"],\
+          ["@smithy/protocol-http", "npm:4.0.0"],\
+          ["@smithy/signature-v4", "npm:3.0.0"],\
+          ["@smithy/types", "npm:3.0.0"],\
           ["tslib", "npm:2.6.2"]\
         ],\
         "linkType": "HARD"\
@@ -2389,87 +2120,28 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "HARD"\
       }],\
-      ["npm:3.410.0", {\
-        "packageLocation": "./.yarn/cache/@aws-sdk-token-providers-npm-3.410.0-c4c6a0dd2e-5e117ada02.zip/node_modules/@aws-sdk/token-providers/",\
+      ["npm:3.575.0", {\
+        "packageLocation": "./.yarn/cache/@aws-sdk-token-providers-npm-3.575.0-8de776575d-ce6735c154.zip/node_modules/@aws-sdk/token-providers/",\
         "packageDependencies": [\
-          ["@aws-sdk/token-providers", "npm:3.410.0"],\
-          ["@aws-crypto/sha256-browser", "npm:3.0.0"],\
-          ["@aws-crypto/sha256-js", "npm:3.0.0"],\
-          ["@aws-sdk/middleware-host-header", "npm:3.410.0"],\
-          ["@aws-sdk/middleware-logger", "npm:3.410.0"],\
-          ["@aws-sdk/middleware-recursion-detection", "npm:3.410.0"],\
-          ["@aws-sdk/middleware-user-agent", "npm:3.410.0"],\
-          ["@aws-sdk/types", "npm:3.410.0"],\
-          ["@aws-sdk/util-endpoints", "npm:3.410.0"],\
-          ["@aws-sdk/util-user-agent-browser", "npm:3.410.0"],\
-          ["@aws-sdk/util-user-agent-node", "virtual:c7975f58467d1dba56c127268c561e37a9aeb3e8ff2db4488146ca26449caeb14e77c14d9661786bb33164386650d156f363ae901de2f0c228f8100fa963f5d2#npm:3.410.0"],\
-          ["@smithy/config-resolver", "npm:2.0.8"],\
-          ["@smithy/fetch-http-handler", "npm:2.1.3"],\
-          ["@smithy/hash-node", "npm:2.0.7"],\
-          ["@smithy/invalid-dependency", "npm:2.0.7"],\
-          ["@smithy/middleware-content-length", "npm:2.0.9"],\
-          ["@smithy/middleware-endpoint", "npm:2.0.7"],\
-          ["@smithy/middleware-retry", "npm:2.0.10"],\
-          ["@smithy/middleware-serde", "npm:2.0.7"],\
-          ["@smithy/middleware-stack", "npm:2.0.0"],\
-          ["@smithy/node-config-provider", "npm:2.0.10"],\
-          ["@smithy/node-http-handler", "npm:2.1.3"],\
-          ["@smithy/property-provider", "npm:2.0.8"],\
-          ["@smithy/protocol-http", "npm:3.0.3"],\
-          ["@smithy/shared-ini-file-loader", "npm:2.0.9"],\
-          ["@smithy/smithy-client", "npm:2.1.4"],\
-          ["@smithy/types", "npm:2.3.1"],\
-          ["@smithy/url-parser", "npm:2.0.7"],\
-          ["@smithy/util-base64", "npm:2.0.0"],\
-          ["@smithy/util-body-length-browser", "npm:2.0.0"],\
-          ["@smithy/util-body-length-node", "npm:2.1.0"],\
-          ["@smithy/util-defaults-mode-browser", "npm:2.0.8"],\
-          ["@smithy/util-defaults-mode-node", "npm:2.0.10"],\
-          ["@smithy/util-retry", "npm:2.0.0"],\
-          ["@smithy/util-utf8", "npm:2.0.0"],\
+          ["@aws-sdk/token-providers", "npm:3.575.0"]\
+        ],\
+        "linkType": "SOFT"\
+      }],\
+      ["virtual:11cd4c9d92793aad42f42cb55bb5aff1e0ca0f7c2f94aabc839146c98ddafc158af7fdf2bad3b0e96cde730847b0c7e91273d50d5870d5573bffa5b705938cd3#npm:3.575.0", {\
+        "packageLocation": "./.yarn/__virtual__/@aws-sdk-token-providers-virtual-711d2ef6eb/0/cache/@aws-sdk-token-providers-npm-3.575.0-8de776575d-ce6735c154.zip/node_modules/@aws-sdk/token-providers/",\
+        "packageDependencies": [\
+          ["@aws-sdk/token-providers", "virtual:11cd4c9d92793aad42f42cb55bb5aff1e0ca0f7c2f94aabc839146c98ddafc158af7fdf2bad3b0e96cde730847b0c7e91273d50d5870d5573bffa5b705938cd3#npm:3.575.0"],\
+          ["@aws-sdk/client-sso-oidc", null],\
+          ["@aws-sdk/types", "npm:3.575.0"],\
+          ["@smithy/property-provider", "npm:3.0.0"],\
+          ["@smithy/shared-ini-file-loader", "npm:3.0.0"],\
+          ["@smithy/types", "npm:3.0.0"],\
+          ["@types/aws-sdk__client-sso-oidc", null],\
           ["tslib", "npm:2.6.2"]\
         ],\
-        "linkType": "HARD"\
-      }],\
-      ["npm:3.418.0", {\
-        "packageLocation": "./.yarn/cache/@aws-sdk-token-providers-npm-3.418.0-129bf05af5-08a33eae8c.zip/node_modules/@aws-sdk/token-providers/",\
-        "packageDependencies": [\
-          ["@aws-sdk/token-providers", "npm:3.418.0"],\
-          ["@aws-crypto/sha256-browser", "npm:3.0.0"],\
-          ["@aws-crypto/sha256-js", "npm:3.0.0"],\
-          ["@aws-sdk/middleware-host-header", "npm:3.418.0"],\
-          ["@aws-sdk/middleware-logger", "npm:3.418.0"],\
-          ["@aws-sdk/middleware-recursion-detection", "npm:3.418.0"],\
-          ["@aws-sdk/middleware-user-agent", "npm:3.418.0"],\
-          ["@aws-sdk/types", "npm:3.418.0"],\
-          ["@aws-sdk/util-endpoints", "npm:3.418.0"],\
-          ["@aws-sdk/util-user-agent-browser", "npm:3.418.0"],\
-          ["@aws-sdk/util-user-agent-node", "virtual:237879ce01b3ff848a2895d7d2678bbddd9a88004cc756cf719f41780198bfd8d3b25aeafa3735ef24f38db5a5ea403a1197167bd689c00be82f590eabdb0d0a#npm:3.418.0"],\
-          ["@smithy/config-resolver", "npm:2.0.10"],\
-          ["@smithy/fetch-http-handler", "npm:2.1.5"],\
-          ["@smithy/hash-node", "npm:2.0.9"],\
-          ["@smithy/invalid-dependency", "npm:2.0.9"],\
-          ["@smithy/middleware-content-length", "npm:2.0.11"],\
-          ["@smithy/middleware-endpoint", "npm:2.0.9"],\
-          ["@smithy/middleware-retry", "npm:2.0.12"],\
-          ["@smithy/middleware-serde", "npm:2.0.9"],\
-          ["@smithy/middleware-stack", "npm:2.0.3"],\
-          ["@smithy/node-config-provider", "npm:2.0.12"],\
-          ["@smithy/node-http-handler", "npm:2.1.5"],\
-          ["@smithy/property-provider", "npm:2.0.8"],\
-          ["@smithy/protocol-http", "npm:3.0.5"],\
-          ["@smithy/shared-ini-file-loader", "npm:2.0.9"],\
-          ["@smithy/smithy-client", "npm:2.1.7"],\
-          ["@smithy/types", "npm:2.3.3"],\
-          ["@smithy/url-parser", "npm:2.0.9"],\
-          ["@smithy/util-base64", "npm:2.0.0"],\
-          ["@smithy/util-body-length-browser", "npm:2.0.0"],\
-          ["@smithy/util-body-length-node", "npm:2.1.0"],\
-          ["@smithy/util-defaults-mode-browser", "npm:2.0.11"],\
-          ["@smithy/util-defaults-mode-node", "npm:2.0.13"],\
-          ["@smithy/util-retry", "npm:2.0.2"],\
-          ["@smithy/util-utf8", "npm:2.0.0"],\
-          ["tslib", "npm:2.6.2"]\
+        "packagePeers": [\
+          "@aws-sdk/client-sso-oidc",\
+          "@types/aws-sdk__client-sso-oidc"\
         ],\
         "linkType": "HARD"\
       }]\
@@ -2498,11 +2170,11 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "HARD"\
       }],\
-      ["npm:3.418.0", {\
-        "packageLocation": "./.yarn/cache/@aws-sdk-types-npm-3.418.0-451c0cadd0-627955c2c9.zip/node_modules/@aws-sdk/types/",\
+      ["npm:3.575.0", {\
+        "packageLocation": "./.yarn/cache/@aws-sdk-types-npm-3.575.0-60215e07d5-e6243ad1eb.zip/node_modules/@aws-sdk/types/",\
         "packageDependencies": [\
-          ["@aws-sdk/types", "npm:3.418.0"],\
-          ["@smithy/types", "npm:2.3.3"],\
+          ["@aws-sdk/types", "npm:3.575.0"],\
+          ["@smithy/types", "npm:3.0.0"],\
           ["tslib", "npm:2.6.2"]\
         ],\
         "linkType": "HARD"\
@@ -2521,10 +2193,10 @@ const RAW_RUNTIME_STATE =
       }]\
     ]],\
     ["@aws-sdk/util-arn-parser", [\
-      ["npm:3.310.0", {\
-        "packageLocation": "./.yarn/cache/@aws-sdk-util-arn-parser-npm-3.310.0-06bb539cba-909d76befc.zip/node_modules/@aws-sdk/util-arn-parser/",\
+      ["npm:3.568.0", {\
+        "packageLocation": "./.yarn/cache/@aws-sdk-util-arn-parser-npm-3.568.0-8b1427ba0d-b1a7f93b4f.zip/node_modules/@aws-sdk/util-arn-parser/",\
         "packageDependencies": [\
-          ["@aws-sdk/util-arn-parser", "npm:3.310.0"],\
+          ["@aws-sdk/util-arn-parser", "npm:3.568.0"],\
           ["tslib", "npm:2.6.2"]\
         ],\
         "linkType": "HARD"\
@@ -2620,20 +2292,13 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "HARD"\
       }],\
-      ["npm:3.410.0", {\
-        "packageLocation": "./.yarn/cache/@aws-sdk-util-endpoints-npm-3.410.0-cd6cd70534-af8c47df01.zip/node_modules/@aws-sdk/util-endpoints/",\
+      ["npm:3.575.0", {\
+        "packageLocation": "./.yarn/cache/@aws-sdk-util-endpoints-npm-3.575.0-33e0a1e6c8-51e88aaede.zip/node_modules/@aws-sdk/util-endpoints/",\
         "packageDependencies": [\
-          ["@aws-sdk/util-endpoints", "npm:3.410.0"],\
-          ["@aws-sdk/types", "npm:3.410.0"],\
-          ["tslib", "npm:2.6.2"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["npm:3.418.0", {\
-        "packageLocation": "./.yarn/cache/@aws-sdk-util-endpoints-npm-3.418.0-6a42c90caf-8ed0c67b56.zip/node_modules/@aws-sdk/util-endpoints/",\
-        "packageDependencies": [\
-          ["@aws-sdk/util-endpoints", "npm:3.418.0"],\
-          ["@aws-sdk/types", "npm:3.418.0"],\
+          ["@aws-sdk/util-endpoints", "npm:3.575.0"],\
+          ["@aws-sdk/types", "npm:3.575.0"],\
+          ["@smithy/types", "npm:3.0.0"],\
+          ["@smithy/util-endpoints", "npm:2.0.0"],\
           ["tslib", "npm:2.6.2"]\
         ],\
         "linkType": "HARD"\
@@ -2690,23 +2355,12 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "HARD"\
       }],\
-      ["npm:3.410.0", {\
-        "packageLocation": "./.yarn/cache/@aws-sdk-util-user-agent-browser-npm-3.410.0-13845e066f-b427a90669.zip/node_modules/@aws-sdk/util-user-agent-browser/",\
+      ["npm:3.575.0", {\
+        "packageLocation": "./.yarn/cache/@aws-sdk-util-user-agent-browser-npm-3.575.0-59b0d2ba30-c0d8b3bce2.zip/node_modules/@aws-sdk/util-user-agent-browser/",\
         "packageDependencies": [\
-          ["@aws-sdk/util-user-agent-browser", "npm:3.410.0"],\
-          ["@aws-sdk/types", "npm:3.410.0"],\
-          ["@smithy/types", "npm:2.3.1"],\
-          ["bowser", "npm:2.11.0"],\
-          ["tslib", "npm:2.6.2"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["npm:3.418.0", {\
-        "packageLocation": "./.yarn/cache/@aws-sdk-util-user-agent-browser-npm-3.418.0-e61e5a5285-a2e53033a0.zip/node_modules/@aws-sdk/util-user-agent-browser/",\
-        "packageDependencies": [\
-          ["@aws-sdk/util-user-agent-browser", "npm:3.418.0"],\
-          ["@aws-sdk/types", "npm:3.418.0"],\
-          ["@smithy/types", "npm:2.3.3"],\
+          ["@aws-sdk/util-user-agent-browser", "npm:3.575.0"],\
+          ["@aws-sdk/types", "npm:3.575.0"],\
+          ["@smithy/types", "npm:3.0.0"],\
           ["bowser", "npm:2.11.0"],\
           ["tslib", "npm:2.6.2"]\
         ],\
@@ -2721,36 +2375,12 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "SOFT"\
       }],\
-      ["npm:3.410.0", {\
-        "packageLocation": "./.yarn/cache/@aws-sdk-util-user-agent-node-npm-3.410.0-08737fa71b-ea815d4150.zip/node_modules/@aws-sdk/util-user-agent-node/",\
+      ["npm:3.575.0", {\
+        "packageLocation": "./.yarn/cache/@aws-sdk-util-user-agent-node-npm-3.575.0-24312859c3-70123dde61.zip/node_modules/@aws-sdk/util-user-agent-node/",\
         "packageDependencies": [\
-          ["@aws-sdk/util-user-agent-node", "npm:3.410.0"]\
+          ["@aws-sdk/util-user-agent-node", "npm:3.575.0"]\
         ],\
         "linkType": "SOFT"\
-      }],\
-      ["npm:3.418.0", {\
-        "packageLocation": "./.yarn/cache/@aws-sdk-util-user-agent-node-npm-3.418.0-c2718455cb-c950f87158.zip/node_modules/@aws-sdk/util-user-agent-node/",\
-        "packageDependencies": [\
-          ["@aws-sdk/util-user-agent-node", "npm:3.418.0"]\
-        ],\
-        "linkType": "SOFT"\
-      }],\
-      ["virtual:237879ce01b3ff848a2895d7d2678bbddd9a88004cc756cf719f41780198bfd8d3b25aeafa3735ef24f38db5a5ea403a1197167bd689c00be82f590eabdb0d0a#npm:3.418.0", {\
-        "packageLocation": "./.yarn/__virtual__/@aws-sdk-util-user-agent-node-virtual-a711cab3f5/0/cache/@aws-sdk-util-user-agent-node-npm-3.418.0-c2718455cb-c950f87158.zip/node_modules/@aws-sdk/util-user-agent-node/",\
-        "packageDependencies": [\
-          ["@aws-sdk/util-user-agent-node", "virtual:237879ce01b3ff848a2895d7d2678bbddd9a88004cc756cf719f41780198bfd8d3b25aeafa3735ef24f38db5a5ea403a1197167bd689c00be82f590eabdb0d0a#npm:3.418.0"],\
-          ["@aws-sdk/types", "npm:3.418.0"],\
-          ["@smithy/node-config-provider", "npm:2.0.12"],\
-          ["@smithy/types", "npm:2.3.3"],\
-          ["@types/aws-crt", null],\
-          ["aws-crt", null],\
-          ["tslib", "npm:2.6.2"]\
-        ],\
-        "packagePeers": [\
-          "@types/aws-crt",\
-          "aws-crt"\
-        ],\
-        "linkType": "HARD"\
       }],\
       ["virtual:af9e1bd5541ae7aa74af08de1134a3e8d4aeee6e342b0f45460073e623366c4880557b447256189d51e11715a349cc214b98ee77a88c17d0a4861da92b8677f9#npm:3.212.0", {\
         "packageLocation": "./.yarn/__virtual__/@aws-sdk-util-user-agent-node-virtual-391f685893/0/cache/@aws-sdk-util-user-agent-node-npm-3.212.0-12e21ef1f3-f79257382c.zip/node_modules/@aws-sdk/util-user-agent-node/",\
@@ -2768,13 +2398,13 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "HARD"\
       }],\
-      ["virtual:c7975f58467d1dba56c127268c561e37a9aeb3e8ff2db4488146ca26449caeb14e77c14d9661786bb33164386650d156f363ae901de2f0c228f8100fa963f5d2#npm:3.410.0", {\
-        "packageLocation": "./.yarn/__virtual__/@aws-sdk-util-user-agent-node-virtual-1bba63b851/0/cache/@aws-sdk-util-user-agent-node-npm-3.410.0-08737fa71b-ea815d4150.zip/node_modules/@aws-sdk/util-user-agent-node/",\
+      ["virtual:e040dbdfd8c517cb5d8a409346f35e678a3acb76496a0d9281895be98ff787119fbf283008021c4dcf1b6d48be6af86b553dee0f028567f0a199ea55e4659b36#npm:3.575.0", {\
+        "packageLocation": "./.yarn/__virtual__/@aws-sdk-util-user-agent-node-virtual-01421ce032/0/cache/@aws-sdk-util-user-agent-node-npm-3.575.0-24312859c3-70123dde61.zip/node_modules/@aws-sdk/util-user-agent-node/",\
         "packageDependencies": [\
-          ["@aws-sdk/util-user-agent-node", "virtual:c7975f58467d1dba56c127268c561e37a9aeb3e8ff2db4488146ca26449caeb14e77c14d9661786bb33164386650d156f363ae901de2f0c228f8100fa963f5d2#npm:3.410.0"],\
-          ["@aws-sdk/types", "npm:3.410.0"],\
-          ["@smithy/node-config-provider", "npm:2.0.10"],\
-          ["@smithy/types", "npm:2.3.1"],\
+          ["@aws-sdk/util-user-agent-node", "virtual:e040dbdfd8c517cb5d8a409346f35e678a3acb76496a0d9281895be98ff787119fbf283008021c4dcf1b6d48be6af86b553dee0f028567f0a199ea55e4659b36#npm:3.575.0"],\
+          ["@aws-sdk/types", "npm:3.575.0"],\
+          ["@smithy/node-config-provider", "npm:3.0.0"],\
+          ["@smithy/types", "npm:3.0.0"],\
           ["@types/aws-crt", null],\
           ["aws-crt", null],\
           ["tslib", "npm:2.6.2"]\
@@ -2816,10 +2446,11 @@ const RAW_RUNTIME_STATE =
       }]\
     ]],\
     ["@aws-sdk/xml-builder", [\
-      ["npm:3.310.0", {\
-        "packageLocation": "./.yarn/cache/@aws-sdk-xml-builder-npm-3.310.0-5c3886db44-d6bcb30b5f.zip/node_modules/@aws-sdk/xml-builder/",\
+      ["npm:3.575.0", {\
+        "packageLocation": "./.yarn/cache/@aws-sdk-xml-builder-npm-3.575.0-910965cf59-b1ca3cca6d.zip/node_modules/@aws-sdk/xml-builder/",\
         "packageDependencies": [\
-          ["@aws-sdk/xml-builder", "npm:3.310.0"],\
+          ["@aws-sdk/xml-builder", "npm:3.575.0"],\
+          ["@smithy/types", "npm:3.0.0"],\
           ["tslib", "npm:2.6.2"]\
         ],\
         "linkType": "HARD"\
@@ -3156,10 +2787,10 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "SOFT"\
       }],\
-      ["virtual:9d095a45298058459f9fa9d0c1ccea3cb78701b24087dcd86f0b11cb6da35a2de4281a3205aa11ec0331d10c69737c7e98913433c4c7b3241117f41bb679b7a6#npm:7.8.4", {\
-        "packageLocation": "./.yarn/__virtual__/@babel-plugin-syntax-async-generators-virtual-6ab82493fa/0/cache/@babel-plugin-syntax-async-generators-npm-7.8.4-d10cf993c9-7ed1c1d9b9.zip/node_modules/@babel/plugin-syntax-async-generators/",\
+      ["virtual:7c45d5bdb104824b7cfbce10fe870bbdeabef939883ee590ea09caf588d04fc3541654d1ca2ff56edd281f48bc3e260b381a56a263284f9107b23f63b38369c4#npm:7.8.4", {\
+        "packageLocation": "./.yarn/__virtual__/@babel-plugin-syntax-async-generators-virtual-88fe289dd9/0/cache/@babel-plugin-syntax-async-generators-npm-7.8.4-d10cf993c9-7ed1c1d9b9.zip/node_modules/@babel/plugin-syntax-async-generators/",\
         "packageDependencies": [\
-          ["@babel/plugin-syntax-async-generators", "virtual:9d095a45298058459f9fa9d0c1ccea3cb78701b24087dcd86f0b11cb6da35a2de4281a3205aa11ec0331d10c69737c7e98913433c4c7b3241117f41bb679b7a6#npm:7.8.4"],\
+          ["@babel/plugin-syntax-async-generators", "virtual:7c45d5bdb104824b7cfbce10fe870bbdeabef939883ee590ea09caf588d04fc3541654d1ca2ff56edd281f48bc3e260b381a56a263284f9107b23f63b38369c4#npm:7.8.4"],\
           ["@babel/core", "npm:7.22.17"],\
           ["@babel/helper-plugin-utils", "npm:7.22.5"],\
           ["@types/babel__core", "npm:7.20.1"]\
@@ -3193,10 +2824,10 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "SOFT"\
       }],\
-      ["virtual:9d095a45298058459f9fa9d0c1ccea3cb78701b24087dcd86f0b11cb6da35a2de4281a3205aa11ec0331d10c69737c7e98913433c4c7b3241117f41bb679b7a6#npm:7.8.3", {\
-        "packageLocation": "./.yarn/__virtual__/@babel-plugin-syntax-bigint-virtual-587204fa04/0/cache/@babel-plugin-syntax-bigint-npm-7.8.3-b05d971e6c-3a10849d83.zip/node_modules/@babel/plugin-syntax-bigint/",\
+      ["virtual:7c45d5bdb104824b7cfbce10fe870bbdeabef939883ee590ea09caf588d04fc3541654d1ca2ff56edd281f48bc3e260b381a56a263284f9107b23f63b38369c4#npm:7.8.3", {\
+        "packageLocation": "./.yarn/__virtual__/@babel-plugin-syntax-bigint-virtual-49af33812b/0/cache/@babel-plugin-syntax-bigint-npm-7.8.3-b05d971e6c-3a10849d83.zip/node_modules/@babel/plugin-syntax-bigint/",\
         "packageDependencies": [\
-          ["@babel/plugin-syntax-bigint", "virtual:9d095a45298058459f9fa9d0c1ccea3cb78701b24087dcd86f0b11cb6da35a2de4281a3205aa11ec0331d10c69737c7e98913433c4c7b3241117f41bb679b7a6#npm:7.8.3"],\
+          ["@babel/plugin-syntax-bigint", "virtual:7c45d5bdb104824b7cfbce10fe870bbdeabef939883ee590ea09caf588d04fc3541654d1ca2ff56edd281f48bc3e260b381a56a263284f9107b23f63b38369c4#npm:7.8.3"],\
           ["@babel/core", "npm:7.22.17"],\
           ["@babel/helper-plugin-utils", "npm:7.22.5"],\
           ["@types/babel__core", "npm:7.20.1"]\
@@ -3230,10 +2861,10 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "SOFT"\
       }],\
-      ["virtual:9d095a45298058459f9fa9d0c1ccea3cb78701b24087dcd86f0b11cb6da35a2de4281a3205aa11ec0331d10c69737c7e98913433c4c7b3241117f41bb679b7a6#npm:7.12.13", {\
-        "packageLocation": "./.yarn/__virtual__/@babel-plugin-syntax-class-properties-virtual-68c0f1c4ee/0/cache/@babel-plugin-syntax-class-properties-npm-7.12.13-002ee9d930-24f34b196d.zip/node_modules/@babel/plugin-syntax-class-properties/",\
+      ["virtual:7c45d5bdb104824b7cfbce10fe870bbdeabef939883ee590ea09caf588d04fc3541654d1ca2ff56edd281f48bc3e260b381a56a263284f9107b23f63b38369c4#npm:7.12.13", {\
+        "packageLocation": "./.yarn/__virtual__/@babel-plugin-syntax-class-properties-virtual-acbb64f666/0/cache/@babel-plugin-syntax-class-properties-npm-7.12.13-002ee9d930-24f34b196d.zip/node_modules/@babel/plugin-syntax-class-properties/",\
         "packageDependencies": [\
-          ["@babel/plugin-syntax-class-properties", "virtual:9d095a45298058459f9fa9d0c1ccea3cb78701b24087dcd86f0b11cb6da35a2de4281a3205aa11ec0331d10c69737c7e98913433c4c7b3241117f41bb679b7a6#npm:7.12.13"],\
+          ["@babel/plugin-syntax-class-properties", "virtual:7c45d5bdb104824b7cfbce10fe870bbdeabef939883ee590ea09caf588d04fc3541654d1ca2ff56edd281f48bc3e260b381a56a263284f9107b23f63b38369c4#npm:7.12.13"],\
           ["@babel/core", "npm:7.22.17"],\
           ["@babel/helper-plugin-utils", "npm:7.22.5"],\
           ["@types/babel__core", "npm:7.20.1"]\
@@ -3267,10 +2898,10 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "SOFT"\
       }],\
-      ["virtual:9d095a45298058459f9fa9d0c1ccea3cb78701b24087dcd86f0b11cb6da35a2de4281a3205aa11ec0331d10c69737c7e98913433c4c7b3241117f41bb679b7a6#npm:7.10.4", {\
-        "packageLocation": "./.yarn/__virtual__/@babel-plugin-syntax-import-meta-virtual-b1a2a5324b/0/cache/@babel-plugin-syntax-import-meta-npm-7.10.4-4a0a0158bc-166ac1125d.zip/node_modules/@babel/plugin-syntax-import-meta/",\
+      ["virtual:7c45d5bdb104824b7cfbce10fe870bbdeabef939883ee590ea09caf588d04fc3541654d1ca2ff56edd281f48bc3e260b381a56a263284f9107b23f63b38369c4#npm:7.10.4", {\
+        "packageLocation": "./.yarn/__virtual__/@babel-plugin-syntax-import-meta-virtual-cf247e2b01/0/cache/@babel-plugin-syntax-import-meta-npm-7.10.4-4a0a0158bc-166ac1125d.zip/node_modules/@babel/plugin-syntax-import-meta/",\
         "packageDependencies": [\
-          ["@babel/plugin-syntax-import-meta", "virtual:9d095a45298058459f9fa9d0c1ccea3cb78701b24087dcd86f0b11cb6da35a2de4281a3205aa11ec0331d10c69737c7e98913433c4c7b3241117f41bb679b7a6#npm:7.10.4"],\
+          ["@babel/plugin-syntax-import-meta", "virtual:7c45d5bdb104824b7cfbce10fe870bbdeabef939883ee590ea09caf588d04fc3541654d1ca2ff56edd281f48bc3e260b381a56a263284f9107b23f63b38369c4#npm:7.10.4"],\
           ["@babel/core", "npm:7.22.17"],\
           ["@babel/helper-plugin-utils", "npm:7.22.5"],\
           ["@types/babel__core", "npm:7.20.1"]\
@@ -3304,10 +2935,10 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "SOFT"\
       }],\
-      ["virtual:9d095a45298058459f9fa9d0c1ccea3cb78701b24087dcd86f0b11cb6da35a2de4281a3205aa11ec0331d10c69737c7e98913433c4c7b3241117f41bb679b7a6#npm:7.8.3", {\
-        "packageLocation": "./.yarn/__virtual__/@babel-plugin-syntax-json-strings-virtual-90041c6eae/0/cache/@babel-plugin-syntax-json-strings-npm-7.8.3-6dc7848179-bf5aea1f31.zip/node_modules/@babel/plugin-syntax-json-strings/",\
+      ["virtual:7c45d5bdb104824b7cfbce10fe870bbdeabef939883ee590ea09caf588d04fc3541654d1ca2ff56edd281f48bc3e260b381a56a263284f9107b23f63b38369c4#npm:7.8.3", {\
+        "packageLocation": "./.yarn/__virtual__/@babel-plugin-syntax-json-strings-virtual-3b19f023b5/0/cache/@babel-plugin-syntax-json-strings-npm-7.8.3-6dc7848179-bf5aea1f31.zip/node_modules/@babel/plugin-syntax-json-strings/",\
         "packageDependencies": [\
-          ["@babel/plugin-syntax-json-strings", "virtual:9d095a45298058459f9fa9d0c1ccea3cb78701b24087dcd86f0b11cb6da35a2de4281a3205aa11ec0331d10c69737c7e98913433c4c7b3241117f41bb679b7a6#npm:7.8.3"],\
+          ["@babel/plugin-syntax-json-strings", "virtual:7c45d5bdb104824b7cfbce10fe870bbdeabef939883ee590ea09caf588d04fc3541654d1ca2ff56edd281f48bc3e260b381a56a263284f9107b23f63b38369c4#npm:7.8.3"],\
           ["@babel/core", "npm:7.22.17"],\
           ["@babel/helper-plugin-utils", "npm:7.22.5"],\
           ["@types/babel__core", "npm:7.20.1"]\
@@ -3364,10 +2995,10 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "SOFT"\
       }],\
-      ["virtual:9d095a45298058459f9fa9d0c1ccea3cb78701b24087dcd86f0b11cb6da35a2de4281a3205aa11ec0331d10c69737c7e98913433c4c7b3241117f41bb679b7a6#npm:7.10.4", {\
-        "packageLocation": "./.yarn/__virtual__/@babel-plugin-syntax-logical-assignment-operators-virtual-493025a17a/0/cache/@babel-plugin-syntax-logical-assignment-operators-npm-7.10.4-72ae00fdf6-aff3357703.zip/node_modules/@babel/plugin-syntax-logical-assignment-operators/",\
+      ["virtual:7c45d5bdb104824b7cfbce10fe870bbdeabef939883ee590ea09caf588d04fc3541654d1ca2ff56edd281f48bc3e260b381a56a263284f9107b23f63b38369c4#npm:7.10.4", {\
+        "packageLocation": "./.yarn/__virtual__/@babel-plugin-syntax-logical-assignment-operators-virtual-025688a119/0/cache/@babel-plugin-syntax-logical-assignment-operators-npm-7.10.4-72ae00fdf6-aff3357703.zip/node_modules/@babel/plugin-syntax-logical-assignment-operators/",\
         "packageDependencies": [\
-          ["@babel/plugin-syntax-logical-assignment-operators", "virtual:9d095a45298058459f9fa9d0c1ccea3cb78701b24087dcd86f0b11cb6da35a2de4281a3205aa11ec0331d10c69737c7e98913433c4c7b3241117f41bb679b7a6#npm:7.10.4"],\
+          ["@babel/plugin-syntax-logical-assignment-operators", "virtual:7c45d5bdb104824b7cfbce10fe870bbdeabef939883ee590ea09caf588d04fc3541654d1ca2ff56edd281f48bc3e260b381a56a263284f9107b23f63b38369c4#npm:7.10.4"],\
           ["@babel/core", "npm:7.22.17"],\
           ["@babel/helper-plugin-utils", "npm:7.22.5"],\
           ["@types/babel__core", "npm:7.20.1"]\
@@ -3401,10 +3032,10 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "SOFT"\
       }],\
-      ["virtual:9d095a45298058459f9fa9d0c1ccea3cb78701b24087dcd86f0b11cb6da35a2de4281a3205aa11ec0331d10c69737c7e98913433c4c7b3241117f41bb679b7a6#npm:7.8.3", {\
-        "packageLocation": "./.yarn/__virtual__/@babel-plugin-syntax-nullish-coalescing-operator-virtual-5b9cb4baf8/0/cache/@babel-plugin-syntax-nullish-coalescing-operator-npm-7.8.3-8a723173b5-87aca49189.zip/node_modules/@babel/plugin-syntax-nullish-coalescing-operator/",\
+      ["virtual:7c45d5bdb104824b7cfbce10fe870bbdeabef939883ee590ea09caf588d04fc3541654d1ca2ff56edd281f48bc3e260b381a56a263284f9107b23f63b38369c4#npm:7.8.3", {\
+        "packageLocation": "./.yarn/__virtual__/@babel-plugin-syntax-nullish-coalescing-operator-virtual-4b85c8fa9a/0/cache/@babel-plugin-syntax-nullish-coalescing-operator-npm-7.8.3-8a723173b5-87aca49189.zip/node_modules/@babel/plugin-syntax-nullish-coalescing-operator/",\
         "packageDependencies": [\
-          ["@babel/plugin-syntax-nullish-coalescing-operator", "virtual:9d095a45298058459f9fa9d0c1ccea3cb78701b24087dcd86f0b11cb6da35a2de4281a3205aa11ec0331d10c69737c7e98913433c4c7b3241117f41bb679b7a6#npm:7.8.3"],\
+          ["@babel/plugin-syntax-nullish-coalescing-operator", "virtual:7c45d5bdb104824b7cfbce10fe870bbdeabef939883ee590ea09caf588d04fc3541654d1ca2ff56edd281f48bc3e260b381a56a263284f9107b23f63b38369c4#npm:7.8.3"],\
           ["@babel/core", "npm:7.22.17"],\
           ["@babel/helper-plugin-utils", "npm:7.22.5"],\
           ["@types/babel__core", "npm:7.20.1"]\
@@ -3438,10 +3069,10 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "SOFT"\
       }],\
-      ["virtual:9d095a45298058459f9fa9d0c1ccea3cb78701b24087dcd86f0b11cb6da35a2de4281a3205aa11ec0331d10c69737c7e98913433c4c7b3241117f41bb679b7a6#npm:7.10.4", {\
-        "packageLocation": "./.yarn/__virtual__/@babel-plugin-syntax-numeric-separator-virtual-72822b2211/0/cache/@babel-plugin-syntax-numeric-separator-npm-7.10.4-81444be605-01ec5547bd.zip/node_modules/@babel/plugin-syntax-numeric-separator/",\
+      ["virtual:7c45d5bdb104824b7cfbce10fe870bbdeabef939883ee590ea09caf588d04fc3541654d1ca2ff56edd281f48bc3e260b381a56a263284f9107b23f63b38369c4#npm:7.10.4", {\
+        "packageLocation": "./.yarn/__virtual__/@babel-plugin-syntax-numeric-separator-virtual-95013f3c1d/0/cache/@babel-plugin-syntax-numeric-separator-npm-7.10.4-81444be605-01ec5547bd.zip/node_modules/@babel/plugin-syntax-numeric-separator/",\
         "packageDependencies": [\
-          ["@babel/plugin-syntax-numeric-separator", "virtual:9d095a45298058459f9fa9d0c1ccea3cb78701b24087dcd86f0b11cb6da35a2de4281a3205aa11ec0331d10c69737c7e98913433c4c7b3241117f41bb679b7a6#npm:7.10.4"],\
+          ["@babel/plugin-syntax-numeric-separator", "virtual:7c45d5bdb104824b7cfbce10fe870bbdeabef939883ee590ea09caf588d04fc3541654d1ca2ff56edd281f48bc3e260b381a56a263284f9107b23f63b38369c4#npm:7.10.4"],\
           ["@babel/core", "npm:7.22.17"],\
           ["@babel/helper-plugin-utils", "npm:7.22.5"],\
           ["@types/babel__core", "npm:7.20.1"]\
@@ -3475,10 +3106,10 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "SOFT"\
       }],\
-      ["virtual:9d095a45298058459f9fa9d0c1ccea3cb78701b24087dcd86f0b11cb6da35a2de4281a3205aa11ec0331d10c69737c7e98913433c4c7b3241117f41bb679b7a6#npm:7.8.3", {\
-        "packageLocation": "./.yarn/__virtual__/@babel-plugin-syntax-object-rest-spread-virtual-663da5956a/0/cache/@babel-plugin-syntax-object-rest-spread-npm-7.8.3-60bd05b6ae-fddcf581a5.zip/node_modules/@babel/plugin-syntax-object-rest-spread/",\
+      ["virtual:7c45d5bdb104824b7cfbce10fe870bbdeabef939883ee590ea09caf588d04fc3541654d1ca2ff56edd281f48bc3e260b381a56a263284f9107b23f63b38369c4#npm:7.8.3", {\
+        "packageLocation": "./.yarn/__virtual__/@babel-plugin-syntax-object-rest-spread-virtual-a1ec28cd9a/0/cache/@babel-plugin-syntax-object-rest-spread-npm-7.8.3-60bd05b6ae-fddcf581a5.zip/node_modules/@babel/plugin-syntax-object-rest-spread/",\
         "packageDependencies": [\
-          ["@babel/plugin-syntax-object-rest-spread", "virtual:9d095a45298058459f9fa9d0c1ccea3cb78701b24087dcd86f0b11cb6da35a2de4281a3205aa11ec0331d10c69737c7e98913433c4c7b3241117f41bb679b7a6#npm:7.8.3"],\
+          ["@babel/plugin-syntax-object-rest-spread", "virtual:7c45d5bdb104824b7cfbce10fe870bbdeabef939883ee590ea09caf588d04fc3541654d1ca2ff56edd281f48bc3e260b381a56a263284f9107b23f63b38369c4#npm:7.8.3"],\
           ["@babel/core", "npm:7.22.17"],\
           ["@babel/helper-plugin-utils", "npm:7.22.5"],\
           ["@types/babel__core", "npm:7.20.1"]\
@@ -3512,10 +3143,10 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "SOFT"\
       }],\
-      ["virtual:9d095a45298058459f9fa9d0c1ccea3cb78701b24087dcd86f0b11cb6da35a2de4281a3205aa11ec0331d10c69737c7e98913433c4c7b3241117f41bb679b7a6#npm:7.8.3", {\
-        "packageLocation": "./.yarn/__virtual__/@babel-plugin-syntax-optional-catch-binding-virtual-f91e09dd8b/0/cache/@babel-plugin-syntax-optional-catch-binding-npm-7.8.3-ce337427d8-910d90e72b.zip/node_modules/@babel/plugin-syntax-optional-catch-binding/",\
+      ["virtual:7c45d5bdb104824b7cfbce10fe870bbdeabef939883ee590ea09caf588d04fc3541654d1ca2ff56edd281f48bc3e260b381a56a263284f9107b23f63b38369c4#npm:7.8.3", {\
+        "packageLocation": "./.yarn/__virtual__/@babel-plugin-syntax-optional-catch-binding-virtual-3ea1faa40a/0/cache/@babel-plugin-syntax-optional-catch-binding-npm-7.8.3-ce337427d8-910d90e72b.zip/node_modules/@babel/plugin-syntax-optional-catch-binding/",\
         "packageDependencies": [\
-          ["@babel/plugin-syntax-optional-catch-binding", "virtual:9d095a45298058459f9fa9d0c1ccea3cb78701b24087dcd86f0b11cb6da35a2de4281a3205aa11ec0331d10c69737c7e98913433c4c7b3241117f41bb679b7a6#npm:7.8.3"],\
+          ["@babel/plugin-syntax-optional-catch-binding", "virtual:7c45d5bdb104824b7cfbce10fe870bbdeabef939883ee590ea09caf588d04fc3541654d1ca2ff56edd281f48bc3e260b381a56a263284f9107b23f63b38369c4#npm:7.8.3"],\
           ["@babel/core", "npm:7.22.17"],\
           ["@babel/helper-plugin-utils", "npm:7.22.5"],\
           ["@types/babel__core", "npm:7.20.1"]\
@@ -3549,10 +3180,10 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "SOFT"\
       }],\
-      ["virtual:9d095a45298058459f9fa9d0c1ccea3cb78701b24087dcd86f0b11cb6da35a2de4281a3205aa11ec0331d10c69737c7e98913433c4c7b3241117f41bb679b7a6#npm:7.8.3", {\
-        "packageLocation": "./.yarn/__virtual__/@babel-plugin-syntax-optional-chaining-virtual-ba04e729f9/0/cache/@babel-plugin-syntax-optional-chaining-npm-7.8.3-f3f3c79579-eef94d53a1.zip/node_modules/@babel/plugin-syntax-optional-chaining/",\
+      ["virtual:7c45d5bdb104824b7cfbce10fe870bbdeabef939883ee590ea09caf588d04fc3541654d1ca2ff56edd281f48bc3e260b381a56a263284f9107b23f63b38369c4#npm:7.8.3", {\
+        "packageLocation": "./.yarn/__virtual__/@babel-plugin-syntax-optional-chaining-virtual-f78ff5e496/0/cache/@babel-plugin-syntax-optional-chaining-npm-7.8.3-f3f3c79579-eef94d53a1.zip/node_modules/@babel/plugin-syntax-optional-chaining/",\
         "packageDependencies": [\
-          ["@babel/plugin-syntax-optional-chaining", "virtual:9d095a45298058459f9fa9d0c1ccea3cb78701b24087dcd86f0b11cb6da35a2de4281a3205aa11ec0331d10c69737c7e98913433c4c7b3241117f41bb679b7a6#npm:7.8.3"],\
+          ["@babel/plugin-syntax-optional-chaining", "virtual:7c45d5bdb104824b7cfbce10fe870bbdeabef939883ee590ea09caf588d04fc3541654d1ca2ff56edd281f48bc3e260b381a56a263284f9107b23f63b38369c4#npm:7.8.3"],\
           ["@babel/core", "npm:7.22.17"],\
           ["@babel/helper-plugin-utils", "npm:7.22.5"],\
           ["@types/babel__core", "npm:7.20.1"]\
@@ -3586,10 +3217,10 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "SOFT"\
       }],\
-      ["virtual:9d095a45298058459f9fa9d0c1ccea3cb78701b24087dcd86f0b11cb6da35a2de4281a3205aa11ec0331d10c69737c7e98913433c4c7b3241117f41bb679b7a6#npm:7.14.5", {\
-        "packageLocation": "./.yarn/__virtual__/@babel-plugin-syntax-top-level-await-virtual-200f2607bd/0/cache/@babel-plugin-syntax-top-level-await-npm-7.14.5-60a0a2e83b-bbd1a56b09.zip/node_modules/@babel/plugin-syntax-top-level-await/",\
+      ["virtual:7c45d5bdb104824b7cfbce10fe870bbdeabef939883ee590ea09caf588d04fc3541654d1ca2ff56edd281f48bc3e260b381a56a263284f9107b23f63b38369c4#npm:7.14.5", {\
+        "packageLocation": "./.yarn/__virtual__/@babel-plugin-syntax-top-level-await-virtual-af07b5c56e/0/cache/@babel-plugin-syntax-top-level-await-npm-7.14.5-60a0a2e83b-bbd1a56b09.zip/node_modules/@babel/plugin-syntax-top-level-await/",\
         "packageDependencies": [\
-          ["@babel/plugin-syntax-top-level-await", "virtual:9d095a45298058459f9fa9d0c1ccea3cb78701b24087dcd86f0b11cb6da35a2de4281a3205aa11ec0331d10c69737c7e98913433c4c7b3241117f41bb679b7a6#npm:7.14.5"],\
+          ["@babel/plugin-syntax-top-level-await", "virtual:7c45d5bdb104824b7cfbce10fe870bbdeabef939883ee590ea09caf588d04fc3541654d1ca2ff56edd281f48bc3e260b381a56a263284f9107b23f63b38369c4#npm:7.14.5"],\
           ["@babel/core", "npm:7.22.17"],\
           ["@babel/helper-plugin-utils", "npm:7.22.5"],\
           ["@types/babel__core", "npm:7.20.1"]\
@@ -3644,14 +3275,6 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["@babel/runtime", "npm:7.15.4"],\
           ["regenerator-runtime", "npm:0.13.9"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["npm:7.22.15", {\
-        "packageLocation": "./.yarn/cache/@babel-runtime-npm-7.22.15-b21c55a700-9670da63b7.zip/node_modules/@babel/runtime/",\
-        "packageDependencies": [\
-          ["@babel/runtime", "npm:7.22.15"],\
-          ["regenerator-runtime", "npm:0.14.0"]\
         ],\
         "linkType": "HARD"\
       }],\
@@ -4810,12 +4433,12 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "SOFT"\
       }],\
-      ["virtual:e0c6ca93c4a55e387c5762a3376217419ca60912cbd1a0d547f351af8accbd101f8edd79ca9ffefa3f0b94c5b15ee6d0e818f1656b624955c40f5662048f8410#npm:29.7.0", {\
-        "packageLocation": "./.yarn/__virtual__/@jest-core-virtual-d15ebbabf5/0/cache/@jest-core-npm-29.7.0-cef60d74c4-ab6ac2e562.zip/node_modules/@jest/core/",\
+      ["virtual:49316054cd7bff615bf5d3f57290200a437c8a6f01070e97f8df569a6ca1b182a1b140b761e01eb7a7e23e10fd80cea9b102526787e63400a46092ca863b52d0#npm:29.7.0", {\
+        "packageLocation": "./.yarn/__virtual__/@jest-core-virtual-93536b146e/0/cache/@jest-core-npm-29.7.0-cef60d74c4-ab6ac2e562.zip/node_modules/@jest/core/",\
         "packageDependencies": [\
-          ["@jest/core", "virtual:e0c6ca93c4a55e387c5762a3376217419ca60912cbd1a0d547f351af8accbd101f8edd79ca9ffefa3f0b94c5b15ee6d0e818f1656b624955c40f5662048f8410#npm:29.7.0"],\
+          ["@jest/core", "virtual:49316054cd7bff615bf5d3f57290200a437c8a6f01070e97f8df569a6ca1b182a1b140b761e01eb7a7e23e10fd80cea9b102526787e63400a46092ca863b52d0#npm:29.7.0"],\
           ["@jest/console", "npm:29.7.0"],\
-          ["@jest/reporters", "virtual:d15ebbabf58e5006c1e7680a90d8b036c141da05ed45cc36ee0b4221f535b2227396ef34e75485afc0706e56cfa780e7ac0a95784ddeafec362dfb667ea9ccfe#npm:29.7.0"],\
+          ["@jest/reporters", "virtual:93536b146e1c0ae2a89d84dd126c3cd76033ce104d6db478c7788bfcfffdc52e5f9d7d3bcf3ab2a892dd3cb435c9c6dc48870a3809bf9dd8ddbcddd064bc5424#npm:29.7.0"],\
           ["@jest/test-result", "npm:29.7.0"],\
           ["@jest/transform", "npm:29.7.0"],\
           ["@jest/types", "npm:29.6.3"],\
@@ -4827,7 +4450,7 @@ const RAW_RUNTIME_STATE =
           ["exit", "npm:0.1.2"],\
           ["graceful-fs", "npm:4.2.10"],\
           ["jest-changed-files", "npm:29.7.0"],\
-          ["jest-config", "virtual:d15ebbabf58e5006c1e7680a90d8b036c141da05ed45cc36ee0b4221f535b2227396ef34e75485afc0706e56cfa780e7ac0a95784ddeafec362dfb667ea9ccfe#npm:29.7.0"],\
+          ["jest-config", "virtual:93536b146e1c0ae2a89d84dd126c3cd76033ce104d6db478c7788bfcfffdc52e5f9d7d3bcf3ab2a892dd3cb435c9c6dc48870a3809bf9dd8ddbcddd064bc5424#npm:29.7.0"],\
           ["jest-haste-map", "npm:29.7.0"],\
           ["jest-message-util", "npm:29.7.0"],\
           ["jest-regex-util", "npm:29.6.3"],\
@@ -4930,10 +4553,10 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "SOFT"\
       }],\
-      ["virtual:d15ebbabf58e5006c1e7680a90d8b036c141da05ed45cc36ee0b4221f535b2227396ef34e75485afc0706e56cfa780e7ac0a95784ddeafec362dfb667ea9ccfe#npm:29.7.0", {\
-        "packageLocation": "./.yarn/__virtual__/@jest-reporters-virtual-9c99c5458b/0/cache/@jest-reporters-npm-29.7.0-2561cd7a09-a17d1644b2.zip/node_modules/@jest/reporters/",\
+      ["virtual:93536b146e1c0ae2a89d84dd126c3cd76033ce104d6db478c7788bfcfffdc52e5f9d7d3bcf3ab2a892dd3cb435c9c6dc48870a3809bf9dd8ddbcddd064bc5424#npm:29.7.0", {\
+        "packageLocation": "./.yarn/__virtual__/@jest-reporters-virtual-fc83ab05d9/0/cache/@jest-reporters-npm-29.7.0-2561cd7a09-a17d1644b2.zip/node_modules/@jest/reporters/",\
         "packageDependencies": [\
-          ["@jest/reporters", "virtual:d15ebbabf58e5006c1e7680a90d8b036c141da05ed45cc36ee0b4221f535b2227396ef34e75485afc0706e56cfa780e7ac0a95784ddeafec362dfb667ea9ccfe#npm:29.7.0"],\
+          ["@jest/reporters", "virtual:93536b146e1c0ae2a89d84dd126c3cd76033ce104d6db478c7788bfcfffdc52e5f9d7d3bcf3ab2a892dd3cb435c9c6dc48870a3809bf9dd8ddbcddd064bc5424#npm:29.7.0"],\
           ["@bcoe/v8-coverage", "npm:0.2.3"],\
           ["@jest/console", "npm:29.7.0"],\
           ["@jest/test-result", "npm:29.7.0"],\
@@ -5263,16 +4886,6 @@ const RAW_RUNTIME_STATE =
           ["strong-log-transformer", "npm:2.1.0"]\
         ],\
         "linkType": "HARD"\
-      }],\
-      ["npm:7.3.0", {\
-        "packageLocation": "./.yarn/cache/@lerna-child-process-npm-7.3.0-8f83fafbc8-f0c4782bb2.zip/node_modules/@lerna/child-process/",\
-        "packageDependencies": [\
-          ["@lerna/child-process", "npm:7.3.0"],\
-          ["chalk", "npm:4.1.2"],\
-          ["execa", "npm:5.1.1"],\
-          ["strong-log-transformer", "npm:2.1.0"]\
-        ],\
-        "linkType": "HARD"\
       }]\
     ]],\
     ["@lerna/clean", [\
@@ -5397,13 +5010,12 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "HARD"\
       }],\
-      ["npm:7.3.0", {\
-        "packageLocation": "./.yarn/cache/@lerna-create-npm-7.3.0-27294a026b-db6f3b6b7a.zip/node_modules/@lerna/create/",\
+      ["npm:8.1.3", {\
+        "packageLocation": "./.yarn/cache/@lerna-create-npm-8.1.3-231b41c796-52cc1ce736.zip/node_modules/@lerna/create/",\
         "packageDependencies": [\
-          ["@lerna/create", "npm:7.3.0"],\
-          ["@lerna/child-process", "npm:7.3.0"],\
-          ["@npmcli/run-script", "npm:6.0.2"],\
-          ["@nx/devkit", "virtual:27294a026b403a125127a01c506649a66f963443d98b165f595b35d84f3a7f3acf7257fab805d9a5c66db9a766498808df6100c11de52d69e5f1edabcba2aa61#npm:16.8.1"],\
+          ["@lerna/create", "npm:8.1.3"],\
+          ["@npmcli/run-script", "npm:7.0.2"],\
+          ["@nx/devkit", "virtual:231b41c796fb4c3a1878ccc2b284d7acc71e342654f1dcf3bec9e756c379469380938482d22d651d850cf92850f594f3b751114f8c7660ab24c8aee2d7081537#npm:19.0.3"],\
           ["@octokit/plugin-enterprise-rest", "npm:6.0.1"],\
           ["@octokit/rest", "npm:19.0.11"],\
           ["byte-size", "npm:8.1.1"],\
@@ -5413,7 +5025,7 @@ const RAW_RUNTIME_STATE =
           ["columnify", "npm:1.6.0"],\
           ["conventional-changelog-core", "npm:5.0.1"],\
           ["conventional-recommended-bump", "npm:7.0.1"],\
-          ["cosmiconfig", "virtual:27294a026b403a125127a01c506649a66f963443d98b165f595b35d84f3a7f3acf7257fab805d9a5c66db9a766498808df6100c11de52d69e5f1edabcba2aa61#npm:8.3.6"],\
+          ["cosmiconfig", "virtual:231b41c796fb4c3a1878ccc2b284d7acc71e342654f1dcf3bec9e756c379469380938482d22d651d850cf92850f594f3b751114f8c7660ab24c8aee2d7081537#npm:8.3.6"],\
           ["dedent", "npm:0.7.0"],\
           ["execa", "npm:5.0.0"],\
           ["fs-extra", "npm:11.1.1"],\
@@ -5435,17 +5047,17 @@ const RAW_RUNTIME_STATE =
           ["make-dir", "npm:4.0.0"],\
           ["minimatch", "npm:3.0.5"],\
           ["multimatch", "npm:5.0.0"],\
-          ["node-fetch", "virtual:27294a026b403a125127a01c506649a66f963443d98b165f595b35d84f3a7f3acf7257fab805d9a5c66db9a766498808df6100c11de52d69e5f1edabcba2aa61#npm:2.6.7"],\
+          ["node-fetch", "virtual:231b41c796fb4c3a1878ccc2b284d7acc71e342654f1dcf3bec9e756c379469380938482d22d651d850cf92850f594f3b751114f8c7660ab24c8aee2d7081537#npm:2.6.7"],\
           ["npm-package-arg", "npm:8.1.1"],\
           ["npm-packlist", "npm:5.1.1"],\
           ["npm-registry-fetch", "npm:14.0.5"],\
           ["npmlog", "npm:6.0.2"],\
-          ["nx", "virtual:27294a026b403a125127a01c506649a66f963443d98b165f595b35d84f3a7f3acf7257fab805d9a5c66db9a766498808df6100c11de52d69e5f1edabcba2aa61#npm:16.8.1"],\
+          ["nx", "virtual:231b41c796fb4c3a1878ccc2b284d7acc71e342654f1dcf3bec9e756c379469380938482d22d651d850cf92850f594f3b751114f8c7660ab24c8aee2d7081537#npm:19.0.3"],\
           ["p-map", "npm:4.0.0"],\
           ["p-map-series", "npm:2.1.0"],\
           ["p-queue", "npm:6.6.2"],\
           ["p-reduce", "npm:2.1.0"],\
-          ["pacote", "npm:15.2.0"],\
+          ["pacote", "npm:17.0.7"],\
           ["pify", "npm:5.0.0"],\
           ["read-cmd-shim", "npm:4.0.0"],\
           ["read-package-json", "npm:6.0.4"],\
@@ -5456,7 +5068,7 @@ const RAW_RUNTIME_STATE =
           ["slash", "npm:3.0.0"],\
           ["ssri", "npm:9.0.1"],\
           ["strong-log-transformer", "npm:2.1.0"],\
-          ["tar", "npm:6.1.11"],\
+          ["tar", "npm:6.2.1"],\
           ["temp-dir", "npm:1.0.0"],\
           ["upath", "npm:2.0.1"],\
           ["uuid", "npm:9.0.0"],\
@@ -5464,8 +5076,8 @@ const RAW_RUNTIME_STATE =
           ["validate-npm-package-name", "npm:5.0.0"],\
           ["write-file-atomic", "npm:5.0.1"],\
           ["write-pkg", "npm:4.0.0"],\
-          ["yargs", "npm:16.2.0"],\
-          ["yargs-parser", "npm:20.2.4"]\
+          ["yargs", "npm:17.7.2"],\
+          ["yargs-parser", "npm:21.1.1"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -6167,91 +5779,91 @@ const RAW_RUNTIME_STATE =
       }]\
     ]],\
     ["@next/env", [\
-      ["npm:13.4.19", {\
-        "packageLocation": "./.yarn/cache/@next-env-npm-13.4.19-b5a63a2ff8-9454485caf.zip/node_modules/@next/env/",\
+      ["npm:14.2.3", {\
+        "packageLocation": "./.yarn/cache/@next-env-npm-14.2.3-439888dc66-82b445331d.zip/node_modules/@next/env/",\
         "packageDependencies": [\
-          ["@next/env", "npm:13.4.19"]\
+          ["@next/env", "npm:14.2.3"]\
         ],\
         "linkType": "HARD"\
       }]\
     ]],\
     ["@next/swc-darwin-arm64", [\
-      ["npm:13.4.19", {\
-        "packageLocation": "./.yarn/unplugged/@next-swc-darwin-arm64-npm-13.4.19-fca715fb2a/node_modules/@next/swc-darwin-arm64/",\
+      ["npm:14.2.3", {\
+        "packageLocation": "./.yarn/unplugged/@next-swc-darwin-arm64-npm-14.2.3-a4a36e8f73/node_modules/@next/swc-darwin-arm64/",\
         "packageDependencies": [\
-          ["@next/swc-darwin-arm64", "npm:13.4.19"]\
+          ["@next/swc-darwin-arm64", "npm:14.2.3"]\
         ],\
         "linkType": "HARD"\
       }]\
     ]],\
     ["@next/swc-darwin-x64", [\
-      ["npm:13.4.19", {\
-        "packageLocation": "./.yarn/unplugged/@next-swc-darwin-x64-npm-13.4.19-39dbd25b1a/node_modules/@next/swc-darwin-x64/",\
+      ["npm:14.2.3", {\
+        "packageLocation": "./.yarn/unplugged/@next-swc-darwin-x64-npm-14.2.3-bb811d66d3/node_modules/@next/swc-darwin-x64/",\
         "packageDependencies": [\
-          ["@next/swc-darwin-x64", "npm:13.4.19"]\
+          ["@next/swc-darwin-x64", "npm:14.2.3"]\
         ],\
         "linkType": "HARD"\
       }]\
     ]],\
     ["@next/swc-linux-arm64-gnu", [\
-      ["npm:13.4.19", {\
-        "packageLocation": "./.yarn/unplugged/@next-swc-linux-arm64-gnu-npm-13.4.19-bb52ec0212/node_modules/@next/swc-linux-arm64-gnu/",\
+      ["npm:14.2.3", {\
+        "packageLocation": "./.yarn/unplugged/@next-swc-linux-arm64-gnu-npm-14.2.3-8a1a464ce1/node_modules/@next/swc-linux-arm64-gnu/",\
         "packageDependencies": [\
-          ["@next/swc-linux-arm64-gnu", "npm:13.4.19"]\
+          ["@next/swc-linux-arm64-gnu", "npm:14.2.3"]\
         ],\
         "linkType": "HARD"\
       }]\
     ]],\
     ["@next/swc-linux-arm64-musl", [\
-      ["npm:13.4.19", {\
-        "packageLocation": "./.yarn/unplugged/@next-swc-linux-arm64-musl-npm-13.4.19-33bcd9280e/node_modules/@next/swc-linux-arm64-musl/",\
+      ["npm:14.2.3", {\
+        "packageLocation": "./.yarn/unplugged/@next-swc-linux-arm64-musl-npm-14.2.3-ae66d88cf4/node_modules/@next/swc-linux-arm64-musl/",\
         "packageDependencies": [\
-          ["@next/swc-linux-arm64-musl", "npm:13.4.19"]\
+          ["@next/swc-linux-arm64-musl", "npm:14.2.3"]\
         ],\
         "linkType": "HARD"\
       }]\
     ]],\
     ["@next/swc-linux-x64-gnu", [\
-      ["npm:13.4.19", {\
-        "packageLocation": "./.yarn/unplugged/@next-swc-linux-x64-gnu-npm-13.4.19-40547007d0/node_modules/@next/swc-linux-x64-gnu/",\
+      ["npm:14.2.3", {\
+        "packageLocation": "./.yarn/unplugged/@next-swc-linux-x64-gnu-npm-14.2.3-635f7187f5/node_modules/@next/swc-linux-x64-gnu/",\
         "packageDependencies": [\
-          ["@next/swc-linux-x64-gnu", "npm:13.4.19"]\
+          ["@next/swc-linux-x64-gnu", "npm:14.2.3"]\
         ],\
         "linkType": "HARD"\
       }]\
     ]],\
     ["@next/swc-linux-x64-musl", [\
-      ["npm:13.4.19", {\
-        "packageLocation": "./.yarn/unplugged/@next-swc-linux-x64-musl-npm-13.4.19-3dc2914f24/node_modules/@next/swc-linux-x64-musl/",\
+      ["npm:14.2.3", {\
+        "packageLocation": "./.yarn/unplugged/@next-swc-linux-x64-musl-npm-14.2.3-b72b7c2b49/node_modules/@next/swc-linux-x64-musl/",\
         "packageDependencies": [\
-          ["@next/swc-linux-x64-musl", "npm:13.4.19"]\
+          ["@next/swc-linux-x64-musl", "npm:14.2.3"]\
         ],\
         "linkType": "HARD"\
       }]\
     ]],\
     ["@next/swc-win32-arm64-msvc", [\
-      ["npm:13.4.19", {\
-        "packageLocation": "./.yarn/unplugged/@next-swc-win32-arm64-msvc-npm-13.4.19-00255581e4/node_modules/@next/swc-win32-arm64-msvc/",\
+      ["npm:14.2.3", {\
+        "packageLocation": "./.yarn/unplugged/@next-swc-win32-arm64-msvc-npm-14.2.3-ea400e0417/node_modules/@next/swc-win32-arm64-msvc/",\
         "packageDependencies": [\
-          ["@next/swc-win32-arm64-msvc", "npm:13.4.19"]\
+          ["@next/swc-win32-arm64-msvc", "npm:14.2.3"]\
         ],\
         "linkType": "HARD"\
       }]\
     ]],\
     ["@next/swc-win32-ia32-msvc", [\
-      ["npm:13.4.19", {\
-        "packageLocation": "./.yarn/unplugged/@next-swc-win32-ia32-msvc-npm-13.4.19-c83b439706/node_modules/@next/swc-win32-ia32-msvc/",\
+      ["npm:14.2.3", {\
+        "packageLocation": "./.yarn/unplugged/@next-swc-win32-ia32-msvc-npm-14.2.3-f9b5545461/node_modules/@next/swc-win32-ia32-msvc/",\
         "packageDependencies": [\
-          ["@next/swc-win32-ia32-msvc", "npm:13.4.19"]\
+          ["@next/swc-win32-ia32-msvc", "npm:14.2.3"]\
         ],\
         "linkType": "HARD"\
       }]\
     ]],\
     ["@next/swc-win32-x64-msvc", [\
-      ["npm:13.4.19", {\
-        "packageLocation": "./.yarn/unplugged/@next-swc-win32-x64-msvc-npm-13.4.19-a7d9a1e2ab/node_modules/@next/swc-win32-x64-msvc/",\
+      ["npm:14.2.3", {\
+        "packageLocation": "./.yarn/unplugged/@next-swc-win32-x64-msvc-npm-14.2.3-d5afefe541/node_modules/@next/swc-win32-x64-msvc/",\
         "packageDependencies": [\
-          ["@next/swc-win32-x64-msvc", "npm:13.4.19"]\
+          ["@next/swc-win32-x64-msvc", "npm:14.2.3"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -6310,6 +5922,20 @@ const RAW_RUNTIME_STATE =
         "linkType": "HARD"\
       }]\
     ]],\
+    ["@npmcli/agent", [\
+      ["npm:2.2.2", {\
+        "packageLocation": "./.yarn/cache/@npmcli-agent-npm-2.2.2-e2f559d6c0-96fc0036b1.zip/node_modules/@npmcli/agent/",\
+        "packageDependencies": [\
+          ["@npmcli/agent", "npm:2.2.2"],\
+          ["agent-base", "npm:7.1.1"],\
+          ["http-proxy-agent", "npm:7.0.2"],\
+          ["https-proxy-agent", "npm:7.0.4"],\
+          ["lru-cache", "npm:10.1.0"],\
+          ["socks-proxy-agent", "npm:8.0.3"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
     ["@npmcli/fs", [\
       ["npm:1.0.0", {\
         "packageLocation": "./.yarn/cache/@npmcli-fs-npm-1.0.0-92194475f3-3f93c1d9a8.zip/node_modules/@npmcli/fs/",\
@@ -6330,18 +5956,18 @@ const RAW_RUNTIME_STATE =
       }]\
     ]],\
     ["@npmcli/git", [\
-      ["npm:4.1.0", {\
-        "packageLocation": "./.yarn/cache/@npmcli-git-npm-4.1.0-f7322fced9-33512ce127.zip/node_modules/@npmcli/git/",\
+      ["npm:5.0.7", {\
+        "packageLocation": "./.yarn/cache/@npmcli-git-npm-5.0.7-620f3173f0-73b4821310.zip/node_modules/@npmcli/git/",\
         "packageDependencies": [\
-          ["@npmcli/git", "npm:4.1.0"],\
-          ["@npmcli/promise-spawn", "npm:6.0.2"],\
-          ["lru-cache", "npm:7.18.3"],\
-          ["npm-pick-manifest", "npm:8.0.2"],\
-          ["proc-log", "npm:3.0.0"],\
+          ["@npmcli/git", "npm:5.0.7"],\
+          ["@npmcli/promise-spawn", "npm:7.0.2"],\
+          ["lru-cache", "npm:10.1.0"],\
+          ["npm-pick-manifest", "npm:9.0.1"],\
+          ["proc-log", "npm:4.2.0"],\
           ["promise-inflight", "virtual:a7e5239c6ae68bf6359adfd3598326db000e94dbb349bc00a3852ed53a31712a0e2e787228c6e859d3e5cf2fbb872aba1ea4abe4995cef8086a77ef619ae1be6#npm:1.0.1"],\
           ["promise-retry", "npm:2.0.1"],\
           ["semver", "npm:7.5.4"],\
-          ["which", "npm:3.0.1"]\
+          ["which", "npm:4.0.0"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -6377,72 +6003,111 @@ const RAW_RUNTIME_STATE =
         "linkType": "HARD"\
       }]\
     ]],\
-    ["@npmcli/promise-spawn", [\
-      ["npm:6.0.2", {\
-        "packageLocation": "./.yarn/cache/@npmcli-promise-spawn-npm-6.0.2-c9941b207c-cc94a83ff1.zip/node_modules/@npmcli/promise-spawn/",\
+    ["@npmcli/package-json", [\
+      ["npm:5.1.0", {\
+        "packageLocation": "./.yarn/cache/@npmcli-package-json-npm-5.1.0-d858bde50a-0e5cb5eff3.zip/node_modules/@npmcli/package-json/",\
         "packageDependencies": [\
-          ["@npmcli/promise-spawn", "npm:6.0.2"],\
-          ["which", "npm:3.0.1"]\
+          ["@npmcli/package-json", "npm:5.1.0"],\
+          ["@npmcli/git", "npm:5.0.7"],\
+          ["glob", "npm:10.3.4"],\
+          ["hosted-git-info", "npm:7.0.2"],\
+          ["json-parse-even-better-errors", "npm:3.0.0"],\
+          ["normalize-package-data", "npm:6.0.1"],\
+          ["proc-log", "npm:4.2.0"],\
+          ["semver", "npm:7.5.4"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["@npmcli/promise-spawn", [\
+      ["npm:7.0.2", {\
+        "packageLocation": "./.yarn/cache/@npmcli-promise-spawn-npm-7.0.2-643915b5c0-94cbbbeeb2.zip/node_modules/@npmcli/promise-spawn/",\
+        "packageDependencies": [\
+          ["@npmcli/promise-spawn", "npm:7.0.2"],\
+          ["which", "npm:4.0.0"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["@npmcli/redact", [\
+      ["npm:1.1.0", {\
+        "packageLocation": "./.yarn/cache/@npmcli-redact-npm-1.1.0-71fbcc73bc-c6c81c2d14.zip/node_modules/@npmcli/redact/",\
+        "packageDependencies": [\
+          ["@npmcli/redact", "npm:1.1.0"]\
         ],\
         "linkType": "HARD"\
       }]\
     ]],\
     ["@npmcli/run-script", [\
-      ["npm:6.0.2", {\
-        "packageLocation": "./.yarn/cache/@npmcli-run-script-npm-6.0.2-6a98dec431-9b22c4c53d.zip/node_modules/@npmcli/run-script/",\
+      ["npm:7.0.2", {\
+        "packageLocation": "./.yarn/cache/@npmcli-run-script-npm-7.0.2-b958bd07cc-4549311f3b.zip/node_modules/@npmcli/run-script/",\
         "packageDependencies": [\
-          ["@npmcli/run-script", "npm:6.0.2"],\
+          ["@npmcli/run-script", "npm:7.0.2"],\
           ["@npmcli/node-gyp", "npm:3.0.0"],\
-          ["@npmcli/promise-spawn", "npm:6.0.2"],\
-          ["node-gyp", "npm:9.4.0"],\
+          ["@npmcli/promise-spawn", "npm:7.0.2"],\
+          ["node-gyp", "npm:10.1.0"],\
           ["read-package-json-fast", "npm:3.0.2"],\
-          ["which", "npm:3.0.1"]\
+          ["which", "npm:4.0.0"]\
+        ],\
+        "linkType": "HARD"\
+      }],\
+      ["npm:7.0.4", {\
+        "packageLocation": "./.yarn/cache/@npmcli-run-script-npm-7.0.4-0d1c1e883b-f09268051f.zip/node_modules/@npmcli/run-script/",\
+        "packageDependencies": [\
+          ["@npmcli/run-script", "npm:7.0.4"],\
+          ["@npmcli/node-gyp", "npm:3.0.0"],\
+          ["@npmcli/package-json", "npm:5.1.0"],\
+          ["@npmcli/promise-spawn", "npm:7.0.2"],\
+          ["node-gyp", "npm:10.1.0"],\
+          ["which", "npm:4.0.0"]\
         ],\
         "linkType": "HARD"\
       }]\
     ]],\
     ["@nrwl/devkit", [\
-      ["npm:16.8.1", {\
-        "packageLocation": "./.yarn/cache/@nrwl-devkit-npm-16.8.1-0417054cc3-17dcc80e7a.zip/node_modules/@nrwl/devkit/",\
+      ["npm:19.0.3", {\
+        "packageLocation": "./.yarn/cache/@nrwl-devkit-npm-19.0.3-92959e652c-3ad69accae.zip/node_modules/@nrwl/devkit/",\
         "packageDependencies": [\
-          ["@nrwl/devkit", "npm:16.8.1"],\
-          ["@nx/devkit", "virtual:0417054cc3013e68d78ec07693e07a290b4ebcac0f96f69ff3ffef8315c96b41388fb1d89fd7714c1ecbcb9825a3ba9f649219a76df658ce841266a03465d9fe#npm:16.8.1"]\
+          ["@nrwl/devkit", "npm:19.0.3"],\
+          ["@nx/devkit", "virtual:92959e652c35ec64e7ed77759271c38566880546b1cafe9ef0d6de89bfefdde0536b78000c9e6c88b51488dacd46950f9d7f7336f84e6264a09ad2fd8a8fd73e#npm:19.0.3"]\
         ],\
         "linkType": "HARD"\
       }]\
     ]],\
     ["@nrwl/tao", [\
-      ["npm:16.8.1", {\
-        "packageLocation": "./.yarn/cache/@nrwl-tao-npm-16.8.1-3e0b0f1848-f1ee57f0ad.zip/node_modules/@nrwl/tao/",\
+      ["npm:19.0.3", {\
+        "packageLocation": "./.yarn/cache/@nrwl-tao-npm-19.0.3-77fadfb5fa-419f2a9901.zip/node_modules/@nrwl/tao/",\
         "packageDependencies": [\
-          ["@nrwl/tao", "npm:16.8.1"],\
-          ["nx", "virtual:27294a026b403a125127a01c506649a66f963443d98b165f595b35d84f3a7f3acf7257fab805d9a5c66db9a766498808df6100c11de52d69e5f1edabcba2aa61#npm:16.8.1"],\
+          ["@nrwl/tao", "npm:19.0.3"],\
+          ["nx", "virtual:231b41c796fb4c3a1878ccc2b284d7acc71e342654f1dcf3bec9e756c379469380938482d22d651d850cf92850f594f3b751114f8c7660ab24c8aee2d7081537#npm:19.0.3"],\
           ["tslib", "npm:2.3.1"]\
         ],\
         "linkType": "HARD"\
       }]\
     ]],\
     ["@nx/devkit", [\
-      ["npm:16.8.1", {\
-        "packageLocation": "./.yarn/cache/@nx-devkit-npm-16.8.1-de57ecb9e9-537c489602.zip/node_modules/@nx/devkit/",\
+      ["npm:19.0.3", {\
+        "packageLocation": "./.yarn/cache/@nx-devkit-npm-19.0.3-14710e511d-7a725d18c3.zip/node_modules/@nx/devkit/",\
         "packageDependencies": [\
-          ["@nx/devkit", "npm:16.8.1"]\
+          ["@nx/devkit", "npm:19.0.3"]\
         ],\
         "linkType": "SOFT"\
       }],\
-      ["virtual:0417054cc3013e68d78ec07693e07a290b4ebcac0f96f69ff3ffef8315c96b41388fb1d89fd7714c1ecbcb9825a3ba9f649219a76df658ce841266a03465d9fe#npm:16.8.1", {\
-        "packageLocation": "./.yarn/__virtual__/@nx-devkit-virtual-d92e8cb868/0/cache/@nx-devkit-npm-16.8.1-de57ecb9e9-537c489602.zip/node_modules/@nx/devkit/",\
+      ["virtual:231b41c796fb4c3a1878ccc2b284d7acc71e342654f1dcf3bec9e756c379469380938482d22d651d850cf92850f594f3b751114f8c7660ab24c8aee2d7081537#npm:19.0.3", {\
+        "packageLocation": "./.yarn/__virtual__/@nx-devkit-virtual-b8d067145d/0/cache/@nx-devkit-npm-19.0.3-14710e511d-7a725d18c3.zip/node_modules/@nx/devkit/",\
         "packageDependencies": [\
-          ["@nx/devkit", "virtual:0417054cc3013e68d78ec07693e07a290b4ebcac0f96f69ff3ffef8315c96b41388fb1d89fd7714c1ecbcb9825a3ba9f649219a76df658ce841266a03465d9fe#npm:16.8.1"],\
-          ["@nrwl/devkit", "npm:16.8.1"],\
+          ["@nx/devkit", "virtual:231b41c796fb4c3a1878ccc2b284d7acc71e342654f1dcf3bec9e756c379469380938482d22d651d850cf92850f594f3b751114f8c7660ab24c8aee2d7081537#npm:19.0.3"],\
+          ["@nrwl/devkit", "npm:19.0.3"],\
           ["@types/nx", null],\
           ["ejs", "npm:3.1.10"],\
           ["enquirer", "npm:2.3.6"],\
           ["ignore", "npm:5.2.4"],\
-          ["nx", null],\
-          ["semver", "npm:7.5.3"],\
+          ["minimatch", "npm:9.0.3"],\
+          ["nx", "virtual:231b41c796fb4c3a1878ccc2b284d7acc71e342654f1dcf3bec9e756c379469380938482d22d651d850cf92850f594f3b751114f8c7660ab24c8aee2d7081537#npm:19.0.3"],\
+          ["semver", "npm:7.5.4"],\
           ["tmp", "npm:0.2.1"],\
-          ["tslib", "npm:2.3.1"]\
+          ["tslib", "npm:2.3.1"],\
+          ["yargs-parser", "npm:21.1.1"]\
         ],\
         "packagePeers": [\
           "@types/nx",\
@@ -6450,19 +6115,21 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "HARD"\
       }],\
-      ["virtual:27294a026b403a125127a01c506649a66f963443d98b165f595b35d84f3a7f3acf7257fab805d9a5c66db9a766498808df6100c11de52d69e5f1edabcba2aa61#npm:16.8.1", {\
-        "packageLocation": "./.yarn/__virtual__/@nx-devkit-virtual-e6128577eb/0/cache/@nx-devkit-npm-16.8.1-de57ecb9e9-537c489602.zip/node_modules/@nx/devkit/",\
+      ["virtual:92959e652c35ec64e7ed77759271c38566880546b1cafe9ef0d6de89bfefdde0536b78000c9e6c88b51488dacd46950f9d7f7336f84e6264a09ad2fd8a8fd73e#npm:19.0.3", {\
+        "packageLocation": "./.yarn/__virtual__/@nx-devkit-virtual-226aed7e8e/0/cache/@nx-devkit-npm-19.0.3-14710e511d-7a725d18c3.zip/node_modules/@nx/devkit/",\
         "packageDependencies": [\
-          ["@nx/devkit", "virtual:27294a026b403a125127a01c506649a66f963443d98b165f595b35d84f3a7f3acf7257fab805d9a5c66db9a766498808df6100c11de52d69e5f1edabcba2aa61#npm:16.8.1"],\
-          ["@nrwl/devkit", "npm:16.8.1"],\
+          ["@nx/devkit", "virtual:92959e652c35ec64e7ed77759271c38566880546b1cafe9ef0d6de89bfefdde0536b78000c9e6c88b51488dacd46950f9d7f7336f84e6264a09ad2fd8a8fd73e#npm:19.0.3"],\
+          ["@nrwl/devkit", "npm:19.0.3"],\
           ["@types/nx", null],\
           ["ejs", "npm:3.1.10"],\
           ["enquirer", "npm:2.3.6"],\
           ["ignore", "npm:5.2.4"],\
-          ["nx", "virtual:27294a026b403a125127a01c506649a66f963443d98b165f595b35d84f3a7f3acf7257fab805d9a5c66db9a766498808df6100c11de52d69e5f1edabcba2aa61#npm:16.8.1"],\
-          ["semver", "npm:7.5.3"],\
+          ["minimatch", "npm:9.0.3"],\
+          ["nx", null],\
+          ["semver", "npm:7.5.4"],\
           ["tmp", "npm:0.2.1"],\
-          ["tslib", "npm:2.3.1"]\
+          ["tslib", "npm:2.3.1"],\
+          ["yargs-parser", "npm:21.1.1"]\
         ],\
         "packagePeers": [\
           "@types/nx",\
@@ -6472,91 +6139,91 @@ const RAW_RUNTIME_STATE =
       }]\
     ]],\
     ["@nx/nx-darwin-arm64", [\
-      ["npm:16.8.1", {\
-        "packageLocation": "./.yarn/unplugged/@nx-nx-darwin-arm64-npm-16.8.1-0a5ed0861c/node_modules/@nx/nx-darwin-arm64/",\
+      ["npm:19.0.3", {\
+        "packageLocation": "./.yarn/unplugged/@nx-nx-darwin-arm64-npm-19.0.3-23e922c430/node_modules/@nx/nx-darwin-arm64/",\
         "packageDependencies": [\
-          ["@nx/nx-darwin-arm64", "npm:16.8.1"]\
+          ["@nx/nx-darwin-arm64", "npm:19.0.3"]\
         ],\
         "linkType": "HARD"\
       }]\
     ]],\
     ["@nx/nx-darwin-x64", [\
-      ["npm:16.8.1", {\
-        "packageLocation": "./.yarn/unplugged/@nx-nx-darwin-x64-npm-16.8.1-91b1899ada/node_modules/@nx/nx-darwin-x64/",\
+      ["npm:19.0.3", {\
+        "packageLocation": "./.yarn/unplugged/@nx-nx-darwin-x64-npm-19.0.3-b8ca698cdd/node_modules/@nx/nx-darwin-x64/",\
         "packageDependencies": [\
-          ["@nx/nx-darwin-x64", "npm:16.8.1"]\
+          ["@nx/nx-darwin-x64", "npm:19.0.3"]\
         ],\
         "linkType": "HARD"\
       }]\
     ]],\
     ["@nx/nx-freebsd-x64", [\
-      ["npm:16.8.1", {\
-        "packageLocation": "./.yarn/unplugged/@nx-nx-freebsd-x64-npm-16.8.1-7b631864d5/node_modules/@nx/nx-freebsd-x64/",\
+      ["npm:19.0.3", {\
+        "packageLocation": "./.yarn/unplugged/@nx-nx-freebsd-x64-npm-19.0.3-a62113f65a/node_modules/@nx/nx-freebsd-x64/",\
         "packageDependencies": [\
-          ["@nx/nx-freebsd-x64", "npm:16.8.1"]\
+          ["@nx/nx-freebsd-x64", "npm:19.0.3"]\
         ],\
         "linkType": "HARD"\
       }]\
     ]],\
     ["@nx/nx-linux-arm-gnueabihf", [\
-      ["npm:16.8.1", {\
-        "packageLocation": "./.yarn/unplugged/@nx-nx-linux-arm-gnueabihf-npm-16.8.1-8c1dc78eb0/node_modules/@nx/nx-linux-arm-gnueabihf/",\
+      ["npm:19.0.3", {\
+        "packageLocation": "./.yarn/unplugged/@nx-nx-linux-arm-gnueabihf-npm-19.0.3-ffde1f9449/node_modules/@nx/nx-linux-arm-gnueabihf/",\
         "packageDependencies": [\
-          ["@nx/nx-linux-arm-gnueabihf", "npm:16.8.1"]\
+          ["@nx/nx-linux-arm-gnueabihf", "npm:19.0.3"]\
         ],\
         "linkType": "HARD"\
       }]\
     ]],\
     ["@nx/nx-linux-arm64-gnu", [\
-      ["npm:16.8.1", {\
-        "packageLocation": "./.yarn/unplugged/@nx-nx-linux-arm64-gnu-npm-16.8.1-a50c2dee7d/node_modules/@nx/nx-linux-arm64-gnu/",\
+      ["npm:19.0.3", {\
+        "packageLocation": "./.yarn/unplugged/@nx-nx-linux-arm64-gnu-npm-19.0.3-fa3b7f863d/node_modules/@nx/nx-linux-arm64-gnu/",\
         "packageDependencies": [\
-          ["@nx/nx-linux-arm64-gnu", "npm:16.8.1"]\
+          ["@nx/nx-linux-arm64-gnu", "npm:19.0.3"]\
         ],\
         "linkType": "HARD"\
       }]\
     ]],\
     ["@nx/nx-linux-arm64-musl", [\
-      ["npm:16.8.1", {\
-        "packageLocation": "./.yarn/unplugged/@nx-nx-linux-arm64-musl-npm-16.8.1-74c6f00a7c/node_modules/@nx/nx-linux-arm64-musl/",\
+      ["npm:19.0.3", {\
+        "packageLocation": "./.yarn/unplugged/@nx-nx-linux-arm64-musl-npm-19.0.3-2793dfe7b6/node_modules/@nx/nx-linux-arm64-musl/",\
         "packageDependencies": [\
-          ["@nx/nx-linux-arm64-musl", "npm:16.8.1"]\
+          ["@nx/nx-linux-arm64-musl", "npm:19.0.3"]\
         ],\
         "linkType": "HARD"\
       }]\
     ]],\
     ["@nx/nx-linux-x64-gnu", [\
-      ["npm:16.8.1", {\
-        "packageLocation": "./.yarn/unplugged/@nx-nx-linux-x64-gnu-npm-16.8.1-7a4c75e521/node_modules/@nx/nx-linux-x64-gnu/",\
+      ["npm:19.0.3", {\
+        "packageLocation": "./.yarn/unplugged/@nx-nx-linux-x64-gnu-npm-19.0.3-45a200dd05/node_modules/@nx/nx-linux-x64-gnu/",\
         "packageDependencies": [\
-          ["@nx/nx-linux-x64-gnu", "npm:16.8.1"]\
+          ["@nx/nx-linux-x64-gnu", "npm:19.0.3"]\
         ],\
         "linkType": "HARD"\
       }]\
     ]],\
     ["@nx/nx-linux-x64-musl", [\
-      ["npm:16.8.1", {\
-        "packageLocation": "./.yarn/unplugged/@nx-nx-linux-x64-musl-npm-16.8.1-dfbc2dab9e/node_modules/@nx/nx-linux-x64-musl/",\
+      ["npm:19.0.3", {\
+        "packageLocation": "./.yarn/unplugged/@nx-nx-linux-x64-musl-npm-19.0.3-01f5d3a875/node_modules/@nx/nx-linux-x64-musl/",\
         "packageDependencies": [\
-          ["@nx/nx-linux-x64-musl", "npm:16.8.1"]\
+          ["@nx/nx-linux-x64-musl", "npm:19.0.3"]\
         ],\
         "linkType": "HARD"\
       }]\
     ]],\
     ["@nx/nx-win32-arm64-msvc", [\
-      ["npm:16.8.1", {\
-        "packageLocation": "./.yarn/unplugged/@nx-nx-win32-arm64-msvc-npm-16.8.1-107d0affa2/node_modules/@nx/nx-win32-arm64-msvc/",\
+      ["npm:19.0.3", {\
+        "packageLocation": "./.yarn/unplugged/@nx-nx-win32-arm64-msvc-npm-19.0.3-875cfcbb4c/node_modules/@nx/nx-win32-arm64-msvc/",\
         "packageDependencies": [\
-          ["@nx/nx-win32-arm64-msvc", "npm:16.8.1"]\
+          ["@nx/nx-win32-arm64-msvc", "npm:19.0.3"]\
         ],\
         "linkType": "HARD"\
       }]\
     ]],\
     ["@nx/nx-win32-x64-msvc", [\
-      ["npm:16.8.1", {\
-        "packageLocation": "./.yarn/unplugged/@nx-nx-win32-x64-msvc-npm-16.8.1-814198e256/node_modules/@nx/nx-win32-x64-msvc/",\
+      ["npm:19.0.3", {\
+        "packageLocation": "./.yarn/unplugged/@nx-nx-win32-x64-msvc-npm-19.0.3-52ba00c48a/node_modules/@nx/nx-win32-x64-msvc/",\
         "packageDependencies": [\
-          ["@nx/nx-win32-x64-msvc", "npm:16.8.1"]\
+          ["@nx/nx-win32-x64-msvc", "npm:19.0.3"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -6921,7 +6588,7 @@ const RAW_RUNTIME_STATE =
           ["@types/react-dom", "npm:18.2.19"],\
           ["@types/react-router-dom", "npm:5.3.3"],\
           ["@types/testing-library__jest-dom", "npm:5.14.5"],\
-          ["bids-validator", "npm:1.13.0"],\
+          ["bids-validator", "npm:1.14.6"],\
           ["bytes", "npm:3.1.0"],\
           ["comlink", "npm:4.3.1"],\
           ["core-js", "npm:3.25.1"],\
@@ -6970,7 +6637,7 @@ const RAW_RUNTIME_STATE =
           ["@openneuro/client", "workspace:packages/openneuro-client"],\
           ["@types/mkdirp", "npm:1.0.2"],\
           ["@types/node", "npm:20.12.7"],\
-          ["bids-validator", "npm:1.10.0"],\
+          ["bids-validator", "npm:1.14.6"],\
           ["cli-progress", "npm:3.9.1"],\
           ["commander", "npm:7.2.0"],\
           ["core-js", "npm:3.18.0"],\
@@ -7245,18 +6912,6 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./.yarn/cache/@opentelemetry-semantic-conventions-npm-1.15.2-455630b2df-1f35515109.zip/node_modules/@opentelemetry/semantic-conventions/",\
         "packageDependencies": [\
           ["@opentelemetry/semantic-conventions", "npm:1.15.2"]\
-        ],\
-        "linkType": "HARD"\
-      }]\
-    ]],\
-    ["@parcel/watcher", [\
-      ["npm:2.0.4", {\
-        "packageLocation": "./.yarn/unplugged/@parcel-watcher-npm-2.0.4-e2975fa1d0/node_modules/@parcel/watcher/",\
-        "packageDependencies": [\
-          ["@parcel/watcher", "npm:2.0.4"],\
-          ["node-addon-api", "npm:3.2.1"],\
-          ["node-gyp", "npm:8.2.0"],\
-          ["node-gyp-build", "npm:4.6.1"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -7688,6 +7343,23 @@ const RAW_RUNTIME_STATE =
           ["@sigstore/protobuf-specs", "npm:0.2.1"]\
         ],\
         "linkType": "HARD"\
+      }],\
+      ["npm:2.3.1", {\
+        "packageLocation": "./.yarn/cache/@sigstore-bundle-npm-2.3.1-0752f486b4-5e1024dfc5.zip/node_modules/@sigstore/bundle/",\
+        "packageDependencies": [\
+          ["@sigstore/bundle", "npm:2.3.1"],\
+          ["@sigstore/protobuf-specs", "npm:0.3.2"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["@sigstore/core", [\
+      ["npm:1.1.0", {\
+        "packageLocation": "./.yarn/cache/@sigstore-core-npm-1.1.0-44b420f972-4149572091.zip/node_modules/@sigstore/core/",\
+        "packageDependencies": [\
+          ["@sigstore/core", "npm:1.1.0"]\
+        ],\
+        "linkType": "HARD"\
       }]\
     ]],\
     ["@sigstore/protobuf-specs", [\
@@ -7695,6 +7367,13 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./.yarn/cache/@sigstore-protobuf-specs-npm-0.2.1-feecdcc08c-cb0b9d9b3e.zip/node_modules/@sigstore/protobuf-specs/",\
         "packageDependencies": [\
           ["@sigstore/protobuf-specs", "npm:0.2.1"]\
+        ],\
+        "linkType": "HARD"\
+      }],\
+      ["npm:0.3.2", {\
+        "packageLocation": "./.yarn/cache/@sigstore-protobuf-specs-npm-0.3.2-ff6825392f-350a6eb834.zip/node_modules/@sigstore/protobuf-specs/",\
+        "packageDependencies": [\
+          ["@sigstore/protobuf-specs", "npm:0.3.2"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -7709,6 +7388,19 @@ const RAW_RUNTIME_STATE =
           ["make-fetch-happen", "npm:11.1.1"]\
         ],\
         "linkType": "HARD"\
+      }],\
+      ["npm:2.3.1", {\
+        "packageLocation": "./.yarn/cache/@sigstore-sign-npm-2.3.1-bd0a456259-99d64bfcd0.zip/node_modules/@sigstore/sign/",\
+        "packageDependencies": [\
+          ["@sigstore/sign", "npm:2.3.1"],\
+          ["@sigstore/bundle", "npm:2.3.1"],\
+          ["@sigstore/core", "npm:1.1.0"],\
+          ["@sigstore/protobuf-specs", "npm:0.3.2"],\
+          ["make-fetch-happen", "npm:13.0.1"],\
+          ["proc-log", "npm:4.2.0"],\
+          ["promise-retry", "npm:2.0.1"]\
+        ],\
+        "linkType": "HARD"\
       }]\
     ]],\
     ["@sigstore/tuf", [\
@@ -7718,6 +7410,27 @@ const RAW_RUNTIME_STATE =
           ["@sigstore/tuf", "npm:1.0.3"],\
           ["@sigstore/protobuf-specs", "npm:0.2.1"],\
           ["tuf-js", "npm:1.1.7"]\
+        ],\
+        "linkType": "HARD"\
+      }],\
+      ["npm:2.3.3", {\
+        "packageLocation": "./.yarn/cache/@sigstore-tuf-npm-2.3.3-fb3fa27cd1-4d3c5aa897.zip/node_modules/@sigstore/tuf/",\
+        "packageDependencies": [\
+          ["@sigstore/tuf", "npm:2.3.3"],\
+          ["@sigstore/protobuf-specs", "npm:0.3.2"],\
+          ["tuf-js", "npm:2.2.1"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["@sigstore/verify", [\
+      ["npm:1.2.0", {\
+        "packageLocation": "./.yarn/cache/@sigstore-verify-npm-1.2.0-0c4afb4f6e-f93728c425.zip/node_modules/@sigstore/verify/",\
+        "packageDependencies": [\
+          ["@sigstore/verify", "npm:1.2.0"],\
+          ["@sigstore/bundle", "npm:2.3.1"],\
+          ["@sigstore/core", "npm:1.1.0"],\
+          ["@sigstore/protobuf-specs", "npm:0.3.2"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -7768,680 +7481,414 @@ const RAW_RUNTIME_STATE =
       }]\
     ]],\
     ["@smithy/abort-controller", [\
-      ["npm:2.0.7", {\
-        "packageLocation": "./.yarn/cache/@smithy-abort-controller-npm-2.0.7-8c9760406d-d1f898bb23.zip/node_modules/@smithy/abort-controller/",\
+      ["npm:3.0.0", {\
+        "packageLocation": "./.yarn/cache/@smithy-abort-controller-npm-3.0.0-1756310f66-08bf21e792.zip/node_modules/@smithy/abort-controller/",\
         "packageDependencies": [\
-          ["@smithy/abort-controller", "npm:2.0.7"],\
-          ["@smithy/types", "npm:2.3.1"],\
-          ["tslib", "npm:2.6.2"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["npm:2.0.9", {\
-        "packageLocation": "./.yarn/cache/@smithy-abort-controller-npm-2.0.9-c60fc73397-cfdda8b16b.zip/node_modules/@smithy/abort-controller/",\
-        "packageDependencies": [\
-          ["@smithy/abort-controller", "npm:2.0.9"],\
-          ["@smithy/types", "npm:2.3.3"],\
+          ["@smithy/abort-controller", "npm:3.0.0"],\
+          ["@smithy/types", "npm:3.0.0"],\
           ["tslib", "npm:2.6.2"]\
         ],\
         "linkType": "HARD"\
       }]\
     ]],\
     ["@smithy/chunked-blob-reader", [\
-      ["npm:2.0.0", {\
-        "packageLocation": "./.yarn/cache/@smithy-chunked-blob-reader-npm-2.0.0-1b1d26e056-3e35ce2bb2.zip/node_modules/@smithy/chunked-blob-reader/",\
+      ["npm:3.0.0", {\
+        "packageLocation": "./.yarn/cache/@smithy-chunked-blob-reader-npm-3.0.0-4eeb81fd25-1c7955ae69.zip/node_modules/@smithy/chunked-blob-reader/",\
         "packageDependencies": [\
-          ["@smithy/chunked-blob-reader", "npm:2.0.0"],\
+          ["@smithy/chunked-blob-reader", "npm:3.0.0"],\
           ["tslib", "npm:2.6.2"]\
         ],\
         "linkType": "HARD"\
       }]\
     ]],\
     ["@smithy/chunked-blob-reader-native", [\
-      ["npm:2.0.0", {\
-        "packageLocation": "./.yarn/cache/@smithy-chunked-blob-reader-native-npm-2.0.0-71b147e93a-7f8c3946d5.zip/node_modules/@smithy/chunked-blob-reader-native/",\
+      ["npm:3.0.0", {\
+        "packageLocation": "./.yarn/cache/@smithy-chunked-blob-reader-native-npm-3.0.0-3b387a57fd-424aa83f4f.zip/node_modules/@smithy/chunked-blob-reader-native/",\
         "packageDependencies": [\
-          ["@smithy/chunked-blob-reader-native", "npm:2.0.0"],\
-          ["@smithy/util-base64", "npm:2.0.0"],\
+          ["@smithy/chunked-blob-reader-native", "npm:3.0.0"],\
+          ["@smithy/util-base64", "npm:3.0.0"],\
           ["tslib", "npm:2.6.2"]\
         ],\
         "linkType": "HARD"\
       }]\
     ]],\
     ["@smithy/config-resolver", [\
-      ["npm:2.0.10", {\
-        "packageLocation": "./.yarn/cache/@smithy-config-resolver-npm-2.0.10-dfa64a833d-ca0f8cbacc.zip/node_modules/@smithy/config-resolver/",\
+      ["npm:3.0.0", {\
+        "packageLocation": "./.yarn/cache/@smithy-config-resolver-npm-3.0.0-f642f0206e-78d6a13cb7.zip/node_modules/@smithy/config-resolver/",\
         "packageDependencies": [\
-          ["@smithy/config-resolver", "npm:2.0.10"],\
-          ["@smithy/node-config-provider", "npm:2.0.12"],\
-          ["@smithy/types", "npm:2.3.3"],\
-          ["@smithy/util-config-provider", "npm:2.0.0"],\
-          ["@smithy/util-middleware", "npm:2.0.2"],\
+          ["@smithy/config-resolver", "npm:3.0.0"],\
+          ["@smithy/node-config-provider", "npm:3.0.0"],\
+          ["@smithy/types", "npm:3.0.0"],\
+          ["@smithy/util-config-provider", "npm:3.0.0"],\
+          ["@smithy/util-middleware", "npm:3.0.0"],\
           ["tslib", "npm:2.6.2"]\
         ],\
         "linkType": "HARD"\
-      }],\
-      ["npm:2.0.8", {\
-        "packageLocation": "./.yarn/cache/@smithy-config-resolver-npm-2.0.8-42dd6f5f6b-9c560f19a5.zip/node_modules/@smithy/config-resolver/",\
+      }]\
+    ]],\
+    ["@smithy/core", [\
+      ["npm:2.0.0", {\
+        "packageLocation": "./.yarn/cache/@smithy-core-npm-2.0.0-072afa6bd4-793c845069.zip/node_modules/@smithy/core/",\
         "packageDependencies": [\
-          ["@smithy/config-resolver", "npm:2.0.8"],\
-          ["@smithy/node-config-provider", "npm:2.0.10"],\
-          ["@smithy/types", "npm:2.3.1"],\
-          ["@smithy/util-config-provider", "npm:2.0.0"],\
-          ["@smithy/util-middleware", "npm:2.0.0"],\
+          ["@smithy/core", "npm:2.0.0"],\
+          ["@smithy/middleware-endpoint", "npm:3.0.0"],\
+          ["@smithy/middleware-retry", "npm:3.0.0"],\
+          ["@smithy/middleware-serde", "npm:3.0.0"],\
+          ["@smithy/protocol-http", "npm:4.0.0"],\
+          ["@smithy/smithy-client", "npm:3.0.0"],\
+          ["@smithy/types", "npm:3.0.0"],\
+          ["@smithy/util-middleware", "npm:3.0.0"],\
           ["tslib", "npm:2.6.2"]\
         ],\
         "linkType": "HARD"\
       }]\
     ]],\
     ["@smithy/credential-provider-imds", [\
-      ["npm:2.0.10", {\
-        "packageLocation": "./.yarn/cache/@smithy-credential-provider-imds-npm-2.0.10-820c8a1763-5a5b56c7e9.zip/node_modules/@smithy/credential-provider-imds/",\
+      ["npm:3.0.0", {\
+        "packageLocation": "./.yarn/cache/@smithy-credential-provider-imds-npm-3.0.0-376a668b41-793e826a6d.zip/node_modules/@smithy/credential-provider-imds/",\
         "packageDependencies": [\
-          ["@smithy/credential-provider-imds", "npm:2.0.10"],\
-          ["@smithy/node-config-provider", "npm:2.0.10"],\
-          ["@smithy/property-provider", "npm:2.0.8"],\
-          ["@smithy/types", "npm:2.3.1"],\
-          ["@smithy/url-parser", "npm:2.0.7"],\
-          ["tslib", "npm:2.6.2"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["npm:2.0.12", {\
-        "packageLocation": "./.yarn/cache/@smithy-credential-provider-imds-npm-2.0.12-482deb8e11-edc90dff66.zip/node_modules/@smithy/credential-provider-imds/",\
-        "packageDependencies": [\
-          ["@smithy/credential-provider-imds", "npm:2.0.12"],\
-          ["@smithy/node-config-provider", "npm:2.0.12"],\
-          ["@smithy/property-provider", "npm:2.0.10"],\
-          ["@smithy/types", "npm:2.3.3"],\
-          ["@smithy/url-parser", "npm:2.0.9"],\
+          ["@smithy/credential-provider-imds", "npm:3.0.0"],\
+          ["@smithy/node-config-provider", "npm:3.0.0"],\
+          ["@smithy/property-provider", "npm:3.0.0"],\
+          ["@smithy/types", "npm:3.0.0"],\
+          ["@smithy/url-parser", "npm:3.0.0"],\
           ["tslib", "npm:2.6.2"]\
         ],\
         "linkType": "HARD"\
       }]\
     ]],\
     ["@smithy/eventstream-codec", [\
-      ["npm:2.0.7", {\
-        "packageLocation": "./.yarn/cache/@smithy-eventstream-codec-npm-2.0.7-6beb80a410-9c63f2a9b7.zip/node_modules/@smithy/eventstream-codec/",\
+      ["npm:3.0.0", {\
+        "packageLocation": "./.yarn/cache/@smithy-eventstream-codec-npm-3.0.0-96584120c9-66ec273253.zip/node_modules/@smithy/eventstream-codec/",\
         "packageDependencies": [\
-          ["@smithy/eventstream-codec", "npm:2.0.7"],\
+          ["@smithy/eventstream-codec", "npm:3.0.0"],\
           ["@aws-crypto/crc32", "npm:3.0.0"],\
-          ["@smithy/types", "npm:2.3.1"],\
-          ["@smithy/util-hex-encoding", "npm:2.0.0"],\
-          ["tslib", "npm:2.6.2"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["npm:2.0.9", {\
-        "packageLocation": "./.yarn/cache/@smithy-eventstream-codec-npm-2.0.9-53191f50ce-969547a9e8.zip/node_modules/@smithy/eventstream-codec/",\
-        "packageDependencies": [\
-          ["@smithy/eventstream-codec", "npm:2.0.9"],\
-          ["@aws-crypto/crc32", "npm:3.0.0"],\
-          ["@smithy/types", "npm:2.3.3"],\
-          ["@smithy/util-hex-encoding", "npm:2.0.0"],\
+          ["@smithy/types", "npm:3.0.0"],\
+          ["@smithy/util-hex-encoding", "npm:3.0.0"],\
           ["tslib", "npm:2.6.2"]\
         ],\
         "linkType": "HARD"\
       }]\
     ]],\
     ["@smithy/eventstream-serde-browser", [\
-      ["npm:2.0.7", {\
-        "packageLocation": "./.yarn/cache/@smithy-eventstream-serde-browser-npm-2.0.7-9af1a42cb7-226647236f.zip/node_modules/@smithy/eventstream-serde-browser/",\
+      ["npm:3.0.0", {\
+        "packageLocation": "./.yarn/cache/@smithy-eventstream-serde-browser-npm-3.0.0-01c0aa5553-a04c6a5207.zip/node_modules/@smithy/eventstream-serde-browser/",\
         "packageDependencies": [\
-          ["@smithy/eventstream-serde-browser", "npm:2.0.7"],\
-          ["@smithy/eventstream-serde-universal", "npm:2.0.7"],\
-          ["@smithy/types", "npm:2.3.1"],\
-          ["tslib", "npm:2.6.2"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["npm:2.0.9", {\
-        "packageLocation": "./.yarn/cache/@smithy-eventstream-serde-browser-npm-2.0.9-2231189b76-2d4ea68b40.zip/node_modules/@smithy/eventstream-serde-browser/",\
-        "packageDependencies": [\
-          ["@smithy/eventstream-serde-browser", "npm:2.0.9"],\
-          ["@smithy/eventstream-serde-universal", "npm:2.0.9"],\
-          ["@smithy/types", "npm:2.3.3"],\
+          ["@smithy/eventstream-serde-browser", "npm:3.0.0"],\
+          ["@smithy/eventstream-serde-universal", "npm:3.0.0"],\
+          ["@smithy/types", "npm:3.0.0"],\
           ["tslib", "npm:2.6.2"]\
         ],\
         "linkType": "HARD"\
       }]\
     ]],\
     ["@smithy/eventstream-serde-config-resolver", [\
-      ["npm:2.0.7", {\
-        "packageLocation": "./.yarn/cache/@smithy-eventstream-serde-config-resolver-npm-2.0.7-d4073940a1-8a79029a73.zip/node_modules/@smithy/eventstream-serde-config-resolver/",\
+      ["npm:3.0.0", {\
+        "packageLocation": "./.yarn/cache/@smithy-eventstream-serde-config-resolver-npm-3.0.0-8e8ce639e7-c07f698072.zip/node_modules/@smithy/eventstream-serde-config-resolver/",\
         "packageDependencies": [\
-          ["@smithy/eventstream-serde-config-resolver", "npm:2.0.7"],\
-          ["@smithy/types", "npm:2.3.1"],\
-          ["tslib", "npm:2.6.2"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["npm:2.0.9", {\
-        "packageLocation": "./.yarn/cache/@smithy-eventstream-serde-config-resolver-npm-2.0.9-6b4e2e01a2-92fc631766.zip/node_modules/@smithy/eventstream-serde-config-resolver/",\
-        "packageDependencies": [\
-          ["@smithy/eventstream-serde-config-resolver", "npm:2.0.9"],\
-          ["@smithy/types", "npm:2.3.3"],\
+          ["@smithy/eventstream-serde-config-resolver", "npm:3.0.0"],\
+          ["@smithy/types", "npm:3.0.0"],\
           ["tslib", "npm:2.6.2"]\
         ],\
         "linkType": "HARD"\
       }]\
     ]],\
     ["@smithy/eventstream-serde-node", [\
-      ["npm:2.0.7", {\
-        "packageLocation": "./.yarn/cache/@smithy-eventstream-serde-node-npm-2.0.7-021ea16ffd-f92d16e1aa.zip/node_modules/@smithy/eventstream-serde-node/",\
+      ["npm:3.0.0", {\
+        "packageLocation": "./.yarn/cache/@smithy-eventstream-serde-node-npm-3.0.0-1612b9ffcb-46921fae3e.zip/node_modules/@smithy/eventstream-serde-node/",\
         "packageDependencies": [\
-          ["@smithy/eventstream-serde-node", "npm:2.0.7"],\
-          ["@smithy/eventstream-serde-universal", "npm:2.0.7"],\
-          ["@smithy/types", "npm:2.3.1"],\
-          ["tslib", "npm:2.6.2"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["npm:2.0.9", {\
-        "packageLocation": "./.yarn/cache/@smithy-eventstream-serde-node-npm-2.0.9-3c453d079c-f1ff4a62d6.zip/node_modules/@smithy/eventstream-serde-node/",\
-        "packageDependencies": [\
-          ["@smithy/eventstream-serde-node", "npm:2.0.9"],\
-          ["@smithy/eventstream-serde-universal", "npm:2.0.9"],\
-          ["@smithy/types", "npm:2.3.3"],\
+          ["@smithy/eventstream-serde-node", "npm:3.0.0"],\
+          ["@smithy/eventstream-serde-universal", "npm:3.0.0"],\
+          ["@smithy/types", "npm:3.0.0"],\
           ["tslib", "npm:2.6.2"]\
         ],\
         "linkType": "HARD"\
       }]\
     ]],\
     ["@smithy/eventstream-serde-universal", [\
-      ["npm:2.0.7", {\
-        "packageLocation": "./.yarn/cache/@smithy-eventstream-serde-universal-npm-2.0.7-232c7d5515-7221b54170.zip/node_modules/@smithy/eventstream-serde-universal/",\
+      ["npm:3.0.0", {\
+        "packageLocation": "./.yarn/cache/@smithy-eventstream-serde-universal-npm-3.0.0-8245fd2986-6bca578541.zip/node_modules/@smithy/eventstream-serde-universal/",\
         "packageDependencies": [\
-          ["@smithy/eventstream-serde-universal", "npm:2.0.7"],\
-          ["@smithy/eventstream-codec", "npm:2.0.7"],\
-          ["@smithy/types", "npm:2.3.1"],\
-          ["tslib", "npm:2.6.2"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["npm:2.0.9", {\
-        "packageLocation": "./.yarn/cache/@smithy-eventstream-serde-universal-npm-2.0.9-8a68007e38-6d101a8a81.zip/node_modules/@smithy/eventstream-serde-universal/",\
-        "packageDependencies": [\
-          ["@smithy/eventstream-serde-universal", "npm:2.0.9"],\
-          ["@smithy/eventstream-codec", "npm:2.0.9"],\
-          ["@smithy/types", "npm:2.3.3"],\
+          ["@smithy/eventstream-serde-universal", "npm:3.0.0"],\
+          ["@smithy/eventstream-codec", "npm:3.0.0"],\
+          ["@smithy/types", "npm:3.0.0"],\
           ["tslib", "npm:2.6.2"]\
         ],\
         "linkType": "HARD"\
       }]\
     ]],\
     ["@smithy/fetch-http-handler", [\
-      ["npm:2.1.3", {\
-        "packageLocation": "./.yarn/cache/@smithy-fetch-http-handler-npm-2.1.3-b1c9487e74-93750fac4b.zip/node_modules/@smithy/fetch-http-handler/",\
+      ["npm:3.0.0", {\
+        "packageLocation": "./.yarn/cache/@smithy-fetch-http-handler-npm-3.0.0-d96810917a-357b6c5438.zip/node_modules/@smithy/fetch-http-handler/",\
         "packageDependencies": [\
-          ["@smithy/fetch-http-handler", "npm:2.1.3"],\
-          ["@smithy/protocol-http", "npm:3.0.3"],\
-          ["@smithy/querystring-builder", "npm:2.0.7"],\
-          ["@smithy/types", "npm:2.3.1"],\
-          ["@smithy/util-base64", "npm:2.0.0"],\
-          ["tslib", "npm:2.6.2"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["npm:2.1.5", {\
-        "packageLocation": "./.yarn/cache/@smithy-fetch-http-handler-npm-2.1.5-77195bd32d-c0da440982.zip/node_modules/@smithy/fetch-http-handler/",\
-        "packageDependencies": [\
-          ["@smithy/fetch-http-handler", "npm:2.1.5"],\
-          ["@smithy/protocol-http", "npm:3.0.5"],\
-          ["@smithy/querystring-builder", "npm:2.0.9"],\
-          ["@smithy/types", "npm:2.3.3"],\
-          ["@smithy/util-base64", "npm:2.0.0"],\
+          ["@smithy/fetch-http-handler", "npm:3.0.0"],\
+          ["@smithy/protocol-http", "npm:4.0.0"],\
+          ["@smithy/querystring-builder", "npm:3.0.0"],\
+          ["@smithy/types", "npm:3.0.0"],\
+          ["@smithy/util-base64", "npm:3.0.0"],\
           ["tslib", "npm:2.6.2"]\
         ],\
         "linkType": "HARD"\
       }]\
     ]],\
     ["@smithy/hash-blob-browser", [\
-      ["npm:2.0.7", {\
-        "packageLocation": "./.yarn/cache/@smithy-hash-blob-browser-npm-2.0.7-642725dc32-4f3273dd29.zip/node_modules/@smithy/hash-blob-browser/",\
+      ["npm:3.0.0", {\
+        "packageLocation": "./.yarn/cache/@smithy-hash-blob-browser-npm-3.0.0-04eb6d1d7e-c8f6d76d8d.zip/node_modules/@smithy/hash-blob-browser/",\
         "packageDependencies": [\
-          ["@smithy/hash-blob-browser", "npm:2.0.7"],\
-          ["@smithy/chunked-blob-reader", "npm:2.0.0"],\
-          ["@smithy/chunked-blob-reader-native", "npm:2.0.0"],\
-          ["@smithy/types", "npm:2.3.1"],\
-          ["tslib", "npm:2.6.2"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["npm:2.0.9", {\
-        "packageLocation": "./.yarn/cache/@smithy-hash-blob-browser-npm-2.0.9-757c485769-cc0fcc85f2.zip/node_modules/@smithy/hash-blob-browser/",\
-        "packageDependencies": [\
-          ["@smithy/hash-blob-browser", "npm:2.0.9"],\
-          ["@smithy/chunked-blob-reader", "npm:2.0.0"],\
-          ["@smithy/chunked-blob-reader-native", "npm:2.0.0"],\
-          ["@smithy/types", "npm:2.3.3"],\
+          ["@smithy/hash-blob-browser", "npm:3.0.0"],\
+          ["@smithy/chunked-blob-reader", "npm:3.0.0"],\
+          ["@smithy/chunked-blob-reader-native", "npm:3.0.0"],\
+          ["@smithy/types", "npm:3.0.0"],\
           ["tslib", "npm:2.6.2"]\
         ],\
         "linkType": "HARD"\
       }]\
     ]],\
     ["@smithy/hash-node", [\
-      ["npm:2.0.7", {\
-        "packageLocation": "./.yarn/cache/@smithy-hash-node-npm-2.0.7-575fd3a029-eca84eb769.zip/node_modules/@smithy/hash-node/",\
+      ["npm:3.0.0", {\
+        "packageLocation": "./.yarn/cache/@smithy-hash-node-npm-3.0.0-b4e21fde67-99c65bc992.zip/node_modules/@smithy/hash-node/",\
         "packageDependencies": [\
-          ["@smithy/hash-node", "npm:2.0.7"],\
-          ["@smithy/types", "npm:2.3.1"],\
-          ["@smithy/util-buffer-from", "npm:2.0.0"],\
-          ["@smithy/util-utf8", "npm:2.0.0"],\
-          ["tslib", "npm:2.6.2"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["npm:2.0.9", {\
-        "packageLocation": "./.yarn/cache/@smithy-hash-node-npm-2.0.9-2fa21ac4f5-c237fe6f13.zip/node_modules/@smithy/hash-node/",\
-        "packageDependencies": [\
-          ["@smithy/hash-node", "npm:2.0.9"],\
-          ["@smithy/types", "npm:2.3.3"],\
-          ["@smithy/util-buffer-from", "npm:2.0.0"],\
-          ["@smithy/util-utf8", "npm:2.0.0"],\
+          ["@smithy/hash-node", "npm:3.0.0"],\
+          ["@smithy/types", "npm:3.0.0"],\
+          ["@smithy/util-buffer-from", "npm:3.0.0"],\
+          ["@smithy/util-utf8", "npm:3.0.0"],\
           ["tslib", "npm:2.6.2"]\
         ],\
         "linkType": "HARD"\
       }]\
     ]],\
     ["@smithy/hash-stream-node", [\
-      ["npm:2.0.7", {\
-        "packageLocation": "./.yarn/cache/@smithy-hash-stream-node-npm-2.0.7-6c03c8ea45-e256629eac.zip/node_modules/@smithy/hash-stream-node/",\
+      ["npm:3.0.0", {\
+        "packageLocation": "./.yarn/cache/@smithy-hash-stream-node-npm-3.0.0-c0484bac53-1e67ad7942.zip/node_modules/@smithy/hash-stream-node/",\
         "packageDependencies": [\
-          ["@smithy/hash-stream-node", "npm:2.0.7"],\
-          ["@smithy/types", "npm:2.3.1"],\
-          ["@smithy/util-utf8", "npm:2.0.0"],\
-          ["tslib", "npm:2.6.2"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["npm:2.0.9", {\
-        "packageLocation": "./.yarn/cache/@smithy-hash-stream-node-npm-2.0.9-273c8b02e0-5a424f4c77.zip/node_modules/@smithy/hash-stream-node/",\
-        "packageDependencies": [\
-          ["@smithy/hash-stream-node", "npm:2.0.9"],\
-          ["@smithy/types", "npm:2.3.3"],\
-          ["@smithy/util-utf8", "npm:2.0.0"],\
+          ["@smithy/hash-stream-node", "npm:3.0.0"],\
+          ["@smithy/types", "npm:3.0.0"],\
+          ["@smithy/util-utf8", "npm:3.0.0"],\
           ["tslib", "npm:2.6.2"]\
         ],\
         "linkType": "HARD"\
       }]\
     ]],\
     ["@smithy/invalid-dependency", [\
-      ["npm:2.0.7", {\
-        "packageLocation": "./.yarn/cache/@smithy-invalid-dependency-npm-2.0.7-c0559f400f-eaf0fa963f.zip/node_modules/@smithy/invalid-dependency/",\
+      ["npm:3.0.0", {\
+        "packageLocation": "./.yarn/cache/@smithy-invalid-dependency-npm-3.0.0-4023cdc9a6-e78e9cbe1c.zip/node_modules/@smithy/invalid-dependency/",\
         "packageDependencies": [\
-          ["@smithy/invalid-dependency", "npm:2.0.7"],\
-          ["@smithy/types", "npm:2.3.1"],\
-          ["tslib", "npm:2.6.2"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["npm:2.0.9", {\
-        "packageLocation": "./.yarn/cache/@smithy-invalid-dependency-npm-2.0.9-107520c4f5-24e0d2da9c.zip/node_modules/@smithy/invalid-dependency/",\
-        "packageDependencies": [\
-          ["@smithy/invalid-dependency", "npm:2.0.9"],\
-          ["@smithy/types", "npm:2.3.3"],\
+          ["@smithy/invalid-dependency", "npm:3.0.0"],\
+          ["@smithy/types", "npm:3.0.0"],\
           ["tslib", "npm:2.6.2"]\
         ],\
         "linkType": "HARD"\
       }]\
     ]],\
     ["@smithy/is-array-buffer", [\
-      ["npm:2.0.0", {\
-        "packageLocation": "./.yarn/cache/@smithy-is-array-buffer-npm-2.0.0-c87c41f2d4-30f8e51403.zip/node_modules/@smithy/is-array-buffer/",\
+      ["npm:3.0.0", {\
+        "packageLocation": "./.yarn/cache/@smithy-is-array-buffer-npm-3.0.0-8e8215ad1c-cab1fd4033.zip/node_modules/@smithy/is-array-buffer/",\
         "packageDependencies": [\
-          ["@smithy/is-array-buffer", "npm:2.0.0"],\
+          ["@smithy/is-array-buffer", "npm:3.0.0"],\
           ["tslib", "npm:2.6.2"]\
         ],\
         "linkType": "HARD"\
       }]\
     ]],\
     ["@smithy/md5-js", [\
-      ["npm:2.0.7", {\
-        "packageLocation": "./.yarn/cache/@smithy-md5-js-npm-2.0.7-27bb120d58-e25cf7e842.zip/node_modules/@smithy/md5-js/",\
+      ["npm:3.0.0", {\
+        "packageLocation": "./.yarn/cache/@smithy-md5-js-npm-3.0.0-ed3d301283-098b849ee7.zip/node_modules/@smithy/md5-js/",\
         "packageDependencies": [\
-          ["@smithy/md5-js", "npm:2.0.7"],\
-          ["@smithy/types", "npm:2.3.1"],\
-          ["@smithy/util-utf8", "npm:2.0.0"],\
-          ["tslib", "npm:2.6.2"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["npm:2.0.9", {\
-        "packageLocation": "./.yarn/cache/@smithy-md5-js-npm-2.0.9-2e680aa6c3-9a18576ee7.zip/node_modules/@smithy/md5-js/",\
-        "packageDependencies": [\
-          ["@smithy/md5-js", "npm:2.0.9"],\
-          ["@smithy/types", "npm:2.3.3"],\
-          ["@smithy/util-utf8", "npm:2.0.0"],\
+          ["@smithy/md5-js", "npm:3.0.0"],\
+          ["@smithy/types", "npm:3.0.0"],\
+          ["@smithy/util-utf8", "npm:3.0.0"],\
           ["tslib", "npm:2.6.2"]\
         ],\
         "linkType": "HARD"\
       }]\
     ]],\
     ["@smithy/middleware-content-length", [\
-      ["npm:2.0.11", {\
-        "packageLocation": "./.yarn/cache/@smithy-middleware-content-length-npm-2.0.11-d0c03ab81c-39351662a4.zip/node_modules/@smithy/middleware-content-length/",\
+      ["npm:3.0.0", {\
+        "packageLocation": "./.yarn/cache/@smithy-middleware-content-length-npm-3.0.0-67a9e7d99b-2d1dc5766a.zip/node_modules/@smithy/middleware-content-length/",\
         "packageDependencies": [\
-          ["@smithy/middleware-content-length", "npm:2.0.11"],\
-          ["@smithy/protocol-http", "npm:3.0.5"],\
-          ["@smithy/types", "npm:2.3.3"],\
-          ["tslib", "npm:2.6.2"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["npm:2.0.9", {\
-        "packageLocation": "./.yarn/cache/@smithy-middleware-content-length-npm-2.0.9-af47c33cde-707f6fcb58.zip/node_modules/@smithy/middleware-content-length/",\
-        "packageDependencies": [\
-          ["@smithy/middleware-content-length", "npm:2.0.9"],\
-          ["@smithy/protocol-http", "npm:3.0.3"],\
-          ["@smithy/types", "npm:2.3.1"],\
+          ["@smithy/middleware-content-length", "npm:3.0.0"],\
+          ["@smithy/protocol-http", "npm:4.0.0"],\
+          ["@smithy/types", "npm:3.0.0"],\
           ["tslib", "npm:2.6.2"]\
         ],\
         "linkType": "HARD"\
       }]\
     ]],\
     ["@smithy/middleware-endpoint", [\
-      ["npm:2.0.7", {\
-        "packageLocation": "./.yarn/cache/@smithy-middleware-endpoint-npm-2.0.7-fe51c1765a-19f4ae3696.zip/node_modules/@smithy/middleware-endpoint/",\
+      ["npm:3.0.0", {\
+        "packageLocation": "./.yarn/cache/@smithy-middleware-endpoint-npm-3.0.0-c166be89ba-b39b8a3c8d.zip/node_modules/@smithy/middleware-endpoint/",\
         "packageDependencies": [\
-          ["@smithy/middleware-endpoint", "npm:2.0.7"],\
-          ["@smithy/middleware-serde", "npm:2.0.7"],\
-          ["@smithy/types", "npm:2.3.1"],\
-          ["@smithy/url-parser", "npm:2.0.7"],\
-          ["@smithy/util-middleware", "npm:2.0.0"],\
-          ["tslib", "npm:2.6.2"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["npm:2.0.9", {\
-        "packageLocation": "./.yarn/cache/@smithy-middleware-endpoint-npm-2.0.9-cd3b8cea8c-40394629c3.zip/node_modules/@smithy/middleware-endpoint/",\
-        "packageDependencies": [\
-          ["@smithy/middleware-endpoint", "npm:2.0.9"],\
-          ["@smithy/middleware-serde", "npm:2.0.9"],\
-          ["@smithy/types", "npm:2.3.3"],\
-          ["@smithy/url-parser", "npm:2.0.9"],\
-          ["@smithy/util-middleware", "npm:2.0.2"],\
+          ["@smithy/middleware-endpoint", "npm:3.0.0"],\
+          ["@smithy/middleware-serde", "npm:3.0.0"],\
+          ["@smithy/node-config-provider", "npm:3.0.0"],\
+          ["@smithy/shared-ini-file-loader", "npm:3.0.0"],\
+          ["@smithy/types", "npm:3.0.0"],\
+          ["@smithy/url-parser", "npm:3.0.0"],\
+          ["@smithy/util-middleware", "npm:3.0.0"],\
           ["tslib", "npm:2.6.2"]\
         ],\
         "linkType": "HARD"\
       }]\
     ]],\
     ["@smithy/middleware-retry", [\
-      ["npm:2.0.10", {\
-        "packageLocation": "./.yarn/cache/@smithy-middleware-retry-npm-2.0.10-891452d2a0-c44d1c8e60.zip/node_modules/@smithy/middleware-retry/",\
+      ["npm:3.0.0", {\
+        "packageLocation": "./.yarn/cache/@smithy-middleware-retry-npm-3.0.0-0feefd16e7-9158545d29.zip/node_modules/@smithy/middleware-retry/",\
         "packageDependencies": [\
-          ["@smithy/middleware-retry", "npm:2.0.10"],\
-          ["@smithy/node-config-provider", "npm:2.0.10"],\
-          ["@smithy/protocol-http", "npm:3.0.3"],\
-          ["@smithy/service-error-classification", "npm:2.0.0"],\
-          ["@smithy/types", "npm:2.3.1"],\
-          ["@smithy/util-middleware", "npm:2.0.0"],\
-          ["@smithy/util-retry", "npm:2.0.0"],\
+          ["@smithy/middleware-retry", "npm:3.0.0"],\
+          ["@smithy/node-config-provider", "npm:3.0.0"],\
+          ["@smithy/protocol-http", "npm:4.0.0"],\
+          ["@smithy/service-error-classification", "npm:3.0.0"],\
+          ["@smithy/smithy-client", "npm:3.0.0"],\
+          ["@smithy/types", "npm:3.0.0"],\
+          ["@smithy/util-middleware", "npm:3.0.0"],\
+          ["@smithy/util-retry", "npm:3.0.0"],\
           ["tslib", "npm:2.6.2"],\
-          ["uuid", "npm:8.3.2"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["npm:2.0.12", {\
-        "packageLocation": "./.yarn/cache/@smithy-middleware-retry-npm-2.0.12-df09beec52-2265c95d1c.zip/node_modules/@smithy/middleware-retry/",\
-        "packageDependencies": [\
-          ["@smithy/middleware-retry", "npm:2.0.12"],\
-          ["@smithy/node-config-provider", "npm:2.0.12"],\
-          ["@smithy/protocol-http", "npm:3.0.5"],\
-          ["@smithy/service-error-classification", "npm:2.0.2"],\
-          ["@smithy/types", "npm:2.3.3"],\
-          ["@smithy/util-middleware", "npm:2.0.2"],\
-          ["@smithy/util-retry", "npm:2.0.2"],\
-          ["tslib", "npm:2.6.2"],\
-          ["uuid", "npm:8.3.2"]\
+          ["uuid", "npm:9.0.1"]\
         ],\
         "linkType": "HARD"\
       }]\
     ]],\
     ["@smithy/middleware-serde", [\
-      ["npm:2.0.7", {\
-        "packageLocation": "./.yarn/cache/@smithy-middleware-serde-npm-2.0.7-7e821cf0b6-91e46d1758.zip/node_modules/@smithy/middleware-serde/",\
+      ["npm:3.0.0", {\
+        "packageLocation": "./.yarn/cache/@smithy-middleware-serde-npm-3.0.0-47c903c77e-7ca5256fe9.zip/node_modules/@smithy/middleware-serde/",\
         "packageDependencies": [\
-          ["@smithy/middleware-serde", "npm:2.0.7"],\
-          ["@smithy/types", "npm:2.3.1"],\
-          ["tslib", "npm:2.6.2"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["npm:2.0.9", {\
-        "packageLocation": "./.yarn/cache/@smithy-middleware-serde-npm-2.0.9-c1db4566a4-fa10b0c671.zip/node_modules/@smithy/middleware-serde/",\
-        "packageDependencies": [\
-          ["@smithy/middleware-serde", "npm:2.0.9"],\
-          ["@smithy/types", "npm:2.3.3"],\
+          ["@smithy/middleware-serde", "npm:3.0.0"],\
+          ["@smithy/types", "npm:3.0.0"],\
           ["tslib", "npm:2.6.2"]\
         ],\
         "linkType": "HARD"\
       }]\
     ]],\
     ["@smithy/middleware-stack", [\
-      ["npm:2.0.0", {\
-        "packageLocation": "./.yarn/cache/@smithy-middleware-stack-npm-2.0.0-dc7cdb14e8-6bbc3ff23f.zip/node_modules/@smithy/middleware-stack/",\
+      ["npm:3.0.0", {\
+        "packageLocation": "./.yarn/cache/@smithy-middleware-stack-npm-3.0.0-2defb8d4ac-e85695b2d2.zip/node_modules/@smithy/middleware-stack/",\
         "packageDependencies": [\
-          ["@smithy/middleware-stack", "npm:2.0.0"],\
-          ["tslib", "npm:2.6.2"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["npm:2.0.3", {\
-        "packageLocation": "./.yarn/cache/@smithy-middleware-stack-npm-2.0.3-91b57d32e7-ab4ea66a24.zip/node_modules/@smithy/middleware-stack/",\
-        "packageDependencies": [\
-          ["@smithy/middleware-stack", "npm:2.0.3"],\
-          ["@smithy/types", "npm:2.3.3"],\
+          ["@smithy/middleware-stack", "npm:3.0.0"],\
+          ["@smithy/types", "npm:3.0.0"],\
           ["tslib", "npm:2.6.2"]\
         ],\
         "linkType": "HARD"\
       }]\
     ]],\
     ["@smithy/node-config-provider", [\
-      ["npm:2.0.10", {\
-        "packageLocation": "./.yarn/cache/@smithy-node-config-provider-npm-2.0.10-0814cc717c-6b770152af.zip/node_modules/@smithy/node-config-provider/",\
+      ["npm:3.0.0", {\
+        "packageLocation": "./.yarn/cache/@smithy-node-config-provider-npm-3.0.0-588f2e842c-6f53261624.zip/node_modules/@smithy/node-config-provider/",\
         "packageDependencies": [\
-          ["@smithy/node-config-provider", "npm:2.0.10"],\
-          ["@smithy/property-provider", "npm:2.0.8"],\
-          ["@smithy/shared-ini-file-loader", "npm:2.0.9"],\
-          ["@smithy/types", "npm:2.3.1"],\
-          ["tslib", "npm:2.6.2"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["npm:2.0.12", {\
-        "packageLocation": "./.yarn/cache/@smithy-node-config-provider-npm-2.0.12-3246a77776-b98bdd2555.zip/node_modules/@smithy/node-config-provider/",\
-        "packageDependencies": [\
-          ["@smithy/node-config-provider", "npm:2.0.12"],\
-          ["@smithy/property-provider", "npm:2.0.10"],\
-          ["@smithy/shared-ini-file-loader", "npm:2.0.11"],\
-          ["@smithy/types", "npm:2.3.3"],\
+          ["@smithy/node-config-provider", "npm:3.0.0"],\
+          ["@smithy/property-provider", "npm:3.0.0"],\
+          ["@smithy/shared-ini-file-loader", "npm:3.0.0"],\
+          ["@smithy/types", "npm:3.0.0"],\
           ["tslib", "npm:2.6.2"]\
         ],\
         "linkType": "HARD"\
       }]\
     ]],\
     ["@smithy/node-http-handler", [\
-      ["npm:2.1.3", {\
-        "packageLocation": "./.yarn/cache/@smithy-node-http-handler-npm-2.1.3-65027f1236-df7349e993.zip/node_modules/@smithy/node-http-handler/",\
+      ["npm:3.0.0", {\
+        "packageLocation": "./.yarn/cache/@smithy-node-http-handler-npm-3.0.0-c1c492cac9-3d2d0fff55.zip/node_modules/@smithy/node-http-handler/",\
         "packageDependencies": [\
-          ["@smithy/node-http-handler", "npm:2.1.3"],\
-          ["@smithy/abort-controller", "npm:2.0.7"],\
-          ["@smithy/protocol-http", "npm:3.0.3"],\
-          ["@smithy/querystring-builder", "npm:2.0.7"],\
-          ["@smithy/types", "npm:2.3.1"],\
-          ["tslib", "npm:2.6.2"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["npm:2.1.5", {\
-        "packageLocation": "./.yarn/cache/@smithy-node-http-handler-npm-2.1.5-b94716ff90-4dfd0009b2.zip/node_modules/@smithy/node-http-handler/",\
-        "packageDependencies": [\
-          ["@smithy/node-http-handler", "npm:2.1.5"],\
-          ["@smithy/abort-controller", "npm:2.0.9"],\
-          ["@smithy/protocol-http", "npm:3.0.5"],\
-          ["@smithy/querystring-builder", "npm:2.0.9"],\
-          ["@smithy/types", "npm:2.3.3"],\
+          ["@smithy/node-http-handler", "npm:3.0.0"],\
+          ["@smithy/abort-controller", "npm:3.0.0"],\
+          ["@smithy/protocol-http", "npm:4.0.0"],\
+          ["@smithy/querystring-builder", "npm:3.0.0"],\
+          ["@smithy/types", "npm:3.0.0"],\
           ["tslib", "npm:2.6.2"]\
         ],\
         "linkType": "HARD"\
       }]\
     ]],\
     ["@smithy/property-provider", [\
-      ["npm:2.0.10", {\
-        "packageLocation": "./.yarn/cache/@smithy-property-provider-npm-2.0.10-3bd50aecf3-94b06d7e40.zip/node_modules/@smithy/property-provider/",\
+      ["npm:3.0.0", {\
+        "packageLocation": "./.yarn/cache/@smithy-property-provider-npm-3.0.0-d87bb680eb-37c9b949f0.zip/node_modules/@smithy/property-provider/",\
         "packageDependencies": [\
-          ["@smithy/property-provider", "npm:2.0.10"],\
-          ["@smithy/types", "npm:2.3.3"],\
-          ["tslib", "npm:2.6.2"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["npm:2.0.8", {\
-        "packageLocation": "./.yarn/cache/@smithy-property-provider-npm-2.0.8-cdadb38afd-e34142edc4.zip/node_modules/@smithy/property-provider/",\
-        "packageDependencies": [\
-          ["@smithy/property-provider", "npm:2.0.8"],\
-          ["@smithy/types", "npm:2.3.1"],\
+          ["@smithy/property-provider", "npm:3.0.0"],\
+          ["@smithy/types", "npm:3.0.0"],\
           ["tslib", "npm:2.6.2"]\
         ],\
         "linkType": "HARD"\
       }]\
     ]],\
     ["@smithy/protocol-http", [\
-      ["npm:3.0.3", {\
-        "packageLocation": "./.yarn/cache/@smithy-protocol-http-npm-3.0.3-47729a343c-cf6fdd63da.zip/node_modules/@smithy/protocol-http/",\
+      ["npm:4.0.0", {\
+        "packageLocation": "./.yarn/cache/@smithy-protocol-http-npm-4.0.0-75a5e206a3-0e663013be.zip/node_modules/@smithy/protocol-http/",\
         "packageDependencies": [\
-          ["@smithy/protocol-http", "npm:3.0.3"],\
-          ["@smithy/types", "npm:2.3.1"],\
-          ["tslib", "npm:2.6.2"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["npm:3.0.5", {\
-        "packageLocation": "./.yarn/cache/@smithy-protocol-http-npm-3.0.5-cb279f9fd1-1fddbff8b1.zip/node_modules/@smithy/protocol-http/",\
-        "packageDependencies": [\
-          ["@smithy/protocol-http", "npm:3.0.5"],\
-          ["@smithy/types", "npm:2.3.3"],\
+          ["@smithy/protocol-http", "npm:4.0.0"],\
+          ["@smithy/types", "npm:3.0.0"],\
           ["tslib", "npm:2.6.2"]\
         ],\
         "linkType": "HARD"\
       }]\
     ]],\
     ["@smithy/querystring-builder", [\
-      ["npm:2.0.7", {\
-        "packageLocation": "./.yarn/cache/@smithy-querystring-builder-npm-2.0.7-9dda46d947-16651e9185.zip/node_modules/@smithy/querystring-builder/",\
+      ["npm:3.0.0", {\
+        "packageLocation": "./.yarn/cache/@smithy-querystring-builder-npm-3.0.0-0534085e5a-bca3e4c321.zip/node_modules/@smithy/querystring-builder/",\
         "packageDependencies": [\
-          ["@smithy/querystring-builder", "npm:2.0.7"],\
-          ["@smithy/types", "npm:2.3.1"],\
-          ["@smithy/util-uri-escape", "npm:2.0.0"],\
-          ["tslib", "npm:2.6.2"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["npm:2.0.9", {\
-        "packageLocation": "./.yarn/cache/@smithy-querystring-builder-npm-2.0.9-fd5f7ad9b1-b06bca2c9f.zip/node_modules/@smithy/querystring-builder/",\
-        "packageDependencies": [\
-          ["@smithy/querystring-builder", "npm:2.0.9"],\
-          ["@smithy/types", "npm:2.3.3"],\
-          ["@smithy/util-uri-escape", "npm:2.0.0"],\
+          ["@smithy/querystring-builder", "npm:3.0.0"],\
+          ["@smithy/types", "npm:3.0.0"],\
+          ["@smithy/util-uri-escape", "npm:3.0.0"],\
           ["tslib", "npm:2.6.2"]\
         ],\
         "linkType": "HARD"\
       }]\
     ]],\
     ["@smithy/querystring-parser", [\
-      ["npm:2.0.7", {\
-        "packageLocation": "./.yarn/cache/@smithy-querystring-parser-npm-2.0.7-02206c9e75-7bdcc6de61.zip/node_modules/@smithy/querystring-parser/",\
+      ["npm:3.0.0", {\
+        "packageLocation": "./.yarn/cache/@smithy-querystring-parser-npm-3.0.0-7a5901d5a3-c0258dd552.zip/node_modules/@smithy/querystring-parser/",\
         "packageDependencies": [\
-          ["@smithy/querystring-parser", "npm:2.0.7"],\
-          ["@smithy/types", "npm:2.3.1"],\
-          ["tslib", "npm:2.6.2"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["npm:2.0.9", {\
-        "packageLocation": "./.yarn/cache/@smithy-querystring-parser-npm-2.0.9-4229639234-5977ca9194.zip/node_modules/@smithy/querystring-parser/",\
-        "packageDependencies": [\
-          ["@smithy/querystring-parser", "npm:2.0.9"],\
-          ["@smithy/types", "npm:2.3.3"],\
+          ["@smithy/querystring-parser", "npm:3.0.0"],\
+          ["@smithy/types", "npm:3.0.0"],\
           ["tslib", "npm:2.6.2"]\
         ],\
         "linkType": "HARD"\
       }]\
     ]],\
     ["@smithy/service-error-classification", [\
-      ["npm:2.0.0", {\
-        "packageLocation": "./.yarn/cache/@smithy-service-error-classification-npm-2.0.0-38f8ea988d-2dfb6baccf.zip/node_modules/@smithy/service-error-classification/",\
+      ["npm:3.0.0", {\
+        "packageLocation": "./.yarn/cache/@smithy-service-error-classification-npm-3.0.0-61a6847a3a-b7922ac401.zip/node_modules/@smithy/service-error-classification/",\
         "packageDependencies": [\
-          ["@smithy/service-error-classification", "npm:2.0.0"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["npm:2.0.2", {\
-        "packageLocation": "./.yarn/cache/@smithy-service-error-classification-npm-2.0.2-3bf98ab671-41e901ebd2.zip/node_modules/@smithy/service-error-classification/",\
-        "packageDependencies": [\
-          ["@smithy/service-error-classification", "npm:2.0.2"],\
-          ["@smithy/types", "npm:2.3.3"]\
+          ["@smithy/service-error-classification", "npm:3.0.0"],\
+          ["@smithy/types", "npm:3.0.0"]\
         ],\
         "linkType": "HARD"\
       }]\
     ]],\
     ["@smithy/shared-ini-file-loader", [\
-      ["npm:2.0.11", {\
-        "packageLocation": "./.yarn/cache/@smithy-shared-ini-file-loader-npm-2.0.11-ff89a790f6-434fb81f1e.zip/node_modules/@smithy/shared-ini-file-loader/",\
+      ["npm:3.0.0", {\
+        "packageLocation": "./.yarn/cache/@smithy-shared-ini-file-loader-npm-3.0.0-7ab13b5c41-29b2fda4aa.zip/node_modules/@smithy/shared-ini-file-loader/",\
         "packageDependencies": [\
-          ["@smithy/shared-ini-file-loader", "npm:2.0.11"],\
-          ["@smithy/types", "npm:2.3.3"],\
-          ["tslib", "npm:2.6.2"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["npm:2.0.9", {\
-        "packageLocation": "./.yarn/cache/@smithy-shared-ini-file-loader-npm-2.0.9-d995056929-8bd9c2e9cf.zip/node_modules/@smithy/shared-ini-file-loader/",\
-        "packageDependencies": [\
-          ["@smithy/shared-ini-file-loader", "npm:2.0.9"],\
-          ["@smithy/types", "npm:2.3.1"],\
+          ["@smithy/shared-ini-file-loader", "npm:3.0.0"],\
+          ["@smithy/types", "npm:3.0.0"],\
           ["tslib", "npm:2.6.2"]\
         ],\
         "linkType": "HARD"\
       }]\
     ]],\
     ["@smithy/signature-v4", [\
-      ["npm:2.0.7", {\
-        "packageLocation": "./.yarn/cache/@smithy-signature-v4-npm-2.0.7-7c8029a935-9147ee8d0d.zip/node_modules/@smithy/signature-v4/",\
+      ["npm:3.0.0", {\
+        "packageLocation": "./.yarn/cache/@smithy-signature-v4-npm-3.0.0-05cd3e777d-528461766b.zip/node_modules/@smithy/signature-v4/",\
         "packageDependencies": [\
-          ["@smithy/signature-v4", "npm:2.0.7"],\
-          ["@smithy/eventstream-codec", "npm:2.0.7"],\
-          ["@smithy/is-array-buffer", "npm:2.0.0"],\
-          ["@smithy/types", "npm:2.3.1"],\
-          ["@smithy/util-hex-encoding", "npm:2.0.0"],\
-          ["@smithy/util-middleware", "npm:2.0.0"],\
-          ["@smithy/util-uri-escape", "npm:2.0.0"],\
-          ["@smithy/util-utf8", "npm:2.0.0"],\
+          ["@smithy/signature-v4", "npm:3.0.0"],\
+          ["@smithy/is-array-buffer", "npm:3.0.0"],\
+          ["@smithy/types", "npm:3.0.0"],\
+          ["@smithy/util-hex-encoding", "npm:3.0.0"],\
+          ["@smithy/util-middleware", "npm:3.0.0"],\
+          ["@smithy/util-uri-escape", "npm:3.0.0"],\
+          ["@smithy/util-utf8", "npm:3.0.0"],\
           ["tslib", "npm:2.6.2"]\
         ],\
         "linkType": "HARD"\
       }]\
     ]],\
     ["@smithy/smithy-client", [\
-      ["npm:2.1.4", {\
-        "packageLocation": "./.yarn/cache/@smithy-smithy-client-npm-2.1.4-136a5102c7-ce1e768fa8.zip/node_modules/@smithy/smithy-client/",\
+      ["npm:3.0.0", {\
+        "packageLocation": "./.yarn/cache/@smithy-smithy-client-npm-3.0.0-8a180afacb-22c940ac2b.zip/node_modules/@smithy/smithy-client/",\
         "packageDependencies": [\
-          ["@smithy/smithy-client", "npm:2.1.4"],\
-          ["@smithy/middleware-stack", "npm:2.0.0"],\
-          ["@smithy/types", "npm:2.3.1"],\
-          ["@smithy/util-stream", "npm:2.0.10"],\
-          ["tslib", "npm:2.6.2"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["npm:2.1.7", {\
-        "packageLocation": "./.yarn/cache/@smithy-smithy-client-npm-2.1.7-de2aff64e8-061658efed.zip/node_modules/@smithy/smithy-client/",\
-        "packageDependencies": [\
-          ["@smithy/smithy-client", "npm:2.1.7"],\
-          ["@smithy/middleware-stack", "npm:2.0.3"],\
-          ["@smithy/types", "npm:2.3.3"],\
-          ["@smithy/util-stream", "npm:2.0.12"],\
+          ["@smithy/smithy-client", "npm:3.0.0"],\
+          ["@smithy/middleware-endpoint", "npm:3.0.0"],\
+          ["@smithy/middleware-stack", "npm:3.0.0"],\
+          ["@smithy/protocol-http", "npm:4.0.0"],\
+          ["@smithy/types", "npm:3.0.0"],\
+          ["@smithy/util-stream", "npm:3.0.0"],\
           ["tslib", "npm:2.6.2"]\
         ],\
         "linkType": "HARD"\
@@ -8456,108 +7903,88 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "HARD"\
       }],\
-      ["npm:2.3.3", {\
-        "packageLocation": "./.yarn/cache/@smithy-types-npm-2.3.3-a3ff2e24c4-d79acfa741.zip/node_modules/@smithy/types/",\
+      ["npm:3.0.0", {\
+        "packageLocation": "./.yarn/cache/@smithy-types-npm-3.0.0-8f81574d4f-8b9a45fc24.zip/node_modules/@smithy/types/",\
         "packageDependencies": [\
-          ["@smithy/types", "npm:2.3.3"],\
+          ["@smithy/types", "npm:3.0.0"],\
           ["tslib", "npm:2.6.2"]\
         ],\
         "linkType": "HARD"\
       }]\
     ]],\
     ["@smithy/url-parser", [\
-      ["npm:2.0.7", {\
-        "packageLocation": "./.yarn/cache/@smithy-url-parser-npm-2.0.7-e666eb346e-fbb6d7ee58.zip/node_modules/@smithy/url-parser/",\
+      ["npm:3.0.0", {\
+        "packageLocation": "./.yarn/cache/@smithy-url-parser-npm-3.0.0-8a711f9f95-f88c1a2537.zip/node_modules/@smithy/url-parser/",\
         "packageDependencies": [\
-          ["@smithy/url-parser", "npm:2.0.7"],\
-          ["@smithy/querystring-parser", "npm:2.0.7"],\
-          ["@smithy/types", "npm:2.3.1"],\
-          ["tslib", "npm:2.6.2"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["npm:2.0.9", {\
-        "packageLocation": "./.yarn/cache/@smithy-url-parser-npm-2.0.9-e832b7a312-43a8b8d879.zip/node_modules/@smithy/url-parser/",\
-        "packageDependencies": [\
-          ["@smithy/url-parser", "npm:2.0.9"],\
-          ["@smithy/querystring-parser", "npm:2.0.9"],\
-          ["@smithy/types", "npm:2.3.3"],\
+          ["@smithy/url-parser", "npm:3.0.0"],\
+          ["@smithy/querystring-parser", "npm:3.0.0"],\
+          ["@smithy/types", "npm:3.0.0"],\
           ["tslib", "npm:2.6.2"]\
         ],\
         "linkType": "HARD"\
       }]\
     ]],\
     ["@smithy/util-base64", [\
-      ["npm:2.0.0", {\
-        "packageLocation": "./.yarn/cache/@smithy-util-base64-npm-2.0.0-622e14ad86-1e99afde11.zip/node_modules/@smithy/util-base64/",\
+      ["npm:3.0.0", {\
+        "packageLocation": "./.yarn/cache/@smithy-util-base64-npm-3.0.0-38fc40fa27-3c883d63a3.zip/node_modules/@smithy/util-base64/",\
         "packageDependencies": [\
-          ["@smithy/util-base64", "npm:2.0.0"],\
-          ["@smithy/util-buffer-from", "npm:2.0.0"],\
+          ["@smithy/util-base64", "npm:3.0.0"],\
+          ["@smithy/util-buffer-from", "npm:3.0.0"],\
+          ["@smithy/util-utf8", "npm:3.0.0"],\
           ["tslib", "npm:2.6.2"]\
         ],\
         "linkType": "HARD"\
       }]\
     ]],\
     ["@smithy/util-body-length-browser", [\
-      ["npm:2.0.0", {\
-        "packageLocation": "./.yarn/cache/@smithy-util-body-length-browser-npm-2.0.0-5b13b6fc56-59ccbe316f.zip/node_modules/@smithy/util-body-length-browser/",\
+      ["npm:3.0.0", {\
+        "packageLocation": "./.yarn/cache/@smithy-util-body-length-browser-npm-3.0.0-868397df97-a0ab6a6d41.zip/node_modules/@smithy/util-body-length-browser/",\
         "packageDependencies": [\
-          ["@smithy/util-body-length-browser", "npm:2.0.0"],\
+          ["@smithy/util-body-length-browser", "npm:3.0.0"],\
           ["tslib", "npm:2.6.2"]\
         ],\
         "linkType": "HARD"\
       }]\
     ]],\
     ["@smithy/util-body-length-node", [\
-      ["npm:2.1.0", {\
-        "packageLocation": "./.yarn/cache/@smithy-util-body-length-node-npm-2.1.0-a60ca675f9-1b2e3a9981.zip/node_modules/@smithy/util-body-length-node/",\
+      ["npm:3.0.0", {\
+        "packageLocation": "./.yarn/cache/@smithy-util-body-length-node-npm-3.0.0-9d33ec493b-aabac66d71.zip/node_modules/@smithy/util-body-length-node/",\
         "packageDependencies": [\
-          ["@smithy/util-body-length-node", "npm:2.1.0"],\
+          ["@smithy/util-body-length-node", "npm:3.0.0"],\
           ["tslib", "npm:2.6.2"]\
         ],\
         "linkType": "HARD"\
       }]\
     ]],\
     ["@smithy/util-buffer-from", [\
-      ["npm:2.0.0", {\
-        "packageLocation": "./.yarn/cache/@smithy-util-buffer-from-npm-2.0.0-f9e4f4f662-15326acdb8.zip/node_modules/@smithy/util-buffer-from/",\
+      ["npm:3.0.0", {\
+        "packageLocation": "./.yarn/cache/@smithy-util-buffer-from-npm-3.0.0-7f54bf03c3-7e6596b388.zip/node_modules/@smithy/util-buffer-from/",\
         "packageDependencies": [\
-          ["@smithy/util-buffer-from", "npm:2.0.0"],\
-          ["@smithy/is-array-buffer", "npm:2.0.0"],\
+          ["@smithy/util-buffer-from", "npm:3.0.0"],\
+          ["@smithy/is-array-buffer", "npm:3.0.0"],\
           ["tslib", "npm:2.6.2"]\
         ],\
         "linkType": "HARD"\
       }]\
     ]],\
     ["@smithy/util-config-provider", [\
-      ["npm:2.0.0", {\
-        "packageLocation": "./.yarn/cache/@smithy-util-config-provider-npm-2.0.0-aad699993d-13910f0643.zip/node_modules/@smithy/util-config-provider/",\
+      ["npm:3.0.0", {\
+        "packageLocation": "./.yarn/cache/@smithy-util-config-provider-npm-3.0.0-f3b040d73b-614c321c5a.zip/node_modules/@smithy/util-config-provider/",\
         "packageDependencies": [\
-          ["@smithy/util-config-provider", "npm:2.0.0"],\
+          ["@smithy/util-config-provider", "npm:3.0.0"],\
           ["tslib", "npm:2.6.2"]\
         ],\
         "linkType": "HARD"\
       }]\
     ]],\
     ["@smithy/util-defaults-mode-browser", [\
-      ["npm:2.0.11", {\
-        "packageLocation": "./.yarn/cache/@smithy-util-defaults-mode-browser-npm-2.0.11-584ff1deba-5022ef5847.zip/node_modules/@smithy/util-defaults-mode-browser/",\
+      ["npm:3.0.0", {\
+        "packageLocation": "./.yarn/cache/@smithy-util-defaults-mode-browser-npm-3.0.0-2a783fdb45-b55f2f1c83.zip/node_modules/@smithy/util-defaults-mode-browser/",\
         "packageDependencies": [\
-          ["@smithy/util-defaults-mode-browser", "npm:2.0.11"],\
-          ["@smithy/property-provider", "npm:2.0.10"],\
-          ["@smithy/smithy-client", "npm:2.1.7"],\
-          ["@smithy/types", "npm:2.3.3"],\
-          ["bowser", "npm:2.11.0"],\
-          ["tslib", "npm:2.6.2"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["npm:2.0.8", {\
-        "packageLocation": "./.yarn/cache/@smithy-util-defaults-mode-browser-npm-2.0.8-bc4dfe1712-5845b29927.zip/node_modules/@smithy/util-defaults-mode-browser/",\
-        "packageDependencies": [\
-          ["@smithy/util-defaults-mode-browser", "npm:2.0.8"],\
-          ["@smithy/property-provider", "npm:2.0.8"],\
-          ["@smithy/types", "npm:2.3.1"],\
+          ["@smithy/util-defaults-mode-browser", "npm:3.0.0"],\
+          ["@smithy/property-provider", "npm:3.0.0"],\
+          ["@smithy/smithy-client", "npm:3.0.0"],\
+          ["@smithy/types", "npm:3.0.0"],\
           ["bowser", "npm:2.11.0"],\
           ["tslib", "npm:2.6.2"]\
         ],\
@@ -8565,164 +7992,131 @@ const RAW_RUNTIME_STATE =
       }]\
     ]],\
     ["@smithy/util-defaults-mode-node", [\
-      ["npm:2.0.10", {\
-        "packageLocation": "./.yarn/cache/@smithy-util-defaults-mode-node-npm-2.0.10-1892515bd2-c8ff3c2ffd.zip/node_modules/@smithy/util-defaults-mode-node/",\
+      ["npm:3.0.0", {\
+        "packageLocation": "./.yarn/cache/@smithy-util-defaults-mode-node-npm-3.0.0-2ce9ef93a2-0a26701c01.zip/node_modules/@smithy/util-defaults-mode-node/",\
         "packageDependencies": [\
-          ["@smithy/util-defaults-mode-node", "npm:2.0.10"],\
-          ["@smithy/config-resolver", "npm:2.0.8"],\
-          ["@smithy/credential-provider-imds", "npm:2.0.10"],\
-          ["@smithy/node-config-provider", "npm:2.0.10"],\
-          ["@smithy/property-provider", "npm:2.0.8"],\
-          ["@smithy/types", "npm:2.3.1"],\
+          ["@smithy/util-defaults-mode-node", "npm:3.0.0"],\
+          ["@smithy/config-resolver", "npm:3.0.0"],\
+          ["@smithy/credential-provider-imds", "npm:3.0.0"],\
+          ["@smithy/node-config-provider", "npm:3.0.0"],\
+          ["@smithy/property-provider", "npm:3.0.0"],\
+          ["@smithy/smithy-client", "npm:3.0.0"],\
+          ["@smithy/types", "npm:3.0.0"],\
           ["tslib", "npm:2.6.2"]\
         ],\
         "linkType": "HARD"\
-      }],\
-      ["npm:2.0.13", {\
-        "packageLocation": "./.yarn/cache/@smithy-util-defaults-mode-node-npm-2.0.13-ace590dc55-58757f7375.zip/node_modules/@smithy/util-defaults-mode-node/",\
+      }]\
+    ]],\
+    ["@smithy/util-endpoints", [\
+      ["npm:2.0.0", {\
+        "packageLocation": "./.yarn/cache/@smithy-util-endpoints-npm-2.0.0-ca86db1958-49e897e8b1.zip/node_modules/@smithy/util-endpoints/",\
         "packageDependencies": [\
-          ["@smithy/util-defaults-mode-node", "npm:2.0.13"],\
-          ["@smithy/config-resolver", "npm:2.0.10"],\
-          ["@smithy/credential-provider-imds", "npm:2.0.12"],\
-          ["@smithy/node-config-provider", "npm:2.0.12"],\
-          ["@smithy/property-provider", "npm:2.0.10"],\
-          ["@smithy/smithy-client", "npm:2.1.7"],\
-          ["@smithy/types", "npm:2.3.3"],\
+          ["@smithy/util-endpoints", "npm:2.0.0"],\
+          ["@smithy/node-config-provider", "npm:3.0.0"],\
+          ["@smithy/types", "npm:3.0.0"],\
           ["tslib", "npm:2.6.2"]\
         ],\
         "linkType": "HARD"\
       }]\
     ]],\
     ["@smithy/util-hex-encoding", [\
-      ["npm:2.0.0", {\
-        "packageLocation": "./.yarn/cache/@smithy-util-hex-encoding-npm-2.0.0-c8ab536d98-196b594d5e.zip/node_modules/@smithy/util-hex-encoding/",\
+      ["npm:3.0.0", {\
+        "packageLocation": "./.yarn/cache/@smithy-util-hex-encoding-npm-3.0.0-55c86ac7d0-d9f8c4c676.zip/node_modules/@smithy/util-hex-encoding/",\
         "packageDependencies": [\
-          ["@smithy/util-hex-encoding", "npm:2.0.0"],\
+          ["@smithy/util-hex-encoding", "npm:3.0.0"],\
           ["tslib", "npm:2.6.2"]\
         ],\
         "linkType": "HARD"\
       }]\
     ]],\
     ["@smithy/util-middleware", [\
-      ["npm:2.0.0", {\
-        "packageLocation": "./.yarn/cache/@smithy-util-middleware-npm-2.0.0-1291df3e19-4dad0f427a.zip/node_modules/@smithy/util-middleware/",\
+      ["npm:3.0.0", {\
+        "packageLocation": "./.yarn/cache/@smithy-util-middleware-npm-3.0.0-6045ce7e88-e9878f8532.zip/node_modules/@smithy/util-middleware/",\
         "packageDependencies": [\
-          ["@smithy/util-middleware", "npm:2.0.0"],\
-          ["tslib", "npm:2.6.2"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["npm:2.0.2", {\
-        "packageLocation": "./.yarn/cache/@smithy-util-middleware-npm-2.0.2-c46bcf4213-2931d99f69.zip/node_modules/@smithy/util-middleware/",\
-        "packageDependencies": [\
-          ["@smithy/util-middleware", "npm:2.0.2"],\
-          ["@smithy/types", "npm:2.3.3"],\
+          ["@smithy/util-middleware", "npm:3.0.0"],\
+          ["@smithy/types", "npm:3.0.0"],\
           ["tslib", "npm:2.6.2"]\
         ],\
         "linkType": "HARD"\
       }]\
     ]],\
     ["@smithy/util-retry", [\
-      ["npm:2.0.0", {\
-        "packageLocation": "./.yarn/cache/@smithy-util-retry-npm-2.0.0-0db19fc544-b98bb03454.zip/node_modules/@smithy/util-retry/",\
+      ["npm:3.0.0", {\
+        "packageLocation": "./.yarn/cache/@smithy-util-retry-npm-3.0.0-2052731cbc-9e38115e47.zip/node_modules/@smithy/util-retry/",\
         "packageDependencies": [\
-          ["@smithy/util-retry", "npm:2.0.0"],\
-          ["@smithy/service-error-classification", "npm:2.0.0"],\
-          ["tslib", "npm:2.6.2"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["npm:2.0.2", {\
-        "packageLocation": "./.yarn/cache/@smithy-util-retry-npm-2.0.2-2700811dcc-2a5c517661.zip/node_modules/@smithy/util-retry/",\
-        "packageDependencies": [\
-          ["@smithy/util-retry", "npm:2.0.2"],\
-          ["@smithy/service-error-classification", "npm:2.0.2"],\
-          ["@smithy/types", "npm:2.3.3"],\
+          ["@smithy/util-retry", "npm:3.0.0"],\
+          ["@smithy/service-error-classification", "npm:3.0.0"],\
+          ["@smithy/types", "npm:3.0.0"],\
           ["tslib", "npm:2.6.2"]\
         ],\
         "linkType": "HARD"\
       }]\
     ]],\
     ["@smithy/util-stream", [\
-      ["npm:2.0.10", {\
-        "packageLocation": "./.yarn/cache/@smithy-util-stream-npm-2.0.10-0572160288-57fe09ebb2.zip/node_modules/@smithy/util-stream/",\
+      ["npm:3.0.0", {\
+        "packageLocation": "./.yarn/cache/@smithy-util-stream-npm-3.0.0-199dba418d-ad263551e2.zip/node_modules/@smithy/util-stream/",\
         "packageDependencies": [\
-          ["@smithy/util-stream", "npm:2.0.10"],\
-          ["@smithy/fetch-http-handler", "npm:2.1.3"],\
-          ["@smithy/node-http-handler", "npm:2.1.3"],\
-          ["@smithy/types", "npm:2.3.1"],\
-          ["@smithy/util-base64", "npm:2.0.0"],\
-          ["@smithy/util-buffer-from", "npm:2.0.0"],\
-          ["@smithy/util-hex-encoding", "npm:2.0.0"],\
-          ["@smithy/util-utf8", "npm:2.0.0"],\
-          ["tslib", "npm:2.6.2"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["npm:2.0.12", {\
-        "packageLocation": "./.yarn/cache/@smithy-util-stream-npm-2.0.12-bcbe27c640-c4a6af8653.zip/node_modules/@smithy/util-stream/",\
-        "packageDependencies": [\
-          ["@smithy/util-stream", "npm:2.0.12"],\
-          ["@smithy/fetch-http-handler", "npm:2.1.5"],\
-          ["@smithy/node-http-handler", "npm:2.1.5"],\
-          ["@smithy/types", "npm:2.3.3"],\
-          ["@smithy/util-base64", "npm:2.0.0"],\
-          ["@smithy/util-buffer-from", "npm:2.0.0"],\
-          ["@smithy/util-hex-encoding", "npm:2.0.0"],\
-          ["@smithy/util-utf8", "npm:2.0.0"],\
+          ["@smithy/util-stream", "npm:3.0.0"],\
+          ["@smithy/fetch-http-handler", "npm:3.0.0"],\
+          ["@smithy/node-http-handler", "npm:3.0.0"],\
+          ["@smithy/types", "npm:3.0.0"],\
+          ["@smithy/util-base64", "npm:3.0.0"],\
+          ["@smithy/util-buffer-from", "npm:3.0.0"],\
+          ["@smithy/util-hex-encoding", "npm:3.0.0"],\
+          ["@smithy/util-utf8", "npm:3.0.0"],\
           ["tslib", "npm:2.6.2"]\
         ],\
         "linkType": "HARD"\
       }]\
     ]],\
     ["@smithy/util-uri-escape", [\
-      ["npm:2.0.0", {\
-        "packageLocation": "./.yarn/cache/@smithy-util-uri-escape-npm-2.0.0-0a38e06daa-2f121d1fce.zip/node_modules/@smithy/util-uri-escape/",\
+      ["npm:3.0.0", {\
+        "packageLocation": "./.yarn/cache/@smithy-util-uri-escape-npm-3.0.0-aa29683710-d445223393.zip/node_modules/@smithy/util-uri-escape/",\
         "packageDependencies": [\
-          ["@smithy/util-uri-escape", "npm:2.0.0"],\
+          ["@smithy/util-uri-escape", "npm:3.0.0"],\
           ["tslib", "npm:2.6.2"]\
         ],\
         "linkType": "HARD"\
       }]\
     ]],\
     ["@smithy/util-utf8", [\
-      ["npm:2.0.0", {\
-        "packageLocation": "./.yarn/cache/@smithy-util-utf8-npm-2.0.0-392d380026-43c924be78.zip/node_modules/@smithy/util-utf8/",\
+      ["npm:3.0.0", {\
+        "packageLocation": "./.yarn/cache/@smithy-util-utf8-npm-3.0.0-1695d28ad7-1aead297d8.zip/node_modules/@smithy/util-utf8/",\
         "packageDependencies": [\
-          ["@smithy/util-utf8", "npm:2.0.0"],\
-          ["@smithy/util-buffer-from", "npm:2.0.0"],\
+          ["@smithy/util-utf8", "npm:3.0.0"],\
+          ["@smithy/util-buffer-from", "npm:3.0.0"],\
           ["tslib", "npm:2.6.2"]\
         ],\
         "linkType": "HARD"\
       }]\
     ]],\
     ["@smithy/util-waiter", [\
-      ["npm:2.0.7", {\
-        "packageLocation": "./.yarn/cache/@smithy-util-waiter-npm-2.0.7-f46893109c-b78f7d5a2a.zip/node_modules/@smithy/util-waiter/",\
+      ["npm:3.0.0", {\
+        "packageLocation": "./.yarn/cache/@smithy-util-waiter-npm-3.0.0-07c6bbfcf9-d206c9f661.zip/node_modules/@smithy/util-waiter/",\
         "packageDependencies": [\
-          ["@smithy/util-waiter", "npm:2.0.7"],\
-          ["@smithy/abort-controller", "npm:2.0.7"],\
-          ["@smithy/types", "npm:2.3.1"],\
-          ["tslib", "npm:2.6.2"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["npm:2.0.9", {\
-        "packageLocation": "./.yarn/cache/@smithy-util-waiter-npm-2.0.9-4969a32d72-8327505b38.zip/node_modules/@smithy/util-waiter/",\
-        "packageDependencies": [\
-          ["@smithy/util-waiter", "npm:2.0.9"],\
-          ["@smithy/abort-controller", "npm:2.0.9"],\
-          ["@smithy/types", "npm:2.3.3"],\
+          ["@smithy/util-waiter", "npm:3.0.0"],\
+          ["@smithy/abort-controller", "npm:3.0.0"],\
+          ["@smithy/types", "npm:3.0.0"],\
           ["tslib", "npm:2.6.2"]\
         ],\
         "linkType": "HARD"\
       }]\
     ]],\
-    ["@swc/helpers", [\
-      ["npm:0.5.1", {\
-        "packageLocation": "./.yarn/cache/@swc-helpers-npm-0.5.1-424376f311-4954c4d2dd.zip/node_modules/@swc/helpers/",\
+    ["@swc/counter", [\
+      ["npm:0.1.3", {\
+        "packageLocation": "./.yarn/cache/@swc-counter-npm-0.1.3-ce42b0e3f5-df8f9cfba9.zip/node_modules/@swc/counter/",\
         "packageDependencies": [\
-          ["@swc/helpers", "npm:0.5.1"],\
+          ["@swc/counter", "npm:0.1.3"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["@swc/helpers", [\
+      ["npm:0.5.5", {\
+        "packageLocation": "./.yarn/cache/@swc-helpers-npm-0.5.5-a0698e6ac9-1c5ef04f64.zip/node_modules/@swc/helpers/",\
+        "packageDependencies": [\
+          ["@swc/helpers", "npm:0.5.5"],\
+          ["@swc/counter", "npm:0.1.3"],\
           ["tslib", "npm:2.6.1"]\
         ],\
         "linkType": "HARD"\
@@ -8949,6 +8343,13 @@ const RAW_RUNTIME_STATE =
           ["@tufjs/canonical-json", "npm:1.0.0"]\
         ],\
         "linkType": "HARD"\
+      }],\
+      ["npm:2.0.0", {\
+        "packageLocation": "./.yarn/cache/@tufjs-canonical-json-npm-2.0.0-46a22aa444-cc719a1d0d.zip/node_modules/@tufjs/canonical-json/",\
+        "packageDependencies": [\
+          ["@tufjs/canonical-json", "npm:2.0.0"]\
+        ],\
+        "linkType": "HARD"\
       }]\
     ]],\
     ["@tufjs/models", [\
@@ -8958,6 +8359,15 @@ const RAW_RUNTIME_STATE =
           ["@tufjs/models", "npm:1.0.4"],\
           ["@tufjs/canonical-json", "npm:1.0.0"],\
           ["minimatch", "npm:9.0.3"]\
+        ],\
+        "linkType": "HARD"\
+      }],\
+      ["npm:2.0.1", {\
+        "packageLocation": "./.yarn/cache/@tufjs-models-npm-2.0.1-39153b9fec-7c5d2b8194.zip/node_modules/@tufjs/models/",\
+        "packageDependencies": [\
+          ["@tufjs/models", "npm:2.0.1"],\
+          ["@tufjs/canonical-json", "npm:2.0.0"],\
+          ["minimatch", "npm:9.0.4"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -9045,16 +8455,6 @@ const RAW_RUNTIME_STATE =
           ["@types/keyv", "npm:3.1.3"],\
           ["@types/node", "npm:16.9.6"],\
           ["@types/responselike", "npm:1.0.0"]\
-        ],\
-        "linkType": "HARD"\
-      }]\
-    ]],\
-    ["@types/concat-stream", [\
-      ["npm:1.6.1", {\
-        "packageLocation": "./.yarn/cache/@types-concat-stream-npm-1.6.1-42cd06b019-7d211e7433.zip/node_modules/@types/concat-stream/",\
-        "packageDependencies": [\
-          ["@types/concat-stream", "npm:1.6.1"],\
-          ["@types/node", "npm:16.9.6"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -9176,16 +8576,6 @@ const RAW_RUNTIME_STATE =
           ["@types/qs", "npm:6.9.7"],\
           ["@types/range-parser", "npm:1.2.4"],\
           ["@types/send", "npm:0.17.1"]\
-        ],\
-        "linkType": "HARD"\
-      }]\
-    ]],\
-    ["@types/form-data", [\
-      ["npm:0.0.33", {\
-        "packageLocation": "./.yarn/cache/@types-form-data-npm-0.0.33-3cbbcd9710-f0c7437e9d.zip/node_modules/@types/form-data/",\
-        "packageDependencies": [\
-          ["@types/form-data", "npm:0.0.33"],\
-          ["@types/node", "npm:16.9.6"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -9460,13 +8850,6 @@ const RAW_RUNTIME_STATE =
       }]\
     ]],\
     ["@types/node", [\
-      ["npm:10.17.60", {\
-        "packageLocation": "./.yarn/cache/@types-node-npm-10.17.60-63ac1f669f-f9161493b3.zip/node_modules/@types/node/",\
-        "packageDependencies": [\
-          ["@types/node", "npm:10.17.60"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
       ["npm:13.13.52", {\
         "packageLocation": "./.yarn/cache/@types-node-npm-13.13.52-95159539bb-a1fbd080dd.zip/node_modules/@types/node/",\
         "packageDependencies": [\
@@ -9486,13 +8869,6 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["@types/node", "npm:20.12.7"],\
           ["undici-types", "npm:5.26.5"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["npm:8.10.66", {\
-        "packageLocation": "./.yarn/cache/@types-node-npm-8.10.66-b849acaf16-49a93cbeec.zip/node_modules/@types/node/",\
-        "packageDependencies": [\
-          ["@types/node", "npm:8.10.66"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -10457,6 +9833,13 @@ const RAW_RUNTIME_STATE =
           ["abbrev", "npm:1.1.1"]\
         ],\
         "linkType": "HARD"\
+      }],\
+      ["npm:2.0.0", {\
+        "packageLocation": "./.yarn/cache/abbrev-npm-2.0.0-0eb38a17e5-ca0a54e35b.zip/node_modules/abbrev/",\
+        "packageDependencies": [\
+          ["abbrev", "npm:2.0.0"]\
+        ],\
+        "linkType": "HARD"\
       }]\
     ]],\
     ["abort-controller", [\
@@ -11126,13 +10509,6 @@ const RAW_RUNTIME_STATE =
       }]\
     ]],\
     ["astral-regex", [\
-      ["npm:1.0.0", {\
-        "packageLocation": "./.yarn/cache/astral-regex-npm-1.0.0-2df7c41332-93417fc087.zip/node_modules/astral-regex/",\
-        "packageDependencies": [\
-          ["astral-regex", "npm:1.0.0"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
       ["npm:2.0.0", {\
         "packageLocation": "./.yarn/cache/astral-regex-npm-2.0.0-f30d866aab-876231688c.zip/node_modules/astral-regex/",\
         "packageDependencies": [\
@@ -11263,11 +10639,11 @@ const RAW_RUNTIME_STATE =
       }]\
     ]],\
     ["axios", [\
-      ["npm:1.6.1", {\
-        "packageLocation": "./.yarn/cache/axios-npm-1.6.1-ffaff76449-fb091af3ad.zip/node_modules/axios/",\
+      ["npm:1.6.8", {\
+        "packageLocation": "./.yarn/cache/axios-npm-1.6.8-85cf1e7152-3f9a79eaf1.zip/node_modules/axios/",\
         "packageDependencies": [\
-          ["axios", "npm:1.6.1"],\
-          ["follow-redirects", "virtual:ffaff76449f02e83712a7d24e03c564489516739c78ebeffb0fbcdb3893ad9a0e48504f9acfa70fe6f16debe9c8dabde3679d63bf648278ea98a5ff38cf77a9e#npm:1.15.6"],\
+          ["axios", "npm:1.6.8"],\
+          ["follow-redirects", "virtual:85cf1e7152e3c0d8e39e61ad2b81b59a43fb6bdb8f3bf49869bb97804b1403ecaee4505fcb0d4869cfdd99ee3eaa880b79498575407fb770c800bf64c64156ec#npm:1.15.6"],\
           ["form-data", "npm:4.0.0"],\
           ["proxy-from-env", "npm:1.1.0"]\
         ],\
@@ -11291,15 +10667,15 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "SOFT"\
       }],\
-      ["virtual:827cf270b09d65729a6a1ff7cc9e3a99a22577de879192dfaefa0c1007d108c5cce9652a9127acef6bae7e84235b313d150e197d10314a3c4a2e25fa269a20f9#npm:29.7.0", {\
-        "packageLocation": "./.yarn/__virtual__/babel-jest-virtual-f4fe7bee42/0/cache/babel-jest-npm-29.7.0-273152fbe9-8a0953bd81.zip/node_modules/babel-jest/",\
+      ["virtual:b278756a522c5a2b833fa7b26fda1dba58349ff098950c76beb604c833e7de837b9c5b74af2d6668937e192e4e2d692b9881f4a9e845577acfe54f9ad8e57a0e#npm:29.7.0", {\
+        "packageLocation": "./.yarn/__virtual__/babel-jest-virtual-848dba78b5/0/cache/babel-jest-npm-29.7.0-273152fbe9-8a0953bd81.zip/node_modules/babel-jest/",\
         "packageDependencies": [\
-          ["babel-jest", "virtual:827cf270b09d65729a6a1ff7cc9e3a99a22577de879192dfaefa0c1007d108c5cce9652a9127acef6bae7e84235b313d150e197d10314a3c4a2e25fa269a20f9#npm:29.7.0"],\
+          ["babel-jest", "virtual:b278756a522c5a2b833fa7b26fda1dba58349ff098950c76beb604c833e7de837b9c5b74af2d6668937e192e4e2d692b9881f4a9e845577acfe54f9ad8e57a0e#npm:29.7.0"],\
           ["@babel/core", "npm:7.22.17"],\
           ["@jest/transform", "npm:29.7.0"],\
           ["@types/babel__core", "npm:7.20.1"],\
           ["babel-plugin-istanbul", "npm:6.1.1"],\
-          ["babel-preset-jest", "virtual:f4fe7bee42903abc6679ba3008a2a5fa31f33c5bea6bf0f7059b5cf7f6b7448208b0c635019903fcefb5766a054666f9ef7a9bf360a65176c3e2d9f132d2c098#npm:29.6.3"],\
+          ["babel-preset-jest", "virtual:848dba78b5b7a62147f485362f0d363b0e326d33a4bf90290b5959701a221c14690901c1a0bbc55184cbe670ca02f1ea455c7a1b4c95f52be53f4c9a6363fa92#npm:29.6.3"],\
           ["chalk", "npm:4.1.2"],\
           ["graceful-fs", "npm:4.2.10"],\
           ["slash", "npm:3.0.0"]\
@@ -11382,23 +10758,23 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "HARD"\
       }],\
-      ["virtual:28b1c651e2efbcd400e435840e311e4803bb797aa11a4fe60fa76307fdb036ed58132a51dbf2d77165b4f609c13ae8071b1d301f33dad6ca4c2aa1d614b77228#npm:1.0.1", {\
-        "packageLocation": "./.yarn/__virtual__/babel-preset-current-node-syntax-virtual-9d095a4529/0/cache/babel-preset-current-node-syntax-npm-1.0.1-849ec71e32-94561959cb.zip/node_modules/babel-preset-current-node-syntax/",\
+      ["virtual:5e0c83a6ea5219acad44160a9fec2b5decda9414e15a2baa98ee0aec5cb7ae59ec85d2ca97c14d89da825f299db16b408b9b54f472b562b6cde14563710d2780#npm:1.0.1", {\
+        "packageLocation": "./.yarn/__virtual__/babel-preset-current-node-syntax-virtual-7c45d5bdb1/0/cache/babel-preset-current-node-syntax-npm-1.0.1-849ec71e32-94561959cb.zip/node_modules/babel-preset-current-node-syntax/",\
         "packageDependencies": [\
-          ["babel-preset-current-node-syntax", "virtual:28b1c651e2efbcd400e435840e311e4803bb797aa11a4fe60fa76307fdb036ed58132a51dbf2d77165b4f609c13ae8071b1d301f33dad6ca4c2aa1d614b77228#npm:1.0.1"],\
+          ["babel-preset-current-node-syntax", "virtual:5e0c83a6ea5219acad44160a9fec2b5decda9414e15a2baa98ee0aec5cb7ae59ec85d2ca97c14d89da825f299db16b408b9b54f472b562b6cde14563710d2780#npm:1.0.1"],\
           ["@babel/core", "npm:7.22.17"],\
-          ["@babel/plugin-syntax-async-generators", "virtual:9d095a45298058459f9fa9d0c1ccea3cb78701b24087dcd86f0b11cb6da35a2de4281a3205aa11ec0331d10c69737c7e98913433c4c7b3241117f41bb679b7a6#npm:7.8.4"],\
-          ["@babel/plugin-syntax-bigint", "virtual:9d095a45298058459f9fa9d0c1ccea3cb78701b24087dcd86f0b11cb6da35a2de4281a3205aa11ec0331d10c69737c7e98913433c4c7b3241117f41bb679b7a6#npm:7.8.3"],\
-          ["@babel/plugin-syntax-class-properties", "virtual:9d095a45298058459f9fa9d0c1ccea3cb78701b24087dcd86f0b11cb6da35a2de4281a3205aa11ec0331d10c69737c7e98913433c4c7b3241117f41bb679b7a6#npm:7.12.13"],\
-          ["@babel/plugin-syntax-import-meta", "virtual:9d095a45298058459f9fa9d0c1ccea3cb78701b24087dcd86f0b11cb6da35a2de4281a3205aa11ec0331d10c69737c7e98913433c4c7b3241117f41bb679b7a6#npm:7.10.4"],\
-          ["@babel/plugin-syntax-json-strings", "virtual:9d095a45298058459f9fa9d0c1ccea3cb78701b24087dcd86f0b11cb6da35a2de4281a3205aa11ec0331d10c69737c7e98913433c4c7b3241117f41bb679b7a6#npm:7.8.3"],\
-          ["@babel/plugin-syntax-logical-assignment-operators", "virtual:9d095a45298058459f9fa9d0c1ccea3cb78701b24087dcd86f0b11cb6da35a2de4281a3205aa11ec0331d10c69737c7e98913433c4c7b3241117f41bb679b7a6#npm:7.10.4"],\
-          ["@babel/plugin-syntax-nullish-coalescing-operator", "virtual:9d095a45298058459f9fa9d0c1ccea3cb78701b24087dcd86f0b11cb6da35a2de4281a3205aa11ec0331d10c69737c7e98913433c4c7b3241117f41bb679b7a6#npm:7.8.3"],\
-          ["@babel/plugin-syntax-numeric-separator", "virtual:9d095a45298058459f9fa9d0c1ccea3cb78701b24087dcd86f0b11cb6da35a2de4281a3205aa11ec0331d10c69737c7e98913433c4c7b3241117f41bb679b7a6#npm:7.10.4"],\
-          ["@babel/plugin-syntax-object-rest-spread", "virtual:9d095a45298058459f9fa9d0c1ccea3cb78701b24087dcd86f0b11cb6da35a2de4281a3205aa11ec0331d10c69737c7e98913433c4c7b3241117f41bb679b7a6#npm:7.8.3"],\
-          ["@babel/plugin-syntax-optional-catch-binding", "virtual:9d095a45298058459f9fa9d0c1ccea3cb78701b24087dcd86f0b11cb6da35a2de4281a3205aa11ec0331d10c69737c7e98913433c4c7b3241117f41bb679b7a6#npm:7.8.3"],\
-          ["@babel/plugin-syntax-optional-chaining", "virtual:9d095a45298058459f9fa9d0c1ccea3cb78701b24087dcd86f0b11cb6da35a2de4281a3205aa11ec0331d10c69737c7e98913433c4c7b3241117f41bb679b7a6#npm:7.8.3"],\
-          ["@babel/plugin-syntax-top-level-await", "virtual:9d095a45298058459f9fa9d0c1ccea3cb78701b24087dcd86f0b11cb6da35a2de4281a3205aa11ec0331d10c69737c7e98913433c4c7b3241117f41bb679b7a6#npm:7.14.5"],\
+          ["@babel/plugin-syntax-async-generators", "virtual:7c45d5bdb104824b7cfbce10fe870bbdeabef939883ee590ea09caf588d04fc3541654d1ca2ff56edd281f48bc3e260b381a56a263284f9107b23f63b38369c4#npm:7.8.4"],\
+          ["@babel/plugin-syntax-bigint", "virtual:7c45d5bdb104824b7cfbce10fe870bbdeabef939883ee590ea09caf588d04fc3541654d1ca2ff56edd281f48bc3e260b381a56a263284f9107b23f63b38369c4#npm:7.8.3"],\
+          ["@babel/plugin-syntax-class-properties", "virtual:7c45d5bdb104824b7cfbce10fe870bbdeabef939883ee590ea09caf588d04fc3541654d1ca2ff56edd281f48bc3e260b381a56a263284f9107b23f63b38369c4#npm:7.12.13"],\
+          ["@babel/plugin-syntax-import-meta", "virtual:7c45d5bdb104824b7cfbce10fe870bbdeabef939883ee590ea09caf588d04fc3541654d1ca2ff56edd281f48bc3e260b381a56a263284f9107b23f63b38369c4#npm:7.10.4"],\
+          ["@babel/plugin-syntax-json-strings", "virtual:7c45d5bdb104824b7cfbce10fe870bbdeabef939883ee590ea09caf588d04fc3541654d1ca2ff56edd281f48bc3e260b381a56a263284f9107b23f63b38369c4#npm:7.8.3"],\
+          ["@babel/plugin-syntax-logical-assignment-operators", "virtual:7c45d5bdb104824b7cfbce10fe870bbdeabef939883ee590ea09caf588d04fc3541654d1ca2ff56edd281f48bc3e260b381a56a263284f9107b23f63b38369c4#npm:7.10.4"],\
+          ["@babel/plugin-syntax-nullish-coalescing-operator", "virtual:7c45d5bdb104824b7cfbce10fe870bbdeabef939883ee590ea09caf588d04fc3541654d1ca2ff56edd281f48bc3e260b381a56a263284f9107b23f63b38369c4#npm:7.8.3"],\
+          ["@babel/plugin-syntax-numeric-separator", "virtual:7c45d5bdb104824b7cfbce10fe870bbdeabef939883ee590ea09caf588d04fc3541654d1ca2ff56edd281f48bc3e260b381a56a263284f9107b23f63b38369c4#npm:7.10.4"],\
+          ["@babel/plugin-syntax-object-rest-spread", "virtual:7c45d5bdb104824b7cfbce10fe870bbdeabef939883ee590ea09caf588d04fc3541654d1ca2ff56edd281f48bc3e260b381a56a263284f9107b23f63b38369c4#npm:7.8.3"],\
+          ["@babel/plugin-syntax-optional-catch-binding", "virtual:7c45d5bdb104824b7cfbce10fe870bbdeabef939883ee590ea09caf588d04fc3541654d1ca2ff56edd281f48bc3e260b381a56a263284f9107b23f63b38369c4#npm:7.8.3"],\
+          ["@babel/plugin-syntax-optional-chaining", "virtual:7c45d5bdb104824b7cfbce10fe870bbdeabef939883ee590ea09caf588d04fc3541654d1ca2ff56edd281f48bc3e260b381a56a263284f9107b23f63b38369c4#npm:7.8.3"],\
+          ["@babel/plugin-syntax-top-level-await", "virtual:7c45d5bdb104824b7cfbce10fe870bbdeabef939883ee590ea09caf588d04fc3541654d1ca2ff56edd281f48bc3e260b381a56a263284f9107b23f63b38369c4#npm:7.14.5"],\
           ["@types/babel__core", "npm:7.20.1"]\
         ],\
         "packagePeers": [\
@@ -11416,14 +10792,14 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "SOFT"\
       }],\
-      ["virtual:f4fe7bee42903abc6679ba3008a2a5fa31f33c5bea6bf0f7059b5cf7f6b7448208b0c635019903fcefb5766a054666f9ef7a9bf360a65176c3e2d9f132d2c098#npm:29.6.3", {\
-        "packageLocation": "./.yarn/__virtual__/babel-preset-jest-virtual-28b1c651e2/0/cache/babel-preset-jest-npm-29.6.3-44bf6eeda9-aa4ff2a8a7.zip/node_modules/babel-preset-jest/",\
+      ["virtual:848dba78b5b7a62147f485362f0d363b0e326d33a4bf90290b5959701a221c14690901c1a0bbc55184cbe670ca02f1ea455c7a1b4c95f52be53f4c9a6363fa92#npm:29.6.3", {\
+        "packageLocation": "./.yarn/__virtual__/babel-preset-jest-virtual-5e0c83a6ea/0/cache/babel-preset-jest-npm-29.6.3-44bf6eeda9-aa4ff2a8a7.zip/node_modules/babel-preset-jest/",\
         "packageDependencies": [\
-          ["babel-preset-jest", "virtual:f4fe7bee42903abc6679ba3008a2a5fa31f33c5bea6bf0f7059b5cf7f6b7448208b0c635019903fcefb5766a054666f9ef7a9bf360a65176c3e2d9f132d2c098#npm:29.6.3"],\
+          ["babel-preset-jest", "virtual:848dba78b5b7a62147f485362f0d363b0e326d33a4bf90290b5959701a221c14690901c1a0bbc55184cbe670ca02f1ea455c7a1b4c95f52be53f4c9a6363fa92#npm:29.6.3"],\
           ["@babel/core", "npm:7.22.17"],\
           ["@types/babel__core", "npm:7.20.1"],\
           ["babel-plugin-jest-hoist", "npm:29.6.3"],\
-          ["babel-preset-current-node-syntax", "virtual:28b1c651e2efbcd400e435840e311e4803bb797aa11a4fe60fa76307fdb036ed58132a51dbf2d77165b4f609c13ae8071b1d301f33dad6ca4c2aa1d614b77228#npm:1.0.1"]\
+          ["babel-preset-current-node-syntax", "virtual:5e0c83a6ea5219acad44160a9fec2b5decda9414e15a2baa98ee0aec5cb7ae59ec85d2ca97c14d89da825f299db16b408b9b54f472b562b6cde14563710d2780#npm:1.0.1"]\
         ],\
         "packagePeers": [\
           "@babel/core",\
@@ -11530,67 +10906,35 @@ const RAW_RUNTIME_STATE =
       }]\
     ]],\
     ["bids-validator", [\
-      ["npm:1.10.0", {\
-        "packageLocation": "./.yarn/cache/bids-validator-npm-1.10.0-6d9bc27642-10d9fc6dd8.zip/node_modules/bids-validator/",\
+      ["npm:1.14.6", {\
+        "packageLocation": "./.yarn/cache/bids-validator-npm-1.14.6-963c647ea0-385ce2c482.zip/node_modules/bids-validator/",\
         "packageDependencies": [\
-          ["bids-validator", "npm:1.10.0"],\
-          ["@aws-sdk/client-s3", "npm:3.418.0"],\
-          ["ajv", "npm:6.12.6"],\
-          ["bytes", "npm:3.1.0"],\
-          ["colors", "npm:1.4.0"],\
-          ["cross-fetch", "npm:3.1.4"],\
-          ["date-fns", "npm:2.30.0"],\
-          ["events", "npm:3.3.0"],\
-          ["exifreader", "npm:4.13.0"],\
-          ["hed-validator", "npm:3.12.0"],\
-          ["ignore", "npm:4.0.6"],\
-          ["is-utf8", "npm:0.2.1"],\
-          ["jshint", "npm:2.13.6"],\
-          ["lodash", "npm:4.17.21"],\
-          ["minimatch", "npm:3.0.5"],\
-          ["nifti-js", "npm:1.0.1"],\
-          ["p-limit", "npm:2.3.0"],\
-          ["pako", "npm:1.0.11"],\
-          ["path", "npm:0.12.7"],\
-          ["pluralize", "npm:8.0.0"],\
-          ["semver", "npm:7.5.4"],\
-          ["stream-browserify", "npm:3.0.0"],\
-          ["table", "npm:5.4.6"],\
-          ["xml2js", "npm:0.4.23"],\
-          ["yaml", "npm:1.10.2"],\
-          ["yargs", "npm:16.2.0"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["npm:1.13.0", {\
-        "packageLocation": "./.yarn/cache/bids-validator-npm-1.13.0-dfaa473f53-6fe6918956.zip/node_modules/bids-validator/",\
-        "packageDependencies": [\
-          ["bids-validator", "npm:1.13.0"],\
-          ["@aws-sdk/client-s3", "npm:3.412.0"],\
+          ["bids-validator", "npm:1.14.6"],\
+          ["@aws-sdk/client-s3", "npm:3.575.0"],\
           ["ajv", "npm:6.12.6"],\
           ["bytes", "npm:3.1.2"],\
           ["colors", "npm:1.4.0"],\
           ["cross-fetch", "npm:4.0.0"],\
-          ["date-fns", "npm:2.30.0"],\
+          ["date-fns", "npm:3.6.0"],\
           ["events", "npm:3.3.0"],\
-          ["exifreader", "npm:4.13.0"],\
-          ["hed-validator", "npm:3.12.0"],\
-          ["ignore", "npm:5.2.4"],\
+          ["exifreader", "npm:4.23.1"],\
+          ["hed-validator", "npm:3.13.5"],\
+          ["ignore", "npm:5.3.1"],\
           ["is-utf8", "npm:0.2.1"],\
-          ["jest", "virtual:dfaa473f537ddcbbe9a585bdf89c36b7e8eaba790caa916a9832a8ef0d822fd7416e74adb9c9a9815a0ad1e7ac343cc56ad74f61fe917964c31bdaa195a65414#npm:29.7.0"],\
+          ["jest", "virtual:963c647ea051efd8c590d2c7557349f3372ef2d1a56b4124e7863ebca3fab4680c0f4b8ecbd49d0371d65f2281579c5841fe1dd9c8c0a863c6e96966933908e0#npm:29.7.0"],\
           ["jshint", "npm:2.13.6"],\
-          ["lerna", "npm:7.3.0"],\
+          ["lerna", "npm:8.1.3"],\
           ["lodash", "npm:4.17.21"],\
           ["minimatch", "npm:3.0.5"],\
-          ["next", "virtual:dfaa473f537ddcbbe9a585bdf89c36b7e8eaba790caa916a9832a8ef0d822fd7416e74adb9c9a9815a0ad1e7ac343cc56ad74f61fe917964c31bdaa195a65414#npm:13.4.19"],\
+          ["next", "virtual:963c647ea051efd8c590d2c7557349f3372ef2d1a56b4124e7863ebca3fab4680c0f4b8ecbd49d0371d65f2281579c5841fe1dd9c8c0a863c6e96966933908e0#npm:14.2.3"],\
           ["nifti-js", "npm:1.0.1"],\
           ["p-limit", "npm:2.3.0"],\
           ["pako", "npm:1.0.11"],\
           ["path", "npm:0.12.7"],\
           ["pluralize", "npm:8.0.0"],\
-          ["semver", "npm:7.5.4"],\
+          ["semver", "npm:7.6.0"],\
           ["stream-browserify", "npm:3.0.0"],\
-          ["table", "npm:6.8.1"],\
+          ["table", "npm:6.8.2"],\
           ["util", "npm:0.12.5"],\
           ["xml2js", "npm:0.6.2"],\
           ["yaml", "npm:2.3.2"],\
@@ -11998,6 +11342,25 @@ const RAW_RUNTIME_STATE =
           ["unique-filename", "npm:3.0.0"]\
         ],\
         "linkType": "HARD"\
+      }],\
+      ["npm:18.0.3", {\
+        "packageLocation": "./.yarn/cache/cacache-npm-18.0.3-7936f526c3-d4c161f071.zip/node_modules/cacache/",\
+        "packageDependencies": [\
+          ["cacache", "npm:18.0.3"],\
+          ["@npmcli/fs", "npm:3.1.0"],\
+          ["fs-minipass", "npm:3.0.3"],\
+          ["glob", "npm:10.3.4"],\
+          ["lru-cache", "npm:10.1.0"],\
+          ["minipass", "npm:7.0.3"],\
+          ["minipass-collect", "npm:2.0.1"],\
+          ["minipass-flush", "npm:1.0.5"],\
+          ["minipass-pipeline", "npm:1.2.4"],\
+          ["p-map", "npm:4.0.0"],\
+          ["ssri", "npm:10.0.5"],\
+          ["tar", "npm:6.2.0"],\
+          ["unique-filename", "npm:3.0.0"]\
+        ],\
+        "linkType": "HARD"\
       }]\
     ]],\
     ["cache-base", [\
@@ -12181,6 +11544,13 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./.yarn/cache/caniuse-lite-npm-1.0.30001534-bababd8437-848c94f57f.zip/node_modules/caniuse-lite/",\
         "packageDependencies": [\
           ["caniuse-lite", "npm:1.0.30001534"]\
+        ],\
+        "linkType": "HARD"\
+      }],\
+      ["npm:1.0.30001618", {\
+        "packageLocation": "./.yarn/cache/caniuse-lite-npm-1.0.30001618-c30b37c853-b5a65a60af.zip/node_modules/caniuse-lite/",\
+        "packageDependencies": [\
+          ["caniuse-lite", "npm:1.0.30001618"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -12970,10 +12340,10 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "HARD"\
       }],\
-      ["npm:6.0.0", {\
-        "packageLocation": "./.yarn/cache/conventional-changelog-angular-npm-6.0.0-7d83e24a10-ddc59ead53.zip/node_modules/conventional-changelog-angular/",\
+      ["npm:7.0.0", {\
+        "packageLocation": "./.yarn/cache/conventional-changelog-angular-npm-7.0.0-de5edb79f0-e7966d2fee.zip/node_modules/conventional-changelog-angular/",\
         "packageDependencies": [\
-          ["conventional-changelog-angular", "npm:6.0.0"],\
+          ["conventional-changelog-angular", "npm:7.0.0"],\
           ["compare-func", "npm:2.0.0"]\
         ],\
         "linkType": "HARD"\
@@ -13336,10 +12706,10 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "SOFT"\
       }],\
-      ["virtual:27294a026b403a125127a01c506649a66f963443d98b165f595b35d84f3a7f3acf7257fab805d9a5c66db9a766498808df6100c11de52d69e5f1edabcba2aa61#npm:8.3.6", {\
-        "packageLocation": "./.yarn/__virtual__/cosmiconfig-virtual-5f2b5032fe/0/cache/cosmiconfig-npm-8.3.6-a5566e2779-91d082baca.zip/node_modules/cosmiconfig/",\
+      ["virtual:231b41c796fb4c3a1878ccc2b284d7acc71e342654f1dcf3bec9e756c379469380938482d22d651d850cf92850f594f3b751114f8c7660ab24c8aee2d7081537#npm:8.3.6", {\
+        "packageLocation": "./.yarn/__virtual__/cosmiconfig-virtual-bc9b2f567f/0/cache/cosmiconfig-npm-8.3.6-a5566e2779-91d082baca.zip/node_modules/cosmiconfig/",\
         "packageDependencies": [\
-          ["cosmiconfig", "virtual:27294a026b403a125127a01c506649a66f963443d98b165f595b35d84f3a7f3acf7257fab805d9a5c66db9a766498808df6100c11de52d69e5f1edabcba2aa61#npm:8.3.6"],\
+          ["cosmiconfig", "virtual:231b41c796fb4c3a1878ccc2b284d7acc71e342654f1dcf3bec9e756c379469380938482d22d651d850cf92850f594f3b751114f8c7660ab24c8aee2d7081537#npm:8.3.6"],\
           ["@types/typescript", null],\
           ["import-fresh", "npm:3.3.0"],\
           ["js-yaml", "npm:4.1.0"],\
@@ -13353,10 +12723,10 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "HARD"\
       }],\
-      ["virtual:d75cff27a4008038c929443f4fab5c682c9234034f14e2ff4417bcd1e568bd475b296866223666f43f0543be54daebc7fc015b5b1eecef1f1089f8516b845773#npm:8.3.6", {\
-        "packageLocation": "./.yarn/__virtual__/cosmiconfig-virtual-872c295ba0/0/cache/cosmiconfig-npm-8.3.6-a5566e2779-91d082baca.zip/node_modules/cosmiconfig/",\
+      ["virtual:48f9ae8498438ca8cc7b5946ce00bad482e1d3819f5cf6cb31b22f3bd65e8afe79dac342ace3c8efe70ce03d960bd269a9d17bcc96e05924eb4fa81fbede56dc#npm:8.3.6", {\
+        "packageLocation": "./.yarn/__virtual__/cosmiconfig-virtual-eec355557e/0/cache/cosmiconfig-npm-8.3.6-a5566e2779-91d082baca.zip/node_modules/cosmiconfig/",\
         "packageDependencies": [\
-          ["cosmiconfig", "virtual:d75cff27a4008038c929443f4fab5c682c9234034f14e2ff4417bcd1e568bd475b296866223666f43f0543be54daebc7fc015b5b1eecef1f1089f8516b845773#npm:8.3.6"],\
+          ["cosmiconfig", "virtual:48f9ae8498438ca8cc7b5946ce00bad482e1d3819f5cf6cb31b22f3bd65e8afe79dac342ace3c8efe70ce03d960bd269a9d17bcc96e05924eb4fa81fbede56dc#npm:8.3.6"],\
           ["@types/typescript", null],\
           ["import-fresh", "npm:3.3.0"],\
           ["js-yaml", "npm:4.1.0"],\
@@ -13562,10 +12932,10 @@ const RAW_RUNTIME_STATE =
       }]\
     ]],\
     ["date-and-time", [\
-      ["npm:0.14.2", {\
-        "packageLocation": "./.yarn/cache/date-and-time-npm-0.14.2-e092eac9bd-4708a43c01.zip/node_modules/date-and-time/",\
+      ["npm:3.2.0", {\
+        "packageLocation": "./.yarn/cache/date-and-time-npm-3.2.0-0cd7c7a46d-6a897b2730.zip/node_modules/date-and-time/",\
         "packageDependencies": [\
-          ["date-and-time", "npm:0.14.2"]\
+          ["date-and-time", "npm:3.2.0"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -13578,11 +12948,10 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "HARD"\
       }],\
-      ["npm:2.30.0", {\
-        "packageLocation": "./.yarn/cache/date-fns-npm-2.30.0-895c790e0f-70b3e8ea7a.zip/node_modules/date-fns/",\
+      ["npm:3.6.0", {\
+        "packageLocation": "./.yarn/cache/date-fns-npm-3.6.0-e59d980978-cac35c5892.zip/node_modules/date-fns/",\
         "packageDependencies": [\
-          ["date-fns", "npm:2.30.0"],\
-          ["@babel/runtime", "npm:7.22.15"]\
+          ["date-fns", "npm:3.6.0"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -15536,10 +14905,10 @@ const RAW_RUNTIME_STATE =
       }]\
     ]],\
     ["exifreader", [\
-      ["npm:4.13.0", {\
-        "packageLocation": "./.yarn/unplugged/exifreader-npm-4.13.0-ee4f3d8a3e/node_modules/exifreader/",\
+      ["npm:4.23.1", {\
+        "packageLocation": "./.yarn/unplugged/exifreader-npm-4.23.1-8444b91e63/node_modules/exifreader/",\
         "packageDependencies": [\
-          ["exifreader", "npm:4.13.0"],\
+          ["exifreader", "npm:4.23.1"],\
           ["@xmldom/xmldom", "npm:0.8.10"]\
         ],\
         "linkType": "HARD"\
@@ -16260,10 +15629,10 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "HARD"\
       }],\
-      ["virtual:ffaff76449f02e83712a7d24e03c564489516739c78ebeffb0fbcdb3893ad9a0e48504f9acfa70fe6f16debe9c8dabde3679d63bf648278ea98a5ff38cf77a9e#npm:1.15.6", {\
-        "packageLocation": "./.yarn/__virtual__/follow-redirects-virtual-24b9eeea9f/0/cache/follow-redirects-npm-1.15.6-50635fe51d-70c7612c4c.zip/node_modules/follow-redirects/",\
+      ["virtual:85cf1e7152e3c0d8e39e61ad2b81b59a43fb6bdb8f3bf49869bb97804b1403ecaee4505fcb0d4869cfdd99ee3eaa880b79498575407fb770c800bf64c64156ec#npm:1.15.6", {\
+        "packageLocation": "./.yarn/__virtual__/follow-redirects-virtual-7bb5ea93fd/0/cache/follow-redirects-npm-1.15.6-50635fe51d-70c7612c4c.zip/node_modules/follow-redirects/",\
         "packageDependencies": [\
-          ["follow-redirects", "virtual:ffaff76449f02e83712a7d24e03c564489516739c78ebeffb0fbcdb3893ad9a0e48504f9acfa70fe6f16debe9c8dabde3679d63bf648278ea98a5ff38cf77a9e#npm:1.15.6"],\
+          ["follow-redirects", "virtual:85cf1e7152e3c0d8e39e61ad2b81b59a43fb6bdb8f3bf49869bb97804b1403ecaee4505fcb0d4869cfdd99ee3eaa880b79498575407fb770c800bf64c64156ec#npm:1.15.6"],\
           ["@types/debug", null],\
           ["debug", null]\
         ],\
@@ -16953,6 +16322,18 @@ const RAW_RUNTIME_STATE =
       }]\
     ]],\
     ["glob", [\
+      ["npm:10.3.15", {\
+        "packageLocation": "./.yarn/cache/glob-npm-10.3.15-501e87a16f-b2b1c74309.zip/node_modules/glob/",\
+        "packageDependencies": [\
+          ["glob", "npm:10.3.15"],\
+          ["foreground-child", "npm:3.1.1"],\
+          ["jackspeak", "npm:2.3.6"],\
+          ["minimatch", "npm:9.0.3"],\
+          ["minipass", "npm:7.1.1"],\
+          ["path-scurry", "npm:1.11.1"]\
+        ],\
+        "linkType": "HARD"\
+      }],\
       ["npm:10.3.4", {\
         "packageLocation": "./.yarn/cache/glob-npm-10.3.4-f58cd31f55-6375721bcd.zip/node_modules/glob/",\
         "packageDependencies": [\
@@ -16962,19 +16343,6 @@ const RAW_RUNTIME_STATE =
           ["minimatch", "npm:9.0.3"],\
           ["minipass", "npm:7.0.3"],\
           ["path-scurry", "npm:1.10.1"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["npm:7.1.4", {\
-        "packageLocation": "./.yarn/cache/glob-npm-7.1.4-8bd8317a74-776bcc3137.zip/node_modules/glob/",\
-        "packageDependencies": [\
-          ["glob", "npm:7.1.4"],\
-          ["fs.realpath", "npm:1.0.0"],\
-          ["inflight", "npm:1.0.6"],\
-          ["inherits", "npm:2.0.4"],\
-          ["minimatch", "npm:3.0.4"],\
-          ["once", "npm:1.4.0"],\
-          ["path-is-absolute", "npm:1.0.1"]\
         ],\
         "linkType": "HARD"\
       }],\
@@ -17039,13 +16407,6 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./.yarn/cache/glob-to-regexp-npm-0.3.0-4f55888857-a716708f78.zip/node_modules/glob-to-regexp/",\
         "packageDependencies": [\
           ["glob-to-regexp", "npm:0.3.0"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["npm:0.4.1", {\
-        "packageLocation": "./.yarn/cache/glob-to-regexp-npm-0.4.1-cd697e0fc7-9009529195.zip/node_modules/glob-to-regexp/",\
-        "packageDependencies": [\
-          ["glob-to-regexp", "npm:0.4.1"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -17607,20 +16968,21 @@ const RAW_RUNTIME_STATE =
       }]\
     ]],\
     ["hed-validator", [\
-      ["npm:3.12.0", {\
-        "packageLocation": "./.yarn/cache/hed-validator-npm-3.12.0-210f7bde9a-597f55385a.zip/node_modules/hed-validator/",\
+      ["npm:3.13.5", {\
+        "packageLocation": "./.yarn/cache/hed-validator-npm-3.13.5-5942bce284-e99c35356a.zip/node_modules/hed-validator/",\
         "packageDependencies": [\
-          ["hed-validator", "npm:3.12.0"],\
+          ["hed-validator", "npm:3.13.5"],\
           ["buffer", "npm:6.0.3"],\
-          ["date-and-time", "npm:0.14.2"],\
-          ["date-fns", "npm:2.24.0"],\
+          ["cross-fetch", "npm:4.0.0"],\
+          ["date-and-time", "npm:3.2.0"],\
+          ["date-fns", "npm:3.6.0"],\
           ["events", "npm:3.3.0"],\
           ["lodash", "npm:4.17.21"],\
           ["path", "npm:0.12.7"],\
           ["pluralize", "npm:8.0.0"],\
-          ["semver", "npm:7.5.4"],\
-          ["then-request", "npm:6.0.2"],\
-          ["xml2js", "npm:0.5.0"]\
+          ["semver", "npm:7.6.0"],\
+          ["string_decoder", "npm:1.3.0"],\
+          ["xml2js", "npm:0.6.2"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -17692,6 +17054,14 @@ const RAW_RUNTIME_STATE =
           ["lru-cache", "npm:7.18.3"]\
         ],\
         "linkType": "HARD"\
+      }],\
+      ["npm:7.0.2", {\
+        "packageLocation": "./.yarn/cache/hosted-git-info-npm-7.0.2-cd527dd33f-8f085df8a4.zip/node_modules/hosted-git-info/",\
+        "packageDependencies": [\
+          ["hosted-git-info", "npm:7.0.2"],\
+          ["lru-cache", "npm:10.1.0"]\
+        ],\
+        "linkType": "HARD"\
       }]\
     ]],\
     ["hpagent", [\
@@ -17750,19 +17120,6 @@ const RAW_RUNTIME_STATE =
           ["domutils", "npm:1.5.1"],\
           ["entities", "npm:1.0.0"],\
           ["readable-stream", "npm:1.1.14"]\
-        ],\
-        "linkType": "HARD"\
-      }]\
-    ]],\
-    ["http-basic", [\
-      ["npm:8.1.3", {\
-        "packageLocation": "./.yarn/cache/http-basic-npm-8.1.3-ae54b14025-f515c46159.zip/node_modules/http-basic/",\
-        "packageDependencies": [\
-          ["http-basic", "npm:8.1.3"],\
-          ["caseless", "npm:0.12.0"],\
-          ["concat-stream", "npm:1.6.2"],\
-          ["http-response-object", "npm:3.0.2"],\
-          ["parse-cache-control", "npm:1.0.1"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -17862,16 +17219,6 @@ const RAW_RUNTIME_STATE =
           ["http-proxy-agent", "npm:7.0.2"],\
           ["agent-base", "npm:7.1.1"],\
           ["debug", "virtual:58471071b1e0e7981e3318280660861b4dec874aaf0d60e144b70657cb5ce0af059ae16711a2af10f4d1ff0536527e350e6e47a8f79db2d8d37ff2ec84865bbc#npm:4.3.4"]\
-        ],\
-        "linkType": "HARD"\
-      }]\
-    ]],\
-    ["http-response-object", [\
-      ["npm:3.0.2", {\
-        "packageLocation": "./.yarn/cache/http-response-object-npm-3.0.2-cbb68c5487-f530c1b28d.zip/node_modules/http-response-object/",\
-        "packageDependencies": [\
-          ["http-response-object", "npm:3.0.2"],\
-          ["@types/node", "npm:10.17.60"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -18036,6 +17383,13 @@ const RAW_RUNTIME_STATE =
           ["ignore", "npm:5.2.4"]\
         ],\
         "linkType": "HARD"\
+      }],\
+      ["npm:5.3.1", {\
+        "packageLocation": "./.yarn/cache/ignore-npm-5.3.1-f6947c5df7-0a884c2fbc.zip/node_modules/ignore/",\
+        "packageDependencies": [\
+          ["ignore", "npm:5.3.1"]\
+        ],\
+        "linkType": "HARD"\
       }]\
     ]],\
     ["ignore-by-default", [\
@@ -18064,10 +17418,10 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "HARD"\
       }],\
-      ["npm:6.0.3", {\
-        "packageLocation": "./.yarn/cache/ignore-walk-npm-6.0.3-ebca6b06c4-3cbc0b52c7.zip/node_modules/ignore-walk/",\
+      ["npm:6.0.5", {\
+        "packageLocation": "./.yarn/cache/ignore-walk-npm-6.0.5-dc11005d4e-08757abff4.zip/node_modules/ignore-walk/",\
         "packageDependencies": [\
-          ["ignore-walk", "npm:6.0.3"],\
+          ["ignore-walk", "npm:6.0.5"],\
           ["minimatch", "npm:9.0.3"]\
         ],\
         "linkType": "HARD"\
@@ -19233,6 +18587,13 @@ const RAW_RUNTIME_STATE =
           ["isexe", "npm:2.0.0"]\
         ],\
         "linkType": "HARD"\
+      }],\
+      ["npm:3.1.1", {\
+        "packageLocation": "./.yarn/cache/isexe-npm-3.1.1-9c0061eead-7fe1931ee4.zip/node_modules/isexe/",\
+        "packageDependencies": [\
+          ["isexe", "npm:3.1.1"]\
+        ],\
+        "linkType": "HARD"\
       }]\
     ]],\
     ["isobject", [\
@@ -19385,6 +18746,15 @@ const RAW_RUNTIME_STATE =
           ["@pkgjs/parseargs", "npm:0.11.0"]\
         ],\
         "linkType": "HARD"\
+      }],\
+      ["npm:2.3.6", {\
+        "packageLocation": "./.yarn/cache/jackspeak-npm-2.3.6-42e1233172-6e6490d676.zip/node_modules/jackspeak/",\
+        "packageDependencies": [\
+          ["jackspeak", "npm:2.3.6"],\
+          ["@isaacs/cliui", "npm:8.0.2"],\
+          ["@pkgjs/parseargs", "npm:0.11.0"]\
+        ],\
+        "linkType": "HARD"\
       }]\
     ]],\
     ["jake", [\
@@ -19408,15 +18778,15 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "SOFT"\
       }],\
-      ["virtual:dfaa473f537ddcbbe9a585bdf89c36b7e8eaba790caa916a9832a8ef0d822fd7416e74adb9c9a9815a0ad1e7ac343cc56ad74f61fe917964c31bdaa195a65414#npm:29.7.0", {\
-        "packageLocation": "./.yarn/__virtual__/jest-virtual-e0c6ca93c4/0/cache/jest-npm-29.7.0-d8dd095b81-97023d7844.zip/node_modules/jest/",\
+      ["virtual:963c647ea051efd8c590d2c7557349f3372ef2d1a56b4124e7863ebca3fab4680c0f4b8ecbd49d0371d65f2281579c5841fe1dd9c8c0a863c6e96966933908e0#npm:29.7.0", {\
+        "packageLocation": "./.yarn/__virtual__/jest-virtual-49316054cd/0/cache/jest-npm-29.7.0-d8dd095b81-97023d7844.zip/node_modules/jest/",\
         "packageDependencies": [\
-          ["jest", "virtual:dfaa473f537ddcbbe9a585bdf89c36b7e8eaba790caa916a9832a8ef0d822fd7416e74adb9c9a9815a0ad1e7ac343cc56ad74f61fe917964c31bdaa195a65414#npm:29.7.0"],\
-          ["@jest/core", "virtual:e0c6ca93c4a55e387c5762a3376217419ca60912cbd1a0d547f351af8accbd101f8edd79ca9ffefa3f0b94c5b15ee6d0e818f1656b624955c40f5662048f8410#npm:29.7.0"],\
+          ["jest", "virtual:963c647ea051efd8c590d2c7557349f3372ef2d1a56b4124e7863ebca3fab4680c0f4b8ecbd49d0371d65f2281579c5841fe1dd9c8c0a863c6e96966933908e0#npm:29.7.0"],\
+          ["@jest/core", "virtual:49316054cd7bff615bf5d3f57290200a437c8a6f01070e97f8df569a6ca1b182a1b140b761e01eb7a7e23e10fd80cea9b102526787e63400a46092ca863b52d0#npm:29.7.0"],\
           ["@jest/types", "npm:29.6.3"],\
           ["@types/node-notifier", null],\
           ["import-local", "npm:3.1.0"],\
-          ["jest-cli", "virtual:e0c6ca93c4a55e387c5762a3376217419ca60912cbd1a0d547f351af8accbd101f8edd79ca9ffefa3f0b94c5b15ee6d0e818f1656b624955c40f5662048f8410#npm:29.7.0"],\
+          ["jest-cli", "virtual:49316054cd7bff615bf5d3f57290200a437c8a6f01070e97f8df569a6ca1b182a1b140b761e01eb7a7e23e10fd80cea9b102526787e63400a46092ca863b52d0#npm:29.7.0"],\
           ["node-notifier", null]\
         ],\
         "packagePeers": [\
@@ -19475,11 +18845,11 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "SOFT"\
       }],\
-      ["virtual:e0c6ca93c4a55e387c5762a3376217419ca60912cbd1a0d547f351af8accbd101f8edd79ca9ffefa3f0b94c5b15ee6d0e818f1656b624955c40f5662048f8410#npm:29.7.0", {\
-        "packageLocation": "./.yarn/__virtual__/jest-cli-virtual-2520966da1/0/cache/jest-cli-npm-29.7.0-9adb356180-6cc62b34d0.zip/node_modules/jest-cli/",\
+      ["virtual:49316054cd7bff615bf5d3f57290200a437c8a6f01070e97f8df569a6ca1b182a1b140b761e01eb7a7e23e10fd80cea9b102526787e63400a46092ca863b52d0#npm:29.7.0", {\
+        "packageLocation": "./.yarn/__virtual__/jest-cli-virtual-ced9ae131e/0/cache/jest-cli-npm-29.7.0-9adb356180-6cc62b34d0.zip/node_modules/jest-cli/",\
         "packageDependencies": [\
-          ["jest-cli", "virtual:e0c6ca93c4a55e387c5762a3376217419ca60912cbd1a0d547f351af8accbd101f8edd79ca9ffefa3f0b94c5b15ee6d0e818f1656b624955c40f5662048f8410#npm:29.7.0"],\
-          ["@jest/core", "virtual:e0c6ca93c4a55e387c5762a3376217419ca60912cbd1a0d547f351af8accbd101f8edd79ca9ffefa3f0b94c5b15ee6d0e818f1656b624955c40f5662048f8410#npm:29.7.0"],\
+          ["jest-cli", "virtual:49316054cd7bff615bf5d3f57290200a437c8a6f01070e97f8df569a6ca1b182a1b140b761e01eb7a7e23e10fd80cea9b102526787e63400a46092ca863b52d0#npm:29.7.0"],\
+          ["@jest/core", "virtual:49316054cd7bff615bf5d3f57290200a437c8a6f01070e97f8df569a6ca1b182a1b140b761e01eb7a7e23e10fd80cea9b102526787e63400a46092ca863b52d0#npm:29.7.0"],\
           ["@jest/test-result", "npm:29.7.0"],\
           ["@jest/types", "npm:29.6.3"],\
           ["@types/node-notifier", null],\
@@ -19517,7 +18887,7 @@ const RAW_RUNTIME_STATE =
           ["@jest/types", "npm:29.6.3"],\
           ["@types/node", null],\
           ["@types/ts-node", null],\
-          ["babel-jest", "virtual:827cf270b09d65729a6a1ff7cc9e3a99a22577de879192dfaefa0c1007d108c5cce9652a9127acef6bae7e84235b313d150e197d10314a3c4a2e25fa269a20f9#npm:29.7.0"],\
+          ["babel-jest", "virtual:b278756a522c5a2b833fa7b26fda1dba58349ff098950c76beb604c833e7de837b9c5b74af2d6668937e192e4e2d692b9881f4a9e845577acfe54f9ad8e57a0e#npm:29.7.0"],\
           ["chalk", "npm:4.1.2"],\
           ["ci-info", "npm:3.3.0"],\
           ["deepmerge", "npm:4.2.2"],\
@@ -19545,16 +18915,16 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "HARD"\
       }],\
-      ["virtual:d15ebbabf58e5006c1e7680a90d8b036c141da05ed45cc36ee0b4221f535b2227396ef34e75485afc0706e56cfa780e7ac0a95784ddeafec362dfb667ea9ccfe#npm:29.7.0", {\
-        "packageLocation": "./.yarn/__virtual__/jest-config-virtual-827cf270b0/0/cache/jest-config-npm-29.7.0-97d8544d74-6bdf570e95.zip/node_modules/jest-config/",\
+      ["virtual:93536b146e1c0ae2a89d84dd126c3cd76033ce104d6db478c7788bfcfffdc52e5f9d7d3bcf3ab2a892dd3cb435c9c6dc48870a3809bf9dd8ddbcddd064bc5424#npm:29.7.0", {\
+        "packageLocation": "./.yarn/__virtual__/jest-config-virtual-b278756a52/0/cache/jest-config-npm-29.7.0-97d8544d74-6bdf570e95.zip/node_modules/jest-config/",\
         "packageDependencies": [\
-          ["jest-config", "virtual:d15ebbabf58e5006c1e7680a90d8b036c141da05ed45cc36ee0b4221f535b2227396ef34e75485afc0706e56cfa780e7ac0a95784ddeafec362dfb667ea9ccfe#npm:29.7.0"],\
+          ["jest-config", "virtual:93536b146e1c0ae2a89d84dd126c3cd76033ce104d6db478c7788bfcfffdc52e5f9d7d3bcf3ab2a892dd3cb435c9c6dc48870a3809bf9dd8ddbcddd064bc5424#npm:29.7.0"],\
           ["@babel/core", "npm:7.22.17"],\
           ["@jest/test-sequencer", "npm:29.7.0"],\
           ["@jest/types", "npm:29.6.3"],\
           ["@types/node", "npm:16.9.6"],\
           ["@types/ts-node", null],\
-          ["babel-jest", "virtual:827cf270b09d65729a6a1ff7cc9e3a99a22577de879192dfaefa0c1007d108c5cce9652a9127acef6bae7e84235b313d150e197d10314a3c4a2e25fa269a20f9#npm:29.7.0"],\
+          ["babel-jest", "virtual:b278756a522c5a2b833fa7b26fda1dba58349ff098950c76beb604c833e7de837b9c5b74af2d6668937e192e4e2d692b9881f4a9e845577acfe54f9ad8e57a0e#npm:29.7.0"],\
           ["chalk", "npm:4.1.2"],\
           ["ci-info", "npm:3.3.0"],\
           ["deepmerge", "npm:4.2.2"],\
@@ -20460,14 +19830,13 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "HARD"\
       }],\
-      ["npm:7.3.0", {\
-        "packageLocation": "./.yarn/cache/lerna-npm-7.3.0-d75cff27a4-f3d3cc4ece.zip/node_modules/lerna/",\
+      ["npm:8.1.3", {\
+        "packageLocation": "./.yarn/cache/lerna-npm-8.1.3-48f9ae8498-822268c86f.zip/node_modules/lerna/",\
         "packageDependencies": [\
-          ["lerna", "npm:7.3.0"],\
-          ["@lerna/child-process", "npm:7.3.0"],\
-          ["@lerna/create", "npm:7.3.0"],\
-          ["@npmcli/run-script", "npm:6.0.2"],\
-          ["@nx/devkit", "virtual:27294a026b403a125127a01c506649a66f963443d98b165f595b35d84f3a7f3acf7257fab805d9a5c66db9a766498808df6100c11de52d69e5f1edabcba2aa61#npm:16.8.1"],\
+          ["lerna", "npm:8.1.3"],\
+          ["@lerna/create", "npm:8.1.3"],\
+          ["@npmcli/run-script", "npm:7.0.2"],\
+          ["@nx/devkit", "virtual:231b41c796fb4c3a1878ccc2b284d7acc71e342654f1dcf3bec9e756c379469380938482d22d651d850cf92850f594f3b751114f8c7660ab24c8aee2d7081537#npm:19.0.3"],\
           ["@octokit/plugin-enterprise-rest", "npm:6.0.1"],\
           ["@octokit/rest", "npm:19.0.11"],\
           ["byte-size", "npm:8.1.1"],\
@@ -20475,10 +19844,10 @@ const RAW_RUNTIME_STATE =
           ["clone-deep", "npm:4.0.1"],\
           ["cmd-shim", "npm:6.0.1"],\
           ["columnify", "npm:1.6.0"],\
-          ["conventional-changelog-angular", "npm:6.0.0"],\
+          ["conventional-changelog-angular", "npm:7.0.0"],\
           ["conventional-changelog-core", "npm:5.0.1"],\
           ["conventional-recommended-bump", "npm:7.0.1"],\
-          ["cosmiconfig", "virtual:d75cff27a4008038c929443f4fab5c682c9234034f14e2ff4417bcd1e568bd475b296866223666f43f0543be54daebc7fc015b5b1eecef1f1089f8516b845773#npm:8.3.6"],\
+          ["cosmiconfig", "virtual:48f9ae8498438ca8cc7b5946ce00bad482e1d3819f5cf6cb31b22f3bd65e8afe79dac342ace3c8efe70ce03d960bd269a9d17bcc96e05924eb4fa81fbede56dc#npm:8.3.6"],\
           ["dedent", "npm:0.7.0"],\
           ["envinfo", "npm:7.8.1"],\
           ["execa", "npm:5.0.0"],\
@@ -20505,19 +19874,19 @@ const RAW_RUNTIME_STATE =
           ["make-dir", "npm:4.0.0"],\
           ["minimatch", "npm:3.0.5"],\
           ["multimatch", "npm:5.0.0"],\
-          ["node-fetch", "virtual:27294a026b403a125127a01c506649a66f963443d98b165f595b35d84f3a7f3acf7257fab805d9a5c66db9a766498808df6100c11de52d69e5f1edabcba2aa61#npm:2.6.7"],\
+          ["node-fetch", "virtual:231b41c796fb4c3a1878ccc2b284d7acc71e342654f1dcf3bec9e756c379469380938482d22d651d850cf92850f594f3b751114f8c7660ab24c8aee2d7081537#npm:2.6.7"],\
           ["npm-package-arg", "npm:8.1.1"],\
           ["npm-packlist", "npm:5.1.1"],\
           ["npm-registry-fetch", "npm:14.0.5"],\
           ["npmlog", "npm:6.0.2"],\
-          ["nx", "virtual:27294a026b403a125127a01c506649a66f963443d98b165f595b35d84f3a7f3acf7257fab805d9a5c66db9a766498808df6100c11de52d69e5f1edabcba2aa61#npm:16.8.1"],\
+          ["nx", "virtual:231b41c796fb4c3a1878ccc2b284d7acc71e342654f1dcf3bec9e756c379469380938482d22d651d850cf92850f594f3b751114f8c7660ab24c8aee2d7081537#npm:19.0.3"],\
           ["p-map", "npm:4.0.0"],\
           ["p-map-series", "npm:2.1.0"],\
           ["p-pipe", "npm:3.1.0"],\
           ["p-queue", "npm:6.6.2"],\
           ["p-reduce", "npm:2.1.0"],\
           ["p-waterfall", "npm:2.1.1"],\
-          ["pacote", "npm:15.2.0"],\
+          ["pacote", "npm:17.0.7"],\
           ["pify", "npm:5.0.0"],\
           ["read-cmd-shim", "npm:4.0.0"],\
           ["read-package-json", "npm:6.0.4"],\
@@ -20528,7 +19897,7 @@ const RAW_RUNTIME_STATE =
           ["slash", "npm:3.0.0"],\
           ["ssri", "npm:9.0.1"],\
           ["strong-log-transformer", "npm:2.1.0"],\
-          ["tar", "npm:6.1.11"],\
+          ["tar", "npm:6.2.1"],\
           ["temp-dir", "npm:1.0.0"],\
           ["typescript", "patch:typescript@npm%3A5.2.2#optional!builtin<compat/typescript>::version=5.2.2&hash=f3b441"],\
           ["upath", "npm:2.0.1"],\
@@ -20537,8 +19906,8 @@ const RAW_RUNTIME_STATE =
           ["validate-npm-package-name", "npm:5.0.0"],\
           ["write-file-atomic", "npm:5.0.1"],\
           ["write-pkg", "npm:4.0.0"],\
-          ["yargs", "npm:16.2.0"],\
-          ["yargs-parser", "npm:20.2.4"]\
+          ["yargs", "npm:17.7.2"],\
+          ["yargs-parser", "npm:21.1.1"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -21071,6 +20440,13 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "HARD"\
       }],\
+      ["npm:10.2.2", {\
+        "packageLocation": "./.yarn/cache/lru-cache-npm-10.2.2-c54b721fc3-ff1a496d30.zip/node_modules/lru-cache/",\
+        "packageDependencies": [\
+          ["lru-cache", "npm:10.2.2"]\
+        ],\
+        "linkType": "HARD"\
+      }],\
       ["npm:4.1.5", {\
         "packageLocation": "./.yarn/cache/lru-cache-npm-4.1.5-ede304cc43-9ec7d73f11.zip/node_modules/lru-cache/",\
         "packageDependencies": [\
@@ -21249,6 +20625,25 @@ const RAW_RUNTIME_STATE =
           ["negotiator", "npm:0.6.3"],\
           ["promise-retry", "npm:2.0.1"],\
           ["socks-proxy-agent", "npm:7.0.0"],\
+          ["ssri", "npm:10.0.5"]\
+        ],\
+        "linkType": "HARD"\
+      }],\
+      ["npm:13.0.1", {\
+        "packageLocation": "./.yarn/cache/make-fetch-happen-npm-13.0.1-4180f2aaa8-11bae5ad6a.zip/node_modules/make-fetch-happen/",\
+        "packageDependencies": [\
+          ["make-fetch-happen", "npm:13.0.1"],\
+          ["@npmcli/agent", "npm:2.2.2"],\
+          ["cacache", "npm:18.0.3"],\
+          ["http-cache-semantics", "npm:4.1.1"],\
+          ["is-lambda", "npm:1.0.1"],\
+          ["minipass", "npm:7.1.1"],\
+          ["minipass-fetch", "npm:3.0.4"],\
+          ["minipass-flush", "npm:1.0.5"],\
+          ["minipass-pipeline", "npm:1.2.4"],\
+          ["negotiator", "npm:0.6.3"],\
+          ["proc-log", "npm:4.2.0"],\
+          ["promise-retry", "npm:2.0.1"],\
           ["ssri", "npm:10.0.5"]\
         ],\
         "linkType": "HARD"\
@@ -22294,6 +21689,14 @@ const RAW_RUNTIME_STATE =
           ["brace-expansion", "npm:2.0.1"]\
         ],\
         "linkType": "HARD"\
+      }],\
+      ["npm:9.0.4", {\
+        "packageLocation": "./.yarn/cache/minimatch-npm-9.0.4-7be5a33efc-4cdc18d112.zip/node_modules/minimatch/",\
+        "packageDependencies": [\
+          ["minimatch", "npm:9.0.4"],\
+          ["brace-expansion", "npm:2.0.1"]\
+        ],\
+        "linkType": "HARD"\
       }]\
     ]],\
     ["minimist", [\
@@ -22364,6 +21767,13 @@ const RAW_RUNTIME_STATE =
           ["minipass", "npm:7.0.3"]\
         ],\
         "linkType": "HARD"\
+      }],\
+      ["npm:7.1.1", {\
+        "packageLocation": "./.yarn/cache/minipass-npm-7.1.1-52e31602d3-6f4f920f1b.zip/node_modules/minipass/",\
+        "packageDependencies": [\
+          ["minipass", "npm:7.1.1"]\
+        ],\
+        "linkType": "HARD"\
       }]\
     ]],\
     ["minipass-collect", [\
@@ -22372,6 +21782,14 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["minipass-collect", "npm:1.0.2"],\
           ["minipass", "npm:3.1.5"]\
+        ],\
+        "linkType": "HARD"\
+      }],\
+      ["npm:2.0.1", {\
+        "packageLocation": "./.yarn/cache/minipass-collect-npm-2.0.1-73d3907e40-b251bceea6.zip/node_modules/minipass-collect/",\
+        "packageDependencies": [\
+          ["minipass-collect", "npm:2.0.1"],\
+          ["minipass", "npm:7.0.3"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -22895,46 +22313,49 @@ const RAW_RUNTIME_STATE =
       }]\
     ]],\
     ["next", [\
-      ["npm:13.4.19", {\
-        "packageLocation": "./.yarn/cache/next-npm-13.4.19-bc82e788ec-e5180f07d5.zip/node_modules/next/",\
+      ["npm:14.2.3", {\
+        "packageLocation": "./.yarn/cache/next-npm-14.2.3-7770cdfada-666c977020.zip/node_modules/next/",\
         "packageDependencies": [\
-          ["next", "npm:13.4.19"]\
+          ["next", "npm:14.2.3"]\
         ],\
         "linkType": "SOFT"\
       }],\
-      ["virtual:dfaa473f537ddcbbe9a585bdf89c36b7e8eaba790caa916a9832a8ef0d822fd7416e74adb9c9a9815a0ad1e7ac343cc56ad74f61fe917964c31bdaa195a65414#npm:13.4.19", {\
-        "packageLocation": "./.yarn/__virtual__/next-virtual-15856ab349/0/cache/next-npm-13.4.19-bc82e788ec-e5180f07d5.zip/node_modules/next/",\
+      ["virtual:963c647ea051efd8c590d2c7557349f3372ef2d1a56b4124e7863ebca3fab4680c0f4b8ecbd49d0371d65f2281579c5841fe1dd9c8c0a863c6e96966933908e0#npm:14.2.3", {\
+        "packageLocation": "./.yarn/__virtual__/next-virtual-94cb705d8f/0/cache/next-npm-14.2.3-7770cdfada-666c977020.zip/node_modules/next/",\
         "packageDependencies": [\
-          ["next", "virtual:dfaa473f537ddcbbe9a585bdf89c36b7e8eaba790caa916a9832a8ef0d822fd7416e74adb9c9a9815a0ad1e7ac343cc56ad74f61fe917964c31bdaa195a65414#npm:13.4.19"],\
-          ["@next/env", "npm:13.4.19"],\
-          ["@next/swc-darwin-arm64", "npm:13.4.19"],\
-          ["@next/swc-darwin-x64", "npm:13.4.19"],\
-          ["@next/swc-linux-arm64-gnu", "npm:13.4.19"],\
-          ["@next/swc-linux-arm64-musl", "npm:13.4.19"],\
-          ["@next/swc-linux-x64-gnu", "npm:13.4.19"],\
-          ["@next/swc-linux-x64-musl", "npm:13.4.19"],\
-          ["@next/swc-win32-arm64-msvc", "npm:13.4.19"],\
-          ["@next/swc-win32-ia32-msvc", "npm:13.4.19"],\
-          ["@next/swc-win32-x64-msvc", "npm:13.4.19"],\
+          ["next", "virtual:963c647ea051efd8c590d2c7557349f3372ef2d1a56b4124e7863ebca3fab4680c0f4b8ecbd49d0371d65f2281579c5841fe1dd9c8c0a863c6e96966933908e0#npm:14.2.3"],\
+          ["@next/env", "npm:14.2.3"],\
+          ["@next/swc-darwin-arm64", "npm:14.2.3"],\
+          ["@next/swc-darwin-x64", "npm:14.2.3"],\
+          ["@next/swc-linux-arm64-gnu", "npm:14.2.3"],\
+          ["@next/swc-linux-arm64-musl", "npm:14.2.3"],\
+          ["@next/swc-linux-x64-gnu", "npm:14.2.3"],\
+          ["@next/swc-linux-x64-musl", "npm:14.2.3"],\
+          ["@next/swc-win32-arm64-msvc", "npm:14.2.3"],\
+          ["@next/swc-win32-ia32-msvc", "npm:14.2.3"],\
+          ["@next/swc-win32-x64-msvc", "npm:14.2.3"],\
           ["@opentelemetry/api", null],\
-          ["@swc/helpers", "npm:0.5.1"],\
+          ["@playwright/test", null],\
+          ["@swc/helpers", "npm:0.5.5"],\
           ["@types/opentelemetry__api", null],\
+          ["@types/playwright__test", null],\
           ["@types/react", null],\
           ["@types/react-dom", null],\
           ["@types/sass", null],\
           ["busboy", "npm:1.6.0"],\
-          ["caniuse-lite", "npm:1.0.30001534"],\
-          ["postcss", "npm:8.4.14"],\
+          ["caniuse-lite", "npm:1.0.30001618"],\
+          ["graceful-fs", "npm:4.2.11"],\
+          ["postcss", "npm:8.4.31"],\
           ["react", null],\
           ["react-dom", null],\
           ["sass", null],\
-          ["styled-jsx", "virtual:15856ab34955512a62f786822acaddfde8b3e5fd2698fdc6a1f49e79382c501d29eefe426ece81baacd057f825d8f42b74025dcce309719f589944e495bb6be8#npm:5.1.1"],\
-          ["watchpack", "npm:2.4.0"],\
-          ["zod", "npm:3.21.4"]\
+          ["styled-jsx", "virtual:94cb705d8f2a2b1109015646a11175be495adda31bbc645b083cc9bbf85fc1d13ff9fe785e01febf7a450c2bbcd01c45cf8a80da31422991f38abefcc7e33718#npm:5.1.1"]\
         ],\
         "packagePeers": [\
           "@opentelemetry/api",\
+          "@playwright/test",\
           "@types/opentelemetry__api",\
+          "@types/playwright__test",\
           "@types/react-dom",\
           "@types/react",\
           "@types/sass",\
@@ -22992,16 +22413,6 @@ const RAW_RUNTIME_STATE =
         "linkType": "HARD"\
       }]\
     ]],\
-    ["node-addon-api", [\
-      ["npm:3.2.1", {\
-        "packageLocation": "./.yarn/unplugged/node-addon-api-npm-3.2.1-a29528f81d/node_modules/node-addon-api/",\
-        "packageDependencies": [\
-          ["node-addon-api", "npm:3.2.1"],\
-          ["node-gyp", "npm:8.2.0"]\
-        ],\
-        "linkType": "HARD"\
-      }]\
-    ]],\
     ["node-cleanup", [\
       ["npm:2.1.2", {\
         "packageLocation": "./.yarn/cache/node-cleanup-npm-2.1.2-adfbc95778-eeb831d27d.zip/node_modules/node-cleanup/",\
@@ -23055,10 +22466,10 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "SOFT"\
       }],\
-      ["virtual:27294a026b403a125127a01c506649a66f963443d98b165f595b35d84f3a7f3acf7257fab805d9a5c66db9a766498808df6100c11de52d69e5f1edabcba2aa61#npm:2.6.7", {\
-        "packageLocation": "./.yarn/__virtual__/node-fetch-virtual-c3029731a8/0/cache/node-fetch-npm-2.6.7-777aa2a6df-4bc9245383.zip/node_modules/node-fetch/",\
+      ["virtual:231b41c796fb4c3a1878ccc2b284d7acc71e342654f1dcf3bec9e756c379469380938482d22d651d850cf92850f594f3b751114f8c7660ab24c8aee2d7081537#npm:2.6.7", {\
+        "packageLocation": "./.yarn/__virtual__/node-fetch-virtual-33259e39e2/0/cache/node-fetch-npm-2.6.7-777aa2a6df-4bc9245383.zip/node_modules/node-fetch/",\
         "packageDependencies": [\
-          ["node-fetch", "virtual:27294a026b403a125127a01c506649a66f963443d98b165f595b35d84f3a7f3acf7257fab805d9a5c66db9a766498808df6100c11de52d69e5f1edabcba2aa61#npm:2.6.7"],\
+          ["node-fetch", "virtual:231b41c796fb4c3a1878ccc2b284d7acc71e342654f1dcf3bec9e756c379469380938482d22d651d850cf92850f594f3b751114f8c7660ab24c8aee2d7081537#npm:2.6.7"],\
           ["@types/encoding", null],\
           ["encoding", null],\
           ["whatwg-url", "npm:5.0.0"]\
@@ -23125,6 +22536,23 @@ const RAW_RUNTIME_STATE =
       }]\
     ]],\
     ["node-gyp", [\
+      ["npm:10.1.0", {\
+        "packageLocation": "./.yarn/unplugged/node-gyp-npm-10.1.0-bdea7d2ece/node_modules/node-gyp/",\
+        "packageDependencies": [\
+          ["node-gyp", "npm:10.1.0"],\
+          ["env-paths", "npm:2.2.1"],\
+          ["exponential-backoff", "npm:3.1.1"],\
+          ["glob", "npm:10.3.15"],\
+          ["graceful-fs", "npm:4.2.8"],\
+          ["make-fetch-happen", "npm:13.0.1"],\
+          ["nopt", "npm:7.2.1"],\
+          ["proc-log", "npm:3.0.0"],\
+          ["semver", "npm:7.5.4"],\
+          ["tar", "npm:6.1.11"],\
+          ["which", "npm:4.0.0"]\
+        ],\
+        "linkType": "HARD"\
+      }],\
       ["npm:5.1.1", {\
         "packageLocation": "./.yarn/unplugged/node-gyp-npm-5.1.1-9e002933ea/node_modules/node-gyp/",\
         "packageDependencies": [\
@@ -23157,33 +22585,6 @@ const RAW_RUNTIME_STATE =
           ["semver", "npm:7.5.4"],\
           ["tar", "npm:6.1.11"],\
           ["which", "npm:2.0.2"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["npm:9.4.0", {\
-        "packageLocation": "./.yarn/unplugged/node-gyp-npm-9.4.0-ebf5f5573e/node_modules/node-gyp/",\
-        "packageDependencies": [\
-          ["node-gyp", "npm:9.4.0"],\
-          ["env-paths", "npm:2.2.1"],\
-          ["exponential-backoff", "npm:3.1.1"],\
-          ["glob", "npm:7.2.0"],\
-          ["graceful-fs", "npm:4.2.8"],\
-          ["make-fetch-happen", "npm:11.1.1"],\
-          ["nopt", "npm:6.0.0"],\
-          ["npmlog", "npm:6.0.2"],\
-          ["rimraf", "npm:3.0.2"],\
-          ["semver", "npm:7.5.4"],\
-          ["tar", "npm:6.1.11"],\
-          ["which", "npm:2.0.2"]\
-        ],\
-        "linkType": "HARD"\
-      }]\
-    ]],\
-    ["node-gyp-build", [\
-      ["npm:4.6.1", {\
-        "packageLocation": "./.yarn/cache/node-gyp-build-npm-4.6.1-31ee3c90ee-79b9483774.zip/node_modules/node-gyp-build/",\
-        "packageDependencies": [\
-          ["node-gyp-build", "npm:4.6.1"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -23285,11 +22686,11 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "HARD"\
       }],\
-      ["npm:6.0.0", {\
-        "packageLocation": "./.yarn/cache/nopt-npm-6.0.0-5ea8050815-3c1128e07c.zip/node_modules/nopt/",\
+      ["npm:7.2.1", {\
+        "packageLocation": "./.yarn/cache/nopt-npm-7.2.1-635b7da949-95a1f6dec8.zip/node_modules/nopt/",\
         "packageDependencies": [\
-          ["nopt", "npm:6.0.0"],\
-          ["abbrev", "npm:1.1.1"]\
+          ["nopt", "npm:7.2.1"],\
+          ["abbrev", "npm:2.0.0"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -23322,6 +22723,17 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["normalize-package-data", "npm:5.0.0"],\
           ["hosted-git-info", "npm:6.1.1"],\
+          ["is-core-module", "npm:2.13.0"],\
+          ["semver", "npm:7.5.4"],\
+          ["validate-npm-package-license", "npm:3.0.4"]\
+        ],\
+        "linkType": "HARD"\
+      }],\
+      ["npm:6.0.1", {\
+        "packageLocation": "./.yarn/cache/normalize-package-data-npm-6.0.1-00cae3fa86-eb0b1815a1.zip/node_modules/normalize-package-data/",\
+        "packageDependencies": [\
+          ["normalize-package-data", "npm:6.0.1"],\
+          ["hosted-git-info", "npm:7.0.2"],\
           ["is-core-module", "npm:2.13.0"],\
           ["semver", "npm:7.5.4"],\
           ["validate-npm-package-license", "npm:3.0.4"]\
@@ -23420,6 +22832,17 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "HARD"\
       }],\
+      ["npm:11.0.2", {\
+        "packageLocation": "./.yarn/cache/npm-package-arg-npm-11.0.2-bd9cd2ed92-ce4c51900a.zip/node_modules/npm-package-arg/",\
+        "packageDependencies": [\
+          ["npm-package-arg", "npm:11.0.2"],\
+          ["hosted-git-info", "npm:7.0.2"],\
+          ["proc-log", "npm:4.2.0"],\
+          ["semver", "npm:7.5.4"],\
+          ["validate-npm-package-name", "npm:5.0.0"]\
+        ],\
+        "linkType": "HARD"\
+      }],\
       ["npm:6.1.1", {\
         "packageLocation": "./.yarn/cache/npm-package-arg-npm-6.1.1-7fa8d553e7-8492ce41f3.zip/node_modules/npm-package-arg/",\
         "packageDependencies": [\
@@ -23464,11 +22887,11 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "HARD"\
       }],\
-      ["npm:7.0.4", {\
-        "packageLocation": "./.yarn/cache/npm-packlist-npm-7.0.4-1c0b919056-b24644eefa.zip/node_modules/npm-packlist/",\
+      ["npm:8.0.2", {\
+        "packageLocation": "./.yarn/cache/npm-packlist-npm-8.0.2-f975a473a6-707206e5c0.zip/node_modules/npm-packlist/",\
         "packageDependencies": [\
-          ["npm-packlist", "npm:7.0.4"],\
-          ["ignore-walk", "npm:6.0.3"]\
+          ["npm-packlist", "npm:8.0.2"],\
+          ["ignore-walk", "npm:6.0.5"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -23484,13 +22907,13 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "HARD"\
       }],\
-      ["npm:8.0.2", {\
-        "packageLocation": "./.yarn/cache/npm-pick-manifest-npm-8.0.2-ec194cb513-3f10a34e12.zip/node_modules/npm-pick-manifest/",\
+      ["npm:9.0.1", {\
+        "packageLocation": "./.yarn/cache/npm-pick-manifest-npm-9.0.1-f1f615bc4e-870053b63c.zip/node_modules/npm-pick-manifest/",\
         "packageDependencies": [\
-          ["npm-pick-manifest", "npm:8.0.2"],\
+          ["npm-pick-manifest", "npm:9.0.1"],\
           ["npm-install-checks", "npm:6.2.0"],\
           ["npm-normalize-package-bin", "npm:3.0.1"],\
-          ["npm-package-arg", "npm:10.1.0"],\
+          ["npm-package-arg", "npm:11.0.2"],\
           ["semver", "npm:7.5.4"]\
         ],\
         "linkType": "HARD"\
@@ -23508,6 +22931,21 @@ const RAW_RUNTIME_STATE =
           ["minizlib", "npm:2.1.2"],\
           ["npm-package-arg", "npm:10.1.0"],\
           ["proc-log", "npm:3.0.0"]\
+        ],\
+        "linkType": "HARD"\
+      }],\
+      ["npm:16.2.1", {\
+        "packageLocation": "./.yarn/cache/npm-registry-fetch-npm-16.2.1-f5790ad261-eb5a939f8f.zip/node_modules/npm-registry-fetch/",\
+        "packageDependencies": [\
+          ["npm-registry-fetch", "npm:16.2.1"],\
+          ["@npmcli/redact", "npm:1.1.0"],\
+          ["make-fetch-happen", "npm:13.0.1"],\
+          ["minipass", "npm:7.1.1"],\
+          ["minipass-fetch", "npm:3.0.4"],\
+          ["minipass-json-stream", "npm:1.0.1"],\
+          ["minizlib", "npm:2.1.2"],\
+          ["npm-package-arg", "npm:11.0.2"],\
+          ["proc-log", "npm:4.2.0"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -23581,29 +23019,28 @@ const RAW_RUNTIME_STATE =
       }]\
     ]],\
     ["nx", [\
-      ["npm:16.8.1", {\
-        "packageLocation": "./.yarn/unplugged/nx-virtual-8473d555d5/node_modules/nx/",\
+      ["npm:19.0.3", {\
+        "packageLocation": "./.yarn/unplugged/nx-virtual-3a9a7cef34/node_modules/nx/",\
         "packageDependencies": [\
-          ["nx", "npm:16.8.1"]\
+          ["nx", "npm:19.0.3"]\
         ],\
         "linkType": "SOFT"\
       }],\
-      ["virtual:27294a026b403a125127a01c506649a66f963443d98b165f595b35d84f3a7f3acf7257fab805d9a5c66db9a766498808df6100c11de52d69e5f1edabcba2aa61#npm:16.8.1", {\
-        "packageLocation": "./.yarn/unplugged/nx-virtual-8473d555d5/node_modules/nx/",\
+      ["virtual:231b41c796fb4c3a1878ccc2b284d7acc71e342654f1dcf3bec9e756c379469380938482d22d651d850cf92850f594f3b751114f8c7660ab24c8aee2d7081537#npm:19.0.3", {\
+        "packageLocation": "./.yarn/unplugged/nx-virtual-3a9a7cef34/node_modules/nx/",\
         "packageDependencies": [\
-          ["nx", "virtual:27294a026b403a125127a01c506649a66f963443d98b165f595b35d84f3a7f3acf7257fab805d9a5c66db9a766498808df6100c11de52d69e5f1edabcba2aa61#npm:16.8.1"],\
-          ["@nrwl/tao", "npm:16.8.1"],\
-          ["@nx/nx-darwin-arm64", "npm:16.8.1"],\
-          ["@nx/nx-darwin-x64", "npm:16.8.1"],\
-          ["@nx/nx-freebsd-x64", "npm:16.8.1"],\
-          ["@nx/nx-linux-arm-gnueabihf", "npm:16.8.1"],\
-          ["@nx/nx-linux-arm64-gnu", "npm:16.8.1"],\
-          ["@nx/nx-linux-arm64-musl", "npm:16.8.1"],\
-          ["@nx/nx-linux-x64-gnu", "npm:16.8.1"],\
-          ["@nx/nx-linux-x64-musl", "npm:16.8.1"],\
-          ["@nx/nx-win32-arm64-msvc", "npm:16.8.1"],\
-          ["@nx/nx-win32-x64-msvc", "npm:16.8.1"],\
-          ["@parcel/watcher", "npm:2.0.4"],\
+          ["nx", "virtual:231b41c796fb4c3a1878ccc2b284d7acc71e342654f1dcf3bec9e756c379469380938482d22d651d850cf92850f594f3b751114f8c7660ab24c8aee2d7081537#npm:19.0.3"],\
+          ["@nrwl/tao", "npm:19.0.3"],\
+          ["@nx/nx-darwin-arm64", "npm:19.0.3"],\
+          ["@nx/nx-darwin-x64", "npm:19.0.3"],\
+          ["@nx/nx-freebsd-x64", "npm:19.0.3"],\
+          ["@nx/nx-linux-arm-gnueabihf", "npm:19.0.3"],\
+          ["@nx/nx-linux-arm64-gnu", "npm:19.0.3"],\
+          ["@nx/nx-linux-arm64-musl", "npm:19.0.3"],\
+          ["@nx/nx-linux-x64-gnu", "npm:19.0.3"],\
+          ["@nx/nx-linux-x64-musl", "npm:19.0.3"],\
+          ["@nx/nx-win32-arm64-msvc", "npm:19.0.3"],\
+          ["@nx/nx-win32-x64-msvc", "npm:19.0.3"],\
           ["@swc-node/register", null],\
           ["@swc/core", null],\
           ["@types/swc-node__register", null],\
@@ -23611,35 +23048,34 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/lockfile", "npm:1.1.0"],\
           ["@yarnpkg/parsers", "npm:3.0.0-rc.46"],\
           ["@zkochan/js-yaml", "npm:0.0.6"],\
-          ["axios", "npm:1.6.1"],\
+          ["axios", "npm:1.6.8"],\
           ["chalk", "npm:4.1.2"],\
           ["cli-cursor", "npm:3.1.0"],\
           ["cli-spinners", "npm:2.6.1"],\
-          ["cliui", "npm:7.0.4"],\
+          ["cliui", "npm:8.0.1"],\
           ["dotenv", "npm:16.3.1"],\
           ["dotenv-expand", "npm:10.0.0"],\
           ["enquirer", "npm:2.3.6"],\
-          ["fast-glob", "npm:3.2.7"],\
           ["figures", "npm:3.2.0"],\
           ["flat", "npm:5.0.2"],\
           ["fs-extra", "npm:11.1.1"],\
-          ["glob", "npm:7.1.4"],\
           ["ignore", "npm:5.2.4"],\
+          ["jest-diff", "npm:29.7.0"],\
           ["js-yaml", "npm:4.1.0"],\
           ["jsonc-parser", "npm:3.2.0"],\
           ["lines-and-columns", "npm:2.0.3"],\
-          ["minimatch", "npm:3.0.5"],\
+          ["minimatch", "npm:9.0.3"],\
           ["node-machine-id", "npm:1.1.12"],\
           ["npm-run-path", "npm:4.0.1"],\
           ["open", "npm:8.4.2"],\
-          ["semver", "npm:7.5.3"],\
+          ["ora", "npm:5.3.0"],\
+          ["semver", "npm:7.5.4"],\
           ["string-width", "npm:4.2.3"],\
           ["strong-log-transformer", "npm:2.1.0"],\
           ["tar-stream", "npm:2.2.0"],\
           ["tmp", "npm:0.2.1"],\
           ["tsconfig-paths", "npm:4.2.0"],\
           ["tslib", "npm:2.3.1"],\
-          ["v8-compile-cache", "npm:2.3.0"],\
           ["yargs", "npm:17.7.2"],\
           ["yargs-parser", "npm:21.1.1"]\
         ],\
@@ -24020,6 +23456,21 @@ const RAW_RUNTIME_STATE =
       }]\
     ]],\
     ["ora", [\
+      ["npm:5.3.0", {\
+        "packageLocation": "./.yarn/cache/ora-npm-5.3.0-bb3e7178be-989a075b59.zip/node_modules/ora/",\
+        "packageDependencies": [\
+          ["ora", "npm:5.3.0"],\
+          ["bl", "npm:4.1.0"],\
+          ["chalk", "npm:4.1.2"],\
+          ["cli-cursor", "npm:3.1.0"],\
+          ["cli-spinners", "npm:2.9.1"],\
+          ["is-interactive", "npm:1.0.0"],\
+          ["log-symbols", "npm:4.1.0"],\
+          ["strip-ansi", "npm:6.0.1"],\
+          ["wcwidth", "npm:1.0.1"]\
+        ],\
+        "linkType": "HARD"\
+      }],\
       ["npm:5.4.1", {\
         "packageLocation": "./.yarn/cache/ora-npm-5.4.1-4f0343adb7-8d071828f4.zip/node_modules/ora/",\
         "packageDependencies": [\
@@ -24335,26 +23786,26 @@ const RAW_RUNTIME_STATE =
       }]\
     ]],\
     ["pacote", [\
-      ["npm:15.2.0", {\
-        "packageLocation": "./.yarn/cache/pacote-npm-15.2.0-b9ed3321e9-57e18f4f96.zip/node_modules/pacote/",\
+      ["npm:17.0.7", {\
+        "packageLocation": "./.yarn/cache/pacote-npm-17.0.7-1576d29aec-6aa223428e.zip/node_modules/pacote/",\
         "packageDependencies": [\
-          ["pacote", "npm:15.2.0"],\
-          ["@npmcli/git", "npm:4.1.0"],\
+          ["pacote", "npm:17.0.7"],\
+          ["@npmcli/git", "npm:5.0.7"],\
           ["@npmcli/installed-package-contents", "npm:2.0.2"],\
-          ["@npmcli/promise-spawn", "npm:6.0.2"],\
-          ["@npmcli/run-script", "npm:6.0.2"],\
-          ["cacache", "npm:17.1.4"],\
+          ["@npmcli/promise-spawn", "npm:7.0.2"],\
+          ["@npmcli/run-script", "npm:7.0.4"],\
+          ["cacache", "npm:18.0.3"],\
           ["fs-minipass", "npm:3.0.3"],\
-          ["minipass", "npm:5.0.0"],\
-          ["npm-package-arg", "npm:10.1.0"],\
-          ["npm-packlist", "npm:7.0.4"],\
-          ["npm-pick-manifest", "npm:8.0.2"],\
-          ["npm-registry-fetch", "npm:14.0.5"],\
-          ["proc-log", "npm:3.0.0"],\
+          ["minipass", "npm:7.1.1"],\
+          ["npm-package-arg", "npm:11.0.2"],\
+          ["npm-packlist", "npm:8.0.2"],\
+          ["npm-pick-manifest", "npm:9.0.1"],\
+          ["npm-registry-fetch", "npm:16.2.1"],\
+          ["proc-log", "npm:4.2.0"],\
           ["promise-retry", "npm:2.0.1"],\
-          ["read-package-json", "npm:6.0.4"],\
+          ["read-package-json", "npm:7.0.1"],\
           ["read-package-json-fast", "npm:3.0.2"],\
-          ["sigstore", "npm:1.9.0"],\
+          ["sigstore", "npm:2.3.0"],\
           ["ssri", "npm:10.0.5"],\
           ["tar", "npm:6.2.0"]\
         ],\
@@ -24388,15 +23839,6 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["parent-module", "npm:1.0.1"],\
           ["callsites", "npm:3.1.0"]\
-        ],\
-        "linkType": "HARD"\
-      }]\
-    ]],\
-    ["parse-cache-control", [\
-      ["npm:1.0.1", {\
-        "packageLocation": "./.yarn/cache/parse-cache-control-npm-1.0.1-81068d3680-13171cd973.zip/node_modules/parse-cache-control/",\
-        "packageDependencies": [\
-          ["parse-cache-control", "npm:1.0.1"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -24693,6 +24135,15 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["path-scurry", "npm:1.10.1"],\
           ["lru-cache", "npm:10.0.1"],\
+          ["minipass", "npm:7.0.3"]\
+        ],\
+        "linkType": "HARD"\
+      }],\
+      ["npm:1.11.1", {\
+        "packageLocation": "./.yarn/cache/path-scurry-npm-1.11.1-aaf8c339af-5e8845c159.zip/node_modules/path-scurry/",\
+        "packageDependencies": [\
+          ["path-scurry", "npm:1.11.1"],\
+          ["lru-cache", "npm:10.2.2"],\
           ["minipass", "npm:7.0.3"]\
         ],\
         "linkType": "HARD"\
@@ -25034,20 +24485,20 @@ const RAW_RUNTIME_STATE =
       }]\
     ]],\
     ["postcss", [\
-      ["npm:8.4.14", {\
-        "packageLocation": "./.yarn/cache/postcss-npm-8.4.14-c0d448b728-1940e8d1da.zip/node_modules/postcss/",\
+      ["npm:8.4.29", {\
+        "packageLocation": "./.yarn/cache/postcss-npm-8.4.29-2319a64d31-cfde009612.zip/node_modules/postcss/",\
         "packageDependencies": [\
-          ["postcss", "npm:8.4.14"],\
+          ["postcss", "npm:8.4.29"],\
           ["nanoid", "npm:3.3.6"],\
           ["picocolors", "npm:1.0.0"],\
           ["source-map-js", "npm:1.0.2"]\
         ],\
         "linkType": "HARD"\
       }],\
-      ["npm:8.4.29", {\
-        "packageLocation": "./.yarn/cache/postcss-npm-8.4.29-2319a64d31-cfde009612.zip/node_modules/postcss/",\
+      ["npm:8.4.31", {\
+        "packageLocation": "./.yarn/cache/postcss-npm-8.4.31-385051a82b-1a6653e721.zip/node_modules/postcss/",\
         "packageDependencies": [\
-          ["postcss", "npm:8.4.29"],\
+          ["postcss", "npm:8.4.31"],\
           ["nanoid", "npm:3.3.6"],\
           ["picocolors", "npm:1.0.0"],\
           ["source-map-js", "npm:1.0.2"]\
@@ -25148,6 +24599,13 @@ const RAW_RUNTIME_STATE =
           ["proc-log", "npm:3.0.0"]\
         ],\
         "linkType": "HARD"\
+      }],\
+      ["npm:4.2.0", {\
+        "packageLocation": "./.yarn/cache/proc-log-npm-4.2.0-4d65296a9d-4e1394491b.zip/node_modules/proc-log/",\
+        "packageDependencies": [\
+          ["proc-log", "npm:4.2.0"]\
+        ],\
+        "linkType": "HARD"\
       }]\
     ]],\
     ["process", [\
@@ -25205,14 +24663,6 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./.yarn/cache/promise-npm-7.3.1-5d81d474c0-37dbe58ca7.zip/node_modules/promise/",\
         "packageDependencies": [\
           ["promise", "npm:7.3.1"],\
-          ["asap", "npm:2.0.6"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["npm:8.1.0", {\
-        "packageLocation": "./.yarn/cache/promise-npm-8.1.0-09977f1805-337b5ec09a.zip/node_modules/promise/",\
-        "packageDependencies": [\
-          ["promise", "npm:8.1.0"],\
           ["asap", "npm:2.0.6"]\
         ],\
         "linkType": "HARD"\
@@ -26260,6 +25710,17 @@ const RAW_RUNTIME_STATE =
           ["npm-normalize-package-bin", "npm:3.0.1"]\
         ],\
         "linkType": "HARD"\
+      }],\
+      ["npm:7.0.1", {\
+        "packageLocation": "./.yarn/cache/read-package-json-npm-7.0.1-94653faf6b-4b5684f4ee.zip/node_modules/read-package-json/",\
+        "packageDependencies": [\
+          ["read-package-json", "npm:7.0.1"],\
+          ["glob", "npm:10.3.4"],\
+          ["json-parse-even-better-errors", "npm:3.0.0"],\
+          ["normalize-package-data", "npm:6.0.1"],\
+          ["npm-normalize-package-bin", "npm:3.0.1"]\
+        ],\
+        "linkType": "HARD"\
       }]\
     ]],\
     ["read-package-json-fast", [\
@@ -26527,13 +25988,6 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./.yarn/cache/regenerator-runtime-npm-0.13.9-6d02340eec-efbbcee420.zip/node_modules/regenerator-runtime/",\
         "packageDependencies": [\
           ["regenerator-runtime", "npm:0.13.9"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["npm:0.14.0", {\
-        "packageLocation": "./.yarn/cache/regenerator-runtime-npm-0.14.0-e060897cf7-6c19495bae.zip/node_modules/regenerator-runtime/",\
-        "packageDependencies": [\
-          ["regenerator-runtime", "npm:0.14.0"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -27300,14 +26754,6 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "HARD"\
       }],\
-      ["npm:7.5.3", {\
-        "packageLocation": "./.yarn/cache/semver-npm-7.5.3-275095dbf3-80b4b3784a.zip/node_modules/semver/",\
-        "packageDependencies": [\
-          ["semver", "npm:7.5.3"],\
-          ["lru-cache", "npm:6.0.0"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
       ["npm:7.5.4", {\
         "packageLocation": "./.yarn/cache/semver-npm-7.5.4-c4ad957fcd-985dec0d37.zip/node_modules/semver/",\
         "packageDependencies": [\
@@ -27538,6 +26984,19 @@ const RAW_RUNTIME_STATE =
           ["make-fetch-happen", "npm:11.1.1"]\
         ],\
         "linkType": "HARD"\
+      }],\
+      ["npm:2.3.0", {\
+        "packageLocation": "./.yarn/cache/sigstore-npm-2.3.0-16da955c8d-881c6ee139.zip/node_modules/sigstore/",\
+        "packageDependencies": [\
+          ["sigstore", "npm:2.3.0"],\
+          ["@sigstore/bundle", "npm:2.3.1"],\
+          ["@sigstore/core", "npm:1.1.0"],\
+          ["@sigstore/protobuf-specs", "npm:0.3.2"],\
+          ["@sigstore/sign", "npm:2.3.1"],\
+          ["@sigstore/tuf", "npm:2.3.3"],\
+          ["@sigstore/verify", "npm:1.2.0"]\
+        ],\
+        "linkType": "HARD"\
       }]\
     ]],\
     ["simple-update-notifier", [\
@@ -27588,16 +27047,6 @@ const RAW_RUNTIME_STATE =
       }]\
     ]],\
     ["slice-ansi", [\
-      ["npm:2.1.0", {\
-        "packageLocation": "./.yarn/cache/slice-ansi-npm-2.1.0-02505ccc06-4e82995aa5.zip/node_modules/slice-ansi/",\
-        "packageDependencies": [\
-          ["slice-ansi", "npm:2.1.0"],\
-          ["ansi-styles", "npm:3.2.1"],\
-          ["astral-regex", "npm:1.0.0"],\
-          ["is-fullwidth-code-point", "npm:2.0.0"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
       ["npm:3.0.0", {\
         "packageLocation": "./.yarn/cache/slice-ansi-npm-3.0.0-d9999864af-5ec6d022d1.zip/node_modules/slice-ansi/",\
         "packageDependencies": [\
@@ -27730,6 +27179,16 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["socks-proxy-agent", "npm:7.0.0"],\
           ["agent-base", "npm:6.0.2"],\
+          ["debug", "virtual:58471071b1e0e7981e3318280660861b4dec874aaf0d60e144b70657cb5ce0af059ae16711a2af10f4d1ff0536527e350e6e47a8f79db2d8d37ff2ec84865bbc#npm:4.3.4"],\
+          ["socks", "npm:2.7.1"]\
+        ],\
+        "linkType": "HARD"\
+      }],\
+      ["npm:8.0.3", {\
+        "packageLocation": "./.yarn/cache/socks-proxy-agent-npm-8.0.3-30471cff1b-c2112c66d6.zip/node_modules/socks-proxy-agent/",\
+        "packageDependencies": [\
+          ["socks-proxy-agent", "npm:8.0.3"],\
+          ["agent-base", "npm:7.1.1"],\
           ["debug", "virtual:58471071b1e0e7981e3318280660861b4dec874aaf0d60e144b70657cb5ce0af059ae16711a2af10f4d1ff0536527e350e6e47a8f79db2d8d37ff2ec84865bbc#npm:4.3.4"],\
           ["socks", "npm:2.7.1"]\
         ],\
@@ -28634,10 +28093,10 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "SOFT"\
       }],\
-      ["virtual:15856ab34955512a62f786822acaddfde8b3e5fd2698fdc6a1f49e79382c501d29eefe426ece81baacd057f825d8f42b74025dcce309719f589944e495bb6be8#npm:5.1.1", {\
-        "packageLocation": "./.yarn/__virtual__/styled-jsx-virtual-7886870a6c/0/cache/styled-jsx-npm-5.1.1-2557a209ba-4f6a5d0010.zip/node_modules/styled-jsx/",\
+      ["virtual:94cb705d8f2a2b1109015646a11175be495adda31bbc645b083cc9bbf85fc1d13ff9fe785e01febf7a450c2bbcd01c45cf8a80da31422991f38abefcc7e33718#npm:5.1.1", {\
+        "packageLocation": "./.yarn/__virtual__/styled-jsx-virtual-425467e625/0/cache/styled-jsx-npm-5.1.1-2557a209ba-4f6a5d0010.zip/node_modules/styled-jsx/",\
         "packageDependencies": [\
-          ["styled-jsx", "virtual:15856ab34955512a62f786822acaddfde8b3e5fd2698fdc6a1f49e79382c501d29eefe426ece81baacd057f825d8f42b74025dcce309719f589944e495bb6be8#npm:5.1.1"],\
+          ["styled-jsx", "virtual:94cb705d8f2a2b1109015646a11175be495adda31bbc645b083cc9bbf85fc1d13ff9fe785e01febf7a450c2bbcd01c45cf8a80da31422991f38abefcc7e33718#npm:5.1.1"],\
           ["@babel/core", null],\
           ["@types/babel-plugin-macros", null],\
           ["@types/babel__core", null],\
@@ -28822,17 +28281,6 @@ const RAW_RUNTIME_STATE =
       }]\
     ]],\
     ["table", [\
-      ["npm:5.4.6", {\
-        "packageLocation": "./.yarn/cache/table-npm-5.4.6-190b118384-a00b96779f.zip/node_modules/table/",\
-        "packageDependencies": [\
-          ["table", "npm:5.4.6"],\
-          ["ajv", "npm:6.12.6"],\
-          ["lodash", "npm:4.17.21"],\
-          ["slice-ansi", "npm:2.1.0"],\
-          ["string-width", "npm:3.1.0"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
       ["npm:6.7.1", {\
         "packageLocation": "./.yarn/cache/table-npm-6.7.1-7d70e55c6d-654090e317.zip/node_modules/table/",\
         "packageDependencies": [\
@@ -28846,10 +28294,10 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "HARD"\
       }],\
-      ["npm:6.8.1", {\
-        "packageLocation": "./.yarn/cache/table-npm-6.8.1-83abb79e20-512c4f2bfb.zip/node_modules/table/",\
+      ["npm:6.8.2", {\
+        "packageLocation": "./.yarn/cache/table-npm-6.8.2-e33ecc3c54-2946162eb8.zip/node_modules/table/",\
         "packageDependencies": [\
-          ["table", "npm:6.8.1"],\
+          ["table", "npm:6.8.2"],\
           ["ajv", "npm:8.6.3"],\
           ["lodash.truncate", "npm:4.4.2"],\
           ["slice-ansi", "npm:4.0.0"],\
@@ -28891,6 +28339,19 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./.yarn/cache/tar-npm-6.2.0-3eb25205a7-2042bbb148.zip/node_modules/tar/",\
         "packageDependencies": [\
           ["tar", "npm:6.2.0"],\
+          ["chownr", "npm:2.0.0"],\
+          ["fs-minipass", "npm:2.1.0"],\
+          ["minipass", "npm:5.0.0"],\
+          ["minizlib", "npm:2.1.2"],\
+          ["mkdirp", "npm:1.0.4"],\
+          ["yallist", "npm:4.0.0"]\
+        ],\
+        "linkType": "HARD"\
+      }],\
+      ["npm:6.2.1", {\
+        "packageLocation": "./.yarn/cache/tar-npm-6.2.1-237800bb20-bfbfbb2861.zip/node_modules/tar/",\
+        "packageDependencies": [\
+          ["tar", "npm:6.2.1"],\
           ["chownr", "npm:2.0.0"],\
           ["fs-minipass", "npm:2.1.0"],\
           ["minipass", "npm:5.0.0"],\
@@ -28989,26 +28450,6 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./.yarn/cache/text-table-npm-0.2.0-d92a778b59-4383b5baae.zip/node_modules/text-table/",\
         "packageDependencies": [\
           ["text-table", "npm:0.2.0"]\
-        ],\
-        "linkType": "HARD"\
-      }]\
-    ]],\
-    ["then-request", [\
-      ["npm:6.0.2", {\
-        "packageLocation": "./.yarn/cache/then-request-npm-6.0.2-d89438d618-7a33192fa0.zip/node_modules/then-request/",\
-        "packageDependencies": [\
-          ["then-request", "npm:6.0.2"],\
-          ["@types/concat-stream", "npm:1.6.1"],\
-          ["@types/form-data", "npm:0.0.33"],\
-          ["@types/node", "npm:8.10.66"],\
-          ["@types/qs", "npm:6.9.7"],\
-          ["caseless", "npm:0.12.0"],\
-          ["concat-stream", "npm:1.6.2"],\
-          ["form-data", "npm:2.5.1"],\
-          ["http-basic", "npm:8.1.3"],\
-          ["http-response-object", "npm:3.0.2"],\
-          ["promise", "npm:8.1.0"],\
-          ["qs", "npm:6.10.3"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -29610,6 +29051,16 @@ const RAW_RUNTIME_STATE =
           ["@tufjs/models", "npm:1.0.4"],\
           ["debug", "virtual:58471071b1e0e7981e3318280660861b4dec874aaf0d60e144b70657cb5ce0af059ae16711a2af10f4d1ff0536527e350e6e47a8f79db2d8d37ff2ec84865bbc#npm:4.3.4"],\
           ["make-fetch-happen", "npm:11.1.1"]\
+        ],\
+        "linkType": "HARD"\
+      }],\
+      ["npm:2.2.1", {\
+        "packageLocation": "./.yarn/cache/tuf-js-npm-2.2.1-3baf642bf9-4c057f4f0c.zip/node_modules/tuf-js/",\
+        "packageDependencies": [\
+          ["tuf-js", "npm:2.2.1"],\
+          ["@tufjs/models", "npm:2.0.1"],\
+          ["debug", "virtual:58471071b1e0e7981e3318280660861b4dec874aaf0d60e144b70657cb5ce0af059ae16711a2af10f4d1ff0536527e350e6e47a8f79db2d8d37ff2ec84865bbc#npm:4.3.4"],\
+          ["make-fetch-happen", "npm:13.0.1"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -30264,6 +29715,13 @@ const RAW_RUNTIME_STATE =
           ["uuid", "npm:9.0.0"]\
         ],\
         "linkType": "HARD"\
+      }],\
+      ["npm:9.0.1", {\
+        "packageLocation": "./.yarn/cache/uuid-npm-9.0.1-39a8442bc6-9d0b6adb72.zip/node_modules/uuid/",\
+        "packageDependencies": [\
+          ["uuid", "npm:9.0.1"]\
+        ],\
+        "linkType": "HARD"\
       }]\
     ]],\
     ["v8-compile-cache", [\
@@ -30898,17 +30356,6 @@ const RAW_RUNTIME_STATE =
         "linkType": "HARD"\
       }]\
     ]],\
-    ["watchpack", [\
-      ["npm:2.4.0", {\
-        "packageLocation": "./.yarn/cache/watchpack-npm-2.4.0-7ec4b9cc65-4280b45bc4.zip/node_modules/watchpack/",\
-        "packageDependencies": [\
-          ["watchpack", "npm:2.4.0"],\
-          ["glob-to-regexp", "npm:0.4.1"],\
-          ["graceful-fs", "npm:4.2.8"]\
-        ],\
-        "linkType": "HARD"\
-      }]\
-    ]],\
     ["wcwidth", [\
       ["npm:1.0.1", {\
         "packageLocation": "./.yarn/cache/wcwidth-npm-1.0.1-05fa596453-182ebac8ca.zip/node_modules/wcwidth/",\
@@ -31033,11 +30480,11 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "HARD"\
       }],\
-      ["npm:3.0.1", {\
-        "packageLocation": "./.yarn/cache/which-npm-3.0.1-b2b0f09ace-adf720fe9d.zip/node_modules/which/",\
+      ["npm:4.0.0", {\
+        "packageLocation": "./.yarn/cache/which-npm-4.0.0-dd31cd4928-f17e84c042.zip/node_modules/which/",\
         "packageDependencies": [\
-          ["which", "npm:3.0.1"],\
-          ["isexe", "npm:2.0.0"]\
+          ["which", "npm:4.0.0"],\
+          ["isexe", "npm:3.1.1"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -31370,24 +30817,6 @@ const RAW_RUNTIME_STATE =
       }]\
     ]],\
     ["xml2js", [\
-      ["npm:0.4.23", {\
-        "packageLocation": "./.yarn/cache/xml2js-npm-0.4.23-93a8b2e10b-52896ef394.zip/node_modules/xml2js/",\
-        "packageDependencies": [\
-          ["xml2js", "npm:0.4.23"],\
-          ["sax", "npm:1.2.4"],\
-          ["xmlbuilder", "npm:11.0.1"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["npm:0.5.0", {\
-        "packageLocation": "./.yarn/cache/xml2js-npm-0.5.0-06e57a2771-27c4d75921.zip/node_modules/xml2js/",\
-        "packageDependencies": [\
-          ["xml2js", "npm:0.5.0"],\
-          ["sax", "npm:1.2.4"],\
-          ["xmlbuilder", "npm:11.0.1"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
       ["npm:0.6.2", {\
         "packageLocation": "./.yarn/cache/xml2js-npm-0.6.2-64cd781d74-df29de8eee.zip/node_modules/xml2js/",\
         "packageDependencies": [\
@@ -31585,13 +31014,6 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "HARD"\
       }],\
-      ["npm:20.2.4", {\
-        "packageLocation": "./.yarn/cache/yargs-parser-npm-20.2.4-1de20916a6-db8f251ae4.zip/node_modules/yargs-parser/",\
-        "packageDependencies": [\
-          ["yargs-parser", "npm:20.2.4"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
       ["npm:20.2.9", {\
         "packageLocation": "./.yarn/cache/yargs-parser-npm-20.2.9-a1d19e598d-0188f430a0.zip/node_modules/yargs-parser/",\
         "packageDependencies": [\
@@ -31658,15 +31080,6 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["zen-observable-ts", "npm:1.2.5"],\
           ["zen-observable", "npm:0.8.15"]\
-        ],\
-        "linkType": "HARD"\
-      }]\
-    ]],\
-    ["zod", [\
-      ["npm:3.21.4", {\
-        "packageLocation": "./.yarn/cache/zod-npm-3.21.4-9f570b215c-03c79fa461.zip/node_modules/zod/",\
-        "packageDependencies": [\
-          ["zod", "npm:3.21.4"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -33005,6 +32418,12 @@ class ProxiedFS extends FakeFS {
   rmdirSync(p, opts) {
     return this.baseFs.rmdirSync(this.mapToBase(p), opts);
   }
+  async rmPromise(p, opts) {
+    return this.baseFs.rmPromise(this.mapToBase(p), opts);
+  }
+  rmSync(p, opts) {
+    return this.baseFs.rmSync(this.mapToBase(p), opts);
+  }
   async linkPromise(existingP, newP) {
     return this.baseFs.linkPromise(this.mapToBase(existingP), this.mapToBase(newP));
   }
@@ -33385,6 +32804,18 @@ class NodeFS extends BasePortableFakeFS {
   }
   rmdirSync(p, opts) {
     return this.realFs.rmdirSync(npath.fromPortablePath(p), opts);
+  }
+  async rmPromise(p, opts) {
+    return await new Promise((resolve, reject) => {
+      if (opts) {
+        this.realFs.rm(npath.fromPortablePath(p), opts, this.makeCallback(resolve, reject));
+      } else {
+        this.realFs.rm(npath.fromPortablePath(p), this.makeCallback(resolve, reject));
+      }
+    });
+  }
+  rmSync(p, opts) {
+    return this.realFs.rmSync(npath.fromPortablePath(p), opts);
   }
   async linkPromise(existingP, newP) {
     return await new Promise((resolve, reject) => {
@@ -34041,6 +33472,20 @@ class MountFS extends BasePortableFakeFS {
       return mountFs.rmdirSync(subPath, opts);
     });
   }
+  async rmPromise(p, opts) {
+    return await this.makeCallPromise(p, async () => {
+      return await this.baseFs.rmPromise(p, opts);
+    }, async (mountFs, { subPath }) => {
+      return await mountFs.rmPromise(subPath, opts);
+    });
+  }
+  rmSync(p, opts) {
+    return this.makeCallSync(p, () => {
+      return this.baseFs.rmSync(p, opts);
+    }, (mountFs, { subPath }) => {
+      return mountFs.rmSync(subPath, opts);
+    });
+  }
   async linkPromise(existingP, newP) {
     return await this.makeCallPromise(newP, async () => {
       return await this.baseFs.linkPromise(existingP, newP);
@@ -34679,6 +34124,7 @@ const SYNC_IMPLEMENTATIONS = /* @__PURE__ */ new Set([
   `realpathSync`,
   `renameSync`,
   `rmdirSync`,
+  `rmSync`,
   `statSync`,
   `symlinkSync`,
   `truncateSync`,
@@ -34714,6 +34160,7 @@ const ASYNC_IMPLEMENTATIONS = /* @__PURE__ */ new Set([
   `readlinkPromise`,
   `renamePromise`,
   `rmdirPromise`,
+  `rmPromise`,
   `statPromise`,
   `symlinkPromise`,
   `truncatePromise`,
@@ -36737,6 +36184,27 @@ class ZipFS extends BasePortableFakeFS {
     const index = this.entries.get(resolvedP);
     if (typeof index === `undefined`)
       throw EINVAL(`rmdir '${p}'`);
+    this.deleteEntry(p, index);
+  }
+  async rmPromise(p, opts) {
+    return this.rmSync(p, opts);
+  }
+  rmSync(p, { recursive = false } = {}) {
+    if (this.readOnly)
+      throw EROFS(`rm '${p}'`);
+    if (recursive) {
+      this.removeSync(p);
+      return;
+    }
+    const resolvedP = this.resolveFilename(`rm '${p}'`, p);
+    const directoryListing = this.listings.get(resolvedP);
+    if (!directoryListing)
+      throw ENOTDIR(`rm '${p}'`);
+    if (directoryListing.size > 0)
+      throw ENOTEMPTY(`rm '${p}'`);
+    const index = this.entries.get(resolvedP);
+    if (typeof index === `undefined`)
+      throw EINVAL(`rm '${p}'`);
     this.deleteEntry(p, index);
   }
   hydrateDirectory(resolvedP) {

--- a/packages/openneuro-app/package.json
+++ b/packages/openneuro-app/package.json
@@ -23,7 +23,7 @@
     "@openneuro/client": "^4.23.0",
     "@openneuro/components": "^4.23.0",
     "@tanstack/react-table": "^8.9.3",
-    "bids-validator": "1.13.0",
+    "bids-validator": "1.14.6",
     "bytes": "^3.0.0",
     "comlink": "^4.0.5",
     "date-fns": "^2.16.1",

--- a/packages/openneuro-cli/package.json
+++ b/packages/openneuro-cli/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@apollo/client": "3.7.2",
     "@openneuro/client": "^4.23.0",
-    "bids-validator": "1.10.0",
+    "bids-validator": "1.14.6",
     "cli-progress": "^3.8.2",
     "commander": "7.2.0",
     "elastic-apm-node": "^3.49.1",

--- a/services/datalad/package.json
+++ b/services/datalad/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "bids-validator": "1.10.0"
+    "bids-validator": "1.14.6"
   }
 }

--- a/services/datalad/yarn.lock
+++ b/services/datalad/yarn.lock
@@ -2,951 +2,662 @@
 # Manual changes might be lost - proceed with caution!
 
 __metadata:
-  version: 6
-  cacheKey: 8
+  version: 8
+  cacheKey: 10
 
-"@aws-crypto/crc32@npm:2.0.0":
-  version: 2.0.0
-  resolution: "@aws-crypto/crc32@npm:2.0.0"
+"@ampproject/remapping@npm:^2.2.0":
+  version: 2.3.0
+  resolution: "@ampproject/remapping@npm:2.3.0"
   dependencies:
-    "@aws-crypto/util": ^2.0.0
-    "@aws-sdk/types": ^3.1.0
-    tslib: ^1.11.1
-  checksum: 88ab906da8304a430c655496e363835f3c7ca870db0dec50bb9d53ed0f446337de60c85ba7baa4528c8363bee708474785649262ebfde23a1e099eb69318b53e
+    "@jridgewell/gen-mapping": "npm:^0.3.5"
+    "@jridgewell/trace-mapping": "npm:^0.3.24"
+  checksum: 10/f3451525379c68a73eb0a1e65247fbf28c0cccd126d93af21c75fceff77773d43c0d4a2d51978fb131aff25b5f2cb41a9fe48cc296e61ae65e679c4f6918b0ab
   languageName: node
   linkType: hard
 
-"@aws-crypto/crc32c@npm:2.0.0":
-  version: 2.0.0
-  resolution: "@aws-crypto/crc32c@npm:2.0.0"
+"@aws-crypto/crc32@npm:3.0.0":
+  version: 3.0.0
+  resolution: "@aws-crypto/crc32@npm:3.0.0"
   dependencies:
-    "@aws-crypto/util": ^2.0.0
-    "@aws-sdk/types": ^3.1.0
-    tslib: ^1.11.1
-  checksum: 776e1e61b3bde018b815d3973774a4ec3cd88c282046e49bb5a2625ac7db923068aad708a8e4c21b62a80e50a5c58324a32621b9ba82b7b2ecab66370c4fe893
+    "@aws-crypto/util": "npm:^3.0.0"
+    "@aws-sdk/types": "npm:^3.222.0"
+    tslib: "npm:^1.11.1"
+  checksum: 10/672d593fd98a88709a1b488db92aabf584b6dad3e8099e04b6d2870e34a2ee668cbbe0e5406e60c0d776b9c34a91cfc427999230ad959518fed56a3db037704c
   languageName: node
   linkType: hard
 
-"@aws-crypto/ie11-detection@npm:^2.0.0":
-  version: 2.0.2
-  resolution: "@aws-crypto/ie11-detection@npm:2.0.2"
+"@aws-crypto/crc32c@npm:3.0.0":
+  version: 3.0.0
+  resolution: "@aws-crypto/crc32c@npm:3.0.0"
   dependencies:
-    tslib: ^1.11.1
-  checksum: 713293deea8eefd3ab43dc05e62228571d27754e7293f8ec2fd8a0c693fbbfc55213e6599387776e3cdbc951965dc62e24e92b9c4a853e4a50d00ae6a9f6b2bd
+    "@aws-crypto/util": "npm:^3.0.0"
+    "@aws-sdk/types": "npm:^3.222.0"
+    tslib: "npm:^1.11.1"
+  checksum: 10/3e604ad7a8d3fb10e5fe11597d593d0ae8e1d6dc06a06b8d882d5732a6e181f6a77fd4f92fb3ae9002a2007121d49e40bc6b78d83af62d36deb1b457b7f1d977
   languageName: node
   linkType: hard
 
-"@aws-crypto/sha1-browser@npm:2.0.0":
-  version: 2.0.0
-  resolution: "@aws-crypto/sha1-browser@npm:2.0.0"
+"@aws-crypto/ie11-detection@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@aws-crypto/ie11-detection@npm:3.0.0"
   dependencies:
-    "@aws-crypto/ie11-detection": ^2.0.0
-    "@aws-crypto/supports-web-crypto": ^2.0.0
-    "@aws-sdk/types": ^3.1.0
-    "@aws-sdk/util-locate-window": ^3.0.0
-    "@aws-sdk/util-utf8-browser": ^3.0.0
-    tslib: ^1.11.1
-  checksum: 72c0b24800cd79328fef934553e7a5d5929c90877d7e9a661614542dd29d0d99ee1594bd59fc028ee9ec595d77df56645a396c6336cff3c7784a564302d4a254
+    tslib: "npm:^1.11.1"
+  checksum: 10/f5aee4a11a113ab9640474e75d398c99538aa30775f484cd519f0de0096ae0d4a6b68d2f0c685f24bd6f2425067c565bc20592c36c0dc1f4d28c1b4751a40734
   languageName: node
   linkType: hard
 
-"@aws-crypto/sha256-browser@npm:2.0.0":
-  version: 2.0.0
-  resolution: "@aws-crypto/sha256-browser@npm:2.0.0"
+"@aws-crypto/sha1-browser@npm:3.0.0":
+  version: 3.0.0
+  resolution: "@aws-crypto/sha1-browser@npm:3.0.0"
   dependencies:
-    "@aws-crypto/ie11-detection": ^2.0.0
-    "@aws-crypto/sha256-js": ^2.0.0
-    "@aws-crypto/supports-web-crypto": ^2.0.0
-    "@aws-crypto/util": ^2.0.0
-    "@aws-sdk/types": ^3.1.0
-    "@aws-sdk/util-locate-window": ^3.0.0
-    "@aws-sdk/util-utf8-browser": ^3.0.0
-    tslib: ^1.11.1
-  checksum: 7bc1ff042d0c53a46c0fc3824bd97fb3ed1df7dc030b8a995889471052860b8c8ade469c97866fafd8249a3144d0f48b0f1054f357e2b403606009381c4b8f0e
+    "@aws-crypto/ie11-detection": "npm:^3.0.0"
+    "@aws-crypto/supports-web-crypto": "npm:^3.0.0"
+    "@aws-crypto/util": "npm:^3.0.0"
+    "@aws-sdk/types": "npm:^3.222.0"
+    "@aws-sdk/util-locate-window": "npm:^3.0.0"
+    "@aws-sdk/util-utf8-browser": "npm:^3.0.0"
+    tslib: "npm:^1.11.1"
+  checksum: 10/8c30fa1e427bf2c295077b007835b0dd9af6beb6250e0aa775cecd42a1f517ef211751e7e12c2423f39d9b1c6748b99eb7b73207eb69165abc696cc470d8659e
   languageName: node
   linkType: hard
 
-"@aws-crypto/sha256-js@npm:2.0.0":
-  version: 2.0.0
-  resolution: "@aws-crypto/sha256-js@npm:2.0.0"
+"@aws-crypto/sha256-browser@npm:3.0.0":
+  version: 3.0.0
+  resolution: "@aws-crypto/sha256-browser@npm:3.0.0"
   dependencies:
-    "@aws-crypto/util": ^2.0.0
-    "@aws-sdk/types": ^3.1.0
-    tslib: ^1.11.1
-  checksum: e4abf9baec6bed19d380f92a999a41ac5bdd8890dfd45971d29054c298854c5b7087e7de633413f2e64618ef8238ccf4c0b75797c73063c74bbba3cb5d8b2581
+    "@aws-crypto/ie11-detection": "npm:^3.0.0"
+    "@aws-crypto/sha256-js": "npm:^3.0.0"
+    "@aws-crypto/supports-web-crypto": "npm:^3.0.0"
+    "@aws-crypto/util": "npm:^3.0.0"
+    "@aws-sdk/types": "npm:^3.222.0"
+    "@aws-sdk/util-locate-window": "npm:^3.0.0"
+    "@aws-sdk/util-utf8-browser": "npm:^3.0.0"
+    tslib: "npm:^1.11.1"
+  checksum: 10/4e075906c48a46bbb8babb60db3e6b280db405a88c68b77c1496c26218292d5ea509beae3ccc19366ca6bc944c6d37fe347d0917909900dbac86f054a19c71c7
   languageName: node
   linkType: hard
 
-"@aws-crypto/sha256-js@npm:^2.0.0":
-  version: 2.0.2
-  resolution: "@aws-crypto/sha256-js@npm:2.0.2"
+"@aws-crypto/sha256-js@npm:3.0.0, @aws-crypto/sha256-js@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@aws-crypto/sha256-js@npm:3.0.0"
   dependencies:
-    "@aws-crypto/util": ^2.0.2
-    "@aws-sdk/types": ^3.110.0
-    tslib: ^1.11.1
-  checksum: 9125ec65a2b05fce908ac2289ba97b995a299f2d717684804211df8e8bcffd8cd9b8861582240655b88f2255c46fcee34026f75c057ffb22f44b6a76cd43f65a
+    "@aws-crypto/util": "npm:^3.0.0"
+    "@aws-sdk/types": "npm:^3.222.0"
+    tslib: "npm:^1.11.1"
+  checksum: 10/f9fc2d51631950434d0f91f51c2ce17845d4e8e75971806e21604987e3186ee1e54de8a89e5349585b91cb36e56d5f058d6a45004e1bfbce1351dbb40f479152
   languageName: node
   linkType: hard
 
-"@aws-crypto/supports-web-crypto@npm:^2.0.0":
-  version: 2.0.2
-  resolution: "@aws-crypto/supports-web-crypto@npm:2.0.2"
+"@aws-crypto/supports-web-crypto@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@aws-crypto/supports-web-crypto@npm:3.0.0"
   dependencies:
-    tslib: ^1.11.1
-  checksum: 03d04d29292dc1b76db9bc6becd05f52fa79adee0ec084f971b0767f7e73250dd0422bea57636015f8c27f38aefcd1d9c58800a4749cf35339296c8d670f3ccb
+    tslib: "npm:^1.11.1"
+  checksum: 10/8a48788d2866e391354f256aa79b577b2ba1474b50184cbe690467de7e64a79928afece95007ab69a1556f99da97ea129487db091d94489847e14decdc7c9a6f
   languageName: node
   linkType: hard
 
-"@aws-crypto/util@npm:^2.0.0, @aws-crypto/util@npm:^2.0.2":
-  version: 2.0.2
-  resolution: "@aws-crypto/util@npm:2.0.2"
+"@aws-crypto/util@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@aws-crypto/util@npm:3.0.0"
   dependencies:
-    "@aws-sdk/types": ^3.110.0
-    "@aws-sdk/util-utf8-browser": ^3.0.0
-    tslib: ^1.11.1
-  checksum: 13cb33a39005b09c062398d361043c2224bc8ba42b1432bad52e15bc4bf9ffad4facdddc394b3cc71b3fb8d86a7ec325fd1afa107b5fde0dab84a7e32d311d7f
+    "@aws-sdk/types": "npm:^3.222.0"
+    "@aws-sdk/util-utf8-browser": "npm:^3.0.0"
+    tslib: "npm:^1.11.1"
+  checksum: 10/92c835b83d7a888b37b2f2a37c82e58bb8fabb617e371173c488d2a71b916c69ee566f0ea0b3f7f4e16296226c49793f95b3d59fc07a7ca00af91f8f9f29e6c4
   languageName: node
   linkType: hard
 
-"@aws-sdk/abort-controller@npm:3.178.0":
-  version: 3.178.0
-  resolution: "@aws-sdk/abort-controller@npm:3.178.0"
+"@aws-sdk/client-s3@npm:^3.556.0":
+  version: 3.575.0
+  resolution: "@aws-sdk/client-s3@npm:3.575.0"
   dependencies:
-    "@aws-sdk/types": 3.178.0
-    tslib: ^2.3.1
-  checksum: 6e2730b4fc20c7fdb6d36595feb3d2d2f8e4ba8be27a916a77066b7c48465cc098d3ba6971b4ca29c51c4f6de3adb08a329fba04358a54a5311869c74233782d
+    "@aws-crypto/sha1-browser": "npm:3.0.0"
+    "@aws-crypto/sha256-browser": "npm:3.0.0"
+    "@aws-crypto/sha256-js": "npm:3.0.0"
+    "@aws-sdk/client-sso-oidc": "npm:3.575.0"
+    "@aws-sdk/client-sts": "npm:3.575.0"
+    "@aws-sdk/core": "npm:3.575.0"
+    "@aws-sdk/credential-provider-node": "npm:3.575.0"
+    "@aws-sdk/middleware-bucket-endpoint": "npm:3.575.0"
+    "@aws-sdk/middleware-expect-continue": "npm:3.575.0"
+    "@aws-sdk/middleware-flexible-checksums": "npm:3.575.0"
+    "@aws-sdk/middleware-host-header": "npm:3.575.0"
+    "@aws-sdk/middleware-location-constraint": "npm:3.575.0"
+    "@aws-sdk/middleware-logger": "npm:3.575.0"
+    "@aws-sdk/middleware-recursion-detection": "npm:3.575.0"
+    "@aws-sdk/middleware-sdk-s3": "npm:3.575.0"
+    "@aws-sdk/middleware-signing": "npm:3.575.0"
+    "@aws-sdk/middleware-ssec": "npm:3.575.0"
+    "@aws-sdk/middleware-user-agent": "npm:3.575.0"
+    "@aws-sdk/region-config-resolver": "npm:3.575.0"
+    "@aws-sdk/signature-v4-multi-region": "npm:3.575.0"
+    "@aws-sdk/types": "npm:3.575.0"
+    "@aws-sdk/util-endpoints": "npm:3.575.0"
+    "@aws-sdk/util-user-agent-browser": "npm:3.575.0"
+    "@aws-sdk/util-user-agent-node": "npm:3.575.0"
+    "@aws-sdk/xml-builder": "npm:3.575.0"
+    "@smithy/config-resolver": "npm:^3.0.0"
+    "@smithy/core": "npm:^2.0.0"
+    "@smithy/eventstream-serde-browser": "npm:^3.0.0"
+    "@smithy/eventstream-serde-config-resolver": "npm:^3.0.0"
+    "@smithy/eventstream-serde-node": "npm:^3.0.0"
+    "@smithy/fetch-http-handler": "npm:^3.0.0"
+    "@smithy/hash-blob-browser": "npm:^3.0.0"
+    "@smithy/hash-node": "npm:^3.0.0"
+    "@smithy/hash-stream-node": "npm:^3.0.0"
+    "@smithy/invalid-dependency": "npm:^3.0.0"
+    "@smithy/md5-js": "npm:^3.0.0"
+    "@smithy/middleware-content-length": "npm:^3.0.0"
+    "@smithy/middleware-endpoint": "npm:^3.0.0"
+    "@smithy/middleware-retry": "npm:^3.0.0"
+    "@smithy/middleware-serde": "npm:^3.0.0"
+    "@smithy/middleware-stack": "npm:^3.0.0"
+    "@smithy/node-config-provider": "npm:^3.0.0"
+    "@smithy/node-http-handler": "npm:^3.0.0"
+    "@smithy/protocol-http": "npm:^4.0.0"
+    "@smithy/smithy-client": "npm:^3.0.0"
+    "@smithy/types": "npm:^3.0.0"
+    "@smithy/url-parser": "npm:^3.0.0"
+    "@smithy/util-base64": "npm:^3.0.0"
+    "@smithy/util-body-length-browser": "npm:^3.0.0"
+    "@smithy/util-body-length-node": "npm:^3.0.0"
+    "@smithy/util-defaults-mode-browser": "npm:^3.0.0"
+    "@smithy/util-defaults-mode-node": "npm:^3.0.0"
+    "@smithy/util-endpoints": "npm:^2.0.0"
+    "@smithy/util-retry": "npm:^3.0.0"
+    "@smithy/util-stream": "npm:^3.0.0"
+    "@smithy/util-utf8": "npm:^3.0.0"
+    "@smithy/util-waiter": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/d44c44fd7b8d8dc7cf4a194ab19bf4f14a89c2fa1895b4e9bbdac46f0b2ab2d481d4e0192927b36a57a9f75e376e6c236688dfb423101e9b5c563e514babccf8
   languageName: node
   linkType: hard
 
-"@aws-sdk/chunked-blob-reader-native@npm:3.170.0":
-  version: 3.170.0
-  resolution: "@aws-sdk/chunked-blob-reader-native@npm:3.170.0"
+"@aws-sdk/client-sso-oidc@npm:3.575.0":
+  version: 3.575.0
+  resolution: "@aws-sdk/client-sso-oidc@npm:3.575.0"
   dependencies:
-    "@aws-sdk/util-base64-browser": 3.170.0
-    tslib: ^2.3.1
-  checksum: e1912aaeb32ef2c2040868c6476d273d16b9e6c913f49483648c827308f257adfa8e1b6429194994d6364a389c3b240eb37a6a0f665f9dbd72c60d65ae9cb2e7
+    "@aws-crypto/sha256-browser": "npm:3.0.0"
+    "@aws-crypto/sha256-js": "npm:3.0.0"
+    "@aws-sdk/client-sts": "npm:3.575.0"
+    "@aws-sdk/core": "npm:3.575.0"
+    "@aws-sdk/credential-provider-node": "npm:3.575.0"
+    "@aws-sdk/middleware-host-header": "npm:3.575.0"
+    "@aws-sdk/middleware-logger": "npm:3.575.0"
+    "@aws-sdk/middleware-recursion-detection": "npm:3.575.0"
+    "@aws-sdk/middleware-user-agent": "npm:3.575.0"
+    "@aws-sdk/region-config-resolver": "npm:3.575.0"
+    "@aws-sdk/types": "npm:3.575.0"
+    "@aws-sdk/util-endpoints": "npm:3.575.0"
+    "@aws-sdk/util-user-agent-browser": "npm:3.575.0"
+    "@aws-sdk/util-user-agent-node": "npm:3.575.0"
+    "@smithy/config-resolver": "npm:^3.0.0"
+    "@smithy/core": "npm:^2.0.0"
+    "@smithy/fetch-http-handler": "npm:^3.0.0"
+    "@smithy/hash-node": "npm:^3.0.0"
+    "@smithy/invalid-dependency": "npm:^3.0.0"
+    "@smithy/middleware-content-length": "npm:^3.0.0"
+    "@smithy/middleware-endpoint": "npm:^3.0.0"
+    "@smithy/middleware-retry": "npm:^3.0.0"
+    "@smithy/middleware-serde": "npm:^3.0.0"
+    "@smithy/middleware-stack": "npm:^3.0.0"
+    "@smithy/node-config-provider": "npm:^3.0.0"
+    "@smithy/node-http-handler": "npm:^3.0.0"
+    "@smithy/protocol-http": "npm:^4.0.0"
+    "@smithy/smithy-client": "npm:^3.0.0"
+    "@smithy/types": "npm:^3.0.0"
+    "@smithy/url-parser": "npm:^3.0.0"
+    "@smithy/util-base64": "npm:^3.0.0"
+    "@smithy/util-body-length-browser": "npm:^3.0.0"
+    "@smithy/util-body-length-node": "npm:^3.0.0"
+    "@smithy/util-defaults-mode-browser": "npm:^3.0.0"
+    "@smithy/util-defaults-mode-node": "npm:^3.0.0"
+    "@smithy/util-endpoints": "npm:^2.0.0"
+    "@smithy/util-middleware": "npm:^3.0.0"
+    "@smithy/util-retry": "npm:^3.0.0"
+    "@smithy/util-utf8": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/98cc6f57184d48a2cea4a8e8d304943dd8524e520cb5ae729568e3690927aa6fba6362473b6c3c8829e269f7d6f154557104077f708262a90f78844d1a689578
   languageName: node
   linkType: hard
 
-"@aws-sdk/chunked-blob-reader@npm:3.170.0":
-  version: 3.170.0
-  resolution: "@aws-sdk/chunked-blob-reader@npm:3.170.0"
+"@aws-sdk/client-sso@npm:3.575.0":
+  version: 3.575.0
+  resolution: "@aws-sdk/client-sso@npm:3.575.0"
   dependencies:
-    tslib: ^2.3.1
-  checksum: cd26800b9a8b11d9ad73766ec911779470027140aa928c6640d0092395825963b76cda84759d0faafa1f39ddfb9c9c3b2e5ec7ffd2f05462d12b5c04e07ac810
+    "@aws-crypto/sha256-browser": "npm:3.0.0"
+    "@aws-crypto/sha256-js": "npm:3.0.0"
+    "@aws-sdk/core": "npm:3.575.0"
+    "@aws-sdk/middleware-host-header": "npm:3.575.0"
+    "@aws-sdk/middleware-logger": "npm:3.575.0"
+    "@aws-sdk/middleware-recursion-detection": "npm:3.575.0"
+    "@aws-sdk/middleware-user-agent": "npm:3.575.0"
+    "@aws-sdk/region-config-resolver": "npm:3.575.0"
+    "@aws-sdk/types": "npm:3.575.0"
+    "@aws-sdk/util-endpoints": "npm:3.575.0"
+    "@aws-sdk/util-user-agent-browser": "npm:3.575.0"
+    "@aws-sdk/util-user-agent-node": "npm:3.575.0"
+    "@smithy/config-resolver": "npm:^3.0.0"
+    "@smithy/core": "npm:^2.0.0"
+    "@smithy/fetch-http-handler": "npm:^3.0.0"
+    "@smithy/hash-node": "npm:^3.0.0"
+    "@smithy/invalid-dependency": "npm:^3.0.0"
+    "@smithy/middleware-content-length": "npm:^3.0.0"
+    "@smithy/middleware-endpoint": "npm:^3.0.0"
+    "@smithy/middleware-retry": "npm:^3.0.0"
+    "@smithy/middleware-serde": "npm:^3.0.0"
+    "@smithy/middleware-stack": "npm:^3.0.0"
+    "@smithy/node-config-provider": "npm:^3.0.0"
+    "@smithy/node-http-handler": "npm:^3.0.0"
+    "@smithy/protocol-http": "npm:^4.0.0"
+    "@smithy/smithy-client": "npm:^3.0.0"
+    "@smithy/types": "npm:^3.0.0"
+    "@smithy/url-parser": "npm:^3.0.0"
+    "@smithy/util-base64": "npm:^3.0.0"
+    "@smithy/util-body-length-browser": "npm:^3.0.0"
+    "@smithy/util-body-length-node": "npm:^3.0.0"
+    "@smithy/util-defaults-mode-browser": "npm:^3.0.0"
+    "@smithy/util-defaults-mode-node": "npm:^3.0.0"
+    "@smithy/util-endpoints": "npm:^2.0.0"
+    "@smithy/util-middleware": "npm:^3.0.0"
+    "@smithy/util-retry": "npm:^3.0.0"
+    "@smithy/util-utf8": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/38957b3cacb9e7687595c5f76f3888ecbf3e97c669471ee015fa601b8743fe2e52e36ebe6fe8168b021e0fee3e70d3c07642f106ded5bc0c548e80e286616c70
   languageName: node
   linkType: hard
 
-"@aws-sdk/client-s3@npm:^3.9.0":
-  version: 3.181.0
-  resolution: "@aws-sdk/client-s3@npm:3.181.0"
+"@aws-sdk/client-sts@npm:3.575.0":
+  version: 3.575.0
+  resolution: "@aws-sdk/client-sts@npm:3.575.0"
   dependencies:
-    "@aws-crypto/sha1-browser": 2.0.0
-    "@aws-crypto/sha256-browser": 2.0.0
-    "@aws-crypto/sha256-js": 2.0.0
-    "@aws-sdk/client-sts": 3.181.0
-    "@aws-sdk/config-resolver": 3.178.0
-    "@aws-sdk/credential-provider-node": 3.181.0
-    "@aws-sdk/eventstream-serde-browser": 3.178.0
-    "@aws-sdk/eventstream-serde-config-resolver": 3.178.0
-    "@aws-sdk/eventstream-serde-node": 3.178.0
-    "@aws-sdk/fetch-http-handler": 3.178.0
-    "@aws-sdk/hash-blob-browser": 3.178.0
-    "@aws-sdk/hash-node": 3.178.0
-    "@aws-sdk/hash-stream-node": 3.178.0
-    "@aws-sdk/invalid-dependency": 3.178.0
-    "@aws-sdk/md5-js": 3.178.0
-    "@aws-sdk/middleware-bucket-endpoint": 3.178.0
-    "@aws-sdk/middleware-content-length": 3.178.0
-    "@aws-sdk/middleware-expect-continue": 3.178.0
-    "@aws-sdk/middleware-flexible-checksums": 3.178.0
-    "@aws-sdk/middleware-host-header": 3.178.0
-    "@aws-sdk/middleware-location-constraint": 3.178.0
-    "@aws-sdk/middleware-logger": 3.178.0
-    "@aws-sdk/middleware-recursion-detection": 3.178.0
-    "@aws-sdk/middleware-retry": 3.178.0
-    "@aws-sdk/middleware-sdk-s3": 3.178.0
-    "@aws-sdk/middleware-serde": 3.178.0
-    "@aws-sdk/middleware-signing": 3.179.0
-    "@aws-sdk/middleware-ssec": 3.178.0
-    "@aws-sdk/middleware-stack": 3.178.0
-    "@aws-sdk/middleware-user-agent": 3.178.0
-    "@aws-sdk/node-config-provider": 3.178.0
-    "@aws-sdk/node-http-handler": 3.178.0
-    "@aws-sdk/protocol-http": 3.178.0
-    "@aws-sdk/signature-v4-multi-region": 3.180.0
-    "@aws-sdk/smithy-client": 3.180.0
-    "@aws-sdk/types": 3.178.0
-    "@aws-sdk/url-parser": 3.178.0
-    "@aws-sdk/util-base64-browser": 3.170.0
-    "@aws-sdk/util-base64-node": 3.170.0
-    "@aws-sdk/util-body-length-browser": 3.170.0
-    "@aws-sdk/util-body-length-node": 3.170.0
-    "@aws-sdk/util-defaults-mode-browser": 3.180.0
-    "@aws-sdk/util-defaults-mode-node": 3.180.0
-    "@aws-sdk/util-stream-browser": 3.178.0
-    "@aws-sdk/util-stream-node": 3.178.0
-    "@aws-sdk/util-user-agent-browser": 3.178.0
-    "@aws-sdk/util-user-agent-node": 3.178.0
-    "@aws-sdk/util-utf8-browser": 3.170.0
-    "@aws-sdk/util-utf8-node": 3.170.0
-    "@aws-sdk/util-waiter": 3.180.0
-    "@aws-sdk/xml-builder": 3.170.0
-    entities: 2.2.0
-    fast-xml-parser: 3.19.0
-    tslib: ^2.3.1
-  checksum: cadb55aeea65eb908aa6e59cc18fc4ef46c6c9f98c35b57da1846f9ad350caa67e94255272cd0a7aaf20d6b5c6239f960b2013e534cdc7d158a77b4319da7abd
+    "@aws-crypto/sha256-browser": "npm:3.0.0"
+    "@aws-crypto/sha256-js": "npm:3.0.0"
+    "@aws-sdk/client-sso-oidc": "npm:3.575.0"
+    "@aws-sdk/core": "npm:3.575.0"
+    "@aws-sdk/credential-provider-node": "npm:3.575.0"
+    "@aws-sdk/middleware-host-header": "npm:3.575.0"
+    "@aws-sdk/middleware-logger": "npm:3.575.0"
+    "@aws-sdk/middleware-recursion-detection": "npm:3.575.0"
+    "@aws-sdk/middleware-user-agent": "npm:3.575.0"
+    "@aws-sdk/region-config-resolver": "npm:3.575.0"
+    "@aws-sdk/types": "npm:3.575.0"
+    "@aws-sdk/util-endpoints": "npm:3.575.0"
+    "@aws-sdk/util-user-agent-browser": "npm:3.575.0"
+    "@aws-sdk/util-user-agent-node": "npm:3.575.0"
+    "@smithy/config-resolver": "npm:^3.0.0"
+    "@smithy/core": "npm:^2.0.0"
+    "@smithy/fetch-http-handler": "npm:^3.0.0"
+    "@smithy/hash-node": "npm:^3.0.0"
+    "@smithy/invalid-dependency": "npm:^3.0.0"
+    "@smithy/middleware-content-length": "npm:^3.0.0"
+    "@smithy/middleware-endpoint": "npm:^3.0.0"
+    "@smithy/middleware-retry": "npm:^3.0.0"
+    "@smithy/middleware-serde": "npm:^3.0.0"
+    "@smithy/middleware-stack": "npm:^3.0.0"
+    "@smithy/node-config-provider": "npm:^3.0.0"
+    "@smithy/node-http-handler": "npm:^3.0.0"
+    "@smithy/protocol-http": "npm:^4.0.0"
+    "@smithy/smithy-client": "npm:^3.0.0"
+    "@smithy/types": "npm:^3.0.0"
+    "@smithy/url-parser": "npm:^3.0.0"
+    "@smithy/util-base64": "npm:^3.0.0"
+    "@smithy/util-body-length-browser": "npm:^3.0.0"
+    "@smithy/util-body-length-node": "npm:^3.0.0"
+    "@smithy/util-defaults-mode-browser": "npm:^3.0.0"
+    "@smithy/util-defaults-mode-node": "npm:^3.0.0"
+    "@smithy/util-endpoints": "npm:^2.0.0"
+    "@smithy/util-middleware": "npm:^3.0.0"
+    "@smithy/util-retry": "npm:^3.0.0"
+    "@smithy/util-utf8": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/d37e4ac232b4a32241f8528a726baf04991304e7bb33093ffaef93d7567f1198f1a456068a9c4e535227bff9e5eb14930a41349d092f384c0ac658f9164a80e6
   languageName: node
   linkType: hard
 
-"@aws-sdk/client-sso@npm:3.181.0":
-  version: 3.181.0
-  resolution: "@aws-sdk/client-sso@npm:3.181.0"
+"@aws-sdk/core@npm:3.575.0":
+  version: 3.575.0
+  resolution: "@aws-sdk/core@npm:3.575.0"
   dependencies:
-    "@aws-crypto/sha256-browser": 2.0.0
-    "@aws-crypto/sha256-js": 2.0.0
-    "@aws-sdk/config-resolver": 3.178.0
-    "@aws-sdk/fetch-http-handler": 3.178.0
-    "@aws-sdk/hash-node": 3.178.0
-    "@aws-sdk/invalid-dependency": 3.178.0
-    "@aws-sdk/middleware-content-length": 3.178.0
-    "@aws-sdk/middleware-host-header": 3.178.0
-    "@aws-sdk/middleware-logger": 3.178.0
-    "@aws-sdk/middleware-recursion-detection": 3.178.0
-    "@aws-sdk/middleware-retry": 3.178.0
-    "@aws-sdk/middleware-serde": 3.178.0
-    "@aws-sdk/middleware-stack": 3.178.0
-    "@aws-sdk/middleware-user-agent": 3.178.0
-    "@aws-sdk/node-config-provider": 3.178.0
-    "@aws-sdk/node-http-handler": 3.178.0
-    "@aws-sdk/protocol-http": 3.178.0
-    "@aws-sdk/smithy-client": 3.180.0
-    "@aws-sdk/types": 3.178.0
-    "@aws-sdk/url-parser": 3.178.0
-    "@aws-sdk/util-base64-browser": 3.170.0
-    "@aws-sdk/util-base64-node": 3.170.0
-    "@aws-sdk/util-body-length-browser": 3.170.0
-    "@aws-sdk/util-body-length-node": 3.170.0
-    "@aws-sdk/util-defaults-mode-browser": 3.180.0
-    "@aws-sdk/util-defaults-mode-node": 3.180.0
-    "@aws-sdk/util-user-agent-browser": 3.178.0
-    "@aws-sdk/util-user-agent-node": 3.178.0
-    "@aws-sdk/util-utf8-browser": 3.170.0
-    "@aws-sdk/util-utf8-node": 3.170.0
-    tslib: ^2.3.1
-  checksum: ae4a635fcf496d3efc493ec99d8e2e6fe2c736b62fd6ac575ff62c8690ee006a386637845fb5b9129fcf7e5f80ab8fc9674c03312ded1516c6c8debc4d656431
+    "@smithy/core": "npm:^2.0.0"
+    "@smithy/protocol-http": "npm:^4.0.0"
+    "@smithy/signature-v4": "npm:^3.0.0"
+    "@smithy/smithy-client": "npm:^3.0.0"
+    "@smithy/types": "npm:^3.0.0"
+    fast-xml-parser: "npm:4.2.5"
+    tslib: "npm:^2.6.2"
+  checksum: 10/9458760ba73df3ee4d135068869eb8859e91f3492354f9a2e03ce5829fdf65355f8be719effd2fc09f7bfdb3b6b242cfcd4a316dea1ad047b9cdf464c695b73a
   languageName: node
   linkType: hard
 
-"@aws-sdk/client-sts@npm:3.181.0":
-  version: 3.181.0
-  resolution: "@aws-sdk/client-sts@npm:3.181.0"
+"@aws-sdk/credential-provider-env@npm:3.575.0":
+  version: 3.575.0
+  resolution: "@aws-sdk/credential-provider-env@npm:3.575.0"
   dependencies:
-    "@aws-crypto/sha256-browser": 2.0.0
-    "@aws-crypto/sha256-js": 2.0.0
-    "@aws-sdk/config-resolver": 3.178.0
-    "@aws-sdk/credential-provider-node": 3.181.0
-    "@aws-sdk/fetch-http-handler": 3.178.0
-    "@aws-sdk/hash-node": 3.178.0
-    "@aws-sdk/invalid-dependency": 3.178.0
-    "@aws-sdk/middleware-content-length": 3.178.0
-    "@aws-sdk/middleware-host-header": 3.178.0
-    "@aws-sdk/middleware-logger": 3.178.0
-    "@aws-sdk/middleware-recursion-detection": 3.178.0
-    "@aws-sdk/middleware-retry": 3.178.0
-    "@aws-sdk/middleware-sdk-sts": 3.179.0
-    "@aws-sdk/middleware-serde": 3.178.0
-    "@aws-sdk/middleware-signing": 3.179.0
-    "@aws-sdk/middleware-stack": 3.178.0
-    "@aws-sdk/middleware-user-agent": 3.178.0
-    "@aws-sdk/node-config-provider": 3.178.0
-    "@aws-sdk/node-http-handler": 3.178.0
-    "@aws-sdk/protocol-http": 3.178.0
-    "@aws-sdk/smithy-client": 3.180.0
-    "@aws-sdk/types": 3.178.0
-    "@aws-sdk/url-parser": 3.178.0
-    "@aws-sdk/util-base64-browser": 3.170.0
-    "@aws-sdk/util-base64-node": 3.170.0
-    "@aws-sdk/util-body-length-browser": 3.170.0
-    "@aws-sdk/util-body-length-node": 3.170.0
-    "@aws-sdk/util-defaults-mode-browser": 3.180.0
-    "@aws-sdk/util-defaults-mode-node": 3.180.0
-    "@aws-sdk/util-user-agent-browser": 3.178.0
-    "@aws-sdk/util-user-agent-node": 3.178.0
-    "@aws-sdk/util-utf8-browser": 3.170.0
-    "@aws-sdk/util-utf8-node": 3.170.0
-    entities: 2.2.0
-    fast-xml-parser: 3.19.0
-    tslib: ^2.3.1
-  checksum: e9cf6b407f1500633fd3b9b9994abad8c222b225e9c6b58ad55f906123ad1fe0a8646f700aec66c9769526b6e93dffae5303bb091c76b320d478450d3d9cd68f
+    "@aws-sdk/types": "npm:3.575.0"
+    "@smithy/property-provider": "npm:^3.0.0"
+    "@smithy/types": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/9301c3dc80a50db85e697c13c05945f78ac4ce92189d8ddb157b84b456395e1146b46b6c06cfdc334e7231bb86de9fa4aced95ce83950a9fa76c663d80fc2d81
   languageName: node
   linkType: hard
 
-"@aws-sdk/config-resolver@npm:3.178.0":
-  version: 3.178.0
-  resolution: "@aws-sdk/config-resolver@npm:3.178.0"
+"@aws-sdk/credential-provider-http@npm:3.575.0":
+  version: 3.575.0
+  resolution: "@aws-sdk/credential-provider-http@npm:3.575.0"
   dependencies:
-    "@aws-sdk/signature-v4": 3.178.0
-    "@aws-sdk/types": 3.178.0
-    "@aws-sdk/util-config-provider": 3.170.0
-    "@aws-sdk/util-middleware": 3.178.0
-    tslib: ^2.3.1
-  checksum: 6befe982a46531386fa99fe7e4dacded66381876326c9b6d3e6045c17f0bdb38dbac796890e6a68321bf74071de4630c04644dd42020c88214a66b97de8f8583
+    "@aws-sdk/types": "npm:3.575.0"
+    "@smithy/fetch-http-handler": "npm:^3.0.0"
+    "@smithy/node-http-handler": "npm:^3.0.0"
+    "@smithy/property-provider": "npm:^3.0.0"
+    "@smithy/protocol-http": "npm:^4.0.0"
+    "@smithy/smithy-client": "npm:^3.0.0"
+    "@smithy/types": "npm:^3.0.0"
+    "@smithy/util-stream": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/fec90a520cf73049df60533170547c2725f39b8d96515e7b98a62bd174e725d9ef05153791c5851d65aa53d509b224470a8db26ddcd4eb2e0c80dc99fba82235
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-env@npm:3.178.0":
-  version: 3.178.0
-  resolution: "@aws-sdk/credential-provider-env@npm:3.178.0"
+"@aws-sdk/credential-provider-ini@npm:3.575.0":
+  version: 3.575.0
+  resolution: "@aws-sdk/credential-provider-ini@npm:3.575.0"
   dependencies:
-    "@aws-sdk/property-provider": 3.178.0
-    "@aws-sdk/types": 3.178.0
-    tslib: ^2.3.1
-  checksum: 22498437e8e73105e702d85232f28acd6d245c4d4f43244605d73fc04e04bf69052c7f16012f0557a551b20eec8545ade0eb70cb040045423788f3af888d7b1e
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/credential-provider-imds@npm:3.178.0":
-  version: 3.178.0
-  resolution: "@aws-sdk/credential-provider-imds@npm:3.178.0"
-  dependencies:
-    "@aws-sdk/node-config-provider": 3.178.0
-    "@aws-sdk/property-provider": 3.178.0
-    "@aws-sdk/types": 3.178.0
-    "@aws-sdk/url-parser": 3.178.0
-    tslib: ^2.3.1
-  checksum: 548a6f0c69fc5a6d922b3ed3bd90eb6fc0d3ec8d16d3cc8dca82da0ca22bd9907cf848d01731a5bc85ad53398d55a2acaa2831be07ce08189c98aaf95f6c837a
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/credential-provider-ini@npm:3.181.0":
-  version: 3.181.0
-  resolution: "@aws-sdk/credential-provider-ini@npm:3.181.0"
-  dependencies:
-    "@aws-sdk/credential-provider-env": 3.178.0
-    "@aws-sdk/credential-provider-imds": 3.178.0
-    "@aws-sdk/credential-provider-sso": 3.181.0
-    "@aws-sdk/credential-provider-web-identity": 3.178.0
-    "@aws-sdk/property-provider": 3.178.0
-    "@aws-sdk/shared-ini-file-loader": 3.178.0
-    "@aws-sdk/types": 3.178.0
-    tslib: ^2.3.1
-  checksum: 5f405a6d366b9ffb7d84adcf8c6685fe89f847a730268ce7ddc873624c6f4feb09b860d2fd249618a78b138cb245643ec4d4923f8341451767813e18eeccf72d
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/credential-provider-node@npm:3.181.0":
-  version: 3.181.0
-  resolution: "@aws-sdk/credential-provider-node@npm:3.181.0"
-  dependencies:
-    "@aws-sdk/credential-provider-env": 3.178.0
-    "@aws-sdk/credential-provider-imds": 3.178.0
-    "@aws-sdk/credential-provider-ini": 3.181.0
-    "@aws-sdk/credential-provider-process": 3.178.0
-    "@aws-sdk/credential-provider-sso": 3.181.0
-    "@aws-sdk/credential-provider-web-identity": 3.178.0
-    "@aws-sdk/property-provider": 3.178.0
-    "@aws-sdk/shared-ini-file-loader": 3.178.0
-    "@aws-sdk/types": 3.178.0
-    tslib: ^2.3.1
-  checksum: b84bd76833f8ce3632f136f053a43c538614140b5eec99be19a0d7ca9e305772cba3142201b2ece5ebbc508a7013e8102a8c35f68812eb47710a9025c6e4a764
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/credential-provider-process@npm:3.178.0":
-  version: 3.178.0
-  resolution: "@aws-sdk/credential-provider-process@npm:3.178.0"
-  dependencies:
-    "@aws-sdk/property-provider": 3.178.0
-    "@aws-sdk/shared-ini-file-loader": 3.178.0
-    "@aws-sdk/types": 3.178.0
-    tslib: ^2.3.1
-  checksum: 7ca452d7963d118f2855ebe87862dc064cf5eddf3b8cb21386c359da891f98b1bd5dc8fd98c830d2606225cc370febd91537273230c6e13bec3984e05888435c
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/credential-provider-sso@npm:3.181.0":
-  version: 3.181.0
-  resolution: "@aws-sdk/credential-provider-sso@npm:3.181.0"
-  dependencies:
-    "@aws-sdk/client-sso": 3.181.0
-    "@aws-sdk/property-provider": 3.178.0
-    "@aws-sdk/shared-ini-file-loader": 3.178.0
-    "@aws-sdk/types": 3.178.0
-    tslib: ^2.3.1
-  checksum: 0f215c802fe700a76e660366463bd38e229ecff4abeaaac3d69d2d62117a11e80cbeed9da6ef5f73d9830f83009969c2f6cb0b4bbf0febaf59fe4eea448f805d
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/credential-provider-web-identity@npm:3.178.0":
-  version: 3.178.0
-  resolution: "@aws-sdk/credential-provider-web-identity@npm:3.178.0"
-  dependencies:
-    "@aws-sdk/property-provider": 3.178.0
-    "@aws-sdk/types": 3.178.0
-    tslib: ^2.3.1
-  checksum: 7761bfb8d2046f29ceb3d1020da07fcb0684008ec9529b3daf8c0dab8924f22929274fb31e0740b66f508b3dc31b409ec3175000a9778af3d2025cf4ae1163df
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/eventstream-codec@npm:3.178.0":
-  version: 3.178.0
-  resolution: "@aws-sdk/eventstream-codec@npm:3.178.0"
-  dependencies:
-    "@aws-crypto/crc32": 2.0.0
-    "@aws-sdk/types": 3.178.0
-    "@aws-sdk/util-hex-encoding": 3.170.0
-    tslib: ^2.3.1
-  checksum: a049eb487d663bff95fb03e0dd0a5ad29751ee12a8afa880a0f18de6f99c868814a48289f0f458a462a14ebd91a598eae5b2400b60e8115d0cf69d2eb1dad9b0
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/eventstream-serde-browser@npm:3.178.0":
-  version: 3.178.0
-  resolution: "@aws-sdk/eventstream-serde-browser@npm:3.178.0"
-  dependencies:
-    "@aws-sdk/eventstream-serde-universal": 3.178.0
-    "@aws-sdk/types": 3.178.0
-    tslib: ^2.3.1
-  checksum: ec1e2c7772cfe00f95e57c3a33ffa6189d7455edf915ce5035d8cc385c5d772c68b966f0570cc1a3c9d06ee51078b8e577223ab5c0b818e37a8f022719bb7295
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/eventstream-serde-config-resolver@npm:3.178.0":
-  version: 3.178.0
-  resolution: "@aws-sdk/eventstream-serde-config-resolver@npm:3.178.0"
-  dependencies:
-    "@aws-sdk/types": 3.178.0
-    tslib: ^2.3.1
-  checksum: 1c7f906b31e3241e1360f25e6bc3a10108c7b208d9eda979bb28d875cb7e60371aa0de5c332448f88a8cdf6454989af2c3dc6321c9239b0d03ad9b6f808b554b
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/eventstream-serde-node@npm:3.178.0":
-  version: 3.178.0
-  resolution: "@aws-sdk/eventstream-serde-node@npm:3.178.0"
-  dependencies:
-    "@aws-sdk/eventstream-serde-universal": 3.178.0
-    "@aws-sdk/types": 3.178.0
-    tslib: ^2.3.1
-  checksum: d11754f29b02fa36d31cb0f88aa17d6ebfebab0137ef380cb81e883e7a2358d1c2dfc065bb67802036950decb6859c46eb8f56166741fc89aea0ecf0cd824391
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/eventstream-serde-universal@npm:3.178.0":
-  version: 3.178.0
-  resolution: "@aws-sdk/eventstream-serde-universal@npm:3.178.0"
-  dependencies:
-    "@aws-sdk/eventstream-codec": 3.178.0
-    "@aws-sdk/types": 3.178.0
-    tslib: ^2.3.1
-  checksum: cfd0e42adcab21ad3989a87a0ea257a86aad2e58626ee49aad9cf9f230e22b491b373301eb5333b9133851601828e80a64238fdab0b895922f5f15b6b64a6fe2
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/fetch-http-handler@npm:3.178.0":
-  version: 3.178.0
-  resolution: "@aws-sdk/fetch-http-handler@npm:3.178.0"
-  dependencies:
-    "@aws-sdk/protocol-http": 3.178.0
-    "@aws-sdk/querystring-builder": 3.178.0
-    "@aws-sdk/types": 3.178.0
-    "@aws-sdk/util-base64-browser": 3.170.0
-    tslib: ^2.3.1
-  checksum: d0f5e4d2c156b55d9febc699e0220e267f028e59e611d93e45ea0bcb7486494faf92efb57bbebedb87f01c9b934985dc91456229e82194cb44f47150f044ac47
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/hash-blob-browser@npm:3.178.0":
-  version: 3.178.0
-  resolution: "@aws-sdk/hash-blob-browser@npm:3.178.0"
-  dependencies:
-    "@aws-sdk/chunked-blob-reader": 3.170.0
-    "@aws-sdk/chunked-blob-reader-native": 3.170.0
-    "@aws-sdk/types": 3.178.0
-    tslib: ^2.3.1
-  checksum: 2d7807bde86eeb9a4d3647a263bd8614d9ede5dfc9912fab6fae9c47d20b921183e49918fde3b917a18c74b4d99dfa2d42ea841305f496210aed549562e6edf3
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/hash-node@npm:3.178.0":
-  version: 3.178.0
-  resolution: "@aws-sdk/hash-node@npm:3.178.0"
-  dependencies:
-    "@aws-sdk/types": 3.178.0
-    "@aws-sdk/util-buffer-from": 3.170.0
-    tslib: ^2.3.1
-  checksum: 2158e226cd01ddba35156f847685ab1700333584acdf31a0f821be267c3a1d7b329a764684655eb4cf5a768ef2f7cbb36d24335ee3842a8e2f077d530e07e1e7
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/hash-stream-node@npm:3.178.0":
-  version: 3.178.0
-  resolution: "@aws-sdk/hash-stream-node@npm:3.178.0"
-  dependencies:
-    "@aws-sdk/types": 3.178.0
-    tslib: ^2.3.1
-  checksum: 2159b983ab15ed344fecf7aff82b0259b12f94af8efb966c653c7922cfee9e4e04b7aab6d44b8058734f72ba45d36084ecd3ae65901efb5f6434617b1ff3e6be
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/invalid-dependency@npm:3.178.0":
-  version: 3.178.0
-  resolution: "@aws-sdk/invalid-dependency@npm:3.178.0"
-  dependencies:
-    "@aws-sdk/types": 3.178.0
-    tslib: ^2.3.1
-  checksum: e7bbfbb18755c31d9c476f17b2dbe1fdf81881c03ea417a0900fa328f2099a0d0d0827c44065cad0b4e2060c3d6bf620b58c2900b087c752f7efd8d9a483dbe9
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/is-array-buffer@npm:3.170.0":
-  version: 3.170.0
-  resolution: "@aws-sdk/is-array-buffer@npm:3.170.0"
-  dependencies:
-    tslib: ^2.3.1
-  checksum: d0541a1ad691320115c5965a49f0bed557d188fd26ca7f06eebba2f9dfd0611c2636c15468e01e1de8c5121d4f8f0622e52b4ae716dab5c394eabc8511f701dc
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/md5-js@npm:3.178.0":
-  version: 3.178.0
-  resolution: "@aws-sdk/md5-js@npm:3.178.0"
-  dependencies:
-    "@aws-sdk/types": 3.178.0
-    "@aws-sdk/util-utf8-browser": 3.170.0
-    "@aws-sdk/util-utf8-node": 3.170.0
-    tslib: ^2.3.1
-  checksum: 6bc082bce3a8d7e724a0228564a9c2aa7f8556b0b1393f7969301a40ac3ab037897ea7508692ae0186b51ca4e1948a503161d179aeb966a9b0e58e06f4b6dcfc
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/middleware-bucket-endpoint@npm:3.178.0":
-  version: 3.178.0
-  resolution: "@aws-sdk/middleware-bucket-endpoint@npm:3.178.0"
-  dependencies:
-    "@aws-sdk/protocol-http": 3.178.0
-    "@aws-sdk/types": 3.178.0
-    "@aws-sdk/util-arn-parser": 3.170.0
-    "@aws-sdk/util-config-provider": 3.170.0
-    tslib: ^2.3.1
-  checksum: e511c6990936977d1ef8a0412b5338895ea59838e30c2a9ce6040b4795443133745808ef7af081ee1db9102e0867083409a3afb9d11b815564026c520dde2b8d
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/middleware-content-length@npm:3.178.0":
-  version: 3.178.0
-  resolution: "@aws-sdk/middleware-content-length@npm:3.178.0"
-  dependencies:
-    "@aws-sdk/protocol-http": 3.178.0
-    "@aws-sdk/types": 3.178.0
-    tslib: ^2.3.1
-  checksum: 0d7a28df4e7d1544936f23a2f1d37a1b955a5054781f0d8eeba93057b8489f59e45f84d1d4a23ce3213633f90d48192283455b77481f1e2e614a72e647abe19e
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/middleware-expect-continue@npm:3.178.0":
-  version: 3.178.0
-  resolution: "@aws-sdk/middleware-expect-continue@npm:3.178.0"
-  dependencies:
-    "@aws-sdk/protocol-http": 3.178.0
-    "@aws-sdk/types": 3.178.0
-    tslib: ^2.3.1
-  checksum: 6767ce2dc96fdff49ee93459dae71e4a15ce03db822247f2c1b9f20979d9d22fe172ba243d00feb1dd1bd6dc7227a1093ca4c1176129cf6f251f01d5f48136f7
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/middleware-flexible-checksums@npm:3.178.0":
-  version: 3.178.0
-  resolution: "@aws-sdk/middleware-flexible-checksums@npm:3.178.0"
-  dependencies:
-    "@aws-crypto/crc32": 2.0.0
-    "@aws-crypto/crc32c": 2.0.0
-    "@aws-sdk/is-array-buffer": 3.170.0
-    "@aws-sdk/protocol-http": 3.178.0
-    "@aws-sdk/types": 3.178.0
-    tslib: ^2.3.1
-  checksum: 8a95dcad6b64a745ae2b1f244a863b5c5d2dda84da1bb32415f78aaaff5db1129750466b2956e9fca0c8eafe33d5346b28e1db5060684512ffd6e4adcb7fe33d
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/middleware-host-header@npm:3.178.0":
-  version: 3.178.0
-  resolution: "@aws-sdk/middleware-host-header@npm:3.178.0"
-  dependencies:
-    "@aws-sdk/protocol-http": 3.178.0
-    "@aws-sdk/types": 3.178.0
-    tslib: ^2.3.1
-  checksum: d14db919d9abdec7b7061d35ecc90c75aa3edc723ac50f79e474cf6cd045a34fd7c9f27181f817c21081287b7cad0e312121f308b1f1d12889d1baad01817910
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/middleware-location-constraint@npm:3.178.0":
-  version: 3.178.0
-  resolution: "@aws-sdk/middleware-location-constraint@npm:3.178.0"
-  dependencies:
-    "@aws-sdk/types": 3.178.0
-    tslib: ^2.3.1
-  checksum: 89e58ecf3d70d4a1ceabae53d37143b523daa852a3687750b922fb728dbdb8c71dec838d637eb518b617f9c55e97bba2eae111d095516cb35d0d6f700b06ec98
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/middleware-logger@npm:3.178.0":
-  version: 3.178.0
-  resolution: "@aws-sdk/middleware-logger@npm:3.178.0"
-  dependencies:
-    "@aws-sdk/types": 3.178.0
-    tslib: ^2.3.1
-  checksum: 17d08f51e4b55684443b53b5830713a97c3377db0882c850c0289a2db7bf669207aea26b74a8c627bc7a686c7097697f76b68baf22d7c6be555b4545c0ff93c6
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/middleware-recursion-detection@npm:3.178.0":
-  version: 3.178.0
-  resolution: "@aws-sdk/middleware-recursion-detection@npm:3.178.0"
-  dependencies:
-    "@aws-sdk/protocol-http": 3.178.0
-    "@aws-sdk/types": 3.178.0
-    tslib: ^2.3.1
-  checksum: 1d71f29eab868a546d2734ae49163bb0ff4b137d913e3fb2885ce2e16fe738e73088e9bd4a6726fe131a228087211e15b1a140c095422c48331d0743a8467762
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/middleware-retry@npm:3.178.0":
-  version: 3.178.0
-  resolution: "@aws-sdk/middleware-retry@npm:3.178.0"
-  dependencies:
-    "@aws-sdk/protocol-http": 3.178.0
-    "@aws-sdk/service-error-classification": 3.178.0
-    "@aws-sdk/types": 3.178.0
-    "@aws-sdk/util-middleware": 3.178.0
-    tslib: ^2.3.1
-    uuid: ^8.3.2
-  checksum: 3d2ce86e06fba813fff2e903ea12019f784527fa671b35a9d39f202444c77d4ad8e22e9c892910f94b4ea956b45190f0440fe039b66b28e5199a91bbffa0efd1
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/middleware-sdk-s3@npm:3.178.0":
-  version: 3.178.0
-  resolution: "@aws-sdk/middleware-sdk-s3@npm:3.178.0"
-  dependencies:
-    "@aws-sdk/middleware-bucket-endpoint": 3.178.0
-    "@aws-sdk/protocol-http": 3.178.0
-    "@aws-sdk/types": 3.178.0
-    "@aws-sdk/util-arn-parser": 3.170.0
-    tslib: ^2.3.1
-  checksum: fa3d088b464d67e6f75e582e84a4e22d1c8de6e8991c4e4c411ba0cc84526b5c0b09f6d91e4e4b42b6db84800757cb2886256a077142f68d8f042fc58baa4af8
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/middleware-sdk-sts@npm:3.179.0":
-  version: 3.179.0
-  resolution: "@aws-sdk/middleware-sdk-sts@npm:3.179.0"
-  dependencies:
-    "@aws-sdk/middleware-signing": 3.179.0
-    "@aws-sdk/property-provider": 3.178.0
-    "@aws-sdk/protocol-http": 3.178.0
-    "@aws-sdk/signature-v4": 3.178.0
-    "@aws-sdk/types": 3.178.0
-    tslib: ^2.3.1
-  checksum: 59781ac3c5ac1d0329f7b45d3d99f7203d064cdc7bf12fdf076701ed3fef90e6dd6c7c3fd226ec39995b7b70d73621285e915ed937cd1f70083c252d149dbf17
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/middleware-serde@npm:3.178.0":
-  version: 3.178.0
-  resolution: "@aws-sdk/middleware-serde@npm:3.178.0"
-  dependencies:
-    "@aws-sdk/types": 3.178.0
-    tslib: ^2.3.1
-  checksum: dbd800ee4b943ed986513930c0221682412b4e57576259fe7c306d7a9776c0fca289e5b429ac5015fcd73ffe033e38c85e80d1bd9e5fa3acdb210dd2e22ca6dd
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/middleware-signing@npm:3.179.0":
-  version: 3.179.0
-  resolution: "@aws-sdk/middleware-signing@npm:3.179.0"
-  dependencies:
-    "@aws-sdk/property-provider": 3.178.0
-    "@aws-sdk/protocol-http": 3.178.0
-    "@aws-sdk/signature-v4": 3.178.0
-    "@aws-sdk/types": 3.178.0
-    "@aws-sdk/util-middleware": 3.178.0
-    tslib: ^2.3.1
-  checksum: 8b7e0d0ad20bde7164d7a1efb1fe1d37b3935e96fd277084d2567e771fab3fa441059592a779954d1c94b6a37d156dd56f037021cf620463295f791f2d9bef93
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/middleware-ssec@npm:3.178.0":
-  version: 3.178.0
-  resolution: "@aws-sdk/middleware-ssec@npm:3.178.0"
-  dependencies:
-    "@aws-sdk/types": 3.178.0
-    tslib: ^2.3.1
-  checksum: ac8cb4c7b9702ac8fd276c9ebc55c5867377fe1181771281e3b079bd69a541500f04898f73be373380d93fd869b7c229c8d9e9e7399e307b28d39b67bce8991f
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/middleware-stack@npm:3.178.0":
-  version: 3.178.0
-  resolution: "@aws-sdk/middleware-stack@npm:3.178.0"
-  dependencies:
-    tslib: ^2.3.1
-  checksum: ee7fafa5c2b404c85ceba41af5def110baed7118695fc0e2da5fa7a00d6f1b4f81d8bdd649d738f5acab3667820befcde1a8ed01fb0cb638c74a1f4eb49c7935
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/middleware-user-agent@npm:3.178.0":
-  version: 3.178.0
-  resolution: "@aws-sdk/middleware-user-agent@npm:3.178.0"
-  dependencies:
-    "@aws-sdk/protocol-http": 3.178.0
-    "@aws-sdk/types": 3.178.0
-    tslib: ^2.3.1
-  checksum: 3089cc63cf4094bb0a3380c33b9fdf94b630dfb3956fce95d32c87b496c24f7337567f6c941f5e01ee813deeca11320d1b0318be75d4170bfb9644ac8b356dac
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/node-config-provider@npm:3.178.0":
-  version: 3.178.0
-  resolution: "@aws-sdk/node-config-provider@npm:3.178.0"
-  dependencies:
-    "@aws-sdk/property-provider": 3.178.0
-    "@aws-sdk/shared-ini-file-loader": 3.178.0
-    "@aws-sdk/types": 3.178.0
-    tslib: ^2.3.1
-  checksum: 3846a98e8613155b69c6bd91fdb19b57fca71f6f397bf7d6916c79309ff1604e4d57f6f1ec7979fb144609c0e2e3f5456e221fcbbf24a0a3d083f5274a129cbd
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/node-http-handler@npm:3.178.0":
-  version: 3.178.0
-  resolution: "@aws-sdk/node-http-handler@npm:3.178.0"
-  dependencies:
-    "@aws-sdk/abort-controller": 3.178.0
-    "@aws-sdk/protocol-http": 3.178.0
-    "@aws-sdk/querystring-builder": 3.178.0
-    "@aws-sdk/types": 3.178.0
-    tslib: ^2.3.1
-  checksum: 9a6682c70971a8b31c65eeb286da626a71c06fcd4f21ef53d87e22062eeae8370f43e5cd9e16e2997a80c4ff96a7b8aa84265c310a2a44dc568d9e5e9f7454ba
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/property-provider@npm:3.178.0":
-  version: 3.178.0
-  resolution: "@aws-sdk/property-provider@npm:3.178.0"
-  dependencies:
-    "@aws-sdk/types": 3.178.0
-    tslib: ^2.3.1
-  checksum: 5e190f67c05a0aea48a1d3db651d3abb70a2d7fa3dc14011108b5ad4a64c842f75d3395eca41a782bee1f2275fa59a978605010e2cbd640a14344ca3617767b1
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/protocol-http@npm:3.178.0":
-  version: 3.178.0
-  resolution: "@aws-sdk/protocol-http@npm:3.178.0"
-  dependencies:
-    "@aws-sdk/types": 3.178.0
-    tslib: ^2.3.1
-  checksum: ce3d17ab6ec04e8299b57634694072851e737acd5148f1966f154a96a9018ad47917bea6f3a76cb10c2fe5dc903d4a73536db01276745c28b6f0fdb6b7db1f73
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/querystring-builder@npm:3.178.0":
-  version: 3.178.0
-  resolution: "@aws-sdk/querystring-builder@npm:3.178.0"
-  dependencies:
-    "@aws-sdk/types": 3.178.0
-    "@aws-sdk/util-uri-escape": 3.170.0
-    tslib: ^2.3.1
-  checksum: f96f87c0e7e2b08677a0abca98473c411ac313adaca4c8d44e06d21ff2fcdbe682b87b8ed33ae47137a3af7b4cdd05e7b97852e363c2e5947e2cded18d2af3a8
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/querystring-parser@npm:3.178.0":
-  version: 3.178.0
-  resolution: "@aws-sdk/querystring-parser@npm:3.178.0"
-  dependencies:
-    "@aws-sdk/types": 3.178.0
-    tslib: ^2.3.1
-  checksum: b6092981fec3765fc02e37a1dd32c320a8199e6d21ae5b7b663340c44a2039792e8dc214c911a4662d3dd784897034a6af7b9ce0946aa3854e9a8db27fd6cce2
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/service-error-classification@npm:3.178.0":
-  version: 3.178.0
-  resolution: "@aws-sdk/service-error-classification@npm:3.178.0"
-  checksum: 04e041bec2924dbf21123d45ba90e8a2f21b6c92d655304401a4194b824b6a1787769da3cc1d9f1387f572c833155ad30a0c8e4feabeb7381a71f2f6befd848b
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/shared-ini-file-loader@npm:3.178.0":
-  version: 3.178.0
-  resolution: "@aws-sdk/shared-ini-file-loader@npm:3.178.0"
-  dependencies:
-    tslib: ^2.3.1
-  checksum: 2d133e3e19960f5236b853605d4f152051206614260ca68c5f9783cb31b7983a46acdd0e12afc0783adac20c16b1ed2f01ef045874c808f0e0450e7bd264ff87
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/signature-v4-multi-region@npm:3.180.0":
-  version: 3.180.0
-  resolution: "@aws-sdk/signature-v4-multi-region@npm:3.180.0"
-  dependencies:
-    "@aws-sdk/protocol-http": 3.178.0
-    "@aws-sdk/signature-v4": 3.178.0
-    "@aws-sdk/types": 3.178.0
-    "@aws-sdk/util-arn-parser": 3.170.0
-    tslib: ^2.3.1
+    "@aws-sdk/credential-provider-env": "npm:3.575.0"
+    "@aws-sdk/credential-provider-process": "npm:3.575.0"
+    "@aws-sdk/credential-provider-sso": "npm:3.575.0"
+    "@aws-sdk/credential-provider-web-identity": "npm:3.575.0"
+    "@aws-sdk/types": "npm:3.575.0"
+    "@smithy/credential-provider-imds": "npm:^3.0.0"
+    "@smithy/property-provider": "npm:^3.0.0"
+    "@smithy/shared-ini-file-loader": "npm:^3.0.0"
+    "@smithy/types": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
   peerDependencies:
-    "@aws-sdk/signature-v4-crt": ^3.118.0
-  peerDependenciesMeta:
-    "@aws-sdk/signature-v4-crt":
-      optional: true
-  checksum: 623c0bbf016028317116906921326608e33241256e20c9f0358fa7fdb2599c4bcda01e1740cf2386695a0bda0d11a4b1e3637b60996a5842e7c6e2db5fa65f3e
+    "@aws-sdk/client-sts": 3.575.0
+  checksum: 10/d86df0977a8198570a682d1416e796912e3784002651b4433fd77385946979945e7810d45bc36b76a33f5cbd8600ee25d12d353d79cad0fcd8f4107111975e58
   languageName: node
   linkType: hard
 
-"@aws-sdk/signature-v4@npm:3.178.0":
-  version: 3.178.0
-  resolution: "@aws-sdk/signature-v4@npm:3.178.0"
+"@aws-sdk/credential-provider-node@npm:3.575.0":
+  version: 3.575.0
+  resolution: "@aws-sdk/credential-provider-node@npm:3.575.0"
   dependencies:
-    "@aws-sdk/is-array-buffer": 3.170.0
-    "@aws-sdk/types": 3.178.0
-    "@aws-sdk/util-hex-encoding": 3.170.0
-    "@aws-sdk/util-middleware": 3.178.0
-    "@aws-sdk/util-uri-escape": 3.170.0
-    tslib: ^2.3.1
-  checksum: 8c573efd3d17c440c001e905ec9bccd9277628dcac41b1f98e466ff2dd8e4ade6038e58ec08ddec37441e147f78c865de6f500796b883f6673f8d74ac00eb4f9
+    "@aws-sdk/credential-provider-env": "npm:3.575.0"
+    "@aws-sdk/credential-provider-http": "npm:3.575.0"
+    "@aws-sdk/credential-provider-ini": "npm:3.575.0"
+    "@aws-sdk/credential-provider-process": "npm:3.575.0"
+    "@aws-sdk/credential-provider-sso": "npm:3.575.0"
+    "@aws-sdk/credential-provider-web-identity": "npm:3.575.0"
+    "@aws-sdk/types": "npm:3.575.0"
+    "@smithy/credential-provider-imds": "npm:^3.0.0"
+    "@smithy/property-provider": "npm:^3.0.0"
+    "@smithy/shared-ini-file-loader": "npm:^3.0.0"
+    "@smithy/types": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/91f06aff0d3f24c006cc38dd642feecf8c776b8fa75a31aa8164dc5c17048200d9fc650417d9b84ad625dc4586f2f8f182a7766e0ba8a44d24b2f798fa06579b
   languageName: node
   linkType: hard
 
-"@aws-sdk/smithy-client@npm:3.180.0":
-  version: 3.180.0
-  resolution: "@aws-sdk/smithy-client@npm:3.180.0"
+"@aws-sdk/credential-provider-process@npm:3.575.0":
+  version: 3.575.0
+  resolution: "@aws-sdk/credential-provider-process@npm:3.575.0"
   dependencies:
-    "@aws-sdk/middleware-stack": 3.178.0
-    "@aws-sdk/types": 3.178.0
-    tslib: ^2.3.1
-  checksum: e0ee40a496812829ce53e4624661443107c0449ed8e1c85efeace44b5d54afbe381bb2488f8b96058f0c26519c24643e9645e1e3735a4b35a9e2c4289be7fd17
+    "@aws-sdk/types": "npm:3.575.0"
+    "@smithy/property-provider": "npm:^3.0.0"
+    "@smithy/shared-ini-file-loader": "npm:^3.0.0"
+    "@smithy/types": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/a32fcc6f820399c8b02247a149f4da097e0abab4d06dde7b2b6ed394460e1e73cfa0033ed295473d5001b6e550057cb1f16e966537f927fe8d1dbc5ef0a48725
   languageName: node
   linkType: hard
 
-"@aws-sdk/types@npm:3.178.0, @aws-sdk/types@npm:^3.1.0, @aws-sdk/types@npm:^3.110.0":
-  version: 3.178.0
-  resolution: "@aws-sdk/types@npm:3.178.0"
-  checksum: 9d339078953481c4db38c23a590638b7058698f204ea317369a132d06142bfde65beaf6f6ac724180e98f73917ef6a041aa61e44f447ffff43cc845c771c2510
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/url-parser@npm:3.178.0":
-  version: 3.178.0
-  resolution: "@aws-sdk/url-parser@npm:3.178.0"
+"@aws-sdk/credential-provider-sso@npm:3.575.0":
+  version: 3.575.0
+  resolution: "@aws-sdk/credential-provider-sso@npm:3.575.0"
   dependencies:
-    "@aws-sdk/querystring-parser": 3.178.0
-    "@aws-sdk/types": 3.178.0
-    tslib: ^2.3.1
-  checksum: 4f029aa446c7d52527289da1e9db9ea2dd70a28831c9d12a4b4f56f9683e10d35b6fdf1cb3ab00c819c27eeb0b711bbe6a07aaf580d6ae562b0d846e0fb11c76
+    "@aws-sdk/client-sso": "npm:3.575.0"
+    "@aws-sdk/token-providers": "npm:3.575.0"
+    "@aws-sdk/types": "npm:3.575.0"
+    "@smithy/property-provider": "npm:^3.0.0"
+    "@smithy/shared-ini-file-loader": "npm:^3.0.0"
+    "@smithy/types": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/e9197693fca6732c3b0644e4aa5a88b6c1dbe14af0ca3cce3322025c45042d308b54055b5397dae8a1534aa362df6868e6b49edb8576daa5adf81c1a18766cf1
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-arn-parser@npm:3.170.0":
-  version: 3.170.0
-  resolution: "@aws-sdk/util-arn-parser@npm:3.170.0"
+"@aws-sdk/credential-provider-web-identity@npm:3.575.0":
+  version: 3.575.0
+  resolution: "@aws-sdk/credential-provider-web-identity@npm:3.575.0"
   dependencies:
-    tslib: ^2.3.1
-  checksum: 032d1d11b6e2a5047b8c1f2b5e993cbafbe97bb65f64eca305631b4644c06300c372bf5b05c5771169f84e599dc6db6e6845af58056066f8a7dad49cfd58cec5
+    "@aws-sdk/types": "npm:3.575.0"
+    "@smithy/property-provider": "npm:^3.0.0"
+    "@smithy/types": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  peerDependencies:
+    "@aws-sdk/client-sts": 3.575.0
+  checksum: 10/05088f325d67388d06d7f43f0a69bf3acd71868065c56bbccbbe754455f57b3b1b0d16f943c74e4bc6d37ab88aa5af944dc553fa4ad4e95a56e49eaf235099cd
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-base64-browser@npm:3.170.0":
-  version: 3.170.0
-  resolution: "@aws-sdk/util-base64-browser@npm:3.170.0"
+"@aws-sdk/middleware-bucket-endpoint@npm:3.575.0":
+  version: 3.575.0
+  resolution: "@aws-sdk/middleware-bucket-endpoint@npm:3.575.0"
   dependencies:
-    tslib: ^2.3.1
-  checksum: 74ac479478029f3349782c8235f33135c1e817c16999badde8b9d6b5eac9df52a8388ce1b666dcd8ae891e33e81482ea3cd50b1d35cfda23468275a680e45da2
+    "@aws-sdk/types": "npm:3.575.0"
+    "@aws-sdk/util-arn-parser": "npm:3.568.0"
+    "@smithy/node-config-provider": "npm:^3.0.0"
+    "@smithy/protocol-http": "npm:^4.0.0"
+    "@smithy/types": "npm:^3.0.0"
+    "@smithy/util-config-provider": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/8e41eba73b3ede72da3a132132828c2dabaaff726523cc1da31904e84bf526aa68bedbf8e72bfb5a934ad6db455886223cb47bfc4af38ab3a17b4408bc9bc258
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-base64-node@npm:3.170.0":
-  version: 3.170.0
-  resolution: "@aws-sdk/util-base64-node@npm:3.170.0"
+"@aws-sdk/middleware-expect-continue@npm:3.575.0":
+  version: 3.575.0
+  resolution: "@aws-sdk/middleware-expect-continue@npm:3.575.0"
   dependencies:
-    "@aws-sdk/util-buffer-from": 3.170.0
-    tslib: ^2.3.1
-  checksum: e65e543049e42a0e8e7535ea259f504e9adde02fedc266b5a18fb1c665fdfa285ffe8a1c48438c0e100bf2ba37fc61479bd7d516f7c052fd4885b14563c869a1
+    "@aws-sdk/types": "npm:3.575.0"
+    "@smithy/protocol-http": "npm:^4.0.0"
+    "@smithy/types": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/8836b2c9c83cb1d839d4b58c32904f9194c78fba0e27f4c82d991bffea1b64124238413a28aaf15bb26ba9aa741bdc9d2250023581817e6a4efb53d351166891
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-body-length-browser@npm:3.170.0":
-  version: 3.170.0
-  resolution: "@aws-sdk/util-body-length-browser@npm:3.170.0"
+"@aws-sdk/middleware-flexible-checksums@npm:3.575.0":
+  version: 3.575.0
+  resolution: "@aws-sdk/middleware-flexible-checksums@npm:3.575.0"
   dependencies:
-    tslib: ^2.3.1
-  checksum: fff80b2e77c1e703746f334bda85bcf0f5d97c2e2719493257d67febd74e1a62632abe486836acf618859326b26f9edae03479ee6a13090e692b76c10182843d
+    "@aws-crypto/crc32": "npm:3.0.0"
+    "@aws-crypto/crc32c": "npm:3.0.0"
+    "@aws-sdk/types": "npm:3.575.0"
+    "@smithy/is-array-buffer": "npm:^3.0.0"
+    "@smithy/protocol-http": "npm:^4.0.0"
+    "@smithy/types": "npm:^3.0.0"
+    "@smithy/util-utf8": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/eb30799caaf2fed7687de0838d2779894c1e5db84c2ea806ce1c5d07ffae48ca1800065626e05d35a8063d6e33b8750f6f3ea9702576eb85bbd883cf6ef7d61e
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-body-length-node@npm:3.170.0":
-  version: 3.170.0
-  resolution: "@aws-sdk/util-body-length-node@npm:3.170.0"
+"@aws-sdk/middleware-host-header@npm:3.575.0":
+  version: 3.575.0
+  resolution: "@aws-sdk/middleware-host-header@npm:3.575.0"
   dependencies:
-    tslib: ^2.3.1
-  checksum: b503be9a89a12230d991bdc07d61f6fc0b6c282ce94eb0aafa07f500df97c93f85e7a9d046fbac7881d856317c2f5d30eb0025069669da26f11be1932513e8c2
+    "@aws-sdk/types": "npm:3.575.0"
+    "@smithy/protocol-http": "npm:^4.0.0"
+    "@smithy/types": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/8c5478db6b02629b6a6f3273fbb88a16b379c677dff8103a4b856b9d3842d3c4a2ec200726671a4655b201f575b961b398eff76163602046ee41a39cc483510b
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-buffer-from@npm:3.170.0":
-  version: 3.170.0
-  resolution: "@aws-sdk/util-buffer-from@npm:3.170.0"
+"@aws-sdk/middleware-location-constraint@npm:3.575.0":
+  version: 3.575.0
+  resolution: "@aws-sdk/middleware-location-constraint@npm:3.575.0"
   dependencies:
-    "@aws-sdk/is-array-buffer": 3.170.0
-    tslib: ^2.3.1
-  checksum: 5880609b1fde1a7bb6c27c0fc87c7b80ae9eea74c41ca0d3c96d9f8ecd9d579cc612698b76f862dae51d9edd016d5617f8647fe6e15dd357e949d4ebb4919b9a
+    "@aws-sdk/types": "npm:3.575.0"
+    "@smithy/types": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/690c3628270317748119f7955dd395e837de18aa8e9960422d8b3faf10aaf51e379719c22391f43dcf1daf52dd53273e9e1b0e4f14ad1a3566c4b8ff68202ff9
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-config-provider@npm:3.170.0":
-  version: 3.170.0
-  resolution: "@aws-sdk/util-config-provider@npm:3.170.0"
+"@aws-sdk/middleware-logger@npm:3.575.0":
+  version: 3.575.0
+  resolution: "@aws-sdk/middleware-logger@npm:3.575.0"
   dependencies:
-    tslib: ^2.3.1
-  checksum: f1be922c466cbaf8e25f9b0d21a23e9f1de0aeedd36a5ce7b8745bf89d4744c10066d626c985660abec79c46f5f01a8d4b2b51e7b7303c3b0b5383fb1dc16f39
+    "@aws-sdk/types": "npm:3.575.0"
+    "@smithy/types": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/30b6b986d6669afddbbc307649d6cbcb8387c160756ce43e9977b4e2bc083954945bb6e48fdaa7b433b4d022b5e6cc318d2384895c0c9bbb7d5fa586c59201eb
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-defaults-mode-browser@npm:3.180.0":
-  version: 3.180.0
-  resolution: "@aws-sdk/util-defaults-mode-browser@npm:3.180.0"
+"@aws-sdk/middleware-recursion-detection@npm:3.575.0":
+  version: 3.575.0
+  resolution: "@aws-sdk/middleware-recursion-detection@npm:3.575.0"
   dependencies:
-    "@aws-sdk/property-provider": 3.178.0
-    "@aws-sdk/types": 3.178.0
-    bowser: ^2.11.0
-    tslib: ^2.3.1
-  checksum: bb31885190da82504d009958e0bce53cb9e916f1e0544dba8b10cf409e6575e939d36e451f588667ffad305dd247a4ef567c3666ef5181ddc1d8a062e378374f
+    "@aws-sdk/types": "npm:3.575.0"
+    "@smithy/protocol-http": "npm:^4.0.0"
+    "@smithy/types": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/a80a3b7aec195866b9a01e06c0e11f2d635943aeedd5a674d699b124cd05832c4ef238cedf9a268cd74a4bb6e74f617dc0478b3e87731521d5db0bf6bd432332
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-defaults-mode-node@npm:3.180.0":
-  version: 3.180.0
-  resolution: "@aws-sdk/util-defaults-mode-node@npm:3.180.0"
+"@aws-sdk/middleware-sdk-s3@npm:3.575.0":
+  version: 3.575.0
+  resolution: "@aws-sdk/middleware-sdk-s3@npm:3.575.0"
   dependencies:
-    "@aws-sdk/config-resolver": 3.178.0
-    "@aws-sdk/credential-provider-imds": 3.178.0
-    "@aws-sdk/node-config-provider": 3.178.0
-    "@aws-sdk/property-provider": 3.178.0
-    "@aws-sdk/types": 3.178.0
-    tslib: ^2.3.1
-  checksum: 9129c16e98d15653e87c5f6e63aac4698e52c24f3c89335d94a74d26631ad35c8b889bc4f5ae7acf111048254204f4992eed9ee35ed54e8d7e52ea4447d8e086
+    "@aws-sdk/types": "npm:3.575.0"
+    "@aws-sdk/util-arn-parser": "npm:3.568.0"
+    "@smithy/node-config-provider": "npm:^3.0.0"
+    "@smithy/protocol-http": "npm:^4.0.0"
+    "@smithy/signature-v4": "npm:^3.0.0"
+    "@smithy/smithy-client": "npm:^3.0.0"
+    "@smithy/types": "npm:^3.0.0"
+    "@smithy/util-config-provider": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/52c666f794cd8a705b55d1c2686580db6a3720b2b265fd1cd0f7053d72f3c2e043577bd0ea34ee884d7903abde1f4a956230c2bf556c9db9fbf7905cae6c3f06
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-hex-encoding@npm:3.170.0":
-  version: 3.170.0
-  resolution: "@aws-sdk/util-hex-encoding@npm:3.170.0"
+"@aws-sdk/middleware-signing@npm:3.575.0":
+  version: 3.575.0
+  resolution: "@aws-sdk/middleware-signing@npm:3.575.0"
   dependencies:
-    tslib: ^2.3.1
-  checksum: f2e8a9b33f2394080e5ad4bfd9d8c7e8a9821d018e90e6c569f0e1c251def6a1620f3e13f1a368418198e4223693e997b9fb3cbb54a31b3917e705dfb5684ea5
+    "@aws-sdk/types": "npm:3.575.0"
+    "@smithy/property-provider": "npm:^3.0.0"
+    "@smithy/protocol-http": "npm:^4.0.0"
+    "@smithy/signature-v4": "npm:^3.0.0"
+    "@smithy/types": "npm:^3.0.0"
+    "@smithy/util-middleware": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/d7adaafbc239457229e3a8195cae539f007449720a9c7404853955b2c46e56a1d2dbd5632946c6cffcb10c877792fbfd2e03390f5996d6ea65f4666f1d827043
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-ssec@npm:3.575.0":
+  version: 3.575.0
+  resolution: "@aws-sdk/middleware-ssec@npm:3.575.0"
+  dependencies:
+    "@aws-sdk/types": "npm:3.575.0"
+    "@smithy/types": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/ec7a0dd5fea799fcee509b4647a3967e8e813f99638760620ef4297beb47e97a3a01e19a992938c74c461229ec115227871630b726fa53531a186474696b9687
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-user-agent@npm:3.575.0":
+  version: 3.575.0
+  resolution: "@aws-sdk/middleware-user-agent@npm:3.575.0"
+  dependencies:
+    "@aws-sdk/types": "npm:3.575.0"
+    "@aws-sdk/util-endpoints": "npm:3.575.0"
+    "@smithy/protocol-http": "npm:^4.0.0"
+    "@smithy/types": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/2c2b9b840abc167b4845d02b043fb176514dfa251f1eab946e9951918814c61b9af3150ffe646a442b33890528f26e5c33b8a30cc451bec01c645650a755b162
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/region-config-resolver@npm:3.575.0":
+  version: 3.575.0
+  resolution: "@aws-sdk/region-config-resolver@npm:3.575.0"
+  dependencies:
+    "@aws-sdk/types": "npm:3.575.0"
+    "@smithy/node-config-provider": "npm:^3.0.0"
+    "@smithy/types": "npm:^3.0.0"
+    "@smithy/util-config-provider": "npm:^3.0.0"
+    "@smithy/util-middleware": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/92c4550fd5b002cce5db05be2a77e1aa323eccebc6797835d27e7be7c2a230b2efbba8b1a8aee8a2a6bdbaa41af84bc55b397da0d0546987e003948ce7e47bb2
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/signature-v4-multi-region@npm:3.575.0":
+  version: 3.575.0
+  resolution: "@aws-sdk/signature-v4-multi-region@npm:3.575.0"
+  dependencies:
+    "@aws-sdk/middleware-sdk-s3": "npm:3.575.0"
+    "@aws-sdk/types": "npm:3.575.0"
+    "@smithy/protocol-http": "npm:^4.0.0"
+    "@smithy/signature-v4": "npm:^3.0.0"
+    "@smithy/types": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/c41791cdb218e959d7fa6716d761467044ccedc16868a80eaa08db15755717f8a56d4c044bc35ce8bd3143cd51d0eb506e0634f987184043e517d26ed2f035e2
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/token-providers@npm:3.575.0":
+  version: 3.575.0
+  resolution: "@aws-sdk/token-providers@npm:3.575.0"
+  dependencies:
+    "@aws-sdk/types": "npm:3.575.0"
+    "@smithy/property-provider": "npm:^3.0.0"
+    "@smithy/shared-ini-file-loader": "npm:^3.0.0"
+    "@smithy/types": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  peerDependencies:
+    "@aws-sdk/client-sso-oidc": 3.575.0
+  checksum: 10/ce6735c15487027dc4a380609166281df7cec824ac74b7ebeb7a307285342366612eca93831c5fd3ad806417ffd2ff5b4928911170504f8a769a90493145b6ec
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/types@npm:3.575.0, @aws-sdk/types@npm:^3.222.0":
+  version: 3.575.0
+  resolution: "@aws-sdk/types@npm:3.575.0"
+  dependencies:
+    "@smithy/types": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/e6243ad1ebc63b9ad19f8aa5dbfdd295b4b55a8c09dcb54313c4f624faf414b1b030cf2e6b1cbab312d3771c3e33d412a479f8f3d856cff3182b51512733a47d
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-arn-parser@npm:3.568.0":
+  version: 3.568.0
+  resolution: "@aws-sdk/util-arn-parser@npm:3.568.0"
+  dependencies:
+    tslib: "npm:^2.6.2"
+  checksum: 10/b1a7f93b4f47136ee8d71bcbbd2d5d19581007f0684aff252d3bee6b9ccc7c56e765255bb1bea847171b40cdbd2eca0fb102f24cba857d1c79c54747e8ee0855
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-endpoints@npm:3.575.0":
+  version: 3.575.0
+  resolution: "@aws-sdk/util-endpoints@npm:3.575.0"
+  dependencies:
+    "@aws-sdk/types": "npm:3.575.0"
+    "@smithy/types": "npm:^3.0.0"
+    "@smithy/util-endpoints": "npm:^2.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/51e88aaede9fecf9ac1c4ce3976876eb5997bda67b14b22129604ea11ec6d3131e97b7184c899114f9587c2930f1616ba1e9051ded10a853a5ea6047fbe21eca
   languageName: node
   linkType: hard
 
@@ -954,292 +665,2647 @@ __metadata:
   version: 3.170.0
   resolution: "@aws-sdk/util-locate-window@npm:3.170.0"
   dependencies:
-    tslib: ^2.3.1
-  checksum: 68482addfd016dd168b083b70202d1537bed10cfff1f4700a4711d14a8066e9a6fe1bfa30c953380efb96ca3b935e253ef166d87f6722d4db3afa82d84456e64
+    tslib: "npm:^2.3.1"
+  checksum: 10/7edf75a62df95fb5edbe2618cd6e25c0269c835b9af57c90d49e31d09234ce62fe4c061e78159e9b29e3f2dae3b5a5d6c941fad57e2cfe2260aaf4a123664f9b
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-middleware@npm:3.178.0":
-  version: 3.178.0
-  resolution: "@aws-sdk/util-middleware@npm:3.178.0"
+"@aws-sdk/util-user-agent-browser@npm:3.575.0":
+  version: 3.575.0
+  resolution: "@aws-sdk/util-user-agent-browser@npm:3.575.0"
   dependencies:
-    tslib: ^2.3.1
-  checksum: 82bf08d11fe32b35817ac5df41ef9146b350bcf24b96ff173c67e8b6e7ea34c198c65a8c02f11361b00057b00c2ff98a990c4b8e3f551a790947bfd9d43438c4
+    "@aws-sdk/types": "npm:3.575.0"
+    "@smithy/types": "npm:^3.0.0"
+    bowser: "npm:^2.11.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/c0d8b3bce25c72f0f05c8d0333a485482d76c81c1b6732472c0b6ed9281e9eea68e806611581de09f45f6c0465ef2e0f1f605bc4dbf5f1c037135354dc07d79c
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-stream-browser@npm:3.178.0":
-  version: 3.178.0
-  resolution: "@aws-sdk/util-stream-browser@npm:3.178.0"
+"@aws-sdk/util-user-agent-node@npm:3.575.0":
+  version: 3.575.0
+  resolution: "@aws-sdk/util-user-agent-node@npm:3.575.0"
   dependencies:
-    "@aws-sdk/fetch-http-handler": 3.178.0
-    "@aws-sdk/types": 3.178.0
-    "@aws-sdk/util-base64-browser": 3.170.0
-    "@aws-sdk/util-hex-encoding": 3.170.0
-    "@aws-sdk/util-utf8-browser": 3.170.0
-    tslib: ^2.3.1
-  checksum: 97f548f031f8360fc9cfbbc9e2619e9970d835dab94fe814a1ae0ca828774c23025d5ea7504c33c9d7d14c9aad89f13bc4245ce3815760f9e633e7fcdac14bd3
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/util-stream-node@npm:3.178.0":
-  version: 3.178.0
-  resolution: "@aws-sdk/util-stream-node@npm:3.178.0"
-  dependencies:
-    "@aws-sdk/node-http-handler": 3.178.0
-    "@aws-sdk/types": 3.178.0
-    "@aws-sdk/util-buffer-from": 3.170.0
-    tslib: ^2.3.1
-  checksum: 77a3c1e1c61f8670db68264e4375d61b0bc71dbd93156d0d77354ed4529d53c7c309c6cc1566d5bdb04658cba5696f04365acdd96026c4b1b865468266728a56
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/util-uri-escape@npm:3.170.0":
-  version: 3.170.0
-  resolution: "@aws-sdk/util-uri-escape@npm:3.170.0"
-  dependencies:
-    tslib: ^2.3.1
-  checksum: abcccc8c49cd01deebb97a1d764d97d8bcb2b669682a0bedf26b2e34c0338bd54e9eeea89bd7579d9404434cdfb72467fb71d3a69ebc88c8fb1a9f899f69af70
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/util-user-agent-browser@npm:3.178.0":
-  version: 3.178.0
-  resolution: "@aws-sdk/util-user-agent-browser@npm:3.178.0"
-  dependencies:
-    "@aws-sdk/types": 3.178.0
-    bowser: ^2.11.0
-    tslib: ^2.3.1
-  checksum: 494dc5994f68b86cced4a8fd4e6a19699b1e1c72a2cfd6169f838bae379e6588e2bef6a9cff4b04d33014f7dfe1bc47b8ba77b064bdedc0b3da612eea6429757
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/util-user-agent-node@npm:3.178.0":
-  version: 3.178.0
-  resolution: "@aws-sdk/util-user-agent-node@npm:3.178.0"
-  dependencies:
-    "@aws-sdk/node-config-provider": 3.178.0
-    "@aws-sdk/types": 3.178.0
-    tslib: ^2.3.1
+    "@aws-sdk/types": "npm:3.575.0"
+    "@smithy/node-config-provider": "npm:^3.0.0"
+    "@smithy/types": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
   peerDependencies:
     aws-crt: ">=1.0.0"
   peerDependenciesMeta:
     aws-crt:
       optional: true
-  checksum: 3a174cb1c3aa861939ffa2e9a43350049113d7c71a26553bdd65db0d7608f617355ceba0b9fccd085d25bd1d0074e8e47faa09adb28326ebd00aef6ae78bb1c6
+  checksum: 10/70123dde6108720184544adfd888eeaa0b9d5bcb293126be91bd278ab9c22d68282657781de5d05088356c26f5533701ac9ceb558a32bebd6715edbff43952c7
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-utf8-browser@npm:3.170.0, @aws-sdk/util-utf8-browser@npm:^3.0.0":
+"@aws-sdk/util-utf8-browser@npm:^3.0.0":
   version: 3.170.0
   resolution: "@aws-sdk/util-utf8-browser@npm:3.170.0"
   dependencies:
-    tslib: ^2.3.1
-  checksum: 08c2e14dd1d77276a674a927971f5072af5565f3dcbddf7f67d562ea8e4714e493f79621e9783019578dbb749b54827bddc6a2510cd660021616efd94a7599be
+    tslib: "npm:^2.3.1"
+  checksum: 10/8a658774a5f88b6496725c3cb9ccb229cea1d30b5bf5a351b0e24004792c687048b1179d6c9c0e1c1f1679b9629d18331671544d8cfe1d93c37eedff08d2d624
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-utf8-node@npm:3.170.0":
-  version: 3.170.0
-  resolution: "@aws-sdk/util-utf8-node@npm:3.170.0"
+"@aws-sdk/xml-builder@npm:3.575.0":
+  version: 3.575.0
+  resolution: "@aws-sdk/xml-builder@npm:3.575.0"
   dependencies:
-    "@aws-sdk/util-buffer-from": 3.170.0
-    tslib: ^2.3.1
-  checksum: 85ca76d6420f316fe5dd69b12203bee0bbf7368d48bd167c037bef494f44c48e1f63da821d1006149657f6a33157e335c8c1ca133f5d720bdf9a144e32379dc8
+    "@smithy/types": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/b1ca3cca6d49a10453d9b82242a4fbf2e5867d22c6238ea44f4210bdb64a2a48996b36d3662718995a76308bf4af7a834df7ba8498fba4d5aaabd2f7362f36f1
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-waiter@npm:3.180.0":
-  version: 3.180.0
-  resolution: "@aws-sdk/util-waiter@npm:3.180.0"
+"@babel/code-frame@npm:^7.0.0, @babel/code-frame@npm:^7.12.13, @babel/code-frame@npm:^7.23.5, @babel/code-frame@npm:^7.24.2":
+  version: 7.24.2
+  resolution: "@babel/code-frame@npm:7.24.2"
   dependencies:
-    "@aws-sdk/abort-controller": 3.178.0
-    "@aws-sdk/types": 3.178.0
-    tslib: ^2.3.1
-  checksum: f2bcf231e674dc6d5b58eb14831ffb80e292e82cf47c5a53262e1e82b2c88f97b9ec412a91e88e3bd0a79e8ba943b0caeeb7d29dc5efc4ae86a0ae5a72205de2
+    "@babel/highlight": "npm:^7.24.2"
+    picocolors: "npm:^1.0.0"
+  checksum: 10/7db8f5b36ffa3f47a37f58f61e3d130b9ecad21961f3eede7e2a4ac2c7e4a5efb6e9d03a810c669bc986096831b6c0dfc2c3082673d93351b82359c1b03e0590
   languageName: node
   linkType: hard
 
-"@aws-sdk/xml-builder@npm:3.170.0":
-  version: 3.170.0
-  resolution: "@aws-sdk/xml-builder@npm:3.170.0"
+"@babel/compat-data@npm:^7.23.5":
+  version: 7.24.4
+  resolution: "@babel/compat-data@npm:7.24.4"
+  checksum: 10/e51faec0ac8259f03cc5029d2b4a944b4fee44cb5188c11530769d5beb81f384d031dba951febc3e33dbb48ceb8045b1184f5c1ac4c5f86ab1f5e951e9aaf7af
+  languageName: node
+  linkType: hard
+
+"@babel/core@npm:^7.11.6, @babel/core@npm:^7.12.3, @babel/core@npm:^7.23.9":
+  version: 7.24.5
+  resolution: "@babel/core@npm:7.24.5"
   dependencies:
-    tslib: ^2.3.1
-  checksum: 7b94c360feda151c83607315a26c5c6eb75ccad9e6c005a3b75e2f5994c1853374a759e0711041826c21fc5b68efa8934ef18dc4a2c18d24920e2d0497491cd5
+    "@ampproject/remapping": "npm:^2.2.0"
+    "@babel/code-frame": "npm:^7.24.2"
+    "@babel/generator": "npm:^7.24.5"
+    "@babel/helper-compilation-targets": "npm:^7.23.6"
+    "@babel/helper-module-transforms": "npm:^7.24.5"
+    "@babel/helpers": "npm:^7.24.5"
+    "@babel/parser": "npm:^7.24.5"
+    "@babel/template": "npm:^7.24.0"
+    "@babel/traverse": "npm:^7.24.5"
+    "@babel/types": "npm:^7.24.5"
+    convert-source-map: "npm:^2.0.0"
+    debug: "npm:^4.1.0"
+    gensync: "npm:^1.0.0-beta.2"
+    json5: "npm:^2.2.3"
+    semver: "npm:^6.3.1"
+  checksum: 10/b0d02c51f39cc4c6f8fcaab7052d17dea63aab36d7e2567bfbad074e5a027df737ebcaf3029c3a659bc719bbac806311c2e8786be1d686abd093c48a6068395c
   languageName: node
   linkType: hard
 
-"@types/concat-stream@npm:^1.6.0":
-  version: 1.6.1
-  resolution: "@types/concat-stream@npm:1.6.1"
+"@babel/generator@npm:^7.24.5, @babel/generator@npm:^7.7.2":
+  version: 7.24.5
+  resolution: "@babel/generator@npm:7.24.5"
   dependencies:
-    "@types/node": "*"
-  checksum: 7d211e74331affd3578b5469244f5cef84a93775f38332adb3ef12413559a23862bc682c6873d0a404b01c9d5d5f7d3ae091fe835b435b633eb420e3055b3e56
+    "@babel/types": "npm:^7.24.5"
+    "@jridgewell/gen-mapping": "npm:^0.3.5"
+    "@jridgewell/trace-mapping": "npm:^0.3.25"
+    jsesc: "npm:^2.5.1"
+  checksum: 10/7a3782f1d2f824025a538444a0fce44f5b30a7b013984279561bcb3450eec91a41526533fd0b25b1a6fde627bebd0e645c0ea2aa907cc15c7f3da2d9eb71f069
   languageName: node
   linkType: hard
 
-"@types/form-data@npm:0.0.33":
-  version: 0.0.33
-  resolution: "@types/form-data@npm:0.0.33"
+"@babel/helper-compilation-targets@npm:^7.23.6":
+  version: 7.23.6
+  resolution: "@babel/helper-compilation-targets@npm:7.23.6"
   dependencies:
-    "@types/node": "*"
-  checksum: f0c283fdef2dd7191168a37b9cb2625af3cfbd7f72b5a514f938bea0a135669f79d736186d434b9e81150b47ef1bf20d97b188014a00583556fad6ce59fb9bbf
+    "@babel/compat-data": "npm:^7.23.5"
+    "@babel/helper-validator-option": "npm:^7.23.5"
+    browserslist: "npm:^4.22.2"
+    lru-cache: "npm:^5.1.1"
+    semver: "npm:^6.3.1"
+  checksum: 10/05595cd73087ddcd81b82d2f3297aac0c0422858dfdded43d304786cf680ec33e846e2317e6992d2c964ee61d93945cbf1fa8ec80b55aee5bfb159227fb02cb9
   languageName: node
   linkType: hard
 
-"@types/node@npm:*, @types/node@npm:^8.0.0":
+"@babel/helper-environment-visitor@npm:^7.22.20":
+  version: 7.22.20
+  resolution: "@babel/helper-environment-visitor@npm:7.22.20"
+  checksum: 10/d80ee98ff66f41e233f36ca1921774c37e88a803b2f7dca3db7c057a5fea0473804db9fb6729e5dbfd07f4bed722d60f7852035c2c739382e84c335661590b69
+  languageName: node
+  linkType: hard
+
+"@babel/helper-function-name@npm:^7.23.0":
+  version: 7.23.0
+  resolution: "@babel/helper-function-name@npm:7.23.0"
+  dependencies:
+    "@babel/template": "npm:^7.22.15"
+    "@babel/types": "npm:^7.23.0"
+  checksum: 10/7b2ae024cd7a09f19817daf99e0153b3bf2bc4ab344e197e8d13623d5e36117ed0b110914bc248faa64e8ccd3e97971ec7b41cc6fd6163a2b980220c58dcdf6d
+  languageName: node
+  linkType: hard
+
+"@babel/helper-hoist-variables@npm:^7.22.5":
+  version: 7.22.5
+  resolution: "@babel/helper-hoist-variables@npm:7.22.5"
+  dependencies:
+    "@babel/types": "npm:^7.22.5"
+  checksum: 10/394ca191b4ac908a76e7c50ab52102669efe3a1c277033e49467913c7ed6f7c64d7eacbeabf3bed39ea1f41731e22993f763b1edce0f74ff8563fd1f380d92cc
+  languageName: node
+  linkType: hard
+
+"@babel/helper-module-imports@npm:^7.24.3":
+  version: 7.24.3
+  resolution: "@babel/helper-module-imports@npm:7.24.3"
+  dependencies:
+    "@babel/types": "npm:^7.24.0"
+  checksum: 10/42fe124130b78eeb4bb6af8c094aa749712be0f4606f46716ce74bc18a5ea91c918c547c8bb2307a2e4b33f163e4ad2cb6a7b45f80448e624eae45b597ea3499
+  languageName: node
+  linkType: hard
+
+"@babel/helper-module-transforms@npm:^7.24.5":
+  version: 7.24.5
+  resolution: "@babel/helper-module-transforms@npm:7.24.5"
+  dependencies:
+    "@babel/helper-environment-visitor": "npm:^7.22.20"
+    "@babel/helper-module-imports": "npm:^7.24.3"
+    "@babel/helper-simple-access": "npm:^7.24.5"
+    "@babel/helper-split-export-declaration": "npm:^7.24.5"
+    "@babel/helper-validator-identifier": "npm:^7.24.5"
+  peerDependencies:
+    "@babel/core": ^7.0.0
+  checksum: 10/1a91e8abc2f427f8273ce3b99ef7b9c013eb3628221428553e0d4bc9c6db2e73bc4fc1b8535bd258544936accab9380e0d095f2449f913cad650ddee744b2124
+  languageName: node
+  linkType: hard
+
+"@babel/helper-plugin-utils@npm:^7.0.0, @babel/helper-plugin-utils@npm:^7.10.4, @babel/helper-plugin-utils@npm:^7.12.13, @babel/helper-plugin-utils@npm:^7.14.5, @babel/helper-plugin-utils@npm:^7.24.0, @babel/helper-plugin-utils@npm:^7.8.0":
+  version: 7.24.5
+  resolution: "@babel/helper-plugin-utils@npm:7.24.5"
+  checksum: 10/6e11ca5da73e6bd366848236568c311ac10e433fc2034a6fe6243af28419b07c93b4386f87bbc940aa058b7c83f370ef58f3b0fd598106be040d21a3d1c14276
+  languageName: node
+  linkType: hard
+
+"@babel/helper-simple-access@npm:^7.24.5":
+  version: 7.24.5
+  resolution: "@babel/helper-simple-access@npm:7.24.5"
+  dependencies:
+    "@babel/types": "npm:^7.24.5"
+  checksum: 10/db8768a16592faa1bde9061cac3d903bdbb2ddb2a7e9fb73c5904daee1f1b1dc69ba4d249dc22c45885c0d4b54fd0356ee78e6d67a9a90330c7dd37e6cd3acff
+  languageName: node
+  linkType: hard
+
+"@babel/helper-split-export-declaration@npm:^7.24.5":
+  version: 7.24.5
+  resolution: "@babel/helper-split-export-declaration@npm:7.24.5"
+  dependencies:
+    "@babel/types": "npm:^7.24.5"
+  checksum: 10/84777b6304ef0fe6501038985b61aaa118082688aa54eca8265f14f3ae2e01adf137e9111f4eb9870e0e9bc23901e0b8859bb2a9e4362ddf89d05e1c409c2422
+  languageName: node
+  linkType: hard
+
+"@babel/helper-string-parser@npm:^7.24.1":
+  version: 7.24.1
+  resolution: "@babel/helper-string-parser@npm:7.24.1"
+  checksum: 10/04c0ede77b908b43e6124753b48bc485528112a9335f0a21a226bff1ace75bb6e64fab24c85cb4b1610ef3494dacd1cb807caeb6b79a7b36c43d48c289b35949
+  languageName: node
+  linkType: hard
+
+"@babel/helper-validator-identifier@npm:^7.24.5":
+  version: 7.24.5
+  resolution: "@babel/helper-validator-identifier@npm:7.24.5"
+  checksum: 10/38aaf6a64a0ea2e84766165b461deda3c24fd2173dff18419a2cc9e1ea1d3e709039aee94db29433a07011492717c80900a5eb564cdca7d137757c3c69e26898
+  languageName: node
+  linkType: hard
+
+"@babel/helper-validator-option@npm:^7.23.5":
+  version: 7.23.5
+  resolution: "@babel/helper-validator-option@npm:7.23.5"
+  checksum: 10/537cde2330a8aede223552510e8a13e9c1c8798afee3757995a7d4acae564124fe2bf7e7c3d90d62d3657434a74340a274b3b3b1c6f17e9a2be1f48af29cb09e
+  languageName: node
+  linkType: hard
+
+"@babel/helpers@npm:^7.24.5":
+  version: 7.24.5
+  resolution: "@babel/helpers@npm:7.24.5"
+  dependencies:
+    "@babel/template": "npm:^7.24.0"
+    "@babel/traverse": "npm:^7.24.5"
+    "@babel/types": "npm:^7.24.5"
+  checksum: 10/efd74325823c70a32aa9f5e263c8eb0a1f729f5e9ea168e3226fa92a10b1702593b76034812e9f7b560d6447f9cd446bad231d7086af842129c6596306300094
+  languageName: node
+  linkType: hard
+
+"@babel/highlight@npm:^7.24.2":
+  version: 7.24.5
+  resolution: "@babel/highlight@npm:7.24.5"
+  dependencies:
+    "@babel/helper-validator-identifier": "npm:^7.24.5"
+    chalk: "npm:^2.4.2"
+    js-tokens: "npm:^4.0.0"
+    picocolors: "npm:^1.0.0"
+  checksum: 10/afde0403154ad69ecd58a98903058e776760444bf4d0363fb740a8596bc6278b72c5226637c4f6b3674d70acb1665207fe2fcecfe93a74f2f4ab033e89fd7e8c
+  languageName: node
+  linkType: hard
+
+"@babel/parser@npm:^7.1.0, @babel/parser@npm:^7.14.7, @babel/parser@npm:^7.20.7, @babel/parser@npm:^7.23.9, @babel/parser@npm:^7.24.0, @babel/parser@npm:^7.24.5":
+  version: 7.24.5
+  resolution: "@babel/parser@npm:7.24.5"
+  bin:
+    parser: ./bin/babel-parser.js
+  checksum: 10/f5ed1c5fd4b0045a364fb906f54fd30e2fff93a45069068b6d80d3ab2b64f5569c90fb41d39aff80fb7e925ca4d44917965a76776a3ca11924ec1fae3be5d1ea
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-syntax-async-generators@npm:^7.8.4":
+  version: 7.8.4
+  resolution: "@babel/plugin-syntax-async-generators@npm:7.8.4"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.8.0"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 10/7ed1c1d9b9e5b64ef028ea5e755c0be2d4e5e4e3d6cf7df757b9a8c4cfa4193d268176d0f1f7fbecdda6fe722885c7fda681f480f3741d8a2d26854736f05367
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-syntax-bigint@npm:^7.8.3":
+  version: 7.8.3
+  resolution: "@babel/plugin-syntax-bigint@npm:7.8.3"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.8.0"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 10/3a10849d83e47aec50f367a9e56a6b22d662ddce643334b087f9828f4c3dd73bdc5909aaeabe123fed78515767f9ca43498a0e621c438d1cd2802d7fae3c9648
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-syntax-class-properties@npm:^7.8.3":
+  version: 7.12.13
+  resolution: "@babel/plugin-syntax-class-properties@npm:7.12.13"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.12.13"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 10/24f34b196d6342f28d4bad303612d7ff566ab0a013ce89e775d98d6f832969462e7235f3e7eaf17678a533d4be0ba45d3ae34ab4e5a9dcbda5d98d49e5efa2fc
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-syntax-import-meta@npm:^7.8.3":
+  version: 7.10.4
+  resolution: "@babel/plugin-syntax-import-meta@npm:7.10.4"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.10.4"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 10/166ac1125d10b9c0c430e4156249a13858c0366d38844883d75d27389621ebe651115cb2ceb6dc011534d5055719fa1727b59f39e1ab3ca97820eef3dcab5b9b
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-syntax-json-strings@npm:^7.8.3":
+  version: 7.8.3
+  resolution: "@babel/plugin-syntax-json-strings@npm:7.8.3"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.8.0"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 10/bf5aea1f3188c9a507e16efe030efb996853ca3cadd6512c51db7233cc58f3ac89ff8c6bdfb01d30843b161cfe7d321e1bf28da82f7ab8d7e6bc5464666f354a
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-syntax-jsx@npm:^7.7.2":
+  version: 7.24.1
+  resolution: "@babel/plugin-syntax-jsx@npm:7.24.1"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.24.0"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 10/712f7e7918cb679f106769f57cfab0bc99b311032665c428b98f4c3e2e6d567601d45386a4f246df6a80d741e1f94192b3f008800d66c4f1daae3ad825c243f0
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-syntax-logical-assignment-operators@npm:^7.8.3":
+  version: 7.10.4
+  resolution: "@babel/plugin-syntax-logical-assignment-operators@npm:7.10.4"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.10.4"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 10/aff33577037e34e515911255cdbb1fd39efee33658aa00b8a5fd3a4b903585112d037cce1cc9e4632f0487dc554486106b79ccd5ea63a2e00df4363f6d4ff886
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-syntax-nullish-coalescing-operator@npm:^7.8.3":
+  version: 7.8.3
+  resolution: "@babel/plugin-syntax-nullish-coalescing-operator@npm:7.8.3"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.8.0"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 10/87aca4918916020d1fedba54c0e232de408df2644a425d153be368313fdde40d96088feed6c4e5ab72aac89be5d07fef2ddf329a15109c5eb65df006bf2580d1
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-syntax-numeric-separator@npm:^7.8.3":
+  version: 7.10.4
+  resolution: "@babel/plugin-syntax-numeric-separator@npm:7.10.4"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.10.4"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 10/01ec5547bd0497f76cc903ff4d6b02abc8c05f301c88d2622b6d834e33a5651aa7c7a3d80d8d57656a4588f7276eba357f6b7e006482f5b564b7a6488de493a1
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-syntax-object-rest-spread@npm:^7.8.3":
+  version: 7.8.3
+  resolution: "@babel/plugin-syntax-object-rest-spread@npm:7.8.3"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.8.0"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 10/fddcf581a57f77e80eb6b981b10658421bc321ba5f0a5b754118c6a92a5448f12a0c336f77b8abf734841e102e5126d69110a306eadb03ca3e1547cab31f5cbf
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-syntax-optional-catch-binding@npm:^7.8.3":
+  version: 7.8.3
+  resolution: "@babel/plugin-syntax-optional-catch-binding@npm:7.8.3"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.8.0"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 10/910d90e72bc90ea1ce698e89c1027fed8845212d5ab588e35ef91f13b93143845f94e2539d831dc8d8ededc14ec02f04f7bd6a8179edd43a326c784e7ed7f0b9
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-syntax-optional-chaining@npm:^7.8.3":
+  version: 7.8.3
+  resolution: "@babel/plugin-syntax-optional-chaining@npm:7.8.3"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.8.0"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 10/eef94d53a1453361553c1f98b68d17782861a04a392840341bc91780838dd4e695209c783631cf0de14c635758beafb6a3a65399846ffa4386bff90639347f30
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-syntax-top-level-await@npm:^7.8.3":
+  version: 7.14.5
+  resolution: "@babel/plugin-syntax-top-level-await@npm:7.14.5"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.14.5"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 10/bbd1a56b095be7820029b209677b194db9b1d26691fe999856462e66b25b281f031f3dfd91b1619e9dcf95bebe336211833b854d0fb8780d618e35667c2d0d7e
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-syntax-typescript@npm:^7.7.2":
+  version: 7.24.1
+  resolution: "@babel/plugin-syntax-typescript@npm:7.24.1"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.24.0"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 10/bf4bd70788d5456b5f75572e47a2e31435c7c4e43609bd4dffd2cc0c7a6cf90aabcf6cd389e351854de9a64412a07d30effef5373251fe8f6a4c9db0c0163bda
+  languageName: node
+  linkType: hard
+
+"@babel/template@npm:^7.22.15, @babel/template@npm:^7.24.0, @babel/template@npm:^7.3.3":
+  version: 7.24.0
+  resolution: "@babel/template@npm:7.24.0"
+  dependencies:
+    "@babel/code-frame": "npm:^7.23.5"
+    "@babel/parser": "npm:^7.24.0"
+    "@babel/types": "npm:^7.24.0"
+  checksum: 10/8c538338c7de8fac8ada691a5a812bdcbd60bd4a4eb5adae2cc9ee19773e8fb1a724312a00af9e1ce49056ffd3c3475e7287b5668cf6360bfb3f8ac827a06ffe
+  languageName: node
+  linkType: hard
+
+"@babel/traverse@npm:^7.24.5":
+  version: 7.24.5
+  resolution: "@babel/traverse@npm:7.24.5"
+  dependencies:
+    "@babel/code-frame": "npm:^7.24.2"
+    "@babel/generator": "npm:^7.24.5"
+    "@babel/helper-environment-visitor": "npm:^7.22.20"
+    "@babel/helper-function-name": "npm:^7.23.0"
+    "@babel/helper-hoist-variables": "npm:^7.22.5"
+    "@babel/helper-split-export-declaration": "npm:^7.24.5"
+    "@babel/parser": "npm:^7.24.5"
+    "@babel/types": "npm:^7.24.5"
+    debug: "npm:^4.3.1"
+    globals: "npm:^11.1.0"
+  checksum: 10/e237de56e0c30795293fdb6f2cb09a75e6230836e3dc67dc4fa21781eb4d5842996bf3af95bc57ac5c7e6e97d06446f14732d0952eb57d5d9643de7c4f95bee6
+  languageName: node
+  linkType: hard
+
+"@babel/types@npm:^7.0.0, @babel/types@npm:^7.20.7, @babel/types@npm:^7.22.5, @babel/types@npm:^7.23.0, @babel/types@npm:^7.24.0, @babel/types@npm:^7.24.5, @babel/types@npm:^7.3.3, @babel/types@npm:^7.8.3":
+  version: 7.24.5
+  resolution: "@babel/types@npm:7.24.5"
+  dependencies:
+    "@babel/helper-string-parser": "npm:^7.24.1"
+    "@babel/helper-validator-identifier": "npm:^7.24.5"
+    to-fast-properties: "npm:^2.0.0"
+  checksum: 10/259e7512476ae64830e73f2addf143159232bcbf0eba6a6a27cab25a960cd353a11c826eb54185fdf7d8d9865922cbcd6522149e9ec55b967131193f9c9111a1
+  languageName: node
+  linkType: hard
+
+"@bcoe/v8-coverage@npm:^0.2.3":
+  version: 0.2.3
+  resolution: "@bcoe/v8-coverage@npm:0.2.3"
+  checksum: 10/1a1f0e356a3bb30b5f1ced6f79c413e6ebacf130421f15fac5fcd8be5ddf98aedb4404d7f5624e3285b700e041f9ef938321f3ca4d359d5b716f96afa120d88d
+  languageName: node
+  linkType: hard
+
+"@hutson/parse-repository-url@npm:^3.0.0":
+  version: 3.0.2
+  resolution: "@hutson/parse-repository-url@npm:3.0.2"
+  checksum: 10/dae0656f2e77315a3027ab9ca438ed344bf78a5fda7b145f65a1fface20dfb17e94e1d31e146c8b76de4657c21020aabc72dc53b53941c9f5fe2c27416559283
+  languageName: node
+  linkType: hard
+
+"@isaacs/cliui@npm:^8.0.2":
+  version: 8.0.2
+  resolution: "@isaacs/cliui@npm:8.0.2"
+  dependencies:
+    string-width: "npm:^5.1.2"
+    string-width-cjs: "npm:string-width@^4.2.0"
+    strip-ansi: "npm:^7.0.1"
+    strip-ansi-cjs: "npm:strip-ansi@^6.0.1"
+    wrap-ansi: "npm:^8.1.0"
+    wrap-ansi-cjs: "npm:wrap-ansi@^7.0.0"
+  checksum: 10/e9ed5fd27c3aec1095e3a16e0c0cf148d1fee55a38665c35f7b3f86a9b5d00d042ddaabc98e8a1cb7463b9378c15f22a94eb35e99469c201453eb8375191f243
+  languageName: node
+  linkType: hard
+
+"@istanbuljs/load-nyc-config@npm:^1.0.0":
+  version: 1.1.0
+  resolution: "@istanbuljs/load-nyc-config@npm:1.1.0"
+  dependencies:
+    camelcase: "npm:^5.3.1"
+    find-up: "npm:^4.1.0"
+    get-package-type: "npm:^0.1.0"
+    js-yaml: "npm:^3.13.1"
+    resolve-from: "npm:^5.0.0"
+  checksum: 10/b000a5acd8d4fe6e34e25c399c8bdbb5d3a202b4e10416e17bfc25e12bab90bb56d33db6089ae30569b52686f4b35ff28ef26e88e21e69821d2b85884bd055b8
+  languageName: node
+  linkType: hard
+
+"@istanbuljs/schema@npm:^0.1.2, @istanbuljs/schema@npm:^0.1.3":
+  version: 0.1.3
+  resolution: "@istanbuljs/schema@npm:0.1.3"
+  checksum: 10/a9b1e49acdf5efc2f5b2359f2df7f90c5c725f2656f16099e8b2cd3a000619ecca9fc48cf693ba789cf0fd989f6e0df6a22bc05574be4223ecdbb7997d04384b
+  languageName: node
+  linkType: hard
+
+"@jest/console@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "@jest/console@npm:29.7.0"
+  dependencies:
+    "@jest/types": "npm:^29.6.3"
+    "@types/node": "npm:*"
+    chalk: "npm:^4.0.0"
+    jest-message-util: "npm:^29.7.0"
+    jest-util: "npm:^29.7.0"
+    slash: "npm:^3.0.0"
+  checksum: 10/4a80c750e8a31f344233cb9951dee9b77bf6b89377cb131f8b3cde07ff218f504370133a5963f6a786af4d2ce7f85642db206ff7a15f99fe58df4c38ac04899e
+  languageName: node
+  linkType: hard
+
+"@jest/core@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "@jest/core@npm:29.7.0"
+  dependencies:
+    "@jest/console": "npm:^29.7.0"
+    "@jest/reporters": "npm:^29.7.0"
+    "@jest/test-result": "npm:^29.7.0"
+    "@jest/transform": "npm:^29.7.0"
+    "@jest/types": "npm:^29.6.3"
+    "@types/node": "npm:*"
+    ansi-escapes: "npm:^4.2.1"
+    chalk: "npm:^4.0.0"
+    ci-info: "npm:^3.2.0"
+    exit: "npm:^0.1.2"
+    graceful-fs: "npm:^4.2.9"
+    jest-changed-files: "npm:^29.7.0"
+    jest-config: "npm:^29.7.0"
+    jest-haste-map: "npm:^29.7.0"
+    jest-message-util: "npm:^29.7.0"
+    jest-regex-util: "npm:^29.6.3"
+    jest-resolve: "npm:^29.7.0"
+    jest-resolve-dependencies: "npm:^29.7.0"
+    jest-runner: "npm:^29.7.0"
+    jest-runtime: "npm:^29.7.0"
+    jest-snapshot: "npm:^29.7.0"
+    jest-util: "npm:^29.7.0"
+    jest-validate: "npm:^29.7.0"
+    jest-watcher: "npm:^29.7.0"
+    micromatch: "npm:^4.0.4"
+    pretty-format: "npm:^29.7.0"
+    slash: "npm:^3.0.0"
+    strip-ansi: "npm:^6.0.0"
+  peerDependencies:
+    node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+  peerDependenciesMeta:
+    node-notifier:
+      optional: true
+  checksum: 10/ab6ac2e562d083faac7d8152ec1cc4eccc80f62e9579b69ed40aedf7211a6b2d57024a6cd53c4e35fd051c39a236e86257d1d99ebdb122291969a0a04563b51e
+  languageName: node
+  linkType: hard
+
+"@jest/environment@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "@jest/environment@npm:29.7.0"
+  dependencies:
+    "@jest/fake-timers": "npm:^29.7.0"
+    "@jest/types": "npm:^29.6.3"
+    "@types/node": "npm:*"
+    jest-mock: "npm:^29.7.0"
+  checksum: 10/90b5844a9a9d8097f2cf107b1b5e57007c552f64315da8c1f51217eeb0a9664889d3f145cdf8acf23a84f4d8309a6675e27d5b059659a004db0ea9546d1c81a8
+  languageName: node
+  linkType: hard
+
+"@jest/expect-utils@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "@jest/expect-utils@npm:29.7.0"
+  dependencies:
+    jest-get-type: "npm:^29.6.3"
+  checksum: 10/ef8d379778ef574a17bde2801a6f4469f8022a46a5f9e385191dc73bb1fc318996beaed4513fbd7055c2847227a1bed2469977821866534593a6e52a281499ee
+  languageName: node
+  linkType: hard
+
+"@jest/expect@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "@jest/expect@npm:29.7.0"
+  dependencies:
+    expect: "npm:^29.7.0"
+    jest-snapshot: "npm:^29.7.0"
+  checksum: 10/fea6c3317a8da5c840429d90bfe49d928e89c9e89fceee2149b93a11b7e9c73d2f6e4d7cdf647163da938fc4e2169e4490be6bae64952902bc7a701033fd4880
+  languageName: node
+  linkType: hard
+
+"@jest/fake-timers@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "@jest/fake-timers@npm:29.7.0"
+  dependencies:
+    "@jest/types": "npm:^29.6.3"
+    "@sinonjs/fake-timers": "npm:^10.0.2"
+    "@types/node": "npm:*"
+    jest-message-util: "npm:^29.7.0"
+    jest-mock: "npm:^29.7.0"
+    jest-util: "npm:^29.7.0"
+  checksum: 10/9b394e04ffc46f91725ecfdff34c4e043eb7a16e1d78964094c9db3fde0b1c8803e45943a980e8c740d0a3d45661906de1416ca5891a538b0660481a3a828c27
+  languageName: node
+  linkType: hard
+
+"@jest/globals@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "@jest/globals@npm:29.7.0"
+  dependencies:
+    "@jest/environment": "npm:^29.7.0"
+    "@jest/expect": "npm:^29.7.0"
+    "@jest/types": "npm:^29.6.3"
+    jest-mock: "npm:^29.7.0"
+  checksum: 10/97dbb9459135693ad3a422e65ca1c250f03d82b2a77f6207e7fa0edd2c9d2015fbe4346f3dc9ebff1678b9d8da74754d4d440b7837497f8927059c0642a22123
+  languageName: node
+  linkType: hard
+
+"@jest/reporters@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "@jest/reporters@npm:29.7.0"
+  dependencies:
+    "@bcoe/v8-coverage": "npm:^0.2.3"
+    "@jest/console": "npm:^29.7.0"
+    "@jest/test-result": "npm:^29.7.0"
+    "@jest/transform": "npm:^29.7.0"
+    "@jest/types": "npm:^29.6.3"
+    "@jridgewell/trace-mapping": "npm:^0.3.18"
+    "@types/node": "npm:*"
+    chalk: "npm:^4.0.0"
+    collect-v8-coverage: "npm:^1.0.0"
+    exit: "npm:^0.1.2"
+    glob: "npm:^7.1.3"
+    graceful-fs: "npm:^4.2.9"
+    istanbul-lib-coverage: "npm:^3.0.0"
+    istanbul-lib-instrument: "npm:^6.0.0"
+    istanbul-lib-report: "npm:^3.0.0"
+    istanbul-lib-source-maps: "npm:^4.0.0"
+    istanbul-reports: "npm:^3.1.3"
+    jest-message-util: "npm:^29.7.0"
+    jest-util: "npm:^29.7.0"
+    jest-worker: "npm:^29.7.0"
+    slash: "npm:^3.0.0"
+    string-length: "npm:^4.0.1"
+    strip-ansi: "npm:^6.0.0"
+    v8-to-istanbul: "npm:^9.0.1"
+  peerDependencies:
+    node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+  peerDependenciesMeta:
+    node-notifier:
+      optional: true
+  checksum: 10/a17d1644b26dea14445cedd45567f4ba7834f980be2ef74447204e14238f121b50d8b858fde648083d2cd8f305f81ba434ba49e37a5f4237a6f2a61180cc73dc
+  languageName: node
+  linkType: hard
+
+"@jest/schemas@npm:^29.6.3":
+  version: 29.6.3
+  resolution: "@jest/schemas@npm:29.6.3"
+  dependencies:
+    "@sinclair/typebox": "npm:^0.27.8"
+  checksum: 10/910040425f0fc93cd13e68c750b7885590b8839066dfa0cd78e7def07bbb708ad869381f725945d66f2284de5663bbecf63e8fdd856e2ae6e261ba30b1687e93
+  languageName: node
+  linkType: hard
+
+"@jest/source-map@npm:^29.6.3":
+  version: 29.6.3
+  resolution: "@jest/source-map@npm:29.6.3"
+  dependencies:
+    "@jridgewell/trace-mapping": "npm:^0.3.18"
+    callsites: "npm:^3.0.0"
+    graceful-fs: "npm:^4.2.9"
+  checksum: 10/bcc5a8697d471396c0003b0bfa09722c3cd879ad697eb9c431e6164e2ea7008238a01a07193dfe3cbb48b1d258eb7251f6efcea36f64e1ebc464ea3c03ae2deb
+  languageName: node
+  linkType: hard
+
+"@jest/test-result@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "@jest/test-result@npm:29.7.0"
+  dependencies:
+    "@jest/console": "npm:^29.7.0"
+    "@jest/types": "npm:^29.6.3"
+    "@types/istanbul-lib-coverage": "npm:^2.0.0"
+    collect-v8-coverage: "npm:^1.0.0"
+  checksum: 10/c073ab7dfe3c562bff2b8fee6cc724ccc20aa96bcd8ab48ccb2aa309b4c0c1923a9e703cea386bd6ae9b71133e92810475bb9c7c22328fc63f797ad3324ed189
+  languageName: node
+  linkType: hard
+
+"@jest/test-sequencer@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "@jest/test-sequencer@npm:29.7.0"
+  dependencies:
+    "@jest/test-result": "npm:^29.7.0"
+    graceful-fs: "npm:^4.2.9"
+    jest-haste-map: "npm:^29.7.0"
+    slash: "npm:^3.0.0"
+  checksum: 10/4420c26a0baa7035c5419b0892ff8ffe9a41b1583ec54a10db3037cd46a7e29dd3d7202f8aa9d376e9e53be5f8b1bc0d16e1de6880a6d319b033b01dc4c8f639
+  languageName: node
+  linkType: hard
+
+"@jest/transform@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "@jest/transform@npm:29.7.0"
+  dependencies:
+    "@babel/core": "npm:^7.11.6"
+    "@jest/types": "npm:^29.6.3"
+    "@jridgewell/trace-mapping": "npm:^0.3.18"
+    babel-plugin-istanbul: "npm:^6.1.1"
+    chalk: "npm:^4.0.0"
+    convert-source-map: "npm:^2.0.0"
+    fast-json-stable-stringify: "npm:^2.1.0"
+    graceful-fs: "npm:^4.2.9"
+    jest-haste-map: "npm:^29.7.0"
+    jest-regex-util: "npm:^29.6.3"
+    jest-util: "npm:^29.7.0"
+    micromatch: "npm:^4.0.4"
+    pirates: "npm:^4.0.4"
+    slash: "npm:^3.0.0"
+    write-file-atomic: "npm:^4.0.2"
+  checksum: 10/30f42293545ab037d5799c81d3e12515790bb58513d37f788ce32d53326d0d72ebf5b40f989e6896739aa50a5f77be44686e510966370d58511d5ad2637c68c1
+  languageName: node
+  linkType: hard
+
+"@jest/types@npm:^29.6.3":
+  version: 29.6.3
+  resolution: "@jest/types@npm:29.6.3"
+  dependencies:
+    "@jest/schemas": "npm:^29.6.3"
+    "@types/istanbul-lib-coverage": "npm:^2.0.0"
+    "@types/istanbul-reports": "npm:^3.0.0"
+    "@types/node": "npm:*"
+    "@types/yargs": "npm:^17.0.8"
+    chalk: "npm:^4.0.0"
+  checksum: 10/f74bf512fd09bbe2433a2ad460b04668b7075235eea9a0c77d6a42222c10a79b9747dc2b2a623f140ed40d6865a2ed8f538f3cbb75169120ea863f29a7ed76cd
+  languageName: node
+  linkType: hard
+
+"@jridgewell/gen-mapping@npm:^0.3.5":
+  version: 0.3.5
+  resolution: "@jridgewell/gen-mapping@npm:0.3.5"
+  dependencies:
+    "@jridgewell/set-array": "npm:^1.2.1"
+    "@jridgewell/sourcemap-codec": "npm:^1.4.10"
+    "@jridgewell/trace-mapping": "npm:^0.3.24"
+  checksum: 10/81587b3c4dd8e6c60252122937cea0c637486311f4ed208b52b62aae2e7a87598f63ec330e6cd0984af494bfb16d3f0d60d3b21d7e5b4aedd2602ff3fe9d32e2
+  languageName: node
+  linkType: hard
+
+"@jridgewell/resolve-uri@npm:^3.1.0":
+  version: 3.1.2
+  resolution: "@jridgewell/resolve-uri@npm:3.1.2"
+  checksum: 10/97106439d750a409c22c8bff822d648f6a71f3aa9bc8e5129efdc36343cd3096ddc4eeb1c62d2fe48e9bdd4db37b05d4646a17114ecebd3bbcacfa2de51c3c1d
+  languageName: node
+  linkType: hard
+
+"@jridgewell/set-array@npm:^1.2.1":
+  version: 1.2.1
+  resolution: "@jridgewell/set-array@npm:1.2.1"
+  checksum: 10/832e513a85a588f8ed4f27d1279420d8547743cc37fcad5a5a76fc74bb895b013dfe614d0eed9cb860048e6546b798f8f2652020b4b2ba0561b05caa8c654b10
+  languageName: node
+  linkType: hard
+
+"@jridgewell/sourcemap-codec@npm:^1.4.10, @jridgewell/sourcemap-codec@npm:^1.4.14":
+  version: 1.4.15
+  resolution: "@jridgewell/sourcemap-codec@npm:1.4.15"
+  checksum: 10/89960ac087781b961ad918978975bcdf2051cd1741880469783c42de64239703eab9db5230d776d8e6a09d73bb5e4cb964e07d93ee6e2e7aea5a7d726e865c09
+  languageName: node
+  linkType: hard
+
+"@jridgewell/trace-mapping@npm:^0.3.12, @jridgewell/trace-mapping@npm:^0.3.18, @jridgewell/trace-mapping@npm:^0.3.24, @jridgewell/trace-mapping@npm:^0.3.25":
+  version: 0.3.25
+  resolution: "@jridgewell/trace-mapping@npm:0.3.25"
+  dependencies:
+    "@jridgewell/resolve-uri": "npm:^3.1.0"
+    "@jridgewell/sourcemap-codec": "npm:^1.4.14"
+  checksum: 10/dced32160a44b49d531b80a4a2159dceab6b3ddf0c8e95a0deae4b0e894b172defa63d5ac52a19c2068e1fe7d31ea4ba931fbeec103233ecb4208953967120fc
+  languageName: node
+  linkType: hard
+
+"@lerna/create@npm:8.1.3":
+  version: 8.1.3
+  resolution: "@lerna/create@npm:8.1.3"
+  dependencies:
+    "@npmcli/run-script": "npm:7.0.2"
+    "@nx/devkit": "npm:>=17.1.2 < 20"
+    "@octokit/plugin-enterprise-rest": "npm:6.0.1"
+    "@octokit/rest": "npm:19.0.11"
+    byte-size: "npm:8.1.1"
+    chalk: "npm:4.1.0"
+    clone-deep: "npm:4.0.1"
+    cmd-shim: "npm:6.0.1"
+    columnify: "npm:1.6.0"
+    conventional-changelog-core: "npm:5.0.1"
+    conventional-recommended-bump: "npm:7.0.1"
+    cosmiconfig: "npm:^8.2.0"
+    dedent: "npm:0.7.0"
+    execa: "npm:5.0.0"
+    fs-extra: "npm:^11.1.1"
+    get-stream: "npm:6.0.0"
+    git-url-parse: "npm:13.1.0"
+    glob-parent: "npm:5.1.2"
+    globby: "npm:11.1.0"
+    graceful-fs: "npm:4.2.11"
+    has-unicode: "npm:2.0.1"
+    ini: "npm:^1.3.8"
+    init-package-json: "npm:5.0.0"
+    inquirer: "npm:^8.2.4"
+    is-ci: "npm:3.0.1"
+    is-stream: "npm:2.0.0"
+    js-yaml: "npm:4.1.0"
+    libnpmpublish: "npm:7.3.0"
+    load-json-file: "npm:6.2.0"
+    lodash: "npm:^4.17.21"
+    make-dir: "npm:4.0.0"
+    minimatch: "npm:3.0.5"
+    multimatch: "npm:5.0.0"
+    node-fetch: "npm:2.6.7"
+    npm-package-arg: "npm:8.1.1"
+    npm-packlist: "npm:5.1.1"
+    npm-registry-fetch: "npm:^14.0.5"
+    npmlog: "npm:^6.0.2"
+    nx: "npm:>=17.1.2 < 20"
+    p-map: "npm:4.0.0"
+    p-map-series: "npm:2.1.0"
+    p-queue: "npm:6.6.2"
+    p-reduce: "npm:^2.1.0"
+    pacote: "npm:^17.0.5"
+    pify: "npm:5.0.0"
+    read-cmd-shim: "npm:4.0.0"
+    read-package-json: "npm:6.0.4"
+    resolve-from: "npm:5.0.0"
+    rimraf: "npm:^4.4.1"
+    semver: "npm:^7.3.4"
+    signal-exit: "npm:3.0.7"
+    slash: "npm:^3.0.0"
+    ssri: "npm:^9.0.1"
+    strong-log-transformer: "npm:2.1.0"
+    tar: "npm:6.2.1"
+    temp-dir: "npm:1.0.0"
+    upath: "npm:2.0.1"
+    uuid: "npm:^9.0.0"
+    validate-npm-package-license: "npm:^3.0.4"
+    validate-npm-package-name: "npm:5.0.0"
+    write-file-atomic: "npm:5.0.1"
+    write-pkg: "npm:4.0.0"
+    yargs: "npm:17.7.2"
+    yargs-parser: "npm:21.1.1"
+  checksum: 10/52cc1ce736bd1a30ee7f6c24ded1dbf26fe369927fa1e3923d4b829808249e0e018a9f204d1d69c36352b69b973ab2f5e6fad696aee4c62cfa4ecbe443e91a9a
+  languageName: node
+  linkType: hard
+
+"@next/env@npm:14.2.3":
+  version: 14.2.3
+  resolution: "@next/env@npm:14.2.3"
+  checksum: 10/82b445331d46b4896dc86c0e33a7eaaa6f6abfd2408d49e1cb90fbfd6b26c698ea8e69c911ffe597e30fd8294db4e3445cde44b0771eabbfcd13663a9832a397
+  languageName: node
+  linkType: hard
+
+"@next/swc-darwin-arm64@npm:14.2.3":
+  version: 14.2.3
+  resolution: "@next/swc-darwin-arm64@npm:14.2.3"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@next/swc-darwin-x64@npm:14.2.3":
+  version: 14.2.3
+  resolution: "@next/swc-darwin-x64@npm:14.2.3"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@next/swc-linux-arm64-gnu@npm:14.2.3":
+  version: 14.2.3
+  resolution: "@next/swc-linux-arm64-gnu@npm:14.2.3"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@next/swc-linux-arm64-musl@npm:14.2.3":
+  version: 14.2.3
+  resolution: "@next/swc-linux-arm64-musl@npm:14.2.3"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@next/swc-linux-x64-gnu@npm:14.2.3":
+  version: 14.2.3
+  resolution: "@next/swc-linux-x64-gnu@npm:14.2.3"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@next/swc-linux-x64-musl@npm:14.2.3":
+  version: 14.2.3
+  resolution: "@next/swc-linux-x64-musl@npm:14.2.3"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@next/swc-win32-arm64-msvc@npm:14.2.3":
+  version: 14.2.3
+  resolution: "@next/swc-win32-arm64-msvc@npm:14.2.3"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@next/swc-win32-ia32-msvc@npm:14.2.3":
+  version: 14.2.3
+  resolution: "@next/swc-win32-ia32-msvc@npm:14.2.3"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@next/swc-win32-x64-msvc@npm:14.2.3":
+  version: 14.2.3
+  resolution: "@next/swc-win32-x64-msvc@npm:14.2.3"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@nodelib/fs.scandir@npm:2.1.5":
+  version: 2.1.5
+  resolution: "@nodelib/fs.scandir@npm:2.1.5"
+  dependencies:
+    "@nodelib/fs.stat": "npm:2.0.5"
+    run-parallel: "npm:^1.1.9"
+  checksum: 10/6ab2a9b8a1d67b067922c36f259e3b3dfd6b97b219c540877a4944549a4d49ea5ceba5663905ab5289682f1f3c15ff441d02f0447f620a42e1cb5e1937174d4b
+  languageName: node
+  linkType: hard
+
+"@nodelib/fs.stat@npm:2.0.5, @nodelib/fs.stat@npm:^2.0.2":
+  version: 2.0.5
+  resolution: "@nodelib/fs.stat@npm:2.0.5"
+  checksum: 10/012480b5ca9d97bff9261571dbbec7bbc6033f69cc92908bc1ecfad0792361a5a1994bc48674b9ef76419d056a03efadfce5a6cf6dbc0a36559571a7a483f6f0
+  languageName: node
+  linkType: hard
+
+"@nodelib/fs.walk@npm:^1.2.3":
+  version: 1.2.8
+  resolution: "@nodelib/fs.walk@npm:1.2.8"
+  dependencies:
+    "@nodelib/fs.scandir": "npm:2.1.5"
+    fastq: "npm:^1.6.0"
+  checksum: 10/40033e33e96e97d77fba5a238e4bba4487b8284678906a9f616b5579ddaf868a18874c0054a75402c9fbaaa033a25ceae093af58c9c30278e35c23c9479e79b0
+  languageName: node
+  linkType: hard
+
+"@npmcli/agent@npm:^2.0.0":
+  version: 2.2.2
+  resolution: "@npmcli/agent@npm:2.2.2"
+  dependencies:
+    agent-base: "npm:^7.1.0"
+    http-proxy-agent: "npm:^7.0.0"
+    https-proxy-agent: "npm:^7.0.1"
+    lru-cache: "npm:^10.0.1"
+    socks-proxy-agent: "npm:^8.0.3"
+  checksum: 10/96fc0036b101bae5032dc2a4cd832efb815ce9b33f9ee2f29909ee49d96a0026b3565f73c507a69eb8603f5cb32e0ae45a70cab1e2655990a4e06ae99f7f572a
+  languageName: node
+  linkType: hard
+
+"@npmcli/fs@npm:^3.1.0":
+  version: 3.1.1
+  resolution: "@npmcli/fs@npm:3.1.1"
+  dependencies:
+    semver: "npm:^7.3.5"
+  checksum: 10/1e0e04087049b24b38bc0b30d87a9388ee3ca1d3fdfc347c2f77d84fcfe6a51f250bc57ba2c1f614d7e4285c6c62bf8c769bc19aa0949ea39e5b043ee023b0bd
+  languageName: node
+  linkType: hard
+
+"@npmcli/git@npm:^5.0.0":
+  version: 5.0.7
+  resolution: "@npmcli/git@npm:5.0.7"
+  dependencies:
+    "@npmcli/promise-spawn": "npm:^7.0.0"
+    lru-cache: "npm:^10.0.1"
+    npm-pick-manifest: "npm:^9.0.0"
+    proc-log: "npm:^4.0.0"
+    promise-inflight: "npm:^1.0.1"
+    promise-retry: "npm:^2.0.1"
+    semver: "npm:^7.3.5"
+    which: "npm:^4.0.0"
+  checksum: 10/73b48213109cc3943e977054d3747ec84ba5f2b809df8899242d27d4f574752f9151330996f632e76a546b0e6d13e25a4a70465b8a34c38a38ca4148024a5ceb
+  languageName: node
+  linkType: hard
+
+"@npmcli/installed-package-contents@npm:^2.0.1":
+  version: 2.1.0
+  resolution: "@npmcli/installed-package-contents@npm:2.1.0"
+  dependencies:
+    npm-bundled: "npm:^3.0.0"
+    npm-normalize-package-bin: "npm:^3.0.0"
+  bin:
+    installed-package-contents: bin/index.js
+  checksum: 10/68ab3ea2994f5ea21c61940de94ec4f2755fe569ef0b86e22db0695d651a3c88915c5eab61d634cfa203b9c801ee307c8aa134c2c4bd2e4fe1aa8d295ce8a163
+  languageName: node
+  linkType: hard
+
+"@npmcli/node-gyp@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@npmcli/node-gyp@npm:3.0.0"
+  checksum: 10/dd9fed3e80df8fbb20443f28651a8ed7235f2c15286ecc010e2d3cd392c85912e59ef29218c0b02f098defb4cbc8cdf045aab1d32d5cef6ace289913196ed5df
+  languageName: node
+  linkType: hard
+
+"@npmcli/package-json@npm:^5.0.0":
+  version: 5.1.0
+  resolution: "@npmcli/package-json@npm:5.1.0"
+  dependencies:
+    "@npmcli/git": "npm:^5.0.0"
+    glob: "npm:^10.2.2"
+    hosted-git-info: "npm:^7.0.0"
+    json-parse-even-better-errors: "npm:^3.0.0"
+    normalize-package-data: "npm:^6.0.0"
+    proc-log: "npm:^4.0.0"
+    semver: "npm:^7.5.3"
+  checksum: 10/0e5cb5eff32cf80234525160a702c91a38e4b98ab74e34e2632b43c4350dbad170bd835989cc7d6e18d24798e3242e45b60f3d5e26bd128fe1c4529931105f8e
+  languageName: node
+  linkType: hard
+
+"@npmcli/promise-spawn@npm:^7.0.0":
+  version: 7.0.2
+  resolution: "@npmcli/promise-spawn@npm:7.0.2"
+  dependencies:
+    which: "npm:^4.0.0"
+  checksum: 10/94cbbbeeb20342026c3b68fc8eb09e1600b7645d4e509f2588ef5ea7cff977eb01e628cc8e014595d04a6af4b4bc5c467c950a8135920f39f7c7b57fba43f4e9
+  languageName: node
+  linkType: hard
+
+"@npmcli/redact@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@npmcli/redact@npm:1.1.0"
+  checksum: 10/c6c81c2d1463bc9f30d40f983a3dbb3144503030ff455e5a8904ff82ca39b95e46e9830fa4413f17f9a77604cdbb1f2370c53dd0ba4841cf24b79843e1fcf825
+  languageName: node
+  linkType: hard
+
+"@npmcli/run-script@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@npmcli/run-script@npm:7.0.2"
+  dependencies:
+    "@npmcli/node-gyp": "npm:^3.0.0"
+    "@npmcli/promise-spawn": "npm:^7.0.0"
+    node-gyp: "npm:^10.0.0"
+    read-package-json-fast: "npm:^3.0.0"
+    which: "npm:^4.0.0"
+  checksum: 10/4549311f3b937ca81d147b72fbfd41aa6ed7daf70ecc4e9ee3838f9cce1749e9c62c301943a8a67364a96c31bbc67c49ee31526fb12ec2f4b15148f0ef472f98
+  languageName: node
+  linkType: hard
+
+"@npmcli/run-script@npm:^7.0.0":
+  version: 7.0.4
+  resolution: "@npmcli/run-script@npm:7.0.4"
+  dependencies:
+    "@npmcli/node-gyp": "npm:^3.0.0"
+    "@npmcli/package-json": "npm:^5.0.0"
+    "@npmcli/promise-spawn": "npm:^7.0.0"
+    node-gyp: "npm:^10.0.0"
+    which: "npm:^4.0.0"
+  checksum: 10/f09268051f74af7d7be46e9911a23126d531160c338d3c05d53e6cd7994b88271fb4ec524139fe7f2d826525f15a281eafef3be02831adc1f68556a8a668621a
+  languageName: node
+  linkType: hard
+
+"@nrwl/devkit@npm:19.0.3":
+  version: 19.0.3
+  resolution: "@nrwl/devkit@npm:19.0.3"
+  dependencies:
+    "@nx/devkit": "npm:19.0.3"
+  checksum: 10/3ad69accaed7f35951ffad62e71c56869bbd66bc7c42828cfd4adfe46297c318857176045d3dd8ad0b61eaa1ea7acd62d5762485f6898c7d960a0a0b893b829b
+  languageName: node
+  linkType: hard
+
+"@nrwl/tao@npm:19.0.3":
+  version: 19.0.3
+  resolution: "@nrwl/tao@npm:19.0.3"
+  dependencies:
+    nx: "npm:19.0.3"
+    tslib: "npm:^2.3.0"
+  bin:
+    tao: index.js
+  checksum: 10/419f2a990119e3e12804557da0dbe701fcbe219d1ad6b0477e980ead251cd42e0fa5dd75b4ed4a0a74bc7a7c99a1ca4e56e07c2b565a7d561cf6d6b004d69998
+  languageName: node
+  linkType: hard
+
+"@nx/devkit@npm:19.0.3, @nx/devkit@npm:>=17.1.2 < 20":
+  version: 19.0.3
+  resolution: "@nx/devkit@npm:19.0.3"
+  dependencies:
+    "@nrwl/devkit": "npm:19.0.3"
+    ejs: "npm:^3.1.7"
+    enquirer: "npm:~2.3.6"
+    ignore: "npm:^5.0.4"
+    minimatch: "npm:9.0.3"
+    semver: "npm:^7.5.3"
+    tmp: "npm:~0.2.1"
+    tslib: "npm:^2.3.0"
+    yargs-parser: "npm:21.1.1"
+  peerDependencies:
+    nx: ">= 17 <= 20"
+  checksum: 10/7a725d18c3fd951d7a509d338abd505cd27a6abb9b4b589f0c3c3fb70f6ef208238601f116c41b04930cf1566b0b06996f72141fe85ea215ccd0aedf4568c2b2
+  languageName: node
+  linkType: hard
+
+"@nx/nx-darwin-arm64@npm:19.0.3":
+  version: 19.0.3
+  resolution: "@nx/nx-darwin-arm64@npm:19.0.3"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@nx/nx-darwin-x64@npm:19.0.3":
+  version: 19.0.3
+  resolution: "@nx/nx-darwin-x64@npm:19.0.3"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@nx/nx-freebsd-x64@npm:19.0.3":
+  version: 19.0.3
+  resolution: "@nx/nx-freebsd-x64@npm:19.0.3"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@nx/nx-linux-arm-gnueabihf@npm:19.0.3":
+  version: 19.0.3
+  resolution: "@nx/nx-linux-arm-gnueabihf@npm:19.0.3"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@nx/nx-linux-arm64-gnu@npm:19.0.3":
+  version: 19.0.3
+  resolution: "@nx/nx-linux-arm64-gnu@npm:19.0.3"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@nx/nx-linux-arm64-musl@npm:19.0.3":
+  version: 19.0.3
+  resolution: "@nx/nx-linux-arm64-musl@npm:19.0.3"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@nx/nx-linux-x64-gnu@npm:19.0.3":
+  version: 19.0.3
+  resolution: "@nx/nx-linux-x64-gnu@npm:19.0.3"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@nx/nx-linux-x64-musl@npm:19.0.3":
+  version: 19.0.3
+  resolution: "@nx/nx-linux-x64-musl@npm:19.0.3"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@nx/nx-win32-arm64-msvc@npm:19.0.3":
+  version: 19.0.3
+  resolution: "@nx/nx-win32-arm64-msvc@npm:19.0.3"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@nx/nx-win32-x64-msvc@npm:19.0.3":
+  version: 19.0.3
+  resolution: "@nx/nx-win32-x64-msvc@npm:19.0.3"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@octokit/auth-token@npm:^3.0.0":
+  version: 3.0.4
+  resolution: "@octokit/auth-token@npm:3.0.4"
+  checksum: 10/8e21e567e38ba307fa30497ad77801135e25c328ce8b363c1622a4afb408a7d3315d54082527b38ecd5b3a5449680d89cfca9cb10c516cacf3dfa01e4c8b7195
+  languageName: node
+  linkType: hard
+
+"@octokit/core@npm:^4.2.1":
+  version: 4.2.4
+  resolution: "@octokit/core@npm:4.2.4"
+  dependencies:
+    "@octokit/auth-token": "npm:^3.0.0"
+    "@octokit/graphql": "npm:^5.0.0"
+    "@octokit/request": "npm:^6.0.0"
+    "@octokit/request-error": "npm:^3.0.0"
+    "@octokit/types": "npm:^9.0.0"
+    before-after-hook: "npm:^2.2.0"
+    universal-user-agent: "npm:^6.0.0"
+  checksum: 10/53ba8f990ce2c0ea4583d8c142377770c3ac8fb9221b563d82dbca9d642f19be49607b9e9b472767075e4afa16c2203339680d75f3ebf5ad853af2646e8604ca
+  languageName: node
+  linkType: hard
+
+"@octokit/endpoint@npm:^7.0.0":
+  version: 7.0.6
+  resolution: "@octokit/endpoint@npm:7.0.6"
+  dependencies:
+    "@octokit/types": "npm:^9.0.0"
+    is-plain-object: "npm:^5.0.0"
+    universal-user-agent: "npm:^6.0.0"
+  checksum: 10/e8b9cc09aa8306d63cb0e5b65ac5d29fc421522c92810a9d70bbfef997bc8750fc339f1f4f60e1604c22db77457ea493c51849b0d61cbfcb8655b0c4f2640e4b
+  languageName: node
+  linkType: hard
+
+"@octokit/graphql@npm:^5.0.0":
+  version: 5.0.6
+  resolution: "@octokit/graphql@npm:5.0.6"
+  dependencies:
+    "@octokit/request": "npm:^6.0.0"
+    "@octokit/types": "npm:^9.0.0"
+    universal-user-agent: "npm:^6.0.0"
+  checksum: 10/6014690d184d7b2bfb56ab9be5ddbe4f5c77aa6031d71ec2caf5f56cbd32f4a5b0601049cef7dce1ca8010b89a9fc8bb07ce7833e6213c5bc77b7a564b1f40b9
+  languageName: node
+  linkType: hard
+
+"@octokit/openapi-types@npm:^18.0.0":
+  version: 18.1.1
+  resolution: "@octokit/openapi-types@npm:18.1.1"
+  checksum: 10/bd2920a238f74c6ccc1e2ee916bd3e17adeeef3bbb1726f821b8722dceaeff5ea2786b3170cc25dd51775cb9179d3cdf448a3526e70b8a1fc21cdd8aa52e5d4c
+  languageName: node
+  linkType: hard
+
+"@octokit/plugin-enterprise-rest@npm:6.0.1":
+  version: 6.0.1
+  resolution: "@octokit/plugin-enterprise-rest@npm:6.0.1"
+  checksum: 10/2ea8aca141a0329479cfaf9425f7bc226fe6aa0064fd6e7798b565aa962a5a757a89a03e78b956909e767aa86cd28e1346bf82908dfdf614af921d175a6a95e1
+  languageName: node
+  linkType: hard
+
+"@octokit/plugin-paginate-rest@npm:^6.1.2":
+  version: 6.1.2
+  resolution: "@octokit/plugin-paginate-rest@npm:6.1.2"
+  dependencies:
+    "@octokit/tsconfig": "npm:^1.0.2"
+    "@octokit/types": "npm:^9.2.3"
+  peerDependencies:
+    "@octokit/core": ">=4"
+  checksum: 10/6d5b97fb44a3ed8ff25196b56ebe7bdac64f4023c165792f77938c77876934c01b46e79b83712e26cd3f2f9e36e0735bd3c292a37e8060a2b259f3a6456116dc
+  languageName: node
+  linkType: hard
+
+"@octokit/plugin-request-log@npm:^1.0.4":
+  version: 1.0.4
+  resolution: "@octokit/plugin-request-log@npm:1.0.4"
+  peerDependencies:
+    "@octokit/core": ">=3"
+  checksum: 10/2086db00056aee0f8ebd79797b5b57149ae1014e757ea08985b71eec8c3d85dbb54533f4fd34b6b9ecaa760904ae6a7536be27d71e50a3782ab47809094bfc0c
+  languageName: node
+  linkType: hard
+
+"@octokit/plugin-rest-endpoint-methods@npm:^7.1.2":
+  version: 7.2.3
+  resolution: "@octokit/plugin-rest-endpoint-methods@npm:7.2.3"
+  dependencies:
+    "@octokit/types": "npm:^10.0.0"
+  peerDependencies:
+    "@octokit/core": ">=3"
+  checksum: 10/59fb4e786ab85a5f3ad701e1b193dd3113833cfd1f2657cb06864e45b80a53a1f9ba6c3c66a855c4bf2593c539299fdfe51db639e3a87dc16ffa7602fe9bb999
+  languageName: node
+  linkType: hard
+
+"@octokit/request-error@npm:^3.0.0":
+  version: 3.0.3
+  resolution: "@octokit/request-error@npm:3.0.3"
+  dependencies:
+    "@octokit/types": "npm:^9.0.0"
+    deprecation: "npm:^2.0.0"
+    once: "npm:^1.4.0"
+  checksum: 10/5db0b514732686b627e6ed9ef1ccdbc10501f1b271a9b31f784783f01beee70083d7edcfeb35fbd7e569fa31fdd6762b1ff6b46101700d2d97e7e48e749520d0
+  languageName: node
+  linkType: hard
+
+"@octokit/request@npm:^6.0.0":
+  version: 6.2.8
+  resolution: "@octokit/request@npm:6.2.8"
+  dependencies:
+    "@octokit/endpoint": "npm:^7.0.0"
+    "@octokit/request-error": "npm:^3.0.0"
+    "@octokit/types": "npm:^9.0.0"
+    is-plain-object: "npm:^5.0.0"
+    node-fetch: "npm:^2.6.7"
+    universal-user-agent: "npm:^6.0.0"
+  checksum: 10/47188fa08d28e5e9e6a22f84058fc13f108cdcb68aea97686da4718d32d3ddda8fde8a5c9f189057e3d466560b67c2305a2e343d1eed9517b47a13f68cb329e7
+  languageName: node
+  linkType: hard
+
+"@octokit/rest@npm:19.0.11":
+  version: 19.0.11
+  resolution: "@octokit/rest@npm:19.0.11"
+  dependencies:
+    "@octokit/core": "npm:^4.2.1"
+    "@octokit/plugin-paginate-rest": "npm:^6.1.2"
+    "@octokit/plugin-request-log": "npm:^1.0.4"
+    "@octokit/plugin-rest-endpoint-methods": "npm:^7.1.2"
+  checksum: 10/c9b15de6b544506c85c0297e48aa51a2aeb8f73415eef7331fc5c951c7eaa75f6fcf9d549ca5bb52a5f631553c94a70ac550ef9a3202ee765c49c04a85523d8b
+  languageName: node
+  linkType: hard
+
+"@octokit/tsconfig@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "@octokit/tsconfig@npm:1.0.2"
+  checksum: 10/74d56f3e9f326a8dd63700e9a51a7c75487180629c7a68bbafee97c612fbf57af8347369bfa6610b9268a3e8b833c19c1e4beb03f26db9a9dce31f6f7a19b5b1
+  languageName: node
+  linkType: hard
+
+"@octokit/types@npm:^10.0.0":
+  version: 10.0.0
+  resolution: "@octokit/types@npm:10.0.0"
+  dependencies:
+    "@octokit/openapi-types": "npm:^18.0.0"
+  checksum: 10/6345e605d30c99639a0207cfc7bea5bf29d9007e93cdcd78be3f8218830a462a0f0fbb976f5c2d9ebe70ee2aa33d1b72243cdb955478581ee2cead059ac4f030
+  languageName: node
+  linkType: hard
+
+"@octokit/types@npm:^9.0.0, @octokit/types@npm:^9.2.3":
+  version: 9.3.2
+  resolution: "@octokit/types@npm:9.3.2"
+  dependencies:
+    "@octokit/openapi-types": "npm:^18.0.0"
+  checksum: 10/4bcd18850d5397e5835f5686be88ad95e5d7c23e7d53f898b82a8ca5fc1f6a7b53816ef6f9f3b7a06799c0b030d259bf2bd50a258a1656df2dc7f3e533e334f8
+  languageName: node
+  linkType: hard
+
+"@pkgjs/parseargs@npm:^0.11.0":
+  version: 0.11.0
+  resolution: "@pkgjs/parseargs@npm:0.11.0"
+  checksum: 10/115e8ceeec6bc69dff2048b35c0ab4f8bbee12d8bb6c1f4af758604586d802b6e669dcb02dda61d078de42c2b4ddce41b3d9e726d7daa6b4b850f4adbf7333ff
+  languageName: node
+  linkType: hard
+
+"@sigstore/bundle@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@sigstore/bundle@npm:1.1.0"
+  dependencies:
+    "@sigstore/protobuf-specs": "npm:^0.2.0"
+  checksum: 10/79e6cc4cc1858bccbd852dee85d95c66c891b109ea415d5b7b00b6d73791c4f6064c40d09b5aa3f9ec6c19b3145c5cfeece02302f912c186ff0a769667bb9491
+  languageName: node
+  linkType: hard
+
+"@sigstore/bundle@npm:^2.3.0, @sigstore/bundle@npm:^2.3.1":
+  version: 2.3.1
+  resolution: "@sigstore/bundle@npm:2.3.1"
+  dependencies:
+    "@sigstore/protobuf-specs": "npm:^0.3.1"
+  checksum: 10/5e1024dfc57bd61068be213e2be68607a8fdd7747f56aa64bb8cdfd28fb48af1a54248a26e22c6953ab4e14d64aad9866cabea355e440ecace6147cb2da5bcbc
+  languageName: node
+  linkType: hard
+
+"@sigstore/core@npm:^1.0.0, @sigstore/core@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@sigstore/core@npm:1.1.0"
+  checksum: 10/4149572091d61c246dd2ff636ff9a31441877db78cc3afe25fd0b28ece87f0094576f8b9077d1dc7c1c959ac4b000d407595becb6cd784c3664e9dd7cb6da36a
+  languageName: node
+  linkType: hard
+
+"@sigstore/protobuf-specs@npm:^0.2.0":
+  version: 0.2.1
+  resolution: "@sigstore/protobuf-specs@npm:0.2.1"
+  checksum: 10/cb0b9d9b3ef44a9f1729d85616c5d7c2ebccde303836a5a345ec33a500c7bd5205ffcc31332e0a90831cccc581dafbdf5b868f050c84270c8df6a4a6f2ce0bcb
+  languageName: node
+  linkType: hard
+
+"@sigstore/protobuf-specs@npm:^0.3.0, @sigstore/protobuf-specs@npm:^0.3.1":
+  version: 0.3.2
+  resolution: "@sigstore/protobuf-specs@npm:0.3.2"
+  checksum: 10/350a6eb834e0f5c50987935c329350ba9df5baedba7c3db6ab6bc55d8730d9e6ff2deb31e770e721b9fef53f1cf6b32f376e28ed72c6e090493bceb820acfb4a
+  languageName: node
+  linkType: hard
+
+"@sigstore/sign@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "@sigstore/sign@npm:1.0.0"
+  dependencies:
+    "@sigstore/bundle": "npm:^1.1.0"
+    "@sigstore/protobuf-specs": "npm:^0.2.0"
+    make-fetch-happen: "npm:^11.0.1"
+  checksum: 10/44f23fc5eef5b160c0c36c6b19863039bbf375834eeca1ce7f711c82eb5a022174a475f0c06594f17732473c6878f2512f37e65949b7d33af3b2e2773f1bd34f
+  languageName: node
+  linkType: hard
+
+"@sigstore/sign@npm:^2.3.0":
+  version: 2.3.1
+  resolution: "@sigstore/sign@npm:2.3.1"
+  dependencies:
+    "@sigstore/bundle": "npm:^2.3.0"
+    "@sigstore/core": "npm:^1.0.0"
+    "@sigstore/protobuf-specs": "npm:^0.3.1"
+    make-fetch-happen: "npm:^13.0.1"
+    proc-log: "npm:^4.2.0"
+    promise-retry: "npm:^2.0.1"
+  checksum: 10/99d64bfcd06e2922c2f8baa81882ae3b014dccb7124afa9875dcad4f22a00664e66f724a2c39bb14c4a372d39fce31639d09294936032f8c9dc3e0ec03d21869
+  languageName: node
+  linkType: hard
+
+"@sigstore/tuf@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "@sigstore/tuf@npm:1.0.3"
+  dependencies:
+    "@sigstore/protobuf-specs": "npm:^0.2.0"
+    tuf-js: "npm:^1.1.7"
+  checksum: 10/5aa1cdea05fabb78232f802821f7e8ee9db3352719b325f2f703f940aac75fc2e71d89cfbd3623ef6b0429e125a5c6145c1fc8ede8d3d5af3affcb71c6453c7b
+  languageName: node
+  linkType: hard
+
+"@sigstore/tuf@npm:^2.3.1":
+  version: 2.3.3
+  resolution: "@sigstore/tuf@npm:2.3.3"
+  dependencies:
+    "@sigstore/protobuf-specs": "npm:^0.3.0"
+    tuf-js: "npm:^2.2.1"
+  checksum: 10/4d3c5aa897b9643b8832506894e65d593af72bec70819182a895cf2ba538d9873d611f07ec01de42da0c517361811b662d3f43075c26c1c10e0fed9cfac13b26
+  languageName: node
+  linkType: hard
+
+"@sigstore/verify@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "@sigstore/verify@npm:1.2.0"
+  dependencies:
+    "@sigstore/bundle": "npm:^2.3.1"
+    "@sigstore/core": "npm:^1.1.0"
+    "@sigstore/protobuf-specs": "npm:^0.3.1"
+  checksum: 10/f93728c425528120b1863f04ed2fdd55915ad0c773153e623bd4d32137067d85f2e139bd14e8779883394ae502f1fd0e2094d559eac4225d31ee617127218720
+  languageName: node
+  linkType: hard
+
+"@sinclair/typebox@npm:^0.27.8":
+  version: 0.27.8
+  resolution: "@sinclair/typebox@npm:0.27.8"
+  checksum: 10/297f95ff77c82c54de8c9907f186076e715ff2621c5222ba50b8d40a170661c0c5242c763cba2a4791f0f91cb1d8ffa53ea1d7294570cf8cd4694c0e383e484d
+  languageName: node
+  linkType: hard
+
+"@sinonjs/commons@npm:^3.0.0":
+  version: 3.0.1
+  resolution: "@sinonjs/commons@npm:3.0.1"
+  dependencies:
+    type-detect: "npm:4.0.8"
+  checksum: 10/a0af217ba7044426c78df52c23cedede6daf377586f3ac58857c565769358ab1f44ebf95ba04bbe38814fba6e316ca6f02870a009328294fc2c555d0f85a7117
+  languageName: node
+  linkType: hard
+
+"@sinonjs/fake-timers@npm:^10.0.2":
+  version: 10.3.0
+  resolution: "@sinonjs/fake-timers@npm:10.3.0"
+  dependencies:
+    "@sinonjs/commons": "npm:^3.0.0"
+  checksum: 10/78155c7bd866a85df85e22028e046b8d46cf3e840f72260954f5e3ed5bd97d66c595524305a6841ffb3f681a08f6e5cef572a2cce5442a8a232dc29fb409b83e
+  languageName: node
+  linkType: hard
+
+"@smithy/abort-controller@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/abort-controller@npm:3.0.0"
+  dependencies:
+    "@smithy/types": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/08bf21e79226c60f3654767683a767b34dd7b30d7fd73dfecd4cb13d172a7225f83f45553fd4af2692c95d38bdf2adbe5b132fac0affb4ecece6a41f066d49ba
+  languageName: node
+  linkType: hard
+
+"@smithy/chunked-blob-reader-native@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/chunked-blob-reader-native@npm:3.0.0"
+  dependencies:
+    "@smithy/util-base64": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/424aa83f4fc081625a03ec6c64e74ae38c740c0b202d0b998f2bf341b935613491b39c7bf701790a0625219424340d5cfb042b701bfdff4c1cbedc57ee3f2500
+  languageName: node
+  linkType: hard
+
+"@smithy/chunked-blob-reader@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/chunked-blob-reader@npm:3.0.0"
+  dependencies:
+    tslib: "npm:^2.6.2"
+  checksum: 10/1c7955ae693aa098dd0839d7e8f9e742ab963de4ededa92f201f1982552c35ba625c1b90cf761de81deddd5002ed10f081ad46f6e0a5150066cee8b00f3f6058
+  languageName: node
+  linkType: hard
+
+"@smithy/config-resolver@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/config-resolver@npm:3.0.0"
+  dependencies:
+    "@smithy/node-config-provider": "npm:^3.0.0"
+    "@smithy/types": "npm:^3.0.0"
+    "@smithy/util-config-provider": "npm:^3.0.0"
+    "@smithy/util-middleware": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/78d6a13cb7d8c64ffe4aff675f5fb7114355b406be307576b7f77f880769417ba8e02830dcbb0991dd933c00e9e1e6248706a60e97c98bcf302577bd79ec52e0
+  languageName: node
+  linkType: hard
+
+"@smithy/core@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "@smithy/core@npm:2.0.0"
+  dependencies:
+    "@smithy/middleware-endpoint": "npm:^3.0.0"
+    "@smithy/middleware-retry": "npm:^3.0.0"
+    "@smithy/middleware-serde": "npm:^3.0.0"
+    "@smithy/protocol-http": "npm:^4.0.0"
+    "@smithy/smithy-client": "npm:^3.0.0"
+    "@smithy/types": "npm:^3.0.0"
+    "@smithy/util-middleware": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/793c84506982e41bbf9b529d578fd0a6ec21badccabfbc1898a785e92c12446ad1ef768c6b2b6970b00b6dd273cff2b2063e259143899ef17b80d8e73bc5f0df
+  languageName: node
+  linkType: hard
+
+"@smithy/credential-provider-imds@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/credential-provider-imds@npm:3.0.0"
+  dependencies:
+    "@smithy/node-config-provider": "npm:^3.0.0"
+    "@smithy/property-provider": "npm:^3.0.0"
+    "@smithy/types": "npm:^3.0.0"
+    "@smithy/url-parser": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/793e826a6d2ea1d407a4a0329662b41bc30d2e052520af27845bbd4345f454e1974e389fce622c26b06501c7d5a3c4b3844ec99baedb27e8f89d947d2c28fee6
+  languageName: node
+  linkType: hard
+
+"@smithy/eventstream-codec@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/eventstream-codec@npm:3.0.0"
+  dependencies:
+    "@aws-crypto/crc32": "npm:3.0.0"
+    "@smithy/types": "npm:^3.0.0"
+    "@smithy/util-hex-encoding": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/66ec273253d59c78ff7967d1fcd56c2479dc5807af360773dcad3d669b75a75682f3cd3c6647bda0ecc3c42cce6ea7d6261fd109e9531b209a51b9b6e93d7c2c
+  languageName: node
+  linkType: hard
+
+"@smithy/eventstream-serde-browser@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/eventstream-serde-browser@npm:3.0.0"
+  dependencies:
+    "@smithy/eventstream-serde-universal": "npm:^3.0.0"
+    "@smithy/types": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/a04c6a5207e670ce0c5508d92a70f5372a5fca076e3a7d76e5383753622525042225fdfe8c3cc0b3ee723ce0e7b568b7d2603ed83337538d471a8817c8d4306d
+  languageName: node
+  linkType: hard
+
+"@smithy/eventstream-serde-config-resolver@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/eventstream-serde-config-resolver@npm:3.0.0"
+  dependencies:
+    "@smithy/types": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/c07f698072bc1ddec3fc54cecbe03fece2b86445e9c18183f2621c528258d120a63d3b02b7d6d92fe3e0a73d29275ce18d85a253ebbdb06973666f885586ce72
+  languageName: node
+  linkType: hard
+
+"@smithy/eventstream-serde-node@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/eventstream-serde-node@npm:3.0.0"
+  dependencies:
+    "@smithy/eventstream-serde-universal": "npm:^3.0.0"
+    "@smithy/types": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/46921fae3e47926ef31879dffc3e9743bf2b696a7d4b083c3ddfd06568a30d4fe021a70847d8c8561b9637ba01c4cdfdbd7ba3c418977096945a6cb604b041ea
+  languageName: node
+  linkType: hard
+
+"@smithy/eventstream-serde-universal@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/eventstream-serde-universal@npm:3.0.0"
+  dependencies:
+    "@smithy/eventstream-codec": "npm:^3.0.0"
+    "@smithy/types": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/6bca5785416e8674a032cffab6fd7f93e8a71ba048d300f46e9da82973750e8709c5981c6aa7de2ebe82e01d22eb1df2383b5c5093beedda5f3e600482e84559
+  languageName: node
+  linkType: hard
+
+"@smithy/fetch-http-handler@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/fetch-http-handler@npm:3.0.0"
+  dependencies:
+    "@smithy/protocol-http": "npm:^4.0.0"
+    "@smithy/querystring-builder": "npm:^3.0.0"
+    "@smithy/types": "npm:^3.0.0"
+    "@smithy/util-base64": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/357b6c5438a654477e3cbd6be72efca6c6d9414cffba7450ff5aed9d420428ba08713a5ace62053d73baecfac2c2e2b568c91ca8bab3069be68abc3139f122be
+  languageName: node
+  linkType: hard
+
+"@smithy/hash-blob-browser@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/hash-blob-browser@npm:3.0.0"
+  dependencies:
+    "@smithy/chunked-blob-reader": "npm:^3.0.0"
+    "@smithy/chunked-blob-reader-native": "npm:^3.0.0"
+    "@smithy/types": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/c8f6d76d8dae37bd48334bcd6060195d8d8f6b14d0af7d326cbd7f3dd4db648691bf755f3795e5d6b4ca9b85fbc580a4b010cce6fe9735204e8a667f145f11bb
+  languageName: node
+  linkType: hard
+
+"@smithy/hash-node@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/hash-node@npm:3.0.0"
+  dependencies:
+    "@smithy/types": "npm:^3.0.0"
+    "@smithy/util-buffer-from": "npm:^3.0.0"
+    "@smithy/util-utf8": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/99c65bc992bc3adedb68d4304845bf0acd3e55d3cd851874605a937be5dd4da4eeab01e99e971b59d43d6fb4364dab655530c3a89eb32eac0803f6d07179a63b
+  languageName: node
+  linkType: hard
+
+"@smithy/hash-stream-node@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/hash-stream-node@npm:3.0.0"
+  dependencies:
+    "@smithy/types": "npm:^3.0.0"
+    "@smithy/util-utf8": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/1e67ad794267dcbf2f5008938409b4081e43cbf302d44508f444aaa051ca167e1739418333122b9cce4b98b0815f618326e9c2d55fd5579751ad22ac7e02c9d2
+  languageName: node
+  linkType: hard
+
+"@smithy/invalid-dependency@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/invalid-dependency@npm:3.0.0"
+  dependencies:
+    "@smithy/types": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/e78e9cbe1cc8ad04be0dffbc1094eb15294d29b86389ae62c55f0afb96b7354c615fc20f34affed362f857d497e7b34e04b51e732f0b045c2870b749ecc5a2f4
+  languageName: node
+  linkType: hard
+
+"@smithy/is-array-buffer@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/is-array-buffer@npm:3.0.0"
+  dependencies:
+    tslib: "npm:^2.6.2"
+  checksum: 10/cab1fd4033d9863dcd95ff058463eb591574bd47e6b61e36aaaf4c0d0da9ed966a54e1d33ec4db7d67aa85df7d274203e934e04dbb40323d01ef4815f63997fc
+  languageName: node
+  linkType: hard
+
+"@smithy/md5-js@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/md5-js@npm:3.0.0"
+  dependencies:
+    "@smithy/types": "npm:^3.0.0"
+    "@smithy/util-utf8": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/098b849ee76c83fb33624dac8d3980a50873564de6fae4e159bac90a6aa9abe0b9fe0fce9a150e5ff438e0a8af2010c50cdc08dd2a8d02b7db2ebb89802743b9
+  languageName: node
+  linkType: hard
+
+"@smithy/middleware-content-length@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/middleware-content-length@npm:3.0.0"
+  dependencies:
+    "@smithy/protocol-http": "npm:^4.0.0"
+    "@smithy/types": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/2d1dc5766ac83604d43b75b788d4b1f61d8095c9081fe060d5bb21d69b59c4da52869d38eb4f9e13ca8001974b3bce63619f1d8bddfc553041e5b264162fdac9
+  languageName: node
+  linkType: hard
+
+"@smithy/middleware-endpoint@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/middleware-endpoint@npm:3.0.0"
+  dependencies:
+    "@smithy/middleware-serde": "npm:^3.0.0"
+    "@smithy/node-config-provider": "npm:^3.0.0"
+    "@smithy/shared-ini-file-loader": "npm:^3.0.0"
+    "@smithy/types": "npm:^3.0.0"
+    "@smithy/url-parser": "npm:^3.0.0"
+    "@smithy/util-middleware": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/b39b8a3c8ddc4295ab265ce861360a7a842c94af7fb75d81aba4a89000715e50598138f1a7da4979675738d391472189e9854d35cae10a9e994245ad69c2682f
+  languageName: node
+  linkType: hard
+
+"@smithy/middleware-retry@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/middleware-retry@npm:3.0.0"
+  dependencies:
+    "@smithy/node-config-provider": "npm:^3.0.0"
+    "@smithy/protocol-http": "npm:^4.0.0"
+    "@smithy/service-error-classification": "npm:^3.0.0"
+    "@smithy/smithy-client": "npm:^3.0.0"
+    "@smithy/types": "npm:^3.0.0"
+    "@smithy/util-middleware": "npm:^3.0.0"
+    "@smithy/util-retry": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+    uuid: "npm:^9.0.1"
+  checksum: 10/9158545d2940d77e7ddc1098c1f692041431733e9168183de35a9522af1891a8a1edf55bf549a9c43e4cb43ab544913132b81ec14ee9a7892aea3e7a260fdf1c
+  languageName: node
+  linkType: hard
+
+"@smithy/middleware-serde@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/middleware-serde@npm:3.0.0"
+  dependencies:
+    "@smithy/types": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/7ca5256fe9290b6ae097fdb9c0180e5219e6d3cb39084fadee007d9e698073498d200c32c439486902e386ab76739176765f64d23673882a08aa0e8de837dc8a
+  languageName: node
+  linkType: hard
+
+"@smithy/middleware-stack@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/middleware-stack@npm:3.0.0"
+  dependencies:
+    "@smithy/types": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/e85695b2d2d96230f03500b7111f9917abaab516e1850ec90021db7e984718965e05f7afccda084a7ba96a6bbb9d195a7d6e7882b48d7ccec97239101a2978bc
+  languageName: node
+  linkType: hard
+
+"@smithy/node-config-provider@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/node-config-provider@npm:3.0.0"
+  dependencies:
+    "@smithy/property-provider": "npm:^3.0.0"
+    "@smithy/shared-ini-file-loader": "npm:^3.0.0"
+    "@smithy/types": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/6f5326162484f27c6709796e6f11aaa1cd624cb0632a09340f2f2126c20c64dd10f9ed96400f1e65afdfa11e877f69910951ea2b36264141cc513c51461ac656
+  languageName: node
+  linkType: hard
+
+"@smithy/node-http-handler@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/node-http-handler@npm:3.0.0"
+  dependencies:
+    "@smithy/abort-controller": "npm:^3.0.0"
+    "@smithy/protocol-http": "npm:^4.0.0"
+    "@smithy/querystring-builder": "npm:^3.0.0"
+    "@smithy/types": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/3d2d0fff55ebeabeca4bb9a8b1cc7dd3a9c810281817232eb546b75cfae53da3c9571d25f203232f42cef608f28b795a1cadec3dbfd44aad2029a6141d146ecf
+  languageName: node
+  linkType: hard
+
+"@smithy/property-provider@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/property-provider@npm:3.0.0"
+  dependencies:
+    "@smithy/types": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/37c9b949f0df60240b51a4a6e60a772e4ffc5f50de7fb51c74aec4336f46ba7c424f81181487ba6c7a15b5a43f13d82f7609836e96cfc61728e1c26425a5a2b4
+  languageName: node
+  linkType: hard
+
+"@smithy/protocol-http@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "@smithy/protocol-http@npm:4.0.0"
+  dependencies:
+    "@smithy/types": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/0e663013be49ca6867e4d03d2759bae5a72653918617a0184c0f7ecf84043ebaf0f3e6a174f7f6f81934720f90bfce89cecc56510d572cd8d93f423483b74d93
+  languageName: node
+  linkType: hard
+
+"@smithy/querystring-builder@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/querystring-builder@npm:3.0.0"
+  dependencies:
+    "@smithy/types": "npm:^3.0.0"
+    "@smithy/util-uri-escape": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/bca3e4c32127f444d7d7812c6afc6cc0dadbbd52a6359f09bf4ba04d2a7f6a09395f61c981b4cf64d714e6010a93ba4a729989f869e4cc32c065aca86bd8f2fc
+  languageName: node
+  linkType: hard
+
+"@smithy/querystring-parser@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/querystring-parser@npm:3.0.0"
+  dependencies:
+    "@smithy/types": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/c0258dd552819ffd584abc858d702428da4d6d850eeaa47b29bd15972d428e5b6d62cc9a6609c83ad58e1fedcc38a9189093568163eac6ecf24ea38a96e31779
+  languageName: node
+  linkType: hard
+
+"@smithy/service-error-classification@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/service-error-classification@npm:3.0.0"
+  dependencies:
+    "@smithy/types": "npm:^3.0.0"
+  checksum: 10/b7922ac401773fe4ff500378d8731e9fe8b7dceb6707a48ea93051c0158f2cec7195c718dd80b940af57ef584e36982792f1fe7d31d52c4173c1c495775075a0
+  languageName: node
+  linkType: hard
+
+"@smithy/shared-ini-file-loader@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/shared-ini-file-loader@npm:3.0.0"
+  dependencies:
+    "@smithy/types": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/29b2fda4aa6a5688453dd025a1acf867461c9b59db52998e2bac41b7acca8aea45aa41b275cfac27443446a90e9e22da794fb7fd64c2a244cdce80e0c373237f
+  languageName: node
+  linkType: hard
+
+"@smithy/signature-v4@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/signature-v4@npm:3.0.0"
+  dependencies:
+    "@smithy/is-array-buffer": "npm:^3.0.0"
+    "@smithy/types": "npm:^3.0.0"
+    "@smithy/util-hex-encoding": "npm:^3.0.0"
+    "@smithy/util-middleware": "npm:^3.0.0"
+    "@smithy/util-uri-escape": "npm:^3.0.0"
+    "@smithy/util-utf8": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/528461766bc6a941216a17331ef61ecc72a2e0171b10c6b40bfafb33e3c83a77f1003541a9986a3c5b61320cc28c95c2aff7c3fa650c6e70a62cb765327e9a9e
+  languageName: node
+  linkType: hard
+
+"@smithy/smithy-client@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/smithy-client@npm:3.0.0"
+  dependencies:
+    "@smithy/middleware-endpoint": "npm:^3.0.0"
+    "@smithy/middleware-stack": "npm:^3.0.0"
+    "@smithy/protocol-http": "npm:^4.0.0"
+    "@smithy/types": "npm:^3.0.0"
+    "@smithy/util-stream": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/22c940ac2b884bb91c0bb2746bc782322348fdf9c2e9beff372993dc1705a9d28f12d3bb09a9d7abbe35d76dee937beebd3e53b998691b04035e6462dca75eed
+  languageName: node
+  linkType: hard
+
+"@smithy/types@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/types@npm:3.0.0"
+  dependencies:
+    tslib: "npm:^2.6.2"
+  checksum: 10/8b9a45fc24e2e9702bc9614facbb7ad7c5b3b7a7b438afeeae770e25e62182827e3ea24367e466705f25e4f83e89ff89d0acbcd4c42195fba847821b649205db
+  languageName: node
+  linkType: hard
+
+"@smithy/url-parser@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/url-parser@npm:3.0.0"
+  dependencies:
+    "@smithy/querystring-parser": "npm:^3.0.0"
+    "@smithy/types": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/f88c1a2537593dd8c9643d42fbfde313c630bbb3f2dc9d202d58df298504534c4cedc4595173b1a290ada9220c97096d2653eed9024a00053a08452621db3a9a
+  languageName: node
+  linkType: hard
+
+"@smithy/util-base64@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/util-base64@npm:3.0.0"
+  dependencies:
+    "@smithy/util-buffer-from": "npm:^3.0.0"
+    "@smithy/util-utf8": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/3c883d63a33e1cfeebf7f846f167dfc54c832d1f5514d014fbfff06de3aecd5919f01637fc93668dca8a1029752f3a6fab0a94f455dcb7c88f1d472bde294eef
+  languageName: node
+  linkType: hard
+
+"@smithy/util-body-length-browser@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/util-body-length-browser@npm:3.0.0"
+  dependencies:
+    tslib: "npm:^2.6.2"
+  checksum: 10/a0ab6a6d414a62d18e57f3581769379a54bb1fd93606c69bc8d96a3566fdecb8db7b57da9446568d03eef9f004f2a89d7e94bdda79ef280f28b19a71803c0309
+  languageName: node
+  linkType: hard
+
+"@smithy/util-body-length-node@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/util-body-length-node@npm:3.0.0"
+  dependencies:
+    tslib: "npm:^2.6.2"
+  checksum: 10/aabac66d7111612fd375d67150f8787c5cdc828f7e6acb40ef0b18b4c354e64e0ef2e4b8da2d7f01e8abe931ff2ef8109a408164ce7e5662fd41b470c462f1e4
+  languageName: node
+  linkType: hard
+
+"@smithy/util-buffer-from@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/util-buffer-from@npm:3.0.0"
+  dependencies:
+    "@smithy/is-array-buffer": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/7e6596b38855c07869f7e8f7b0ad9b70c5e658f4a06c7db71c6134a9a785ac1fdaa84f8b3358c4a572767838498df118daad1fa937237d1fb4b9fce735cf8bb0
+  languageName: node
+  linkType: hard
+
+"@smithy/util-config-provider@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/util-config-provider@npm:3.0.0"
+  dependencies:
+    tslib: "npm:^2.6.2"
+  checksum: 10/614c321c5a5a220d7d72d36359c41b4e390566719f7e01cefebffbe7034aae78b4533b27ab2030f93186c5f22893ddf056a3a2376a077d70ce89275f31e1ac46
+  languageName: node
+  linkType: hard
+
+"@smithy/util-defaults-mode-browser@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/util-defaults-mode-browser@npm:3.0.0"
+  dependencies:
+    "@smithy/property-provider": "npm:^3.0.0"
+    "@smithy/smithy-client": "npm:^3.0.0"
+    "@smithy/types": "npm:^3.0.0"
+    bowser: "npm:^2.11.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/b55f2f1c83d326c5eb1b8c57785987a48b361e0b7bc25da67948f226100082ae2d4cd5a4b5e467ae67345d08995e8a506b275b298694cf8b07db3121b2f8578c
+  languageName: node
+  linkType: hard
+
+"@smithy/util-defaults-mode-node@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/util-defaults-mode-node@npm:3.0.0"
+  dependencies:
+    "@smithy/config-resolver": "npm:^3.0.0"
+    "@smithy/credential-provider-imds": "npm:^3.0.0"
+    "@smithy/node-config-provider": "npm:^3.0.0"
+    "@smithy/property-provider": "npm:^3.0.0"
+    "@smithy/smithy-client": "npm:^3.0.0"
+    "@smithy/types": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/0a26701c017a84652bffcc1fd0525e4d90e6014328a87c650c258526059027a91a75db5ac4dba5bad35fb2e1bb900eafb617d13d2d2e2d189e04f0e03af61146
+  languageName: node
+  linkType: hard
+
+"@smithy/util-endpoints@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "@smithy/util-endpoints@npm:2.0.0"
+  dependencies:
+    "@smithy/node-config-provider": "npm:^3.0.0"
+    "@smithy/types": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/49e897e8b1c19a79f71edfa1b5fa58f90b3244e5026e38c32c3bd2ff2672f4a2de9dbb0c0cf7dfaf8ae6de25db3c8ea76cfbbfc0db8415935721863bcda527bd
+  languageName: node
+  linkType: hard
+
+"@smithy/util-hex-encoding@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/util-hex-encoding@npm:3.0.0"
+  dependencies:
+    tslib: "npm:^2.6.2"
+  checksum: 10/d9f8c4c676410ca51bdbcec5d986883bad0028e26b098fc50e2b57bc81e8a5ce20e160786d08c8552ca0ba662c88ca16f33857ff24a0d183174325b2b40e3c8f
+  languageName: node
+  linkType: hard
+
+"@smithy/util-middleware@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/util-middleware@npm:3.0.0"
+  dependencies:
+    "@smithy/types": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/e9878f85326859b8025df7e2cf7aba5b9fb8ec59be2189c61b0082947c967d888d6894ce6e2152a28eda3e03c207453a94fba7dbf084d755e2ada2df5a58cbb5
+  languageName: node
+  linkType: hard
+
+"@smithy/util-retry@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/util-retry@npm:3.0.0"
+  dependencies:
+    "@smithy/service-error-classification": "npm:^3.0.0"
+    "@smithy/types": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/9e38115e47f99bd86360864ed4dd84a266a4e8bc528c6cc834760339cfef857263eb557b85e060776775c1a70b0f03ded0133b9b23c31095d41e51d247a2b1a3
+  languageName: node
+  linkType: hard
+
+"@smithy/util-stream@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/util-stream@npm:3.0.0"
+  dependencies:
+    "@smithy/fetch-http-handler": "npm:^3.0.0"
+    "@smithy/node-http-handler": "npm:^3.0.0"
+    "@smithy/types": "npm:^3.0.0"
+    "@smithy/util-base64": "npm:^3.0.0"
+    "@smithy/util-buffer-from": "npm:^3.0.0"
+    "@smithy/util-hex-encoding": "npm:^3.0.0"
+    "@smithy/util-utf8": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/ad263551e2af5b255f05a957d2932444453d7bc69dbacbfd5be961ff3b368b68500fb2f3ac878cabe6369901bb0b7b5eed2a474cc730bafb13f526f63bd5f44c
+  languageName: node
+  linkType: hard
+
+"@smithy/util-uri-escape@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/util-uri-escape@npm:3.0.0"
+  dependencies:
+    tslib: "npm:^2.6.2"
+  checksum: 10/d44522339325b0f1fe2c5bf1a3f01d5a699eb8718d800dee24378a1a1b301683756dcfd4be4c32db4d6a00cad85893494778ae39fb246a03aef27d06c9852a67
+  languageName: node
+  linkType: hard
+
+"@smithy/util-utf8@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/util-utf8@npm:3.0.0"
+  dependencies:
+    "@smithy/util-buffer-from": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/1aead297d835af419f75e0c3113c021aa0da671110d1b498035530d5f35d8030092cad5147edaa7ca458aafe27c9383399ccd8176d342942465a2d8357e5cbf4
+  languageName: node
+  linkType: hard
+
+"@smithy/util-waiter@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/util-waiter@npm:3.0.0"
+  dependencies:
+    "@smithy/abort-controller": "npm:^3.0.0"
+    "@smithy/types": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/d206c9f6613e1c43675a48214dd762cb7f85ba57182d2dbcff80392a1983a7f6b06bd537c89949017100bf641d71a32d0c62299d172c52480240c5a431b797ac
+  languageName: node
+  linkType: hard
+
+"@swc/counter@npm:^0.1.3":
+  version: 0.1.3
+  resolution: "@swc/counter@npm:0.1.3"
+  checksum: 10/df8f9cfba9904d3d60f511664c70d23bb323b3a0803ec9890f60133954173047ba9bdeabce28cd70ba89ccd3fd6c71c7b0bd58be85f611e1ffbe5d5c18616598
+  languageName: node
+  linkType: hard
+
+"@swc/helpers@npm:0.5.5":
+  version: 0.5.5
+  resolution: "@swc/helpers@npm:0.5.5"
+  dependencies:
+    "@swc/counter": "npm:^0.1.3"
+    tslib: "npm:^2.4.0"
+  checksum: 10/1c5ef04f642542212df28c669438f3e0f459dcde7b448a5b1fcafb2e9e4f13e76d8428535a270e91ed123dd2a21189dbed34086b88a8cf68baf84984d6d0e39b
+  languageName: node
+  linkType: hard
+
+"@tootallnate/once@npm:2":
+  version: 2.0.0
+  resolution: "@tootallnate/once@npm:2.0.0"
+  checksum: 10/ad87447820dd3f24825d2d947ebc03072b20a42bfc96cbafec16bff8bbda6c1a81fcb0be56d5b21968560c5359a0af4038a68ba150c3e1694fe4c109a063bed8
+  languageName: node
+  linkType: hard
+
+"@tufjs/canonical-json@npm:1.0.0":
+  version: 1.0.0
+  resolution: "@tufjs/canonical-json@npm:1.0.0"
+  checksum: 10/9ff3bcd12988fb23643690da3e009f9130b7b10974f8e7af4bd8ad230a228119de8609aa76d75264fe80f152b50872dea6ea53def69534436a4c24b4fcf6a447
+  languageName: node
+  linkType: hard
+
+"@tufjs/canonical-json@npm:2.0.0":
+  version: 2.0.0
+  resolution: "@tufjs/canonical-json@npm:2.0.0"
+  checksum: 10/cc719a1d0d0ae1aa1ba551a82c87dcbefac088e433c03a3d8a1d547ea721350e47dab4ab5b0fca40d5c7ab1f4882e72edc39c9eae15bf47c45c43bcb6ee39f4f
+  languageName: node
+  linkType: hard
+
+"@tufjs/models@npm:1.0.4":
+  version: 1.0.4
+  resolution: "@tufjs/models@npm:1.0.4"
+  dependencies:
+    "@tufjs/canonical-json": "npm:1.0.0"
+    minimatch: "npm:^9.0.0"
+  checksum: 10/2c63e9cfc04a4ce8888e9cc9668a7207e3047d64c50dccc3d2c30057d8bd6c4e89256b6094d2109549278da72c75e20cd8717bb5f4b544dc2323288a2a96607f
+  languageName: node
+  linkType: hard
+
+"@tufjs/models@npm:2.0.1":
+  version: 2.0.1
+  resolution: "@tufjs/models@npm:2.0.1"
+  dependencies:
+    "@tufjs/canonical-json": "npm:2.0.0"
+    minimatch: "npm:^9.0.4"
+  checksum: 10/7c5d2b8194195cecddc92ae37523c1375e7aaf2e554941c0f9b71db93bbef4f0af8190438dd321e8f9dfd4ce2a9b582e35a4c4c04bec87e25a289c9c8bedcd4e
+  languageName: node
+  linkType: hard
+
+"@types/babel__core@npm:^7.1.14":
+  version: 7.20.5
+  resolution: "@types/babel__core@npm:7.20.5"
+  dependencies:
+    "@babel/parser": "npm:^7.20.7"
+    "@babel/types": "npm:^7.20.7"
+    "@types/babel__generator": "npm:*"
+    "@types/babel__template": "npm:*"
+    "@types/babel__traverse": "npm:*"
+  checksum: 10/c32838d280b5ab59d62557f9e331d3831f8e547ee10b4f85cb78753d97d521270cebfc73ce501e9fb27fe71884d1ba75e18658692c2f4117543f0fc4e3e118b3
+  languageName: node
+  linkType: hard
+
+"@types/babel__generator@npm:*":
+  version: 7.6.8
+  resolution: "@types/babel__generator@npm:7.6.8"
+  dependencies:
+    "@babel/types": "npm:^7.0.0"
+  checksum: 10/b53c215e9074c69d212402990b0ca8fa57595d09e10d94bda3130aa22b55d796e50449199867879e4ea0ee968f3a2099e009cfb21a726a53324483abbf25cd30
+  languageName: node
+  linkType: hard
+
+"@types/babel__template@npm:*":
+  version: 7.4.4
+  resolution: "@types/babel__template@npm:7.4.4"
+  dependencies:
+    "@babel/parser": "npm:^7.1.0"
+    "@babel/types": "npm:^7.0.0"
+  checksum: 10/d7a02d2a9b67e822694d8e6a7ddb8f2b71a1d6962dfd266554d2513eefbb205b33ca71a0d163b1caea3981ccf849211f9964d8bd0727124d18ace45aa6c9ae29
+  languageName: node
+  linkType: hard
+
+"@types/babel__traverse@npm:*, @types/babel__traverse@npm:^7.0.6":
+  version: 7.20.5
+  resolution: "@types/babel__traverse@npm:7.20.5"
+  dependencies:
+    "@babel/types": "npm:^7.20.7"
+  checksum: 10/f0352d537448e1e37f27e6bb8c962d7893720a92fde9d8601a68a93dbc14e15c088b4c0c8f71021d0966d09fba802ef3de11fdb6766c33993f8cf24f1277c6a9
+  languageName: node
+  linkType: hard
+
+"@types/graceful-fs@npm:^4.1.3":
+  version: 4.1.9
+  resolution: "@types/graceful-fs@npm:4.1.9"
+  dependencies:
+    "@types/node": "npm:*"
+  checksum: 10/79d746a8f053954bba36bd3d94a90c78de995d126289d656fb3271dd9f1229d33f678da04d10bce6be440494a5a73438e2e363e92802d16b8315b051036c5256
+  languageName: node
+  linkType: hard
+
+"@types/istanbul-lib-coverage@npm:*, @types/istanbul-lib-coverage@npm:^2.0.0, @types/istanbul-lib-coverage@npm:^2.0.1":
+  version: 2.0.6
+  resolution: "@types/istanbul-lib-coverage@npm:2.0.6"
+  checksum: 10/3feac423fd3e5449485afac999dcfcb3d44a37c830af898b689fadc65d26526460bedb889db278e0d4d815a670331796494d073a10ee6e3a6526301fe7415778
+  languageName: node
+  linkType: hard
+
+"@types/istanbul-lib-report@npm:*":
+  version: 3.0.3
+  resolution: "@types/istanbul-lib-report@npm:3.0.3"
+  dependencies:
+    "@types/istanbul-lib-coverage": "npm:*"
+  checksum: 10/b91e9b60f865ff08cb35667a427b70f6c2c63e88105eadd29a112582942af47ed99c60610180aa8dcc22382fa405033f141c119c69b95db78c4c709fbadfeeb4
+  languageName: node
+  linkType: hard
+
+"@types/istanbul-reports@npm:^3.0.0":
+  version: 3.0.4
+  resolution: "@types/istanbul-reports@npm:3.0.4"
+  dependencies:
+    "@types/istanbul-lib-report": "npm:*"
+  checksum: 10/93eb18835770b3431f68ae9ac1ca91741ab85f7606f310a34b3586b5a34450ec038c3eed7ab19266635499594de52ff73723a54a72a75b9f7d6a956f01edee95
+  languageName: node
+  linkType: hard
+
+"@types/minimatch@npm:^3.0.3":
+  version: 3.0.5
+  resolution: "@types/minimatch@npm:3.0.5"
+  checksum: 10/c41d136f67231c3131cf1d4ca0b06687f4a322918a3a5adddc87ce90ed9dbd175a3610adee36b106ae68c0b92c637c35e02b58c8a56c424f71d30993ea220b92
+  languageName: node
+  linkType: hard
+
+"@types/minimist@npm:^1.2.0":
+  version: 1.2.5
+  resolution: "@types/minimist@npm:1.2.5"
+  checksum: 10/477047b606005058ab0263c4f58097136268007f320003c348794f74adedc3166ffc47c80ec3e94687787f2ab7f4e72c468223946e79892cf0fd9e25e9970a90
+  languageName: node
+  linkType: hard
+
+"@types/node@npm:*":
   version: 8.10.66
   resolution: "@types/node@npm:8.10.66"
-  checksum: c52039de862654a139abdc6a51de532a69dd80516ac35a959c3b3a2831ecbaaf065b0df5f9db943f5e28b544ebb9a891730d52b52f7a169b86a82bc060210000
+  checksum: 10/49a93cbeeca74e247970b5c2130abe8204587b6d3c5ec259543e7511234e5fa340341668155807ade7a86c22dab1ec8ee18c0ac745e4d54679de1b2dabd99363
   languageName: node
   linkType: hard
 
-"@types/node@npm:^10.0.3":
-  version: 10.17.60
-  resolution: "@types/node@npm:10.17.60"
-  checksum: 2cdb3a77d071ba8513e5e8306fa64bf50e3c3302390feeaeff1fd325dd25c8441369715dfc8e3701011a72fed5958c7dfa94eb9239a81b3c286caa4d97db6eef
+"@types/normalize-package-data@npm:^2.4.0":
+  version: 2.4.4
+  resolution: "@types/normalize-package-data@npm:2.4.4"
+  checksum: 10/65dff72b543997b7be8b0265eca7ace0e34b75c3e5fee31de11179d08fa7124a7a5587265d53d0409532ecb7f7fba662c2012807963e1f9b059653ec2c83ee05
   languageName: node
   linkType: hard
 
-"@types/qs@npm:^6.2.31":
-  version: 6.9.7
-  resolution: "@types/qs@npm:6.9.7"
-  checksum: 7fd6f9c25053e9b5bb6bc9f9f76c1d89e6c04f7707a7ba0e44cc01f17ef5284adb82f230f542c2d5557d69407c9a40f0f3515e8319afd14e1e16b5543ac6cdba
+"@types/stack-utils@npm:^2.0.0":
+  version: 2.0.3
+  resolution: "@types/stack-utils@npm:2.0.3"
+  checksum: 10/72576cc1522090fe497337c2b99d9838e320659ac57fa5560fcbdcbafcf5d0216c6b3a0a8a4ee4fdb3b1f5e3420aa4f6223ab57b82fef3578bec3206425c6cf5
   languageName: node
   linkType: hard
 
-"@xmldom/xmldom@npm:^0.7.5":
-  version: 0.7.13
-  resolution: "@xmldom/xmldom@npm:0.7.13"
-  checksum: b4054078530e5fa8ede9677425deff0fce6d965f4c477ca73f8490d8a089e60b8498a15560425a1335f5ff99ecb851ed2c734b0a9a879299a5694302f212f37a
+"@types/yargs-parser@npm:*":
+  version: 21.0.3
+  resolution: "@types/yargs-parser@npm:21.0.3"
+  checksum: 10/a794eb750e8ebc6273a51b12a0002de41343ffe46befef460bdbb57262d187fdf608bc6615b7b11c462c63c3ceb70abe2564c8dd8ee0f7628f38a314f74a9b9b
   languageName: node
   linkType: hard
 
-"ajv@npm:^6.10.2, ajv@npm:^6.5.2":
+"@types/yargs@npm:^17.0.8":
+  version: 17.0.32
+  resolution: "@types/yargs@npm:17.0.32"
+  dependencies:
+    "@types/yargs-parser": "npm:*"
+  checksum: 10/1e2b2673847011ce43607df690d392f137d95a2d6ea85aa319403eadda2ef4277365efd4982354d8843f2611ef3846c88599660aaeb537fa9ccddae83c2a89de
+  languageName: node
+  linkType: hard
+
+"@xmldom/xmldom@npm:^0.8.10":
+  version: 0.8.10
+  resolution: "@xmldom/xmldom@npm:0.8.10"
+  checksum: 10/62400bc5e0e75b90650e33a5ceeb8d94829dd11f9b260962b71a784cd014ddccec3e603fe788af9c1e839fa4648d8c521ebd80d8b752878d3a40edabc9ce7ccf
+  languageName: node
+  linkType: hard
+
+"@yarnpkg/lockfile@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@yarnpkg/lockfile@npm:1.1.0"
+  checksum: 10/cd19e1114aaf10a05126aeea8833ef4ca8af8a46e88e12884f8359d19333fd19711036dbc2698dbe937f81f037070cf9a8da45c2e8c6ca19cafd7d15659094ed
+  languageName: node
+  linkType: hard
+
+"@yarnpkg/parsers@npm:3.0.0-rc.46":
+  version: 3.0.0-rc.46
+  resolution: "@yarnpkg/parsers@npm:3.0.0-rc.46"
+  dependencies:
+    js-yaml: "npm:^3.10.0"
+    tslib: "npm:^2.4.0"
+  checksum: 10/3b7d55ebd1b90fe2adf05bfaab53031fb9ddb6315f8dfca1b5ba0393c08fc4a7f22c94603eec06dfe0a67e4121e5227b0ae57a70c73d353614650e2b54b6049d
+  languageName: node
+  linkType: hard
+
+"@zkochan/js-yaml@npm:0.0.6":
+  version: 0.0.6
+  resolution: "@zkochan/js-yaml@npm:0.0.6"
+  dependencies:
+    argparse: "npm:^2.0.1"
+  bin:
+    js-yaml: bin/js-yaml.js
+  checksum: 10/1a079db8bc76dfd200f3d2334c96fd5df6ce072f40b5aa6fe4508e6fd5af0e57cab6fc879ea7f8c376e4c553febd73c4b46c924bd48b838b5b9522936b88517b
+  languageName: node
+  linkType: hard
+
+"JSONStream@npm:^1.3.5":
+  version: 1.3.5
+  resolution: "JSONStream@npm:1.3.5"
+  dependencies:
+    jsonparse: "npm:^1.2.0"
+    through: "npm:>=2.2.7 <3"
+  bin:
+    JSONStream: ./bin.js
+  checksum: 10/e30daf7b9b2da23076181d9a0e4bec33bc1d97e8c0385b949f1b16ba3366a1d241ec6f077850c01fe32379b5ebb8b96b65496984bc1545a93a5150bf4c267439
+  languageName: node
+  linkType: hard
+
+"abbrev@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "abbrev@npm:2.0.0"
+  checksum: 10/ca0a54e35bea4ece0ecb68a47b312e1a9a6f772408d5bcb9051230aaa94b0460671c5b5c9cb3240eb5b7bc94c52476550eb221f65a0bbd0145bdc9f3113a6707
+  languageName: node
+  linkType: hard
+
+"add-stream@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "add-stream@npm:1.0.0"
+  checksum: 10/3e9e8b0b8f0170406d7c3a9a39bfbdf419ccccb0fd2a396338c0fda0a339af73bf738ad414fc520741de74517acf0dd92b4a36fd3298a47fd5371eee8f2c5a06
+  languageName: node
+  linkType: hard
+
+"agent-base@npm:6, agent-base@npm:^6.0.2":
+  version: 6.0.2
+  resolution: "agent-base@npm:6.0.2"
+  dependencies:
+    debug: "npm:4"
+  checksum: 10/21fb903e0917e5cb16591b4d0ef6a028a54b83ac30cd1fca58dece3d4e0990512a8723f9f83130d88a41e2af8b1f7be1386fda3ea2d181bb1a62155e75e95e23
+  languageName: node
+  linkType: hard
+
+"agent-base@npm:^7.0.2, agent-base@npm:^7.1.0, agent-base@npm:^7.1.1":
+  version: 7.1.1
+  resolution: "agent-base@npm:7.1.1"
+  dependencies:
+    debug: "npm:^4.3.4"
+  checksum: 10/c478fec8f79953f118704d007a38f2a185458853f5c45579b9669372bd0e12602e88dc2ad0233077831504f7cd6fcc8251c383375bba5eaaf563b102938bda26
+  languageName: node
+  linkType: hard
+
+"agentkeepalive@npm:^4.2.1":
+  version: 4.5.0
+  resolution: "agentkeepalive@npm:4.5.0"
+  dependencies:
+    humanize-ms: "npm:^1.2.1"
+  checksum: 10/dd210ba2a2e2482028f027b1156789744aadbfd773a6c9dd8e4e8001930d5af82382abe19a69240307b1d8003222ce6b0542935038313434b900e351914fc15f
+  languageName: node
+  linkType: hard
+
+"aggregate-error@npm:^3.0.0":
+  version: 3.1.0
+  resolution: "aggregate-error@npm:3.1.0"
+  dependencies:
+    clean-stack: "npm:^2.0.0"
+    indent-string: "npm:^4.0.0"
+  checksum: 10/1101a33f21baa27a2fa8e04b698271e64616b886795fd43c31068c07533c7b3facfcaf4e9e0cab3624bd88f729a592f1c901a1a229c9e490eafce411a8644b79
+  languageName: node
+  linkType: hard
+
+"ajv@npm:^6.5.2":
   version: 6.12.6
   resolution: "ajv@npm:6.12.6"
   dependencies:
-    fast-deep-equal: ^3.1.1
-    fast-json-stable-stringify: ^2.0.0
-    json-schema-traverse: ^0.4.1
-    uri-js: ^4.2.2
-  checksum: 874972efe5c4202ab0a68379481fbd3d1b5d0a7bd6d3cc21d40d3536ebff3352a2a1fabb632d4fd2cc7fe4cbdcd5ed6782084c9bbf7f32a1536d18f9da5007d4
+    fast-deep-equal: "npm:^3.1.1"
+    fast-json-stable-stringify: "npm:^2.0.0"
+    json-schema-traverse: "npm:^0.4.1"
+    uri-js: "npm:^4.2.2"
+  checksum: 10/48d6ad21138d12eb4d16d878d630079a2bda25a04e745c07846a4ad768319533031e28872a9b3c5790fa1ec41aabdf2abed30a56e5a03ebc2cf92184b8ee306c
+  languageName: node
+  linkType: hard
+
+"ajv@npm:^8.0.1":
+  version: 8.13.0
+  resolution: "ajv@npm:8.13.0"
+  dependencies:
+    fast-deep-equal: "npm:^3.1.3"
+    json-schema-traverse: "npm:^1.0.0"
+    require-from-string: "npm:^2.0.2"
+    uri-js: "npm:^4.4.1"
+  checksum: 10/4ada268c9a6e44be87fd295df0f0a91267a7bae8dbc8a67a2d5799c3cb459232839c99d18b035597bb6e3ffe88af6979f7daece854f590a81ebbbc2dfa80002c
+  languageName: node
+  linkType: hard
+
+"ansi-colors@npm:^4.1.1":
+  version: 4.1.3
+  resolution: "ansi-colors@npm:4.1.3"
+  checksum: 10/43d6e2fc7b1c6e4dc373de708ee76311ec2e0433e7e8bd3194e7ff123ea6a747428fc61afdcf5969da5be3a5f0fd054602bec56fc0ebe249ce2fcde6e649e3c2
+  languageName: node
+  linkType: hard
+
+"ansi-escapes@npm:^4.2.1":
+  version: 4.3.2
+  resolution: "ansi-escapes@npm:4.3.2"
+  dependencies:
+    type-fest: "npm:^0.21.3"
+  checksum: 10/8661034456193ffeda0c15c8c564a9636b0c04094b7f78bd01517929c17c504090a60f7a75f949f5af91289c264d3e1001d91492c1bd58efc8e100500ce04de2
   languageName: node
   linkType: hard
 
 "ansi-regex@npm:^2.0.0":
   version: 2.1.1
   resolution: "ansi-regex@npm:2.1.1"
-  checksum: 190abd03e4ff86794f338a31795d262c1dfe8c91f7e01d04f13f646f1dcb16c5800818f886047876f1272f065570ab86b24b99089f8b68a0e11ff19aed4ca8f1
-  languageName: node
-  linkType: hard
-
-"ansi-regex@npm:^4.1.0":
-  version: 4.1.1
-  resolution: "ansi-regex@npm:4.1.1"
-  checksum: b1a6ee44cb6ecdabaa770b2ed500542714d4395d71c7e5c25baa631f680fb2ad322eb9ba697548d498a6fd366949fc8b5bfcf48d49a32803611f648005b01888
+  checksum: 10/190abd03e4ff86794f338a31795d262c1dfe8c91f7e01d04f13f646f1dcb16c5800818f886047876f1272f065570ab86b24b99089f8b68a0e11ff19aed4ca8f1
   languageName: node
   linkType: hard
 
 "ansi-regex@npm:^5.0.1":
   version: 5.0.1
   resolution: "ansi-regex@npm:5.0.1"
-  checksum: 2aa4bb54caf2d622f1afdad09441695af2a83aa3fe8b8afa581d205e57ed4261c183c4d3877cee25794443fde5876417d859c108078ab788d6af7e4fe52eb66b
+  checksum: 10/2aa4bb54caf2d622f1afdad09441695af2a83aa3fe8b8afa581d205e57ed4261c183c4d3877cee25794443fde5876417d859c108078ab788d6af7e4fe52eb66b
   languageName: node
   linkType: hard
 
-"ansi-styles@npm:^3.2.0":
+"ansi-regex@npm:^6.0.1":
+  version: 6.0.1
+  resolution: "ansi-regex@npm:6.0.1"
+  checksum: 10/1ff8b7667cded1de4fa2c9ae283e979fc87036864317da86a2e546725f96406746411d0d85e87a2d12fa5abd715d90006de7fa4fa0477c92321ad3b4c7d4e169
+  languageName: node
+  linkType: hard
+
+"ansi-styles@npm:^3.2.1":
   version: 3.2.1
   resolution: "ansi-styles@npm:3.2.1"
   dependencies:
-    color-convert: ^1.9.0
-  checksum: d85ade01c10e5dd77b6c89f34ed7531da5830d2cb5882c645f330079975b716438cd7ebb81d0d6e6b4f9c577f19ae41ab55f07f19786b02f9dfd9e0377395665
+    color-convert: "npm:^1.9.0"
+  checksum: 10/d85ade01c10e5dd77b6c89f34ed7531da5830d2cb5882c645f330079975b716438cd7ebb81d0d6e6b4f9c577f19ae41ab55f07f19786b02f9dfd9e0377395665
   languageName: node
   linkType: hard
 
-"ansi-styles@npm:^4.0.0":
+"ansi-styles@npm:^4.0.0, ansi-styles@npm:^4.1.0":
   version: 4.3.0
   resolution: "ansi-styles@npm:4.3.0"
   dependencies:
-    color-convert: ^2.0.1
-  checksum: 513b44c3b2105dd14cc42a19271e80f386466c4be574bccf60b627432f9198571ebf4ab1e4c3ba17347658f4ee1711c163d574248c0c1cdc2d5917a0ad582ec4
+    color-convert: "npm:^2.0.1"
+  checksum: 10/b4494dfbfc7e4591b4711a396bd27e540f8153914123dccb4cdbbcb514015ada63a3809f362b9d8d4f6b17a706f1d7bea3c6f974b15fa5ae76b5b502070889ff
   languageName: node
   linkType: hard
 
-"asap@npm:~2.0.6":
-  version: 2.0.6
-  resolution: "asap@npm:2.0.6"
-  checksum: b296c92c4b969e973260e47523207cd5769abd27c245a68c26dc7a0fe8053c55bb04360237cb51cab1df52be939da77150ace99ad331fb7fb13b3423ed73ff3d
+"ansi-styles@npm:^5.0.0":
+  version: 5.2.0
+  resolution: "ansi-styles@npm:5.2.0"
+  checksum: 10/d7f4e97ce0623aea6bc0d90dcd28881ee04cba06c570b97fd3391bd7a268eedfd9d5e2dd4fdcbdd82b8105df5faf6f24aaedc08eaf3da898e702db5948f63469
   languageName: node
   linkType: hard
 
-"astral-regex@npm:^1.0.0":
+"ansi-styles@npm:^6.1.0":
+  version: 6.2.1
+  resolution: "ansi-styles@npm:6.2.1"
+  checksum: 10/70fdf883b704d17a5dfc9cde206e698c16bcd74e7f196ab821511651aee4f9f76c9514bdfa6ca3a27b5e49138b89cb222a28caf3afe4567570139577f991df32
+  languageName: node
+  linkType: hard
+
+"anymatch@npm:^3.0.3":
+  version: 3.1.3
+  resolution: "anymatch@npm:3.1.3"
+  dependencies:
+    normalize-path: "npm:^3.0.0"
+    picomatch: "npm:^2.0.4"
+  checksum: 10/3e044fd6d1d26545f235a9fe4d7a534e2029d8e59fa7fd9f2a6eb21230f6b5380ea1eaf55136e60cbf8e613544b3b766e7a6fa2102e2a3a117505466e3025dc2
+  languageName: node
+  linkType: hard
+
+"aproba@npm:^1.0.3 || ^2.0.0":
+  version: 2.0.0
+  resolution: "aproba@npm:2.0.0"
+  checksum: 10/c2b9a631298e8d6f3797547e866db642f68493808f5b37cd61da778d5f6ada890d16f668285f7d60bd4fc3b03889bd590ffe62cf81b700e9bb353431238a0a7b
+  languageName: node
+  linkType: hard
+
+"are-we-there-yet@npm:^3.0.0":
+  version: 3.0.1
+  resolution: "are-we-there-yet@npm:3.0.1"
+  dependencies:
+    delegates: "npm:^1.0.0"
+    readable-stream: "npm:^3.6.0"
+  checksum: 10/390731720e1bf9ed5d0efc635ea7df8cbc4c90308b0645a932f06e8495a0bf1ecc7987d3b97e805f62a17d6c4b634074b25200aa4d149be2a7b17250b9744bc4
+  languageName: node
+  linkType: hard
+
+"argparse@npm:^1.0.7":
+  version: 1.0.10
+  resolution: "argparse@npm:1.0.10"
+  dependencies:
+    sprintf-js: "npm:~1.0.2"
+  checksum: 10/c6a621343a553ff3779390bb5ee9c2263d6643ebcd7843227bdde6cc7adbed796eb5540ca98db19e3fd7b4714e1faa51551f8849b268bb62df27ddb15cbcd91e
+  languageName: node
+  linkType: hard
+
+"argparse@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "argparse@npm:2.0.1"
+  checksum: 10/18640244e641a417ec75a9bd38b0b2b6b95af5199aa241b131d4b2fb206f334d7ecc600bd194861610a5579084978bfcbb02baa399dbe442d56d0ae5e60dbaef
+  languageName: node
+  linkType: hard
+
+"array-differ@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "array-differ@npm:3.0.0"
+  checksum: 10/117edd9df5c1530bd116c6e8eea891d4bd02850fd89b1b36e532b6540e47ca620a373b81feca1c62d1395d9ae601516ba538abe5e8172d41091da2c546b05fb7
+  languageName: node
+  linkType: hard
+
+"array-ify@npm:^1.0.0":
   version: 1.0.0
-  resolution: "astral-regex@npm:1.0.0"
-  checksum: 93417fc0879531cd95ace2560a54df865c9461a3ac0714c60cbbaa5f1f85d2bee85489e78d82f70b911b71ac25c5f05fc5a36017f44c9bb33c701bee229ff848
+  resolution: "array-ify@npm:1.0.0"
+  checksum: 10/c0502015b319c93dd4484f18036bcc4b654eb76a4aa1f04afbcef11ac918859bb1f5d71ba1f0f1141770db9eef1a4f40f1761753650873068010bbf7bcdae4a4
+  languageName: node
+  linkType: hard
+
+"array-union@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "array-union@npm:2.1.0"
+  checksum: 10/5bee12395cba82da674931df6d0fea23c4aa4660cb3b338ced9f828782a65caa232573e6bf3968f23e0c5eb301764a382cef2f128b170a9dc59de0e36c39f98d
+  languageName: node
+  linkType: hard
+
+"arrify@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "arrify@npm:1.0.1"
+  checksum: 10/745075dd4a4624ff0225c331dacb99be501a515d39bcb7c84d24660314a6ec28e68131b137e6f7e16318170842ce97538cd298fc4cd6b2cc798e0b957f2747e7
+  languageName: node
+  linkType: hard
+
+"arrify@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "arrify@npm:2.0.1"
+  checksum: 10/067c4c1afd182806a82e4c1cb8acee16ab8b5284fbca1ce29408e6e91281c36bb5b612f6ddfbd40a0f7a7e0c75bf2696eb94c027f6e328d6e9c52465c98e4209
+  languageName: node
+  linkType: hard
+
+"astral-regex@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "astral-regex@npm:2.0.0"
+  checksum: 10/876231688c66400473ba505731df37ea436e574dd524520294cc3bbc54ea40334865e01fa0d074d74d036ee874ee7e62f486ea38bc421ee8e6a871c06f011766
+  languageName: node
+  linkType: hard
+
+"async@npm:^3.2.3":
+  version: 3.2.5
+  resolution: "async@npm:3.2.5"
+  checksum: 10/323c3615c3f0ab1ac25a6f953296bc0ac3213d5e0f1c0debdb12964e55963af288d570293c11e44f7967af58c06d2a88d0ea588c86ec0fbf62fa98037f604a0f
   languageName: node
   linkType: hard
 
 "asynckit@npm:^0.4.0":
   version: 0.4.0
   resolution: "asynckit@npm:0.4.0"
-  checksum: 7b78c451df768adba04e2d02e63e2d0bf3b07adcd6e42b4cf665cb7ce899bedd344c69a1dcbce355b5f972d597b25aaa1c1742b52cffd9caccb22f348114f6be
+  checksum: 10/3ce727cbc78f69d6a4722517a58ee926c8c21083633b1d3fdf66fd688f6c127a53a592141bd4866f9b63240a86e9d8e974b13919450bd17fa33c2d22c4558ad8
+  languageName: node
+  linkType: hard
+
+"available-typed-arrays@npm:^1.0.7":
+  version: 1.0.7
+  resolution: "available-typed-arrays@npm:1.0.7"
+  dependencies:
+    possible-typed-array-names: "npm:^1.0.0"
+  checksum: 10/6c9da3a66caddd83c875010a1ca8ef11eac02ba15fb592dc9418b2b5e7b77b645fa7729380a92d9835c2f05f2ca1b6251f39b993e0feb3f1517c74fa1af02cab
+  languageName: node
+  linkType: hard
+
+"axios@npm:^1.6.0":
+  version: 1.6.8
+  resolution: "axios@npm:1.6.8"
+  dependencies:
+    follow-redirects: "npm:^1.15.6"
+    form-data: "npm:^4.0.0"
+    proxy-from-env: "npm:^1.1.0"
+  checksum: 10/3f9a79eaf1d159544fca9576261ff867cbbff64ed30017848e4210e49f3b01e97cf416390150e6fdf6633f336cd43dc1151f890bbd09c3c01ad60bb0891eee63
+  languageName: node
+  linkType: hard
+
+"babel-jest@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "babel-jest@npm:29.7.0"
+  dependencies:
+    "@jest/transform": "npm:^29.7.0"
+    "@types/babel__core": "npm:^7.1.14"
+    babel-plugin-istanbul: "npm:^6.1.1"
+    babel-preset-jest: "npm:^29.6.3"
+    chalk: "npm:^4.0.0"
+    graceful-fs: "npm:^4.2.9"
+    slash: "npm:^3.0.0"
+  peerDependencies:
+    "@babel/core": ^7.8.0
+  checksum: 10/8a0953bd813b3a8926008f7351611055548869e9a53dd36d6e7e96679001f71e65fd7dbfe253265c3ba6a4e630dc7c845cf3e78b17d758ef1880313ce8fba258
+  languageName: node
+  linkType: hard
+
+"babel-plugin-istanbul@npm:^6.1.1":
+  version: 6.1.1
+  resolution: "babel-plugin-istanbul@npm:6.1.1"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.0.0"
+    "@istanbuljs/load-nyc-config": "npm:^1.0.0"
+    "@istanbuljs/schema": "npm:^0.1.2"
+    istanbul-lib-instrument: "npm:^5.0.4"
+    test-exclude: "npm:^6.0.0"
+  checksum: 10/ffd436bb2a77bbe1942a33245d770506ab2262d9c1b3c1f1da7f0592f78ee7445a95bc2efafe619dd9c1b6ee52c10033d6c7d29ddefe6f5383568e60f31dfe8d
+  languageName: node
+  linkType: hard
+
+"babel-plugin-jest-hoist@npm:^29.6.3":
+  version: 29.6.3
+  resolution: "babel-plugin-jest-hoist@npm:29.6.3"
+  dependencies:
+    "@babel/template": "npm:^7.3.3"
+    "@babel/types": "npm:^7.3.3"
+    "@types/babel__core": "npm:^7.1.14"
+    "@types/babel__traverse": "npm:^7.0.6"
+  checksum: 10/9bfa86ec4170bd805ab8ca5001ae50d8afcb30554d236ba4a7ffc156c1a92452e220e4acbd98daefc12bf0216fccd092d0a2efed49e7e384ec59e0597a926d65
+  languageName: node
+  linkType: hard
+
+"babel-preset-current-node-syntax@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "babel-preset-current-node-syntax@npm:1.0.1"
+  dependencies:
+    "@babel/plugin-syntax-async-generators": "npm:^7.8.4"
+    "@babel/plugin-syntax-bigint": "npm:^7.8.3"
+    "@babel/plugin-syntax-class-properties": "npm:^7.8.3"
+    "@babel/plugin-syntax-import-meta": "npm:^7.8.3"
+    "@babel/plugin-syntax-json-strings": "npm:^7.8.3"
+    "@babel/plugin-syntax-logical-assignment-operators": "npm:^7.8.3"
+    "@babel/plugin-syntax-nullish-coalescing-operator": "npm:^7.8.3"
+    "@babel/plugin-syntax-numeric-separator": "npm:^7.8.3"
+    "@babel/plugin-syntax-object-rest-spread": "npm:^7.8.3"
+    "@babel/plugin-syntax-optional-catch-binding": "npm:^7.8.3"
+    "@babel/plugin-syntax-optional-chaining": "npm:^7.8.3"
+    "@babel/plugin-syntax-top-level-await": "npm:^7.8.3"
+  peerDependencies:
+    "@babel/core": ^7.0.0
+  checksum: 10/94561959cb12bfa80867c9eeeace7c3d48d61707d33e55b4c3fdbe82fc745913eb2dbfafca62aef297421b38aadcb58550e5943f50fbcebbeefd70ce2bed4b74
+  languageName: node
+  linkType: hard
+
+"babel-preset-jest@npm:^29.6.3":
+  version: 29.6.3
+  resolution: "babel-preset-jest@npm:29.6.3"
+  dependencies:
+    babel-plugin-jest-hoist: "npm:^29.6.3"
+    babel-preset-current-node-syntax: "npm:^1.0.0"
+  peerDependencies:
+    "@babel/core": ^7.0.0
+  checksum: 10/aa4ff2a8a728d9d698ed521e3461a109a1e66202b13d3494e41eea30729a5e7cc03b3a2d56c594423a135429c37bf63a9fa8b0b9ce275298be3095a88c69f6fb
   languageName: node
   linkType: hard
 
 "balanced-match@npm:^1.0.0":
   version: 1.0.2
   resolution: "balanced-match@npm:1.0.2"
-  checksum: 9706c088a283058a8a99e0bf91b0a2f75497f185980d9ffa8b304de1d9e58ebda7c72c07ebf01dadedaac5b2907b2c6f566f660d62bd336c3468e960403b9d65
+  checksum: 10/9706c088a283058a8a99e0bf91b0a2f75497f185980d9ffa8b304de1d9e58ebda7c72c07ebf01dadedaac5b2907b2c6f566f660d62bd336c3468e960403b9d65
   languageName: node
   linkType: hard
 
 "base64-js@npm:^1.3.1":
   version: 1.5.1
   resolution: "base64-js@npm:1.5.1"
-  checksum: 669632eb3745404c2f822a18fc3a0122d2f9a7a13f7fb8b5823ee19d1d2ff9ee5b52c53367176ea4ad093c332fd5ab4bd0ebae5a8e27917a4105a4cfc86b1005
+  checksum: 10/669632eb3745404c2f822a18fc3a0122d2f9a7a13f7fb8b5823ee19d1d2ff9ee5b52c53367176ea4ad093c332fd5ab4bd0ebae5a8e27917a4105a4cfc86b1005
   languageName: node
   linkType: hard
 
-"bids-validator@npm:1.10.0":
-  version: 1.10.0
-  resolution: "bids-validator@npm:1.10.0"
+"before-after-hook@npm:^2.2.0":
+  version: 2.2.3
+  resolution: "before-after-hook@npm:2.2.3"
+  checksum: 10/e676f769dbc4abcf4b3317db2fd2badb4a92c0710e0a7da12cf14b59c3482d4febf835ad7de7874499060fd4e13adf0191628e504728b3c5bb4ec7a878c09940
+  languageName: node
+  linkType: hard
+
+"bids-validator@npm:1.14.6":
+  version: 1.14.6
+  resolution: "bids-validator@npm:1.14.6"
   dependencies:
-    "@aws-sdk/client-s3": ^3.9.0
-    ajv: ^6.5.2
-    bytes: ^3.0.0
-    colors: ^1.4.0
-    cross-fetch: ^3.0.6
-    date-fns: ^2.7.0
-    events: ^3.3.0
-    exifreader: ^4.1.0
-    hed-validator: ^3.8.0
-    ignore: ^4.0.2
-    is-utf8: ^0.2.1
-    jshint: ^2.9.6
-    lodash: ^4.17.21
-    minimatch: 3.0.5
-    nifti-js: ^1.0.1
-    p-limit: ^2.1.0
-    pako: ^1.0.6
-    path: ^0.12.7
-    pluralize: ^8.0.0
-    semver: ^7.3.2
-    stream-browserify: ^3.0.0
-    table: ^5.2.3
-    xml2js: ^0.4.23
-    yaml: ^1.10.2
-    yargs: ^16.2.0
+    "@aws-sdk/client-s3": "npm:^3.556.0"
+    ajv: "npm:^6.5.2"
+    bytes: "npm:^3.1.2"
+    colors: "npm:^1.4.0"
+    cross-fetch: "npm:^4.0.0"
+    date-fns: "npm:^3.6.0"
+    events: "npm:^3.3.0"
+    exifreader: "npm:^4.22.1"
+    hed-validator: "npm:^3.13.5"
+    ignore: "npm:^5.3.1"
+    is-utf8: "npm:^0.2.1"
+    jest: "npm:^29.7.0"
+    jshint: "npm:^2.13.6"
+    lerna: "npm:^8.1.2"
+    lodash: "npm:^4.17.21"
+    minimatch: "npm:3.0.5"
+    next: "npm:14.2.3"
+    nifti-js: "npm:^1.0.1"
+    p-limit: "npm:^2.1.0"
+    pako: "npm:^1.0.6"
+    path: "npm:^0.12.7"
+    pluralize: "npm:^8.0.0"
+    semver: "npm:^7.6.0"
+    stream-browserify: "npm:^3.0.0"
+    table: "npm:^6.8.2"
+    util: "npm:^0.12.5"
+    xml2js: "npm:^0.6.2"
+    yaml: "npm:^2.3.1"
+    yargs: "npm:^17.7.2"
   bin:
     bids-validator: bin/bids-validator
-  checksum: 021e35fb6d931beb51780b38ea265399deada2a415a840961862745334bd1bd9db19b8bbb26e5cb2aac8e6471ff20063477c890ee9188892fb1645ab3e3e4c19
+  checksum: 10/385ce2c482b052bcc09a35edb24d92d1442878c0320c74b83dec96e3b72ca745cd725c6b019312b09cdf5b1fb30d973b4ba8fef2a0f0d7853128831cdba5035c
+  languageName: node
+  linkType: hard
+
+"bl@npm:^4.0.3, bl@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "bl@npm:4.1.0"
+  dependencies:
+    buffer: "npm:^5.5.0"
+    inherits: "npm:^2.0.4"
+    readable-stream: "npm:^3.4.0"
+  checksum: 10/b7904e66ed0bdfc813c06ea6c3e35eafecb104369dbf5356d0f416af90c1546de3b74e5b63506f0629acf5e16a6f87c3798f16233dcff086e9129383aa02ab55
   languageName: node
   linkType: hard
 
 "bowser@npm:^2.11.0":
   version: 2.11.0
   resolution: "bowser@npm:2.11.0"
-  checksum: 29c3f01f22e703fa6644fc3b684307442df4240b6e10f6cfe1b61c6ca5721073189ca97cdeedb376081148c8518e33b1d818a57f781d70b0b70e1f31fb48814f
+  checksum: 10/ef46500eafe35072455e7c3ae771244e97827e0626686a9a3601c436d16eb272dad7ccbd49e2130b599b617ca9daa67027de827ffc4c220e02f63c84b69a8751
   languageName: node
   linkType: hard
 
@@ -1247,16 +3313,57 @@ __metadata:
   version: 1.1.11
   resolution: "brace-expansion@npm:1.1.11"
   dependencies:
-    balanced-match: ^1.0.0
-    concat-map: 0.0.1
-  checksum: faf34a7bb0c3fcf4b59c7808bc5d2a96a40988addf2e7e09dfbb67a2251800e0d14cd2bfc1aa79174f2f5095c54ff27f46fb1289fe2d77dac755b5eb3434cc07
+    balanced-match: "npm:^1.0.0"
+    concat-map: "npm:0.0.1"
+  checksum: 10/faf34a7bb0c3fcf4b59c7808bc5d2a96a40988addf2e7e09dfbb67a2251800e0d14cd2bfc1aa79174f2f5095c54ff27f46fb1289fe2d77dac755b5eb3434cc07
+  languageName: node
+  linkType: hard
+
+"brace-expansion@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "brace-expansion@npm:2.0.1"
+  dependencies:
+    balanced-match: "npm:^1.0.0"
+  checksum: 10/a61e7cd2e8a8505e9f0036b3b6108ba5e926b4b55089eeb5550cd04a471fe216c96d4fe7e4c7f995c728c554ae20ddfc4244cad10aef255e72b62930afd233d1
+  languageName: node
+  linkType: hard
+
+"braces@npm:^3.0.2":
+  version: 3.0.2
+  resolution: "braces@npm:3.0.2"
+  dependencies:
+    fill-range: "npm:^7.0.1"
+  checksum: 10/966b1fb48d193b9d155f810e5efd1790962f2c4e0829f8440b8ad236ba009222c501f70185ef732fef17a4c490bb33a03b90dab0631feafbdf447da91e8165b1
+  languageName: node
+  linkType: hard
+
+"browserslist@npm:^4.22.2":
+  version: 4.23.0
+  resolution: "browserslist@npm:4.23.0"
+  dependencies:
+    caniuse-lite: "npm:^1.0.30001587"
+    electron-to-chromium: "npm:^1.4.668"
+    node-releases: "npm:^2.0.14"
+    update-browserslist-db: "npm:^1.0.13"
+  bin:
+    browserslist: cli.js
+  checksum: 10/496c3862df74565dd942b4ae65f502c575cbeba1fa4a3894dad7aa3b16130dc3033bc502d8848147f7b625154a284708253d9598bcdbef5a1e34cf11dc7bad8e
+  languageName: node
+  linkType: hard
+
+"bser@npm:2.1.1":
+  version: 2.1.1
+  resolution: "bser@npm:2.1.1"
+  dependencies:
+    node-int64: "npm:^0.4.0"
+  checksum: 10/edba1b65bae682450be4117b695997972bd9a3c4dfee029cab5bcb72ae5393a79a8f909b8bc77957eb0deec1c7168670f18f4d5c556f46cdd3bca5f3b3a8d020
   languageName: node
   linkType: hard
 
 "buffer-from@npm:^1.0.0":
   version: 1.1.2
   resolution: "buffer-from@npm:1.1.2"
-  checksum: 0448524a562b37d4d7ed9efd91685a5b77a50672c556ea254ac9a6d30e3403a517d8981f10e565db24e8339413b43c97ca2951f10e399c6125a0d8911f5679bb
+  checksum: 10/0448524a562b37d4d7ed9efd91685a5b77a50672c556ea254ac9a6d30e3403a517d8981f10e565db24e8339413b43c97ca2951f10e399c6125a0d8911f5679bb
   languageName: node
   linkType: hard
 
@@ -1264,40 +3371,260 @@ __metadata:
   version: 6.0.3
   resolution: "buffer@npm:6.0.3"
   dependencies:
-    base64-js: ^1.3.1
-    ieee754: ^1.2.1
-  checksum: 5ad23293d9a731e4318e420025800b42bf0d264004c0286c8cc010af7a270c7a0f6522e84f54b9ad65cbd6db20b8badbfd8d2ebf4f80fa03dab093b89e68c3f9
+    base64-js: "npm:^1.3.1"
+    ieee754: "npm:^1.2.1"
+  checksum: 10/b6bc68237ebf29bdacae48ce60e5e28fc53ae886301f2ad9496618efac49427ed79096750033e7eab1897a4f26ae374ace49106a5758f38fb70c78c9fda2c3b1
   languageName: node
   linkType: hard
 
-"bytes@npm:^3.0.0":
+"buffer@npm:^5.5.0":
+  version: 5.7.1
+  resolution: "buffer@npm:5.7.1"
+  dependencies:
+    base64-js: "npm:^1.3.1"
+    ieee754: "npm:^1.1.13"
+  checksum: 10/997434d3c6e3b39e0be479a80288875f71cd1c07d75a3855e6f08ef848a3c966023f79534e22e415ff3a5112708ce06127277ab20e527146d55c84566405c7c6
+  languageName: node
+  linkType: hard
+
+"builtins@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "builtins@npm:1.0.3"
+  checksum: 10/8f756616bd3d92611bcb5bcc3008308e7cdaadbc4603a5ce6fe709193198bc115351d138524d79e5269339ef7ba5ba73185da541c7b4bc076b00dd0124f938f6
+  languageName: node
+  linkType: hard
+
+"builtins@npm:^5.0.0":
+  version: 5.1.0
+  resolution: "builtins@npm:5.1.0"
+  dependencies:
+    semver: "npm:^7.0.0"
+  checksum: 10/60aa9969f69656bf6eab82cd74b23ab805f112ae46a54b912bccc1533875760f2d2ce95e0a7d13144e35ada9f0386f17ed4961908bc9434b5a5e21375b1902b2
+  languageName: node
+  linkType: hard
+
+"busboy@npm:1.6.0":
+  version: 1.6.0
+  resolution: "busboy@npm:1.6.0"
+  dependencies:
+    streamsearch: "npm:^1.1.0"
+  checksum: 10/bee10fa10ea58e7e3e7489ffe4bda6eacd540a17de9f9cd21cc37e297b2dd9fe52b2715a5841afaec82900750d810d01d7edb4b2d456427f449b92b417579763
+  languageName: node
+  linkType: hard
+
+"byte-size@npm:8.1.1":
+  version: 8.1.1
+  resolution: "byte-size@npm:8.1.1"
+  checksum: 10/eacd83b5f39b4b35115160201553150c3c085473ddb1e788d0f4ee22a2f3461470de5732eef8d7874efbbd883b7ae1277190b579128060e616d606ff419fe1e0
+  languageName: node
+  linkType: hard
+
+"bytes@npm:^3.1.2":
   version: 3.1.2
   resolution: "bytes@npm:3.1.2"
-  checksum: e4bcd3948d289c5127591fbedf10c0b639ccbf00243504e4e127374a15c3bc8eed0d28d4aaab08ff6f1cf2abc0cce6ba3085ed32f4f90e82a5683ce0014e1b6e
+  checksum: 10/a10abf2ba70c784471d6b4f58778c0beeb2b5d405148e66affa91f23a9f13d07603d0a0354667310ae1d6dc141474ffd44e2a074be0f6e2254edb8fc21445388
   languageName: node
   linkType: hard
 
-"call-bind@npm:^1.0.0":
-  version: 1.0.2
-  resolution: "call-bind@npm:1.0.2"
+"cacache@npm:^17.0.0":
+  version: 17.1.4
+  resolution: "cacache@npm:17.1.4"
   dependencies:
-    function-bind: ^1.1.1
-    get-intrinsic: ^1.0.2
-  checksum: f8e31de9d19988a4b80f3e704788c4a2d6b6f3d17cfec4f57dc29ced450c53a49270dc66bf0fbd693329ee948dd33e6c90a329519aef17474a4d961e8d6426b0
+    "@npmcli/fs": "npm:^3.1.0"
+    fs-minipass: "npm:^3.0.0"
+    glob: "npm:^10.2.2"
+    lru-cache: "npm:^7.7.1"
+    minipass: "npm:^7.0.3"
+    minipass-collect: "npm:^1.0.2"
+    minipass-flush: "npm:^1.0.5"
+    minipass-pipeline: "npm:^1.2.4"
+    p-map: "npm:^4.0.0"
+    ssri: "npm:^10.0.0"
+    tar: "npm:^6.1.11"
+    unique-filename: "npm:^3.0.0"
+  checksum: 10/6e26c788bc6a18ff42f4d4f97db30d5c60a5dfac8e7c10a03b0307a92cf1b647570547cf3cd96463976c051eb9c7258629863f156e224c82018862c1a8ad0e70
+  languageName: node
+  linkType: hard
+
+"cacache@npm:^18.0.0":
+  version: 18.0.3
+  resolution: "cacache@npm:18.0.3"
+  dependencies:
+    "@npmcli/fs": "npm:^3.1.0"
+    fs-minipass: "npm:^3.0.0"
+    glob: "npm:^10.2.2"
+    lru-cache: "npm:^10.0.1"
+    minipass: "npm:^7.0.3"
+    minipass-collect: "npm:^2.0.1"
+    minipass-flush: "npm:^1.0.5"
+    minipass-pipeline: "npm:^1.2.4"
+    p-map: "npm:^4.0.0"
+    ssri: "npm:^10.0.0"
+    tar: "npm:^6.1.11"
+    unique-filename: "npm:^3.0.0"
+  checksum: 10/d4c161f071524bb636334b8cf94780c014e29c180a886b8184da8f2f44d2aca88d5664797c661e9f74bdbd34697c2f231ed7c24c256cecbb0a0563ad1ada2219
+  languageName: node
+  linkType: hard
+
+"call-bind@npm:^1.0.2, call-bind@npm:^1.0.7":
+  version: 1.0.7
+  resolution: "call-bind@npm:1.0.7"
+  dependencies:
+    es-define-property: "npm:^1.0.0"
+    es-errors: "npm:^1.3.0"
+    function-bind: "npm:^1.1.2"
+    get-intrinsic: "npm:^1.2.4"
+    set-function-length: "npm:^1.2.1"
+  checksum: 10/cd6fe658e007af80985da5185bff7b55e12ef4c2b6f41829a26ed1eef254b1f1c12e3dfd5b2b068c6ba8b86aba62390842d81752e67dcbaec4f6f76e7113b6b7
+  languageName: node
+  linkType: hard
+
+"callsites@npm:^3.0.0":
+  version: 3.1.0
+  resolution: "callsites@npm:3.1.0"
+  checksum: 10/072d17b6abb459c2ba96598918b55868af677154bec7e73d222ef95a8fdb9bbf7dae96a8421085cdad8cd190d86653b5b6dc55a4484f2e5b2e27d5e0c3fc15b3
+  languageName: node
+  linkType: hard
+
+"camelcase-keys@npm:^6.2.2":
+  version: 6.2.2
+  resolution: "camelcase-keys@npm:6.2.2"
+  dependencies:
+    camelcase: "npm:^5.3.1"
+    map-obj: "npm:^4.0.0"
+    quick-lru: "npm:^4.0.1"
+  checksum: 10/c1999f5b6d03bee7be9a36e48eef3da9e93e51b000677348ec8d15d51fc4418375890fb6c7155e387322d2ebb2a2cdebf9cd96607a6753d1d6c170d9b1e2eed5
   languageName: node
   linkType: hard
 
 "camelcase@npm:^2.0.1":
   version: 2.1.1
   resolution: "camelcase@npm:2.1.1"
-  checksum: 20a3ef08f348de832631d605362ffe447d883ada89617144a82649363ed5860923b021f8e09681624ef774afb93ff3597cfbcf8aaf0574f65af7648f1aea5e50
+  checksum: 10/20a3ef08f348de832631d605362ffe447d883ada89617144a82649363ed5860923b021f8e09681624ef774afb93ff3597cfbcf8aaf0574f65af7648f1aea5e50
   languageName: node
   linkType: hard
 
-"caseless@npm:^0.12.0, caseless@npm:~0.12.0":
-  version: 0.12.0
-  resolution: "caseless@npm:0.12.0"
-  checksum: b43bd4c440aa1e8ee6baefee8063b4850fd0d7b378f6aabc796c9ec8cb26d27fb30b46885350777d9bd079c5256c0e1329ad0dc7c2817e0bb466810ebb353751
+"camelcase@npm:^5.3.1":
+  version: 5.3.1
+  resolution: "camelcase@npm:5.3.1"
+  checksum: 10/e6effce26b9404e3c0f301498184f243811c30dfe6d0b9051863bd8e4034d09c8c2923794f280d6827e5aa055f6c434115ff97864a16a963366fb35fd673024b
+  languageName: node
+  linkType: hard
+
+"camelcase@npm:^6.2.0":
+  version: 6.3.0
+  resolution: "camelcase@npm:6.3.0"
+  checksum: 10/8c96818a9076434998511251dcb2761a94817ea17dbdc37f47ac080bd088fc62c7369429a19e2178b993497132c8cbcf5cc1f44ba963e76782ba469c0474938d
+  languageName: node
+  linkType: hard
+
+"caniuse-lite@npm:^1.0.30001579, caniuse-lite@npm:^1.0.30001587":
+  version: 1.0.30001618
+  resolution: "caniuse-lite@npm:1.0.30001618"
+  checksum: 10/b5a65a60af4dd089e80487754a8ea82e41ce104222b3c2b849cc34ffb412282817d6bf2791f2a24caaf8c7bbf36b22e5b17a55c1edeabfbe68912de106ab0f59
+  languageName: node
+  linkType: hard
+
+"chalk@npm:4.1.0":
+  version: 4.1.0
+  resolution: "chalk@npm:4.1.0"
+  dependencies:
+    ansi-styles: "npm:^4.1.0"
+    supports-color: "npm:^7.1.0"
+  checksum: 10/e8d2b9b9abe5aee78caae44e2fd86ade56e440df5822006d702ce18771c00418b6f2c0eb294093d5486b852c83f021e409205d0ee07095fb14f5c8f9db9e7f80
+  languageName: node
+  linkType: hard
+
+"chalk@npm:^2.4.2":
+  version: 2.4.2
+  resolution: "chalk@npm:2.4.2"
+  dependencies:
+    ansi-styles: "npm:^3.2.1"
+    escape-string-regexp: "npm:^1.0.5"
+    supports-color: "npm:^5.3.0"
+  checksum: 10/3d1d103433166f6bfe82ac75724951b33769675252d8417317363ef9d54699b7c3b2d46671b772b893a8e50c3ece70c4b933c73c01e81bc60ea4df9b55afa303
+  languageName: node
+  linkType: hard
+
+"chalk@npm:^4.0.0, chalk@npm:^4.0.2, chalk@npm:^4.1.0, chalk@npm:^4.1.1":
+  version: 4.1.2
+  resolution: "chalk@npm:4.1.2"
+  dependencies:
+    ansi-styles: "npm:^4.1.0"
+    supports-color: "npm:^7.1.0"
+  checksum: 10/cb3f3e594913d63b1814d7ca7c9bafbf895f75fbf93b92991980610dfd7b48500af4e3a5d4e3a8f337990a96b168d7eb84ee55efdce965e2ee8efc20f8c8f139
+  languageName: node
+  linkType: hard
+
+"char-regex@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "char-regex@npm:1.0.2"
+  checksum: 10/1ec5c2906adb9f84e7f6732a40baef05d7c85401b82ffcbc44b85fbd0f7a2b0c2a96f2eb9cf55cae3235dc12d4023003b88f09bcae8be9ae894f52ed746f4d48
+  languageName: node
+  linkType: hard
+
+"chardet@npm:^0.7.0":
+  version: 0.7.0
+  resolution: "chardet@npm:0.7.0"
+  checksum: 10/b0ec668fba5eeec575ed2559a0917ba41a6481f49063c8445400e476754e0957ee09e44dc032310f526182b8f1bf25e9d4ed371f74050af7be1383e06bc44952
+  languageName: node
+  linkType: hard
+
+"chownr@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "chownr@npm:2.0.0"
+  checksum: 10/c57cf9dd0791e2f18a5ee9c1a299ae6e801ff58fee96dc8bfd0dcb4738a6ce58dd252a3605b1c93c6418fe4f9d5093b28ffbf4d66648cb2a9c67eaef9679be2f
+  languageName: node
+  linkType: hard
+
+"ci-info@npm:^3.2.0, ci-info@npm:^3.6.1":
+  version: 3.9.0
+  resolution: "ci-info@npm:3.9.0"
+  checksum: 10/75bc67902b4d1c7b435497adeb91598f6d52a3389398e44294f6601b20cfef32cf2176f7be0eb961d9e085bb333a8a5cae121cb22f81cf238ae7f58eb80e9397
+  languageName: node
+  linkType: hard
+
+"cjs-module-lexer@npm:^1.0.0":
+  version: 1.3.1
+  resolution: "cjs-module-lexer@npm:1.3.1"
+  checksum: 10/6629188d5ce74b57e5dce2222db851b5496a8d65b533a05957fb24089a3cec8d769378013c375a954c5a0f7522cde6a36d5a65bfd88f5575cb2de3176046fa8e
+  languageName: node
+  linkType: hard
+
+"clean-stack@npm:^2.0.0":
+  version: 2.2.0
+  resolution: "clean-stack@npm:2.2.0"
+  checksum: 10/2ac8cd2b2f5ec986a3c743935ec85b07bc174d5421a5efc8017e1f146a1cf5f781ae962618f416352103b32c9cd7e203276e8c28241bbe946160cab16149fb68
+  languageName: node
+  linkType: hard
+
+"cli-cursor@npm:3.1.0, cli-cursor@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "cli-cursor@npm:3.1.0"
+  dependencies:
+    restore-cursor: "npm:^3.1.0"
+  checksum: 10/2692784c6cd2fd85cfdbd11f53aea73a463a6d64a77c3e098b2b4697a20443f430c220629e1ca3b195ea5ac4a97a74c2ee411f3807abf6df2b66211fec0c0a29
+  languageName: node
+  linkType: hard
+
+"cli-spinners@npm:2.6.1":
+  version: 2.6.1
+  resolution: "cli-spinners@npm:2.6.1"
+  checksum: 10/3e2dc5df72cf02120bebe256881fc8e3ec49867e5023d39f1e7340d7da57964f5236f4c75e568aa9dea6460b56f7a6d5870b89453c743c6c15e213cb52be2122
+  languageName: node
+  linkType: hard
+
+"cli-spinners@npm:^2.5.0":
+  version: 2.9.2
+  resolution: "cli-spinners@npm:2.9.2"
+  checksum: 10/a0a863f442df35ed7294424f5491fa1756bd8d2e4ff0c8736531d886cec0ece4d85e8663b77a5afaf1d296e3cbbebff92e2e99f52bbea89b667cbe789b994794
+  languageName: node
+  linkType: hard
+
+"cli-width@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "cli-width@npm:3.0.0"
+  checksum: 10/8730848b04fb189666ab037a35888d191c8f05b630b1d770b0b0e4c920b47bb5cc14bddf6b8ffe5bfc66cee97c8211d4d18e756c1ffcc75d7dbe7e1186cd7826
   languageName: node
   linkType: hard
 
@@ -1305,9 +3632,16 @@ __metadata:
   version: 1.0.1
   resolution: "cli@npm:1.0.1"
   dependencies:
-    exit: 0.1.2
-    glob: ^7.1.1
-  checksum: c47cdbb3b87696e45cc07340e415b5863b20833ae8184ca8a0b1d732fbd908f6e6e13376e4a509685af1bc916afbb3e2a0adf1eec8797575eefe63c7bb516962
+    exit: "npm:0.1.2"
+    glob: "npm:^7.1.1"
+  checksum: 10/b8507c7df6aa39047eb51e55256c92c19456588529cbb0f5acc24e6e9478a81b90489640e45e19cea2b5e20e87a9067150bdf34d5eb8854523fb69900b8123e5
+  languageName: node
+  linkType: hard
+
+"client-only@npm:0.0.1":
+  version: 0.0.1
+  resolution: "client-only@npm:0.0.1"
+  checksum: 10/0c16bf660dadb90610553c1d8946a7fdfb81d624adea073b8440b7d795d5b5b08beb3c950c6a2cf16279365a3265158a236876d92bce16423c485c322d7dfaf8
   languageName: node
   linkType: hard
 
@@ -1315,10 +3649,10 @@ __metadata:
   version: 3.2.0
   resolution: "cliui@npm:3.2.0"
   dependencies:
-    string-width: ^1.0.1
-    strip-ansi: ^3.0.1
-    wrap-ansi: ^2.0.0
-  checksum: c68d1dbc3e347bfe79ed19cc7f48007d5edd6cd8438342e32073e0b4e311e3c44e1f4f19221462bc6590de56c2df520e427533a9dde95dee25710bec322746ad
+    string-width: "npm:^1.0.1"
+    strip-ansi: "npm:^3.0.1"
+    wrap-ansi: "npm:^2.0.0"
+  checksum: 10/a8acc1a2e5f6307bb3200738a55b353ae5ca13d7a9a8001e40bdf2449c228104daf245e29cdfe60652ffafc3e70096fc1624cd9cf8651bb322903dbbb22a4ac3
   languageName: node
   linkType: hard
 
@@ -1326,17 +3660,67 @@ __metadata:
   version: 7.0.4
   resolution: "cliui@npm:7.0.4"
   dependencies:
-    string-width: ^4.2.0
-    strip-ansi: ^6.0.0
-    wrap-ansi: ^7.0.0
-  checksum: ce2e8f578a4813806788ac399b9e866297740eecd4ad1823c27fd344d78b22c5f8597d548adbcc46f0573e43e21e751f39446c5a5e804a12aace402b7a315d7f
+    string-width: "npm:^4.2.0"
+    strip-ansi: "npm:^6.0.0"
+    wrap-ansi: "npm:^7.0.0"
+  checksum: 10/db858c49af9d59a32d603987e6fddaca2ce716cd4602ba5a2bb3a5af1351eebe82aba8dff3ef3e1b331f7fa9d40ca66e67bdf8e7c327ce0ea959747ead65c0ef
+  languageName: node
+  linkType: hard
+
+"cliui@npm:^8.0.1":
+  version: 8.0.1
+  resolution: "cliui@npm:8.0.1"
+  dependencies:
+    string-width: "npm:^4.2.0"
+    strip-ansi: "npm:^6.0.1"
+    wrap-ansi: "npm:^7.0.0"
+  checksum: 10/eaa5561aeb3135c2cddf7a3b3f562fc4238ff3b3fc666869ef2adf264be0f372136702f16add9299087fb1907c2e4ec5dbfe83bd24bce815c70a80c6c1a2e950
+  languageName: node
+  linkType: hard
+
+"clone-deep@npm:4.0.1":
+  version: 4.0.1
+  resolution: "clone-deep@npm:4.0.1"
+  dependencies:
+    is-plain-object: "npm:^2.0.4"
+    kind-of: "npm:^6.0.2"
+    shallow-clone: "npm:^3.0.0"
+  checksum: 10/770f912fe4e6f21873c8e8fbb1e99134db3b93da32df271d00589ea4a29dbe83a9808a322c93f3bcaf8584b8b4fa6fc269fc8032efbaa6728e0c9886c74467d2
+  languageName: node
+  linkType: hard
+
+"clone@npm:^1.0.2":
+  version: 1.0.4
+  resolution: "clone@npm:1.0.4"
+  checksum: 10/d06418b7335897209e77bdd430d04f882189582e67bd1f75a04565f3f07f5b3f119a9d670c943b6697d0afb100f03b866b3b8a1f91d4d02d72c4ecf2bb64b5dd
+  languageName: node
+  linkType: hard
+
+"cmd-shim@npm:6.0.1":
+  version: 6.0.1
+  resolution: "cmd-shim@npm:6.0.1"
+  checksum: 10/d0718e4a49265a9195ced19f662a77569ce5939145451125bdc8bb302781f15564ade92f6c49e231f9d0bb6f3d71db1a2d0a50af940490eb324e152325039541
+  languageName: node
+  linkType: hard
+
+"co@npm:^4.6.0":
+  version: 4.6.0
+  resolution: "co@npm:4.6.0"
+  checksum: 10/a5d9f37091c70398a269e625cedff5622f200ed0aa0cff22ee7b55ed74a123834b58711776eb0f1dc58eb6ebbc1185aa7567b57bd5979a948c6e4f85073e2c05
   languageName: node
   linkType: hard
 
 "code-point-at@npm:^1.0.0":
   version: 1.1.0
   resolution: "code-point-at@npm:1.1.0"
-  checksum: 17d5666611f9b16d64fdf48176d9b7fb1c7d1c1607a189f7e600040a11a6616982876af148230336adb7d8fe728a559f743a4e29db3747e3b1a32fa7f4529681
+  checksum: 10/17d5666611f9b16d64fdf48176d9b7fb1c7d1c1607a189f7e600040a11a6616982876af148230336adb7d8fe728a559f743a4e29db3747e3b1a32fa7f4529681
+  languageName: node
+  linkType: hard
+
+"collect-v8-coverage@npm:^1.0.0":
+  version: 1.0.2
+  resolution: "collect-v8-coverage@npm:1.0.2"
+  checksum: 10/30ea7d5c9ee51f2fdba4901d4186c5b7114a088ef98fd53eda3979da77eed96758a2cae81cc6d97e239aaea6065868cf908b24980663f7b7e96aa291b3e12fa4
   languageName: node
   linkType: hard
 
@@ -1344,8 +3728,8 @@ __metadata:
   version: 1.9.3
   resolution: "color-convert@npm:1.9.3"
   dependencies:
-    color-name: 1.1.3
-  checksum: fd7a64a17cde98fb923b1dd05c5f2e6f7aefda1b60d67e8d449f9328b4e53b228a428fd38bfeaeb2db2ff6b6503a776a996150b80cdf224062af08a5c8a3a203
+    color-name: "npm:1.1.3"
+  checksum: 10/ffa319025045f2973919d155f25e7c00d08836b6b33ea2d205418c59bd63a665d713c52d9737a9e0fe467fb194b40fbef1d849bae80d674568ee220a31ef3d10
   languageName: node
   linkType: hard
 
@@ -1353,57 +3737,86 @@ __metadata:
   version: 2.0.1
   resolution: "color-convert@npm:2.0.1"
   dependencies:
-    color-name: ~1.1.4
-  checksum: 79e6bdb9fd479a205c71d89574fccfb22bd9053bd98c6c4d870d65c132e5e904e6034978e55b43d69fcaa7433af2016ee203ce76eeba9cfa554b373e7f7db336
+    color-name: "npm:~1.1.4"
+  checksum: 10/fa00c91b4332b294de06b443923246bccebe9fab1b253f7fe1772d37b06a2269b4039a85e309abe1fe11b267b11c08d1d0473fda3badd6167f57313af2887a64
   languageName: node
   linkType: hard
 
 "color-name@npm:1.1.3":
   version: 1.1.3
   resolution: "color-name@npm:1.1.3"
-  checksum: 09c5d3e33d2105850153b14466501f2bfb30324a2f76568a408763a3b7433b0e50e5b4ab1947868e65cb101bb7cb75029553f2c333b6d4b8138a73fcc133d69d
+  checksum: 10/09c5d3e33d2105850153b14466501f2bfb30324a2f76568a408763a3b7433b0e50e5b4ab1947868e65cb101bb7cb75029553f2c333b6d4b8138a73fcc133d69d
   languageName: node
   linkType: hard
 
 "color-name@npm:~1.1.4":
   version: 1.1.4
   resolution: "color-name@npm:1.1.4"
-  checksum: b0445859521eb4021cd0fb0cc1a75cecf67fceecae89b63f62b201cca8d345baf8b952c966862a9d9a2632987d4f6581f0ec8d957dfacece86f0a7919316f610
+  checksum: 10/b0445859521eb4021cd0fb0cc1a75cecf67fceecae89b63f62b201cca8d345baf8b952c966862a9d9a2632987d4f6581f0ec8d957dfacece86f0a7919316f610
+  languageName: node
+  linkType: hard
+
+"color-support@npm:^1.1.3":
+  version: 1.1.3
+  resolution: "color-support@npm:1.1.3"
+  bin:
+    color-support: bin.js
+  checksum: 10/4bcfe30eea1498fe1cabc852bbda6c9770f230ea0e4faf4611c5858b1b9e4dde3730ac485e65f54ca182f4c50b626c1bea7c8441ceda47367a54a818c248aa7a
   languageName: node
   linkType: hard
 
 "colors@npm:^1.4.0":
   version: 1.4.0
   resolution: "colors@npm:1.4.0"
-  checksum: 98aa2c2418ad87dedf25d781be69dc5fc5908e279d9d30c34d8b702e586a0474605b3a189511482b9d5ed0d20c867515d22749537f7bc546256c6014f3ebdcec
+  checksum: 10/90b2d5465159813a3983ea72ca8cff75f784824ad70f2cc2b32c233e95bcfbcda101ebc6d6766bc50f57263792629bfb4f1f8a4dfbd1d240f229fc7f69b785fc
   languageName: node
   linkType: hard
 
-"combined-stream@npm:^1.0.6":
+"columnify@npm:1.6.0":
+  version: 1.6.0
+  resolution: "columnify@npm:1.6.0"
+  dependencies:
+    strip-ansi: "npm:^6.0.1"
+    wcwidth: "npm:^1.0.0"
+  checksum: 10/ab742cc646c07293db603f7a4387ca9d46d32beaaba0a08008c2f31f30042e6e5a940096fb7d2d432495597ed3d5c5fe07a5bacd55e4ac24a768d344a47dd678
+  languageName: node
+  linkType: hard
+
+"combined-stream@npm:^1.0.8":
   version: 1.0.8
   resolution: "combined-stream@npm:1.0.8"
   dependencies:
-    delayed-stream: ~1.0.0
-  checksum: 49fa4aeb4916567e33ea81d088f6584749fc90c7abec76fd516bf1c5aa5c79f3584b5ba3de6b86d26ddd64bae5329c4c7479343250cfe71c75bb366eae53bb7c
+    delayed-stream: "npm:~1.0.0"
+  checksum: 10/2e969e637d05d09fa50b02d74c83a1186f6914aae89e6653b62595cc75a221464f884f55f231b8f4df7a49537fba60bdc0427acd2bf324c09a1dbb84837e36e4
+  languageName: node
+  linkType: hard
+
+"compare-func@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "compare-func@npm:2.0.0"
+  dependencies:
+    array-ify: "npm:^1.0.0"
+    dot-prop: "npm:^5.1.0"
+  checksum: 10/fb71d70632baa1e93283cf9d80f30ac97f003aabee026e0b4426c9716678079ef5fea7519b84d012cbed938c476493866a38a79760564a9e21ae9433e40e6f0d
   languageName: node
   linkType: hard
 
 "concat-map@npm:0.0.1":
   version: 0.0.1
   resolution: "concat-map@npm:0.0.1"
-  checksum: 902a9f5d8967a3e2faf138d5cb784b9979bad2e6db5357c5b21c568df4ebe62bcb15108af1b2253744844eb964fc023fbd9afbbbb6ddd0bcc204c6fb5b7bf3af
+  checksum: 10/9680699c8e2b3af0ae22592cb764acaf973f292a7b71b8a06720233011853a58e256c89216a10cbe889727532fd77f8bcd49a760cedfde271b8e006c20e079f2
   languageName: node
   linkType: hard
 
-"concat-stream@npm:^1.6.0, concat-stream@npm:^1.6.2":
-  version: 1.6.2
-  resolution: "concat-stream@npm:1.6.2"
+"concat-stream@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "concat-stream@npm:2.0.0"
   dependencies:
-    buffer-from: ^1.0.0
-    inherits: ^2.0.3
-    readable-stream: ^2.2.2
-    typedarray: ^0.0.6
-  checksum: 1ef77032cb4459dcd5187bd710d6fc962b067b64ec6a505810de3d2b8cc0605638551b42f8ec91edf6fcd26141b32ef19ad749239b58fae3aba99187adc32285
+    buffer-from: "npm:^1.0.0"
+    inherits: "npm:^2.0.3"
+    readable-stream: "npm:^3.0.2"
+    typedarray: "npm:^0.0.6"
+  checksum: 10/250e576d0617e7c58e1c4b2dd6fe69560f316d2c962a409f9f3aac794018499ddb31948b1e4296f217008e124cd5d526432097745157fe504b5d9f3dc469eadb
   languageName: node
   linkType: hard
 
@@ -1411,59 +3824,344 @@ __metadata:
   version: 1.1.0
   resolution: "console-browserify@npm:1.1.0"
   dependencies:
-    date-now: ^0.1.4
-  checksum: ab1fd09cab65b146ccd15a3fcbf18f79d5069e55a0be518a91bee1533d2d4a83be5fa0c5bb4b9f0bc7cf1642fd1850abab464ab515bf7724888187af1baad2c3
+    date-now: "npm:^0.1.4"
+  checksum: 10/ab1fd09cab65b146ccd15a3fcbf18f79d5069e55a0be518a91bee1533d2d4a83be5fa0c5bb4b9f0bc7cf1642fd1850abab464ab515bf7724888187af1baad2c3
+  languageName: node
+  linkType: hard
+
+"console-control-strings@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "console-control-strings@npm:1.1.0"
+  checksum: 10/27b5fa302bc8e9ae9e98c03c66d76ca289ad0c61ce2fe20ab288d288bee875d217512d2edb2363fc83165e88f1c405180cf3f5413a46e51b4fe1a004840c6cdb
+  languageName: node
+  linkType: hard
+
+"conventional-changelog-angular@npm:7.0.0":
+  version: 7.0.0
+  resolution: "conventional-changelog-angular@npm:7.0.0"
+  dependencies:
+    compare-func: "npm:^2.0.0"
+  checksum: 10/e7966d2fee5475e76263f30f8b714b2b592b5bf556df225b7091e5090831fc9a20b99598a7d2997e19c2ef8118c0a3150b1eba290786367b0f55a5ccfa804ec9
+  languageName: node
+  linkType: hard
+
+"conventional-changelog-core@npm:5.0.1":
+  version: 5.0.1
+  resolution: "conventional-changelog-core@npm:5.0.1"
+  dependencies:
+    add-stream: "npm:^1.0.0"
+    conventional-changelog-writer: "npm:^6.0.0"
+    conventional-commits-parser: "npm:^4.0.0"
+    dateformat: "npm:^3.0.3"
+    get-pkg-repo: "npm:^4.2.1"
+    git-raw-commits: "npm:^3.0.0"
+    git-remote-origin-url: "npm:^2.0.0"
+    git-semver-tags: "npm:^5.0.0"
+    normalize-package-data: "npm:^3.0.3"
+    read-pkg: "npm:^3.0.0"
+    read-pkg-up: "npm:^3.0.0"
+  checksum: 10/df716cd61eec26b1379370f7dc87df6eadfb6b42c1c99291fcca1c68cd669643539d619fae3fa0ad9255b4e8c30af3b709e058ba62bc5c3a06dc14190c7ef5cc
+  languageName: node
+  linkType: hard
+
+"conventional-changelog-preset-loader@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "conventional-changelog-preset-loader@npm:3.0.0"
+  checksum: 10/199c4730c5151f243d35c24585114900c2a7091eab5832cfeb49067a18a2b77d5c9a86b779e6e18b49278a1ff83c011c1d9bb6da95bd1f78d9e36d4d379216d5
+  languageName: node
+  linkType: hard
+
+"conventional-changelog-writer@npm:^6.0.0":
+  version: 6.0.1
+  resolution: "conventional-changelog-writer@npm:6.0.1"
+  dependencies:
+    conventional-commits-filter: "npm:^3.0.0"
+    dateformat: "npm:^3.0.3"
+    handlebars: "npm:^4.7.7"
+    json-stringify-safe: "npm:^5.0.1"
+    meow: "npm:^8.1.2"
+    semver: "npm:^7.0.0"
+    split: "npm:^1.0.1"
+  bin:
+    conventional-changelog-writer: cli.js
+  checksum: 10/9649d390b91c0621b17ccd7faf046990385da46c53004fcc3f13e5887ece26d134316d466de8c21d0c90672c1fca2b7ec98f28603ee04df8cfe5bcfc1fb70e76
+  languageName: node
+  linkType: hard
+
+"conventional-commits-filter@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "conventional-commits-filter@npm:3.0.0"
+  dependencies:
+    lodash.ismatch: "npm:^4.4.0"
+    modify-values: "npm:^1.0.1"
+  checksum: 10/73337f42acff7189e1dfca8d13c9448ce085ac1c09976cb33617cc909949621befb1640b1c6c30a1be4953a1be0deea9e93fa0dc86725b8be8e249a64fbb4632
+  languageName: node
+  linkType: hard
+
+"conventional-commits-parser@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "conventional-commits-parser@npm:4.0.0"
+  dependencies:
+    JSONStream: "npm:^1.3.5"
+    is-text-path: "npm:^1.0.1"
+    meow: "npm:^8.1.2"
+    split2: "npm:^3.2.2"
+  bin:
+    conventional-commits-parser: cli.js
+  checksum: 10/d3b7d947b486d3bb40f961808947ee46487429e050be840030211a80aa2eec170e427207c830f2720d8ab898649a652bbbe1825993b8bf0596517e3603f5a1bd
+  languageName: node
+  linkType: hard
+
+"conventional-recommended-bump@npm:7.0.1":
+  version: 7.0.1
+  resolution: "conventional-recommended-bump@npm:7.0.1"
+  dependencies:
+    concat-stream: "npm:^2.0.0"
+    conventional-changelog-preset-loader: "npm:^3.0.0"
+    conventional-commits-filter: "npm:^3.0.0"
+    conventional-commits-parser: "npm:^4.0.0"
+    git-raw-commits: "npm:^3.0.0"
+    git-semver-tags: "npm:^5.0.0"
+    meow: "npm:^8.1.2"
+  bin:
+    conventional-recommended-bump: cli.js
+  checksum: 10/8d815e7c6f8083085ce4c784b27b0799de628ad2671d99e23c4b08885fb04c5b2adcb6053898eb1f183ee26489273edcbb110c7cd9f80cb06153be53fef2b174
+  languageName: node
+  linkType: hard
+
+"convert-source-map@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "convert-source-map@npm:2.0.0"
+  checksum: 10/c987be3ec061348cdb3c2bfb924bec86dea1eacad10550a85ca23edb0fe3556c3a61c7399114f3331ccb3499d7fd0285ab24566e5745929412983494c3926e15
   languageName: node
   linkType: hard
 
 "core-util-is@npm:~1.0.0":
   version: 1.0.3
   resolution: "core-util-is@npm:1.0.3"
-  checksum: 9de8597363a8e9b9952491ebe18167e3b36e7707569eed0ebf14f8bba773611376466ae34575bca8cfe3c767890c859c74056084738f09d4e4a6f902b2ad7d99
+  checksum: 10/9de8597363a8e9b9952491ebe18167e3b36e7707569eed0ebf14f8bba773611376466ae34575bca8cfe3c767890c859c74056084738f09d4e4a6f902b2ad7d99
   languageName: node
   linkType: hard
 
-"cross-fetch@npm:^3.0.6":
-  version: 3.1.5
-  resolution: "cross-fetch@npm:3.1.5"
+"cosmiconfig@npm:^8.2.0":
+  version: 8.3.6
+  resolution: "cosmiconfig@npm:8.3.6"
   dependencies:
-    node-fetch: 2.6.7
-  checksum: f6b8c6ee3ef993ace6277fd789c71b6acf1b504fd5f5c7128df4ef2f125a429e29cd62dc8c127523f04a5f2fa4771ed80e3f3d9695617f441425045f505cf3bb
+    import-fresh: "npm:^3.3.0"
+    js-yaml: "npm:^4.1.0"
+    parse-json: "npm:^5.2.0"
+    path-type: "npm:^4.0.0"
+  peerDependencies:
+    typescript: ">=4.9.5"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10/91d082baca0f33b1c085bf010f9ded4af43cbedacba8821da0fb5667184d0a848addc52c31fadd080007f904a555319c238cf5f4c03e6d58ece2e4876b2e73d6
   languageName: node
   linkType: hard
 
-"date-and-time@npm:^0.14.2":
-  version: 0.14.2
-  resolution: "date-and-time@npm:0.14.2"
-  checksum: dd50a5d343961974bce2d289d23d6b0c3b6face40ea78f7e455ca0f90002b5e32124df4ab8a683a0c626a119e94be436901cb74d12aefc1307e36be68f8d5e48
+"create-jest@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "create-jest@npm:29.7.0"
+  dependencies:
+    "@jest/types": "npm:^29.6.3"
+    chalk: "npm:^4.0.0"
+    exit: "npm:^0.1.2"
+    graceful-fs: "npm:^4.2.9"
+    jest-config: "npm:^29.7.0"
+    jest-util: "npm:^29.7.0"
+    prompts: "npm:^2.0.1"
+  bin:
+    create-jest: bin/create-jest.js
+  checksum: 10/847b4764451672b4174be4d5c6d7d63442ec3aa5f3de52af924e4d996d87d7801c18e125504f25232fc75840f6625b3ac85860fac6ce799b5efae7bdcaf4a2b7
   languageName: node
   linkType: hard
 
-"date-fns@npm:^2.17.0, date-fns@npm:^2.7.0":
-  version: 2.29.3
-  resolution: "date-fns@npm:2.29.3"
-  checksum: e01cf5b62af04e05dfff921bb9c9933310ed0e1ae9a81eb8653452e64dc841acf7f6e01e1a5ae5644d0337e9a7f936175fd2cb6819dc122fdd9c5e86c56be484
+"cross-fetch@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "cross-fetch@npm:4.0.0"
+  dependencies:
+    node-fetch: "npm:^2.6.12"
+  checksum: 10/e231a71926644ef122d334a3a4e73d9ba3ba4b480a8a277fb9badc434c1ba905b3d60c8034e18b348361a09afbec40ba9371036801ba2b675a7b84588f9f55d8
+  languageName: node
+  linkType: hard
+
+"cross-spawn@npm:^7.0.0, cross-spawn@npm:^7.0.3":
+  version: 7.0.3
+  resolution: "cross-spawn@npm:7.0.3"
+  dependencies:
+    path-key: "npm:^3.1.0"
+    shebang-command: "npm:^2.0.0"
+    which: "npm:^2.0.1"
+  checksum: 10/e1a13869d2f57d974de0d9ef7acbf69dc6937db20b918525a01dacb5032129bd552d290d886d981e99f1b624cb03657084cc87bd40f115c07ecf376821c729ce
+  languageName: node
+  linkType: hard
+
+"dargs@npm:^7.0.0":
+  version: 7.0.0
+  resolution: "dargs@npm:7.0.0"
+  checksum: 10/b8f1e3cba59c42e1f13a114ad4848c3fc1cf7470f633ee9e9f1043762429bc97d91ae31b826fb135eefde203a3fdb20deb0c0a0222ac29d937b8046085d668d1
+  languageName: node
+  linkType: hard
+
+"date-and-time@npm:^3.1.1":
+  version: 3.2.0
+  resolution: "date-and-time@npm:3.2.0"
+  checksum: 10/6a897b27308d7bc82641b5f9761b9d43423fad050e99964856a08a88e8db63825c3db5ae2c8efac8c3f0e5de0044dd3b5136ef86b9a59f0595b1456b9ce3f9a9
+  languageName: node
+  linkType: hard
+
+"date-fns@npm:^3.6.0":
+  version: 3.6.0
+  resolution: "date-fns@npm:3.6.0"
+  checksum: 10/cac35c58926a3b5d577082ff2b253612ec1c79eb6754fddef46b6a8e826501ea2cb346ecbd211205f1ba382ddd1f9d8c3f00bf433ad63cc3063454d294e3a6b8
   languageName: node
   linkType: hard
 
 "date-now@npm:^0.1.4":
   version: 0.1.4
   resolution: "date-now@npm:0.1.4"
-  checksum: 7f4762ce64c3535cb004d8f8517dae23b57fed221ffd661ef7db0142dc639a66e95700da10e98b9225d86dd2655d81a3d7bc2186adcb09a6a8e13647265a621d
+  checksum: 10/7f4762ce64c3535cb004d8f8517dae23b57fed221ffd661ef7db0142dc639a66e95700da10e98b9225d86dd2655d81a3d7bc2186adcb09a6a8e13647265a621d
   languageName: node
   linkType: hard
 
-"decamelize@npm:^1.1.1":
+"dateformat@npm:^3.0.3":
+  version: 3.0.3
+  resolution: "dateformat@npm:3.0.3"
+  checksum: 10/0504baf50c3777ad333c96c37d1673d67efcb7dd071563832f70b5cbf7f3f4753f18981d44bfd8f665d5e5a511d2fc0af8e0ead8b585b9b3ddaa90067864d3f0
+  languageName: node
+  linkType: hard
+
+"debug@npm:4, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.1, debug@npm:^4.3.3, debug@npm:^4.3.4":
+  version: 4.3.4
+  resolution: "debug@npm:4.3.4"
+  dependencies:
+    ms: "npm:2.1.2"
+  peerDependenciesMeta:
+    supports-color:
+      optional: true
+  checksum: 10/0073c3bcbd9cb7d71dd5f6b55be8701af42df3e56e911186dfa46fac3a5b9eb7ce7f377dd1d3be6db8977221f8eb333d945216f645cf56f6b688cd484837d255
+  languageName: node
+  linkType: hard
+
+"decamelize-keys@npm:^1.1.0":
+  version: 1.1.1
+  resolution: "decamelize-keys@npm:1.1.1"
+  dependencies:
+    decamelize: "npm:^1.1.0"
+    map-obj: "npm:^1.0.0"
+  checksum: 10/71d5898174f17a8d2303cecc98ba0236e842948c4d042a8180d5e749be8442220bca2d16dd93bebd7b49e86c807814273212e4da0fae67be7c58c282ff76057a
+  languageName: node
+  linkType: hard
+
+"decamelize@npm:^1.1.0, decamelize@npm:^1.1.1":
   version: 1.2.0
   resolution: "decamelize@npm:1.2.0"
-  checksum: ad8c51a7e7e0720c70ec2eeb1163b66da03e7616d7b98c9ef43cce2416395e84c1e9548dd94f5f6ffecfee9f8b94251fc57121a8b021f2ff2469b2bae247b8aa
+  checksum: 10/ad8c51a7e7e0720c70ec2eeb1163b66da03e7616d7b98c9ef43cce2416395e84c1e9548dd94f5f6ffecfee9f8b94251fc57121a8b021f2ff2469b2bae247b8aa
+  languageName: node
+  linkType: hard
+
+"dedent@npm:0.7.0":
+  version: 0.7.0
+  resolution: "dedent@npm:0.7.0"
+  checksum: 10/87de191050d9a40dd70cad01159a0bcf05ecb59750951242070b6abf9569088684880d00ba92a955b4058804f16eeaf91d604f283929b4f614d181cd7ae633d2
+  languageName: node
+  linkType: hard
+
+"dedent@npm:^1.0.0":
+  version: 1.5.3
+  resolution: "dedent@npm:1.5.3"
+  peerDependencies:
+    babel-plugin-macros: ^3.1.0
+  peerDependenciesMeta:
+    babel-plugin-macros:
+      optional: true
+  checksum: 10/e5277f6268f288649503125b781a7b7a2c9b22d011139688c0b3619fe40121e600eb1f077c891938d4b2428bdb6326cc3c77a763e4b1cc681bd9666ab1bad2a1
+  languageName: node
+  linkType: hard
+
+"deepmerge@npm:^4.2.2":
+  version: 4.3.1
+  resolution: "deepmerge@npm:4.3.1"
+  checksum: 10/058d9e1b0ff1a154468bf3837aea436abcfea1ba1d165ddaaf48ca93765fdd01a30d33c36173da8fbbed951dd0a267602bc782fe288b0fc4b7e1e7091afc4529
+  languageName: node
+  linkType: hard
+
+"defaults@npm:^1.0.3":
+  version: 1.0.4
+  resolution: "defaults@npm:1.0.4"
+  dependencies:
+    clone: "npm:^1.0.2"
+  checksum: 10/3a88b7a587fc076b84e60affad8b85245c01f60f38fc1d259e7ac1d89eb9ce6abb19e27215de46b98568dd5bc48471730b327637e6f20b0f1bc85cf00440c80a
+  languageName: node
+  linkType: hard
+
+"define-data-property@npm:^1.1.4":
+  version: 1.1.4
+  resolution: "define-data-property@npm:1.1.4"
+  dependencies:
+    es-define-property: "npm:^1.0.0"
+    es-errors: "npm:^1.3.0"
+    gopd: "npm:^1.0.1"
+  checksum: 10/abdcb2505d80a53524ba871273e5da75e77e52af9e15b3aa65d8aad82b8a3a424dad7aee2cc0b71470ac7acf501e08defac362e8b6a73cdb4309f028061df4ae
+  languageName: node
+  linkType: hard
+
+"define-lazy-prop@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "define-lazy-prop@npm:2.0.0"
+  checksum: 10/0115fdb065e0490918ba271d7339c42453d209d4cb619dfe635870d906731eff3e1ade8028bb461ea27ce8264ec5e22c6980612d332895977e89c1bbc80fcee2
   languageName: node
   linkType: hard
 
 "delayed-stream@npm:~1.0.0":
   version: 1.0.0
   resolution: "delayed-stream@npm:1.0.0"
-  checksum: 46fe6e83e2cb1d85ba50bd52803c68be9bd953282fa7096f51fc29edd5d67ff84ff753c51966061e5ba7cb5e47ef6d36a91924eddb7f3f3483b1c560f77a0020
+  checksum: 10/46fe6e83e2cb1d85ba50bd52803c68be9bd953282fa7096f51fc29edd5d67ff84ff753c51966061e5ba7cb5e47ef6d36a91924eddb7f3f3483b1c560f77a0020
+  languageName: node
+  linkType: hard
+
+"delegates@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "delegates@npm:1.0.0"
+  checksum: 10/a51744d9b53c164ba9c0492471a1a2ffa0b6727451bdc89e31627fdf4adda9d51277cfcbfb20f0a6f08ccb3c436f341df3e92631a3440226d93a8971724771fd
+  languageName: node
+  linkType: hard
+
+"deprecation@npm:^2.0.0":
+  version: 2.3.1
+  resolution: "deprecation@npm:2.3.1"
+  checksum: 10/f56a05e182c2c195071385455956b0c4106fe14e36245b00c689ceef8e8ab639235176a96977ba7c74afb173317fac2e0ec6ec7a1c6d1e6eaa401c586c714132
+  languageName: node
+  linkType: hard
+
+"detect-indent@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "detect-indent@npm:5.0.0"
+  checksum: 10/61763211daa498e00eec073aba95d544ae5baed19286a0a655697fa4fffc9f4539c8376e2c7df8fa11d6f8eaa16c1e6a689f403ac41ee78a060278cdadefe2ff
+  languageName: node
+  linkType: hard
+
+"detect-newline@npm:^3.0.0":
+  version: 3.1.0
+  resolution: "detect-newline@npm:3.1.0"
+  checksum: 10/ae6cd429c41ad01b164c59ea36f264a2c479598e61cba7c99da24175a7ab80ddf066420f2bec9a1c57a6bead411b4655ff15ad7d281c000a89791f48cbe939e7
+  languageName: node
+  linkType: hard
+
+"diff-sequences@npm:^29.6.3":
+  version: 29.6.3
+  resolution: "diff-sequences@npm:29.6.3"
+  checksum: 10/179daf9d2f9af5c57ad66d97cb902a538bcf8ed64963fa7aa0c329b3de3665ce2eb6ffdc2f69f29d445fa4af2517e5e55e5b6e00c00a9ae4f43645f97f7078cb
+  languageName: node
+  linkType: hard
+
+"dir-glob@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "dir-glob@npm:3.0.1"
+  dependencies:
+    path-type: "npm:^4.0.0"
+  checksum: 10/fa05e18324510d7283f55862f3161c6759a3f2f8dbce491a2fc14c8324c498286c54282c1f0e933cb930da8419b30679389499b919122952a4f8592362ef4615
   languageName: node
   linkType: hard
 
@@ -1471,23 +4169,23 @@ __metadata:
   version: 0.2.2
   resolution: "dom-serializer@npm:0.2.2"
   dependencies:
-    domelementtype: ^2.0.1
-    entities: ^2.0.0
-  checksum: 376344893e4feccab649a14ca1a46473e9961f40fe62479ea692d4fee4d9df1c00ca8654811a79c1ca7b020096987e1ca4fb4d7f8bae32c1db800a680a0e5d5e
+    domelementtype: "npm:^2.0.1"
+    entities: "npm:^2.0.0"
+  checksum: 10/376344893e4feccab649a14ca1a46473e9961f40fe62479ea692d4fee4d9df1c00ca8654811a79c1ca7b020096987e1ca4fb4d7f8bae32c1db800a680a0e5d5e
   languageName: node
   linkType: hard
 
 "domelementtype@npm:1":
   version: 1.3.1
   resolution: "domelementtype@npm:1.3.1"
-  checksum: 7893da40218ae2106ec6ffc146b17f203487a52f5228b032ea7aa470e41dfe03e1bd762d0ee0139e792195efda765434b04b43cddcf63207b098f6ae44b36ad6
+  checksum: 10/7893da40218ae2106ec6ffc146b17f203487a52f5228b032ea7aa470e41dfe03e1bd762d0ee0139e792195efda765434b04b43cddcf63207b098f6ae44b36ad6
   languageName: node
   linkType: hard
 
 "domelementtype@npm:^2.0.1":
   version: 2.3.0
   resolution: "domelementtype@npm:2.3.0"
-  checksum: ee837a318ff702622f383409d1f5b25dd1024b692ef64d3096ff702e26339f8e345820f29a68bcdcea8cfee3531776b3382651232fbeae95612d6f0a75efb4f6
+  checksum: 10/ee837a318ff702622f383409d1f5b25dd1024b692ef64d3096ff702e26339f8e345820f29a68bcdcea8cfee3531776b3382651232fbeae95612d6f0a75efb4f6
   languageName: node
   linkType: hard
 
@@ -1495,8 +4193,8 @@ __metadata:
   version: 2.3.0
   resolution: "domhandler@npm:2.3.0"
   dependencies:
-    domelementtype: 1
-  checksum: 721ca27a3b28d1c710697356ba0ecbcc64fe3f0bd61a30eae04a02e6bd7720c7f0e40b9d59938db024a170fedf9b9ebe0c9ba603579b512d87ad4c410d851a94
+    domelementtype: "npm:1"
+  checksum: 10/12feae6311a1398fb858f942453e067e2870fb2e566d2684a0c2107e433c6fba45e0c222f502ce65e25bb071a3dd5326507014070186a991fc775061841e71ec
   languageName: node
   linkType: hard
 
@@ -1504,184 +4202,934 @@ __metadata:
   version: 1.5.1
   resolution: "domutils@npm:1.5.1"
   dependencies:
-    dom-serializer: 0
-    domelementtype: 1
-  checksum: 800d1f9d1c2e637267dae078ff6e24461e6be1baeb52fa70f2e7e7520816c032a925997cd15d822de53ef9896abb1f35e5c439d301500a9cd6b46a395f6f6ca0
+    dom-serializer: "npm:0"
+    domelementtype: "npm:1"
+  checksum: 10/88c610e4bba925946663cd5c5d28a359714dc2b0ed1c2ad99e645cbfba46c14e44c053a02dec8b9b436022402b6a32c5b38177723a3082ccdfa283b61e28b9e1
   languageName: node
   linkType: hard
 
-"emoji-regex@npm:^7.0.1":
-  version: 7.0.3
-  resolution: "emoji-regex@npm:7.0.3"
-  checksum: 9159b2228b1511f2870ac5920f394c7e041715429a68459ebe531601555f11ea782a8e1718f969df2711d38c66268174407cbca57ce36485544f695c2dfdc96e
+"dot-prop@npm:^5.1.0":
+  version: 5.3.0
+  resolution: "dot-prop@npm:5.3.0"
+  dependencies:
+    is-obj: "npm:^2.0.0"
+  checksum: 10/33b2561617bd5c73cf9305368ba4638871c5dbf9c8100c8335acd2e2d590a81ec0e75c11cfaea5cc3cf8c2f668cad4beddb52c11856d0c9e666348eee1baf57a
+  languageName: node
+  linkType: hard
+
+"dotenv-expand@npm:~10.0.0":
+  version: 10.0.0
+  resolution: "dotenv-expand@npm:10.0.0"
+  checksum: 10/b41eb278bc96b92cbf3037ca5f3d21e8845bf165dc06b6f9a0a03d278c2bd5a01c0cfbb3528ae3a60301ba1a8a9cace30e748c54b460753bc00d4c014b675597
+  languageName: node
+  linkType: hard
+
+"dotenv@npm:~16.3.1":
+  version: 16.3.2
+  resolution: "dotenv@npm:16.3.2"
+  checksum: 10/3d788056eb4c84ae8c8aa86642d0e1da1d41604fcd8d99a97c9b9c850e64faf5e6983717cfc071d4649139583f714d38f75414f8f869fe813cc38c6ad4601797
+  languageName: node
+  linkType: hard
+
+"duplexer@npm:^0.1.1":
+  version: 0.1.2
+  resolution: "duplexer@npm:0.1.2"
+  checksum: 10/62ba61a830c56801db28ff6305c7d289b6dc9f859054e8c982abd8ee0b0a14d2e9a8e7d086ffee12e868d43e2bbe8a964be55ddbd8c8957714c87373c7a4f9b0
+  languageName: node
+  linkType: hard
+
+"eastasianwidth@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "eastasianwidth@npm:0.2.0"
+  checksum: 10/9b1d3e1baefeaf7d70799db8774149cef33b97183a6addceeba0cf6b85ba23ee2686f302f14482006df32df75d32b17c509c143a3689627929e4a8efaf483952
+  languageName: node
+  linkType: hard
+
+"ejs@npm:^3.1.7":
+  version: 3.1.10
+  resolution: "ejs@npm:3.1.10"
+  dependencies:
+    jake: "npm:^10.8.5"
+  bin:
+    ejs: bin/cli.js
+  checksum: 10/a9cb7d7cd13b7b1cd0be5c4788e44dd10d92f7285d2f65b942f33e127230c054f99a42db4d99f766d8dbc6c57e94799593ee66a14efd7c8dd70c4812bf6aa384
+  languageName: node
+  linkType: hard
+
+"electron-to-chromium@npm:^1.4.668":
+  version: 1.4.767
+  resolution: "electron-to-chromium@npm:1.4.767"
+  checksum: 10/2352e05e5ed039ce36d7c6dde5df28e308dd9fba03b3cc008703dc468632e6b9b70be9bdf9a21a2942549efd8c05cb3b5b05fd05b9bc3955208814ee77135a19
+  languageName: node
+  linkType: hard
+
+"emittery@npm:^0.13.1":
+  version: 0.13.1
+  resolution: "emittery@npm:0.13.1"
+  checksum: 10/fbe214171d878b924eedf1757badf58a5dce071cd1fa7f620fa841a0901a80d6da47ff05929d53163105e621ce11a71b9d8acb1148ffe1745e045145f6e69521
   languageName: node
   linkType: hard
 
 "emoji-regex@npm:^8.0.0":
   version: 8.0.0
   resolution: "emoji-regex@npm:8.0.0"
-  checksum: d4c5c39d5a9868b5fa152f00cada8a936868fd3367f33f71be515ecee4c803132d11b31a6222b2571b1e5f7e13890156a94880345594d0ce7e3c9895f560f192
+  checksum: 10/c72d67a6821be15ec11997877c437491c313d924306b8da5d87d2a2bcc2cec9903cb5b04ee1a088460501d8e5b44f10df82fdc93c444101a7610b80c8b6938e1
+  languageName: node
+  linkType: hard
+
+"emoji-regex@npm:^9.2.2":
+  version: 9.2.2
+  resolution: "emoji-regex@npm:9.2.2"
+  checksum: 10/915acf859cea7131dac1b2b5c9c8e35c4849e325a1d114c30adb8cd615970f6dca0e27f64f3a4949d7d6ed86ecd79a1c5c63f02e697513cddd7b5835c90948b8
+  languageName: node
+  linkType: hard
+
+"encoding@npm:^0.1.13":
+  version: 0.1.13
+  resolution: "encoding@npm:0.1.13"
+  dependencies:
+    iconv-lite: "npm:^0.6.2"
+  checksum: 10/bb98632f8ffa823996e508ce6a58ffcf5856330fde839ae42c9e1f436cc3b5cc651d4aeae72222916545428e54fd0f6aa8862fd8d25bdbcc4589f1e3f3715e7f
+  languageName: node
+  linkType: hard
+
+"end-of-stream@npm:^1.4.1":
+  version: 1.4.4
+  resolution: "end-of-stream@npm:1.4.4"
+  dependencies:
+    once: "npm:^1.4.0"
+  checksum: 10/530a5a5a1e517e962854a31693dbb5c0b2fc40b46dad2a56a2deec656ca040631124f4795823acc68238147805f8b021abbe221f4afed5ef3c8e8efc2024908b
+  languageName: node
+  linkType: hard
+
+"enquirer@npm:~2.3.6":
+  version: 2.3.6
+  resolution: "enquirer@npm:2.3.6"
+  dependencies:
+    ansi-colors: "npm:^4.1.1"
+  checksum: 10/751d14f037eb7683997e696fb8d5fe2675e0b0cde91182c128cf598acf3f5bd9005f35f7c2a9109e291140af496ebec237b6dac86067d59a9b44f3688107f426
   languageName: node
   linkType: hard
 
 "entities@npm:1.0":
   version: 1.0.0
   resolution: "entities@npm:1.0.0"
-  checksum: 41b33ab98fa62b9b258e287dc2ef2a1e22920651b5170ae3cc95d5489f972a0cb64f5ddecb540ad246c85093b0ab0d4ec5f58fa4d579a00f0088705cd0956eb1
+  checksum: 10/4d2e0c1a8dc0a019055457ca090dd33a8286f1c39ffebcd109443e20061c21f6cad66cb5f087302e57d34b942ab9fe13472f3325399998b4d32224c73cbaa974
   languageName: node
   linkType: hard
 
-"entities@npm:2.2.0, entities@npm:^2.0.0":
+"entities@npm:^2.0.0":
   version: 2.2.0
   resolution: "entities@npm:2.2.0"
-  checksum: 19010dacaf0912c895ea262b4f6128574f9ccf8d4b3b65c7e8334ad0079b3706376360e28d8843ff50a78aabcb8f08f0a32dbfacdc77e47ed77ca08b713669b3
+  checksum: 10/2c765221ee324dbe25e1b8ca5d1bf2a4d39e750548f2e85cbf7ca1d167d709689ddf1796623e66666ae747364c11ed512c03b48c5bbe70968d30f2a4009509b7
+  languageName: node
+  linkType: hard
+
+"env-paths@npm:^2.2.0":
+  version: 2.2.1
+  resolution: "env-paths@npm:2.2.1"
+  checksum: 10/65b5df55a8bab92229ab2b40dad3b387fad24613263d103a97f91c9fe43ceb21965cd3392b1ccb5d77088021e525c4e0481adb309625d0cb94ade1d1fb8dc17e
+  languageName: node
+  linkType: hard
+
+"envinfo@npm:7.8.1":
+  version: 7.8.1
+  resolution: "envinfo@npm:7.8.1"
+  bin:
+    envinfo: dist/cli.js
+  checksum: 10/e7a2d71c7dfe398a4ffda0e844e242d2183ef2627f98e74e4cd71edd2af691c8707a2b34aacef92538c27b3daf9a360d32202f33c0a9f27f767c4e1c6ba8b522
+  languageName: node
+  linkType: hard
+
+"err-code@npm:^2.0.2":
+  version: 2.0.3
+  resolution: "err-code@npm:2.0.3"
+  checksum: 10/1d20d825cdcce8d811bfbe86340f4755c02655a7feb2f13f8c880566d9d72a3f6c92c192a6867632e490d6da67b678271f46e01044996a6443e870331100dfdd
+  languageName: node
+  linkType: hard
+
+"error-ex@npm:^1.3.1":
+  version: 1.3.2
+  resolution: "error-ex@npm:1.3.2"
+  dependencies:
+    is-arrayish: "npm:^0.2.1"
+  checksum: 10/d547740aa29c34e753fb6fed2c5de81802438529c12b3673bd37b6bb1fe49b9b7abdc3c11e6062fe625d8a296b3cf769a80f878865e25e685f787763eede3ffb
+  languageName: node
+  linkType: hard
+
+"es-define-property@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "es-define-property@npm:1.0.0"
+  dependencies:
+    get-intrinsic: "npm:^1.2.4"
+  checksum: 10/f66ece0a887b6dca71848fa71f70461357c0e4e7249696f81bad0a1f347eed7b31262af4a29f5d726dc026426f085483b6b90301855e647aa8e21936f07293c6
+  languageName: node
+  linkType: hard
+
+"es-errors@npm:^1.3.0":
+  version: 1.3.0
+  resolution: "es-errors@npm:1.3.0"
+  checksum: 10/96e65d640156f91b707517e8cdc454dd7d47c32833aa3e85d79f24f9eb7ea85f39b63e36216ef0114996581969b59fe609a94e30316b08f5f4df1d44134cf8d5
   languageName: node
   linkType: hard
 
 "escalade@npm:^3.1.1":
   version: 3.1.1
   resolution: "escalade@npm:3.1.1"
-  checksum: a3e2a99f07acb74b3ad4989c48ca0c3140f69f923e56d0cba0526240ee470b91010f9d39001f2a4a313841d237ede70a729e92125191ba5d21e74b106800b133
+  checksum: 10/afa618e73362576b63f6ca83c975456621095a1ed42ff068174e3f5cea48afc422814dda548c96e6ebb5333e7265140c7292abcc81bbd6ccb1757d50d3a4e182
+  languageName: node
+  linkType: hard
+
+"escalade@npm:^3.1.2":
+  version: 3.1.2
+  resolution: "escalade@npm:3.1.2"
+  checksum: 10/a1e07fea2f15663c30e40b9193d658397846ffe28ce0a3e4da0d8e485fedfeca228ab846aee101a05015829adf39f9934ff45b2a3fca47bed37a29646bd05cd3
+  languageName: node
+  linkType: hard
+
+"escape-string-regexp@npm:^1.0.5":
+  version: 1.0.5
+  resolution: "escape-string-regexp@npm:1.0.5"
+  checksum: 10/6092fda75c63b110c706b6a9bfde8a612ad595b628f0bd2147eea1d3406723020810e591effc7db1da91d80a71a737a313567c5abb3813e8d9c71f4aa595b410
+  languageName: node
+  linkType: hard
+
+"escape-string-regexp@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "escape-string-regexp@npm:2.0.0"
+  checksum: 10/9f8a2d5743677c16e85c810e3024d54f0c8dea6424fad3c79ef6666e81dd0846f7437f5e729dfcdac8981bc9e5294c39b4580814d114076b8d36318f46ae4395
+  languageName: node
+  linkType: hard
+
+"esprima@npm:^4.0.0":
+  version: 4.0.1
+  resolution: "esprima@npm:4.0.1"
+  bin:
+    esparse: ./bin/esparse.js
+    esvalidate: ./bin/esvalidate.js
+  checksum: 10/f1d3c622ad992421362294f7acf866aa9409fbad4eb2e8fa230bd33944ce371d32279667b242d8b8907ec2b6ad7353a717f3c0e60e748873a34a7905174bc0eb
+  languageName: node
+  linkType: hard
+
+"eventemitter3@npm:^4.0.4":
+  version: 4.0.7
+  resolution: "eventemitter3@npm:4.0.7"
+  checksum: 10/8030029382404942c01d0037079f1b1bc8fed524b5849c237b80549b01e2fc49709e1d0c557fa65ca4498fc9e24cff1475ef7b855121fcc15f9d61f93e282346
   languageName: node
   linkType: hard
 
 "events@npm:^3.3.0":
   version: 3.3.0
   resolution: "events@npm:3.3.0"
-  checksum: f6f487ad2198aa41d878fa31452f1a3c00958f46e9019286ff4787c84aac329332ab45c9cdc8c445928fc6d7ded294b9e005a7fce9426488518017831b272780
+  checksum: 10/a3d47e285e28d324d7180f1e493961a2bbb4cad6412090e4dec114f4db1f5b560c7696ee8e758f55e23913ede856e3689cd3aa9ae13c56b5d8314cd3b3ddd1be
   languageName: node
   linkType: hard
 
-"exifreader@npm:^4.1.0":
-  version: 4.5.1
-  resolution: "exifreader@npm:4.5.1"
+"execa@npm:5.0.0":
+  version: 5.0.0
+  resolution: "execa@npm:5.0.0"
   dependencies:
-    "@xmldom/xmldom": ^0.7.5
+    cross-spawn: "npm:^7.0.3"
+    get-stream: "npm:^6.0.0"
+    human-signals: "npm:^2.1.0"
+    is-stream: "npm:^2.0.0"
+    merge-stream: "npm:^2.0.0"
+    npm-run-path: "npm:^4.0.1"
+    onetime: "npm:^5.1.2"
+    signal-exit: "npm:^3.0.3"
+    strip-final-newline: "npm:^2.0.0"
+  checksum: 10/9cc45d682725f0c5d22b5846c06be4542c1df1775332e2e62c7a6a51613e2b7f54792044266e3dcffec8b24c55ee5837349f93f489f75ce52446e3c08feaa32e
+  languageName: node
+  linkType: hard
+
+"execa@npm:^5.0.0":
+  version: 5.1.1
+  resolution: "execa@npm:5.1.1"
+  dependencies:
+    cross-spawn: "npm:^7.0.3"
+    get-stream: "npm:^6.0.0"
+    human-signals: "npm:^2.1.0"
+    is-stream: "npm:^2.0.0"
+    merge-stream: "npm:^2.0.0"
+    npm-run-path: "npm:^4.0.1"
+    onetime: "npm:^5.1.2"
+    signal-exit: "npm:^3.0.3"
+    strip-final-newline: "npm:^2.0.0"
+  checksum: 10/8ada91f2d70f7dff702c861c2c64f21dfdc1525628f3c0454fd6f02fce65f7b958616cbd2b99ca7fa4d474e461a3d363824e91b3eb881705231abbf387470597
+  languageName: node
+  linkType: hard
+
+"exifreader@npm:^4.22.1":
+  version: 4.23.1
+  resolution: "exifreader@npm:4.23.1"
+  dependencies:
+    "@xmldom/xmldom": "npm:^0.8.10"
   dependenciesMeta:
     "@xmldom/xmldom":
       optional: true
-  checksum: 31ac70bc035cc7cde0cc3bb1500be50323f0a42ecfd7684c159ae45560471d7fab3c28bb13de03797f3da335ebb0e68027fe9effe130ff3b76564b65e8e0afdc
+  checksum: 10/cc0a6ead39f9263ae46268ecb54bf1a332b1a6c935a7f58290e9df789d1555ecd0f3dd1e6d1cbd18fa3d0d28994e56575a05d529d42e194be6e38ae926415470
   languageName: node
   linkType: hard
 
-"exit@npm:0.1.2, exit@npm:0.1.x":
+"exit@npm:0.1.2, exit@npm:0.1.x, exit@npm:^0.1.2":
   version: 0.1.2
   resolution: "exit@npm:0.1.2"
-  checksum: abc407f07a875c3961e4781dfcb743b58d6c93de9ab263f4f8c9d23bb6da5f9b7764fc773f86b43dd88030444d5ab8abcb611cb680fba8ca075362b77114bba3
+  checksum: 10/387555050c5b3c10e7a9e8df5f43194e95d7737c74532c409910e585d5554eaff34960c166643f5e23d042196529daad059c292dcf1fb61b8ca878d3677f4b87
   languageName: node
   linkType: hard
 
-"fast-deep-equal@npm:^3.1.1":
+"expect@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "expect@npm:29.7.0"
+  dependencies:
+    "@jest/expect-utils": "npm:^29.7.0"
+    jest-get-type: "npm:^29.6.3"
+    jest-matcher-utils: "npm:^29.7.0"
+    jest-message-util: "npm:^29.7.0"
+    jest-util: "npm:^29.7.0"
+  checksum: 10/63f97bc51f56a491950fb525f9ad94f1916e8a014947f8d8445d3847a665b5471b768522d659f5e865db20b6c2033d2ac10f35fcbd881a4d26407a4f6f18451a
+  languageName: node
+  linkType: hard
+
+"exponential-backoff@npm:^3.1.1":
+  version: 3.1.1
+  resolution: "exponential-backoff@npm:3.1.1"
+  checksum: 10/2d9bbb6473de7051f96790d5f9a678f32e60ed0aa70741dc7fdc96fec8d631124ec3374ac144387604f05afff9500f31a1d45bd9eee4cdc2e4f9ad2d9b9d5dbd
+  languageName: node
+  linkType: hard
+
+"external-editor@npm:^3.0.3":
+  version: 3.1.0
+  resolution: "external-editor@npm:3.1.0"
+  dependencies:
+    chardet: "npm:^0.7.0"
+    iconv-lite: "npm:^0.4.24"
+    tmp: "npm:^0.0.33"
+  checksum: 10/776dff1d64a1d28f77ff93e9e75421a81c062983fd1544279d0a32f563c0b18c52abbb211f31262e2827e48edef5c9dc8f960d06dd2d42d1654443b88568056b
+  languageName: node
+  linkType: hard
+
+"fast-deep-equal@npm:^3.1.1, fast-deep-equal@npm:^3.1.3":
   version: 3.1.3
   resolution: "fast-deep-equal@npm:3.1.3"
-  checksum: e21a9d8d84f53493b6aa15efc9cfd53dd5b714a1f23f67fb5dc8f574af80df889b3bce25dc081887c6d25457cce704e636395333abad896ccdec03abaf1f3f9d
+  checksum: 10/e21a9d8d84f53493b6aa15efc9cfd53dd5b714a1f23f67fb5dc8f574af80df889b3bce25dc081887c6d25457cce704e636395333abad896ccdec03abaf1f3f9d
   languageName: node
   linkType: hard
 
-"fast-json-stable-stringify@npm:^2.0.0":
+"fast-glob@npm:^3.2.9":
+  version: 3.3.2
+  resolution: "fast-glob@npm:3.3.2"
+  dependencies:
+    "@nodelib/fs.stat": "npm:^2.0.2"
+    "@nodelib/fs.walk": "npm:^1.2.3"
+    glob-parent: "npm:^5.1.2"
+    merge2: "npm:^1.3.0"
+    micromatch: "npm:^4.0.4"
+  checksum: 10/222512e9315a0efca1276af9adb2127f02105d7288fa746145bf45e2716383fb79eb983c89601a72a399a56b7c18d38ce70457c5466218c5f13fad957cee16df
+  languageName: node
+  linkType: hard
+
+"fast-json-stable-stringify@npm:^2.0.0, fast-json-stable-stringify@npm:^2.1.0":
   version: 2.1.0
   resolution: "fast-json-stable-stringify@npm:2.1.0"
-  checksum: b191531e36c607977e5b1c47811158733c34ccb3bfde92c44798929e9b4154884378536d26ad90dfecd32e1ffc09c545d23535ad91b3161a27ddbb8ebe0cbecb
+  checksum: 10/2c20055c1fa43c922428f16ca8bb29f2807de63e5c851f665f7ac9790176c01c3b40335257736b299764a8d383388dabc73c8083b8e1bc3d99f0a941444ec60e
   languageName: node
   linkType: hard
 
-"fast-xml-parser@npm:3.19.0":
-  version: 3.19.0
-  resolution: "fast-xml-parser@npm:3.19.0"
-  bin:
-    xml2js: cli.js
-  checksum: d9da9145f73d90c05ee2746d80c78eca4da0249dea8c81ea8f1a6e1245e62988ed4a040dbd1c7229b1e0bdcbf69d33c882e0ac337d10c7eedb159a4dc9779327
-  languageName: node
-  linkType: hard
-
-"form-data@npm:^2.2.0":
-  version: 2.5.1
-  resolution: "form-data@npm:2.5.1"
+"fast-xml-parser@npm:4.2.5":
+  version: 4.2.5
+  resolution: "fast-xml-parser@npm:4.2.5"
   dependencies:
-    asynckit: ^0.4.0
-    combined-stream: ^1.0.6
-    mime-types: ^2.1.12
-  checksum: 5134ada56cc246b293a1ac7678dba6830000603a3979cf83ff7b2f21f2e3725202237cfb89e32bcb38a1d35727efbd3c3a22e65b42321e8ade8eec01ce755d08
+    strnum: "npm:^1.0.5"
+  bin:
+    fxparser: src/cli/cli.js
+  checksum: 10/4be7ebe24d6a9a60c278e1423cd86a7da9a77ec64c95563e2c552363caf7a777e0c87c9de1255c2f4e8dea9bce8905dc2bdc58a34e9f2b73c4693654456ad284
+  languageName: node
+  linkType: hard
+
+"fastq@npm:^1.6.0":
+  version: 1.17.1
+  resolution: "fastq@npm:1.17.1"
+  dependencies:
+    reusify: "npm:^1.0.4"
+  checksum: 10/a443180068b527dd7b3a63dc7f2a47ceca2f3e97b9c00a1efe5538757e6cc4056a3526df94308075d7727561baf09ebaa5b67da8dcbddb913a021c5ae69d1f69
+  languageName: node
+  linkType: hard
+
+"fb-watchman@npm:^2.0.0":
+  version: 2.0.2
+  resolution: "fb-watchman@npm:2.0.2"
+  dependencies:
+    bser: "npm:2.1.1"
+  checksum: 10/4f95d336fb805786759e383fd7fff342ceb7680f53efcc0ef82f502eb479ce35b98e8b207b6dfdfeea0eba845862107dc73813775fc6b56b3098c6e90a2dad77
+  languageName: node
+  linkType: hard
+
+"figures@npm:3.2.0, figures@npm:^3.0.0":
+  version: 3.2.0
+  resolution: "figures@npm:3.2.0"
+  dependencies:
+    escape-string-regexp: "npm:^1.0.5"
+  checksum: 10/a3bf94e001be51d3770500789157f067218d4bc681a65e1f69d482de15120bcac822dceb1a7b3803f32e4e3a61a46df44f7f2c8ba95d6375e7491502e0dd3d97
+  languageName: node
+  linkType: hard
+
+"filelist@npm:^1.0.4":
+  version: 1.0.4
+  resolution: "filelist@npm:1.0.4"
+  dependencies:
+    minimatch: "npm:^5.0.1"
+  checksum: 10/4b436fa944b1508b95cffdfc8176ae6947b92825483639ef1b9a89b27d82f3f8aa22b21eed471993f92709b431670d4e015b39c087d435a61e1bb04564cf51de
+  languageName: node
+  linkType: hard
+
+"fill-range@npm:^7.0.1":
+  version: 7.0.1
+  resolution: "fill-range@npm:7.0.1"
+  dependencies:
+    to-regex-range: "npm:^5.0.1"
+  checksum: 10/e260f7592fd196b4421504d3597cc76f4a1ca7a9488260d533b611fc3cefd61e9a9be1417cb82d3b01ad9f9c0ff2dbf258e1026d2445e26b0cf5148ff4250429
+  languageName: node
+  linkType: hard
+
+"find-up@npm:^2.0.0":
+  version: 2.1.0
+  resolution: "find-up@npm:2.1.0"
+  dependencies:
+    locate-path: "npm:^2.0.0"
+  checksum: 10/43284fe4da09f89011f08e3c32cd38401e786b19226ea440b75386c1b12a4cb738c94969808d53a84f564ede22f732c8409e3cfc3f7fb5b5c32378ad0bbf28bd
+  languageName: node
+  linkType: hard
+
+"find-up@npm:^4.0.0, find-up@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "find-up@npm:4.1.0"
+  dependencies:
+    locate-path: "npm:^5.0.0"
+    path-exists: "npm:^4.0.0"
+  checksum: 10/4c172680e8f8c1f78839486e14a43ef82e9decd0e74145f40707cc42e7420506d5ec92d9a11c22bd2c48fb0c384ea05dd30e10dd152fefeec6f2f75282a8b844
+  languageName: node
+  linkType: hard
+
+"flat@npm:^5.0.2":
+  version: 5.0.2
+  resolution: "flat@npm:5.0.2"
+  bin:
+    flat: cli.js
+  checksum: 10/72479e651c15eab53e25ce04c31bab18cfaac0556505cac19221dbbe85bbb9686bc76e4d397e89e5bf516ce667dcf818f8b07e585568edba55abc2bf1f698fb5
+  languageName: node
+  linkType: hard
+
+"follow-redirects@npm:^1.15.6":
+  version: 1.15.6
+  resolution: "follow-redirects@npm:1.15.6"
+  peerDependenciesMeta:
+    debug:
+      optional: true
+  checksum: 10/70c7612c4cab18e546e36b991bbf8009a1a41cf85354afe04b113d1117569abf760269409cb3eb842d9f7b03d62826687086b081c566ea7b1e6613cf29030bf7
+  languageName: node
+  linkType: hard
+
+"for-each@npm:^0.3.3":
+  version: 0.3.3
+  resolution: "for-each@npm:0.3.3"
+  dependencies:
+    is-callable: "npm:^1.1.3"
+  checksum: 10/fdac0cde1be35610bd635ae958422e8ce0cc1313e8d32ea6d34cfda7b60850940c1fd07c36456ad76bd9c24aef6ff5e03b02beb58c83af5ef6c968a64eada676
+  languageName: node
+  linkType: hard
+
+"foreground-child@npm:^3.1.0":
+  version: 3.1.1
+  resolution: "foreground-child@npm:3.1.1"
+  dependencies:
+    cross-spawn: "npm:^7.0.0"
+    signal-exit: "npm:^4.0.1"
+  checksum: 10/087edd44857d258c4f73ad84cb8df980826569656f2550c341b27adf5335354393eec24ea2fabd43a253233fb27cee177ebe46bd0b7ea129c77e87cb1e9936fb
+  languageName: node
+  linkType: hard
+
+"form-data@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "form-data@npm:4.0.0"
+  dependencies:
+    asynckit: "npm:^0.4.0"
+    combined-stream: "npm:^1.0.8"
+    mime-types: "npm:^2.1.12"
+  checksum: 10/7264aa760a8cf09482816d8300f1b6e2423de1b02bba612a136857413fdc96d7178298ced106817655facc6b89036c6e12ae31c9eb5bdc16aabf502ae8a5d805
+  languageName: node
+  linkType: hard
+
+"fs-constants@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "fs-constants@npm:1.0.0"
+  checksum: 10/18f5b718371816155849475ac36c7d0b24d39a11d91348cfcb308b4494824413e03572c403c86d3a260e049465518c4f0d5bd00f0371cdfcad6d4f30a85b350d
+  languageName: node
+  linkType: hard
+
+"fs-extra@npm:^11.1.0, fs-extra@npm:^11.1.1":
+  version: 11.2.0
+  resolution: "fs-extra@npm:11.2.0"
+  dependencies:
+    graceful-fs: "npm:^4.2.0"
+    jsonfile: "npm:^6.0.1"
+    universalify: "npm:^2.0.0"
+  checksum: 10/0579bf6726a4cd054d4aa308f10b483f52478bb16284f32cf60b4ce0542063d551fca1a08a2af365e35db21a3fa5a06cf2a6ed614004b4368982bc754cb816b3
+  languageName: node
+  linkType: hard
+
+"fs-minipass@npm:^2.0.0":
+  version: 2.1.0
+  resolution: "fs-minipass@npm:2.1.0"
+  dependencies:
+    minipass: "npm:^3.0.0"
+  checksum: 10/03191781e94bc9a54bd376d3146f90fe8e082627c502185dbf7b9b3032f66b0b142c1115f3b2cc5936575fc1b44845ce903dd4c21bec2a8d69f3bd56f9cee9ec
+  languageName: node
+  linkType: hard
+
+"fs-minipass@npm:^3.0.0":
+  version: 3.0.3
+  resolution: "fs-minipass@npm:3.0.3"
+  dependencies:
+    minipass: "npm:^7.0.3"
+  checksum: 10/af143246cf6884fe26fa281621d45cfe111d34b30535a475bfa38dafe343dadb466c047a924ffc7d6b7b18265df4110224ce3803806dbb07173bf2087b648d7f
   languageName: node
   linkType: hard
 
 "fs.realpath@npm:^1.0.0":
   version: 1.0.0
   resolution: "fs.realpath@npm:1.0.0"
-  checksum: 99ddea01a7e75aa276c250a04eedeffe5662bce66c65c07164ad6264f9de18fb21be9433ead460e54cff20e31721c811f4fb5d70591799df5f85dce6d6746fd0
+  checksum: 10/e703107c28e362d8d7b910bbcbfd371e640a3bb45ae157a362b5952c0030c0b6d4981140ec319b347bce7adc025dd7813da1ff908a945ac214d64f5402a51b96
   languageName: node
   linkType: hard
 
-"function-bind@npm:^1.1.1":
-  version: 1.1.1
-  resolution: "function-bind@npm:1.1.1"
-  checksum: b32fbaebb3f8ec4969f033073b43f5c8befbb58f1a79e12f1d7490358150359ebd92f49e72ff0144f65f2c48ea2a605bff2d07965f548f6474fd8efd95bf361a
+"fsevents@npm:^2.3.2":
+  version: 2.3.3
+  resolution: "fsevents@npm:2.3.3"
+  dependencies:
+    node-gyp: "npm:latest"
+  checksum: 10/4c1ade961ded57cdbfbb5cac5106ec17bc8bccd62e16343c569a0ceeca83b9dfef87550b4dc5cbb89642da412b20c5071f304c8c464b80415446e8e155a038c0
+  conditions: os=darwin
+  languageName: node
+  linkType: hard
+
+"fsevents@patch:fsevents@npm%3A^2.3.2#optional!builtin<compat/fsevents>":
+  version: 2.3.3
+  resolution: "fsevents@patch:fsevents@npm%3A2.3.3#optional!builtin<compat/fsevents>::version=2.3.3&hash=df0bf1"
+  dependencies:
+    node-gyp: "npm:latest"
+  conditions: os=darwin
+  languageName: node
+  linkType: hard
+
+"function-bind@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "function-bind@npm:1.1.2"
+  checksum: 10/185e20d20f10c8d661d59aac0f3b63b31132d492e1b11fcc2a93cb2c47257ebaee7407c38513efd2b35cafdf972d9beb2ea4593c1e0f3bf8f2744836928d7454
+  languageName: node
+  linkType: hard
+
+"gauge@npm:^4.0.3":
+  version: 4.0.4
+  resolution: "gauge@npm:4.0.4"
+  dependencies:
+    aproba: "npm:^1.0.3 || ^2.0.0"
+    color-support: "npm:^1.1.3"
+    console-control-strings: "npm:^1.1.0"
+    has-unicode: "npm:^2.0.1"
+    signal-exit: "npm:^3.0.7"
+    string-width: "npm:^4.2.3"
+    strip-ansi: "npm:^6.0.1"
+    wide-align: "npm:^1.1.5"
+  checksum: 10/09535dd53b5ced6a34482b1fa9f3929efdeac02f9858569cde73cef3ed95050e0f3d095706c1689614059898924b7a74aa14042f51381a1ccc4ee5c29d2389c4
+  languageName: node
+  linkType: hard
+
+"gensync@npm:^1.0.0-beta.2":
+  version: 1.0.0-beta.2
+  resolution: "gensync@npm:1.0.0-beta.2"
+  checksum: 10/17d8333460204fbf1f9160d067e1e77f908a5447febb49424b8ab043026049835c9ef3974445c57dbd39161f4d2b04356d7de12b2eecaa27a7a7ea7d871cbedd
   languageName: node
   linkType: hard
 
 "get-caller-file@npm:^2.0.5":
   version: 2.0.5
   resolution: "get-caller-file@npm:2.0.5"
-  checksum: b9769a836d2a98c3ee734a88ba712e62703f1df31b94b784762c433c27a386dd6029ff55c2a920c392e33657d80191edbf18c61487e198844844516f843496b9
+  checksum: 10/b9769a836d2a98c3ee734a88ba712e62703f1df31b94b784762c433c27a386dd6029ff55c2a920c392e33657d80191edbf18c61487e198844844516f843496b9
   languageName: node
   linkType: hard
 
-"get-intrinsic@npm:^1.0.2":
-  version: 1.1.3
-  resolution: "get-intrinsic@npm:1.1.3"
+"get-intrinsic@npm:^1.1.3, get-intrinsic@npm:^1.2.4":
+  version: 1.2.4
+  resolution: "get-intrinsic@npm:1.2.4"
   dependencies:
-    function-bind: ^1.1.1
-    has: ^1.0.3
-    has-symbols: ^1.0.3
-  checksum: 152d79e87251d536cf880ba75cfc3d6c6c50e12b3a64e1ea960e73a3752b47c69f46034456eae1b0894359ce3bc64c55c186f2811f8a788b75b638b06fab228a
+    es-errors: "npm:^1.3.0"
+    function-bind: "npm:^1.1.2"
+    has-proto: "npm:^1.0.1"
+    has-symbols: "npm:^1.0.3"
+    hasown: "npm:^2.0.0"
+  checksum: 10/85bbf4b234c3940edf8a41f4ecbd4e25ce78e5e6ad4e24ca2f77037d983b9ef943fd72f00f3ee97a49ec622a506b67db49c36246150377efcda1c9eb03e5f06d
   languageName: node
   linkType: hard
 
-"glob@npm:^7.1.1":
+"get-package-type@npm:^0.1.0":
+  version: 0.1.0
+  resolution: "get-package-type@npm:0.1.0"
+  checksum: 10/bba0811116d11e56d702682ddef7c73ba3481f114590e705fc549f4d868972263896af313c57a25c076e3c0d567e11d919a64ba1b30c879be985fc9d44f96148
+  languageName: node
+  linkType: hard
+
+"get-pkg-repo@npm:^4.2.1":
+  version: 4.2.1
+  resolution: "get-pkg-repo@npm:4.2.1"
+  dependencies:
+    "@hutson/parse-repository-url": "npm:^3.0.0"
+    hosted-git-info: "npm:^4.0.0"
+    through2: "npm:^2.0.0"
+    yargs: "npm:^16.2.0"
+  bin:
+    get-pkg-repo: src/cli.js
+  checksum: 10/033225cf7cdf3f61885f45c492975f412268cf9f3ec68cc42df9af1bec54cf0b0c5ddb7391a6dc973361e7e10df9d432cca0050892ba8856bc50413e0741804f
+  languageName: node
+  linkType: hard
+
+"get-port@npm:5.1.1":
+  version: 5.1.1
+  resolution: "get-port@npm:5.1.1"
+  checksum: 10/0162663ffe5c09e748cd79d97b74cd70e5a5c84b760a475ce5767b357fb2a57cb821cee412d646aa8a156ed39b78aab88974eddaa9e5ee926173c036c0713787
+  languageName: node
+  linkType: hard
+
+"get-stream@npm:6.0.0":
+  version: 6.0.0
+  resolution: "get-stream@npm:6.0.0"
+  checksum: 10/a8bf40227191743149ab5d5d05f9577cb95768b60456553319296ad4e8566aa9cd3611b5f0f3168697f135233b24e47c761b3b225db6f79fb86326d11a3a0c2c
+  languageName: node
+  linkType: hard
+
+"get-stream@npm:^6.0.0":
+  version: 6.0.1
+  resolution: "get-stream@npm:6.0.1"
+  checksum: 10/781266d29725f35c59f1d214aedc92b0ae855800a980800e2923b3fbc4e56b3cb6e462c42e09a1cf1a00c64e056a78fa407cbe06c7c92b7e5cd49b4b85c2a497
+  languageName: node
+  linkType: hard
+
+"git-raw-commits@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "git-raw-commits@npm:3.0.0"
+  dependencies:
+    dargs: "npm:^7.0.0"
+    meow: "npm:^8.1.2"
+    split2: "npm:^3.2.2"
+  bin:
+    git-raw-commits: cli.js
+  checksum: 10/198892f307829d22fc8ec1c9b4a63876a1fde847763857bb74bd1b04c6f6bc0d7464340c25d0f34fd0fb395759363aa1f8ce324357027320d80523bf234676ab
+  languageName: node
+  linkType: hard
+
+"git-remote-origin-url@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "git-remote-origin-url@npm:2.0.0"
+  dependencies:
+    gitconfiglocal: "npm:^1.0.0"
+    pify: "npm:^2.3.0"
+  checksum: 10/85263a09c044b5f4fe2acc45cbb3c5331ab2bd4484bb53dfe7f3dd593a4bf90a9786a2e00b9884524331f50b3da18e8c924f01c2944087fc7f342282c4437b73
+  languageName: node
+  linkType: hard
+
+"git-semver-tags@npm:^5.0.0":
+  version: 5.0.1
+  resolution: "git-semver-tags@npm:5.0.1"
+  dependencies:
+    meow: "npm:^8.1.2"
+    semver: "npm:^7.0.0"
+  bin:
+    git-semver-tags: cli.js
+  checksum: 10/056e34a3dd0d91ca737225d360e46a0330c92f1508c38ad93965c3a204e5c7bfe7746f1f7e7d6b456bd61245c770fd0755148823bf852eed71099d094bee6cc2
+  languageName: node
+  linkType: hard
+
+"git-up@npm:^7.0.0":
+  version: 7.0.0
+  resolution: "git-up@npm:7.0.0"
+  dependencies:
+    is-ssh: "npm:^1.4.0"
+    parse-url: "npm:^8.1.0"
+  checksum: 10/003ef38424702ac4cbe6d2817ccfb5811251244c955a8011ca40298d12cf1fb6529529f074d5832b5221e193ec05f4742ecf7806e6c4f41a81a2f2cff65d6bf4
+  languageName: node
+  linkType: hard
+
+"git-url-parse@npm:13.1.0":
+  version: 13.1.0
+  resolution: "git-url-parse@npm:13.1.0"
+  dependencies:
+    git-up: "npm:^7.0.0"
+  checksum: 10/a088e9b57235eda6a390a0af31db28c128161861675935d26fca9615c0e5c6078b0adcca00293f25ea5e69a37bed5e8afe8bc5f2a079b286a897738a24ab98a4
+  languageName: node
+  linkType: hard
+
+"gitconfiglocal@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "gitconfiglocal@npm:1.0.0"
+  dependencies:
+    ini: "npm:^1.3.2"
+  checksum: 10/e6d2764c15bbab6d1d1000d1181bb907f6b3796bb04f63614dba571b18369e0ecb1beaf27ce8da5b24307ef607e3a5f262a67cb9575510b9446aac697d421beb
+  languageName: node
+  linkType: hard
+
+"glob-parent@npm:5.1.2, glob-parent@npm:^5.1.2":
+  version: 5.1.2
+  resolution: "glob-parent@npm:5.1.2"
+  dependencies:
+    is-glob: "npm:^4.0.1"
+  checksum: 10/32cd106ce8c0d83731966d31517adb766d02c3812de49c30cfe0675c7c0ae6630c11214c54a5ae67aca882cf738d27fd7768f21aa19118b9245950554be07247
+  languageName: node
+  linkType: hard
+
+"glob@npm:^10.2.2, glob@npm:^10.3.10":
+  version: 10.3.15
+  resolution: "glob@npm:10.3.15"
+  dependencies:
+    foreground-child: "npm:^3.1.0"
+    jackspeak: "npm:^2.3.6"
+    minimatch: "npm:^9.0.1"
+    minipass: "npm:^7.0.4"
+    path-scurry: "npm:^1.11.0"
+  bin:
+    glob: dist/esm/bin.mjs
+  checksum: 10/b2b1c74309979b34fd6010afb50418a12525def32f1d3758d5827fc75d6143fc3ee5d1f3180a43111f6386c9e297c314f208d9d09955a6c6b69f22e92ee97635
+  languageName: node
+  linkType: hard
+
+"glob@npm:^7.1.1, glob@npm:^7.1.3, glob@npm:^7.1.4":
   version: 7.2.3
   resolution: "glob@npm:7.2.3"
   dependencies:
-    fs.realpath: ^1.0.0
-    inflight: ^1.0.4
-    inherits: 2
-    minimatch: ^3.1.1
-    once: ^1.3.0
-    path-is-absolute: ^1.0.0
-  checksum: 29452e97b38fa704dabb1d1045350fb2467cf0277e155aa9ff7077e90ad81d1ea9d53d3ee63bd37c05b09a065e90f16aec4a65f5b8de401d1dac40bc5605d133
+    fs.realpath: "npm:^1.0.0"
+    inflight: "npm:^1.0.4"
+    inherits: "npm:2"
+    minimatch: "npm:^3.1.1"
+    once: "npm:^1.3.0"
+    path-is-absolute: "npm:^1.0.0"
+  checksum: 10/59452a9202c81d4508a43b8af7082ca5c76452b9fcc4a9ab17655822e6ce9b21d4f8fbadabe4fe3faef448294cec249af305e2cd824b7e9aaf689240e5e96a7b
+  languageName: node
+  linkType: hard
+
+"glob@npm:^8.0.1":
+  version: 8.1.0
+  resolution: "glob@npm:8.1.0"
+  dependencies:
+    fs.realpath: "npm:^1.0.0"
+    inflight: "npm:^1.0.4"
+    inherits: "npm:2"
+    minimatch: "npm:^5.0.1"
+    once: "npm:^1.3.0"
+  checksum: 10/9aab1c75eb087c35dbc41d1f742e51d0507aa2b14c910d96fb8287107a10a22f4bbdce26fc0a3da4c69a20f7b26d62f1640b346a4f6e6becfff47f335bb1dc5e
+  languageName: node
+  linkType: hard
+
+"glob@npm:^9.2.0":
+  version: 9.3.5
+  resolution: "glob@npm:9.3.5"
+  dependencies:
+    fs.realpath: "npm:^1.0.0"
+    minimatch: "npm:^8.0.2"
+    minipass: "npm:^4.2.4"
+    path-scurry: "npm:^1.6.1"
+  checksum: 10/e5fa8a58adf53525bca42d82a1fad9e6800032b7e4d372209b80cfdca524dd9a7dbe7d01a92d7ed20d89c572457f12c250092bc8817cb4f1c63efefdf9b658c0
+  languageName: node
+  linkType: hard
+
+"globals@npm:^11.1.0":
+  version: 11.12.0
+  resolution: "globals@npm:11.12.0"
+  checksum: 10/9f054fa38ff8de8fa356502eb9d2dae0c928217b8b5c8de1f09f5c9b6c8a96d8b9bd3afc49acbcd384a98a81fea713c859e1b09e214c60509517bb8fc2bc13c2
+  languageName: node
+  linkType: hard
+
+"globby@npm:11.1.0":
+  version: 11.1.0
+  resolution: "globby@npm:11.1.0"
+  dependencies:
+    array-union: "npm:^2.1.0"
+    dir-glob: "npm:^3.0.1"
+    fast-glob: "npm:^3.2.9"
+    ignore: "npm:^5.2.0"
+    merge2: "npm:^1.4.1"
+    slash: "npm:^3.0.0"
+  checksum: 10/288e95e310227bbe037076ea81b7c2598ccbc3122d87abc6dab39e1eec309aa14f0e366a98cdc45237ffcfcbad3db597778c0068217dcb1950fef6249104e1b1
+  languageName: node
+  linkType: hard
+
+"gopd@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "gopd@npm:1.0.1"
+  dependencies:
+    get-intrinsic: "npm:^1.1.3"
+  checksum: 10/5fbc7ad57b368ae4cd2f41214bd947b045c1a4be2f194a7be1778d71f8af9dbf4004221f3b6f23e30820eb0d052b4f819fe6ebe8221e2a3c6f0ee4ef173421ca
+  languageName: node
+  linkType: hard
+
+"graceful-fs@npm:4.2.11, graceful-fs@npm:^4.1.11, graceful-fs@npm:^4.1.15, graceful-fs@npm:^4.1.2, graceful-fs@npm:^4.1.6, graceful-fs@npm:^4.2.0, graceful-fs@npm:^4.2.11, graceful-fs@npm:^4.2.6, graceful-fs@npm:^4.2.9":
+  version: 4.2.11
+  resolution: "graceful-fs@npm:4.2.11"
+  checksum: 10/bf152d0ed1dc159239db1ba1f74fdbc40cb02f626770dcd5815c427ce0688c2635a06ed69af364396da4636d0408fcf7d4afdf7881724c3307e46aff30ca49e2
+  languageName: node
+  linkType: hard
+
+"handlebars@npm:^4.7.7":
+  version: 4.7.8
+  resolution: "handlebars@npm:4.7.8"
+  dependencies:
+    minimist: "npm:^1.2.5"
+    neo-async: "npm:^2.6.2"
+    source-map: "npm:^0.6.1"
+    uglify-js: "npm:^3.1.4"
+    wordwrap: "npm:^1.0.0"
+  dependenciesMeta:
+    uglify-js:
+      optional: true
+  bin:
+    handlebars: bin/handlebars
+  checksum: 10/bd528f4dd150adf67f3f857118ef0fa43ff79a153b1d943fa0a770f2599e38b25a7a0dbac1a3611a4ec86970fd2325a81310fb788b5c892308c9f8743bd02e11
+  languageName: node
+  linkType: hard
+
+"hard-rejection@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "hard-rejection@npm:2.1.0"
+  checksum: 10/7baaf80a0c7fff4ca79687b4060113f1529589852152fa935e6787a2bc96211e784ad4588fb3048136ff8ffc9dfcf3ae385314a5b24db32de20bea0d1597f9dc
+  languageName: node
+  linkType: hard
+
+"has-flag@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "has-flag@npm:3.0.0"
+  checksum: 10/4a15638b454bf086c8148979aae044dd6e39d63904cd452d970374fa6a87623423da485dfb814e7be882e05c096a7ccf1ebd48e7e7501d0208d8384ff4dea73b
+  languageName: node
+  linkType: hard
+
+"has-flag@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "has-flag@npm:4.0.0"
+  checksum: 10/261a1357037ead75e338156b1f9452c016a37dcd3283a972a30d9e4a87441ba372c8b81f818cd0fbcd9c0354b4ae7e18b9e1afa1971164aef6d18c2b6095a8ad
+  languageName: node
+  linkType: hard
+
+"has-property-descriptors@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "has-property-descriptors@npm:1.0.2"
+  dependencies:
+    es-define-property: "npm:^1.0.0"
+  checksum: 10/2d8c9ab8cebb572e3362f7d06139a4592105983d4317e68f7adba320fe6ddfc8874581e0971e899e633fd5f72e262830edce36d5a0bc863dad17ad20572484b2
+  languageName: node
+  linkType: hard
+
+"has-proto@npm:^1.0.1":
+  version: 1.0.3
+  resolution: "has-proto@npm:1.0.3"
+  checksum: 10/0b67c2c94e3bea37db3e412e3c41f79d59259875e636ba471e94c009cdfb1fa82bf045deeffafc7dbb9c148e36cae6b467055aaa5d9fad4316e11b41e3ba551a
   languageName: node
   linkType: hard
 
 "has-symbols@npm:^1.0.3":
   version: 1.0.3
   resolution: "has-symbols@npm:1.0.3"
-  checksum: a054c40c631c0d5741a8285010a0777ea0c068f99ed43e5d6eb12972da223f8af553a455132fdb0801bdcfa0e0f443c0c03a68d8555aa529b3144b446c3f2410
+  checksum: 10/464f97a8202a7690dadd026e6d73b1ceeddd60fe6acfd06151106f050303eaa75855aaa94969df8015c11ff7c505f196114d22f7386b4a471038da5874cf5e9b
   languageName: node
   linkType: hard
 
-"has@npm:^1.0.3":
-  version: 1.0.3
-  resolution: "has@npm:1.0.3"
+"has-tostringtag@npm:^1.0.0, has-tostringtag@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "has-tostringtag@npm:1.0.2"
   dependencies:
-    function-bind: ^1.1.1
-  checksum: b9ad53d53be4af90ce5d1c38331e712522417d017d5ef1ebd0507e07c2fbad8686fffb8e12ddecd4c39ca9b9b47431afbb975b8abf7f3c3b82c98e9aad052792
+    has-symbols: "npm:^1.0.3"
+  checksum: 10/c74c5f5ceee3c8a5b8bc37719840dc3749f5b0306d818974141dda2471a1a2ca6c8e46b9d6ac222c5345df7a901c9b6f350b1e6d62763fec877e26609a401bfe
   languageName: node
   linkType: hard
 
-"hed-validator@npm:^3.8.0":
-  version: 3.8.0
-  resolution: "hed-validator@npm:3.8.0"
+"has-unicode@npm:2.0.1, has-unicode@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "has-unicode@npm:2.0.1"
+  checksum: 10/041b4293ad6bf391e21c5d85ed03f412506d6623786b801c4ab39e4e6ca54993f13201bceb544d92963f9e0024e6e7fbf0cb1d84c9d6b31cb9c79c8c990d13d8
+  languageName: node
+  linkType: hard
+
+"hasown@npm:^2.0.0":
+  version: 2.0.2
+  resolution: "hasown@npm:2.0.2"
   dependencies:
-    buffer: ^6.0.3
-    date-and-time: ^0.14.2
-    date-fns: ^2.17.0
-    events: ^3.3.0
-    lodash: ^4.17.21
-    path: ^0.12.7
-    pluralize: ^8.0.0
-    semver: ^7.3.4
-    then-request: ^6.0.2
-    xml2js: ^0.4.23
-  checksum: e2978e3155a02197378ffa2d2a7a85e297670bf17beb0fae1727141dae3806815bfb857b30911d6f24f1cbdce1e7fb1133f9ca470da6cd9eb55bc70c81131f54
+    function-bind: "npm:^1.1.2"
+  checksum: 10/7898a9c1788b2862cf0f9c345a6bec77ba4a0c0983c7f19d610c382343d4f98fa260686b225dfb1f88393a66679d2ec58ee310c1d6868c081eda7918f32cc70a
+  languageName: node
+  linkType: hard
+
+"hed-validator@npm:^3.13.5":
+  version: 3.13.5
+  resolution: "hed-validator@npm:3.13.5"
+  dependencies:
+    buffer: "npm:^6.0.3"
+    cross-fetch: "npm:^4.0.0"
+    date-and-time: "npm:^3.1.1"
+    date-fns: "npm:^3.6.0"
+    events: "npm:^3.3.0"
+    lodash: "npm:^4.17.21"
+    path: "npm:^0.12.7"
+    pluralize: "npm:^8.0.0"
+    semver: "npm:^7.6.0"
+    string_decoder: "npm:^1.3.0"
+    xml2js: "npm:^0.6.2"
+  checksum: 10/e99c35356abe97a985764ab7b8ae3d55513fa5e55f187509409477ab878d912c626f1b5b78bd8d3128f756f4d81fec21a0fedca4975fee7f86c34a4579afa7da
+  languageName: node
+  linkType: hard
+
+"hosted-git-info@npm:^2.1.4":
+  version: 2.8.9
+  resolution: "hosted-git-info@npm:2.8.9"
+  checksum: 10/96da7d412303704af41c3819207a09ea2cab2de97951db4cf336bb8bce8d8e36b9a6821036ad2e55e67d3be0af8f967a7b57981203fbfb88bc05cd803407b8c3
+  languageName: node
+  linkType: hard
+
+"hosted-git-info@npm:^3.0.6":
+  version: 3.0.8
+  resolution: "hosted-git-info@npm:3.0.8"
+  dependencies:
+    lru-cache: "npm:^6.0.0"
+  checksum: 10/fac26fe551d87f271b31e80e5a7519cbb50a3c30ea89cad734da8068930f27288a049258e6ed9c39e20ebec9cf4b67c5cb02055bd73230962ef34db0d45da3e7
+  languageName: node
+  linkType: hard
+
+"hosted-git-info@npm:^4.0.0, hosted-git-info@npm:^4.0.1":
+  version: 4.1.0
+  resolution: "hosted-git-info@npm:4.1.0"
+  dependencies:
+    lru-cache: "npm:^6.0.0"
+  checksum: 10/4dc67022b7ecb12829966bd731fb9a5f14d351547aafc6520ef3c8e7211f4f0e69452d24e29eae3d9b17df924d660052e53d8ca321cf3008418fb7e6c7c47d6f
+  languageName: node
+  linkType: hard
+
+"hosted-git-info@npm:^6.0.0":
+  version: 6.1.1
+  resolution: "hosted-git-info@npm:6.1.1"
+  dependencies:
+    lru-cache: "npm:^7.5.1"
+  checksum: 10/2e48e3fac799b52d82277ff5693916bfa33441a2c06d1f11f9e82886bd235514783c2bdffb3abde67b7aeb6af457a48df38e6894740c7fc2e1bb78f5bcfac61e
+  languageName: node
+  linkType: hard
+
+"hosted-git-info@npm:^7.0.0":
+  version: 7.0.2
+  resolution: "hosted-git-info@npm:7.0.2"
+  dependencies:
+    lru-cache: "npm:^10.0.1"
+  checksum: 10/8f085df8a4a637d995f357f48b1e3f6fc1f9f92e82b33fb406415b5741834ed431a510a09141071001e8deea2eee43ce72786463e2aa5e5a70db8648c0eedeab
+  languageName: node
+  linkType: hard
+
+"html-escaper@npm:^2.0.0":
+  version: 2.0.2
+  resolution: "html-escaper@npm:2.0.2"
+  checksum: 10/034d74029dcca544a34fb6135e98d427acd73019796ffc17383eaa3ec2fe1c0471dcbbc8f8ed39e46e86d43ccd753a160631615e4048285e313569609b66d5b7
   languageName: node
   linkType: hard
 
@@ -1689,47 +5137,162 @@ __metadata:
   version: 3.8.3
   resolution: "htmlparser2@npm:3.8.3"
   dependencies:
-    domelementtype: 1
-    domhandler: 2.3
-    domutils: 1.5
-    entities: 1.0
-    readable-stream: 1.1
-  checksum: b6904bbc2c41f44e9c50215fa771387afd1e2ff4798f6d6e8be8df681cb65e43d00b8c1fb23a7382faa5ba25f0448f672e21954f5894f6aed9d292d0c72245fc
+    domelementtype: "npm:1"
+    domhandler: "npm:2.3"
+    domutils: "npm:1.5"
+    entities: "npm:1.0"
+    readable-stream: "npm:1.1"
+  checksum: 10/47db75468728ca587dae3fa5c03dc66caae21f157be5ab6699e411ceca25e7acc7d293ddfea0787b9e6f5c47afd16f7f1a82fc40771f6d7ee84a48c812b9bac5
   languageName: node
   linkType: hard
 
-"http-basic@npm:^8.1.1":
-  version: 8.1.3
-  resolution: "http-basic@npm:8.1.3"
+"http-cache-semantics@npm:^4.1.1":
+  version: 4.1.1
+  resolution: "http-cache-semantics@npm:4.1.1"
+  checksum: 10/362d5ed66b12ceb9c0a328fb31200b590ab1b02f4a254a697dc796850cc4385603e75f53ec59f768b2dad3bfa1464bd229f7de278d2899a0e3beffc634b6683f
+  languageName: node
+  linkType: hard
+
+"http-proxy-agent@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "http-proxy-agent@npm:5.0.0"
   dependencies:
-    caseless: ^0.12.0
-    concat-stream: ^1.6.2
-    http-response-object: ^3.0.1
-    parse-cache-control: ^1.0.1
-  checksum: 7df5dc4d4b6eb8cc3beaa77f8e5c3074288ec3835abd83c85e5bb66d8a95a0ef97664d862caf5e225698cb795f78f9a5abd0d39404e5356ccd3e5e10c87936a5
+    "@tootallnate/once": "npm:2"
+    agent-base: "npm:6"
+    debug: "npm:4"
+  checksum: 10/5ee19423bc3e0fd5f23ce991b0755699ad2a46a440ce9cec99e8126bb98448ad3479d2c0ea54be5519db5b19a4ffaa69616bac01540db18506dd4dac3dc418f0
   languageName: node
   linkType: hard
 
-"http-response-object@npm:^3.0.1":
-  version: 3.0.2
-  resolution: "http-response-object@npm:3.0.2"
+"http-proxy-agent@npm:^7.0.0":
+  version: 7.0.2
+  resolution: "http-proxy-agent@npm:7.0.2"
   dependencies:
-    "@types/node": ^10.0.3
-  checksum: 6cbdcb4ce7b27c9158a131b772c903ed54add2ba831e29cc165e91c3969fa6f8105ddf924aac5b954b534ad15a1ae697b693331b2be5281ee24d79aae20c3264
+    agent-base: "npm:^7.1.0"
+    debug: "npm:^4.3.4"
+  checksum: 10/d062acfa0cb82beeb558f1043c6ba770ea892b5fb7b28654dbc70ea2aeea55226dd34c02a294f6c1ca179a5aa483c4ea641846821b182edbd9cc5d89b54c6848
   languageName: node
   linkType: hard
 
-"ieee754@npm:^1.2.1":
+"https-proxy-agent@npm:^5.0.0":
+  version: 5.0.1
+  resolution: "https-proxy-agent@npm:5.0.1"
+  dependencies:
+    agent-base: "npm:6"
+    debug: "npm:4"
+  checksum: 10/f0dce7bdcac5e8eaa0be3c7368bb8836ed010fb5b6349ffb412b172a203efe8f807d9a6681319105ea1b6901e1972c7b5ea899672a7b9aad58309f766dcbe0df
+  languageName: node
+  linkType: hard
+
+"https-proxy-agent@npm:^7.0.1":
+  version: 7.0.4
+  resolution: "https-proxy-agent@npm:7.0.4"
+  dependencies:
+    agent-base: "npm:^7.0.2"
+    debug: "npm:4"
+  checksum: 10/405fe582bba461bfe5c7e2f8d752b384036854488b828ae6df6a587c654299cbb2c50df38c4b6ab303502c3c5e029a793fbaac965d1e86ee0be03faceb554d63
+  languageName: node
+  linkType: hard
+
+"human-signals@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "human-signals@npm:2.1.0"
+  checksum: 10/df59be9e0af479036798a881d1f136c4a29e0b518d4abb863afbd11bf30efa3eeb1d0425fc65942dcc05ab3bf40205ea436b0ff389f2cd20b75b8643d539bf86
+  languageName: node
+  linkType: hard
+
+"humanize-ms@npm:^1.2.1":
+  version: 1.2.1
+  resolution: "humanize-ms@npm:1.2.1"
+  dependencies:
+    ms: "npm:^2.0.0"
+  checksum: 10/9c7a74a2827f9294c009266c82031030eae811ca87b0da3dceb8d6071b9bde22c9f3daef0469c3c533cc67a97d8a167cd9fc0389350e5f415f61a79b171ded16
+  languageName: node
+  linkType: hard
+
+"iconv-lite@npm:^0.4.24":
+  version: 0.4.24
+  resolution: "iconv-lite@npm:0.4.24"
+  dependencies:
+    safer-buffer: "npm:>= 2.1.2 < 3"
+  checksum: 10/6d3a2dac6e5d1fb126d25645c25c3a1209f70cceecc68b8ef51ae0da3cdc078c151fade7524a30b12a3094926336831fca09c666ef55b37e2c69638b5d6bd2e3
+  languageName: node
+  linkType: hard
+
+"iconv-lite@npm:^0.6.2":
+  version: 0.6.3
+  resolution: "iconv-lite@npm:0.6.3"
+  dependencies:
+    safer-buffer: "npm:>= 2.1.2 < 3.0.0"
+  checksum: 10/24e3292dd3dadaa81d065c6f8c41b274a47098150d444b96e5f53b4638a9a71482921ea6a91a1f59bb71d9796de25e04afd05919fa64c360347ba65d3766f10f
+  languageName: node
+  linkType: hard
+
+"ieee754@npm:^1.1.13, ieee754@npm:^1.2.1":
   version: 1.2.1
   resolution: "ieee754@npm:1.2.1"
-  checksum: 5144c0c9815e54ada181d80a0b810221a253562422e7c6c3a60b1901154184f49326ec239d618c416c1c5945a2e197107aee8d986a3dd836b53dffefd99b5e7e
+  checksum: 10/d9f2557a59036f16c282aaeb107832dc957a93d73397d89bbad4eb1130560560eb695060145e8e6b3b498b15ab95510226649a0b8f52ae06583575419fe10fc4
   languageName: node
   linkType: hard
 
-"ignore@npm:^4.0.2":
-  version: 4.0.6
-  resolution: "ignore@npm:4.0.6"
-  checksum: 248f82e50a430906f9ee7f35e1158e3ec4c3971451dd9f99c9bc1548261b4db2b99709f60ac6c6cac9333494384176cc4cc9b07acbe42d52ac6a09cad734d800
+"ignore-walk@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "ignore-walk@npm:5.0.1"
+  dependencies:
+    minimatch: "npm:^5.0.1"
+  checksum: 10/a88b3fbda155496363fb3db66c7c7b85cf04d614fb51146f0aa5fc6b35c65370c57f9e6c550cd6048651fc378985b7a2bb9015c9fcb3e0dc798fc0728746703c
+  languageName: node
+  linkType: hard
+
+"ignore-walk@npm:^6.0.4":
+  version: 6.0.5
+  resolution: "ignore-walk@npm:6.0.5"
+  dependencies:
+    minimatch: "npm:^9.0.0"
+  checksum: 10/08757abff4dabca4f9f005f9a6cb6684e0c460a1e08c50319460ac13002de0ba8bbde6ad1f4477fefb264135d6253d1268339c18292f82485fcce576af0539d9
+  languageName: node
+  linkType: hard
+
+"ignore@npm:^5.0.4, ignore@npm:^5.2.0, ignore@npm:^5.3.1":
+  version: 5.3.1
+  resolution: "ignore@npm:5.3.1"
+  checksum: 10/0a884c2fbc8c316f0b9f92beaf84464253b73230a4d4d286697be45fca081199191ca33e1c2e82d9e5f851f5e9a48a78e25a35c951e7eb41e59f150db3530065
+  languageName: node
+  linkType: hard
+
+"import-fresh@npm:^3.3.0":
+  version: 3.3.0
+  resolution: "import-fresh@npm:3.3.0"
+  dependencies:
+    parent-module: "npm:^1.0.0"
+    resolve-from: "npm:^4.0.0"
+  checksum: 10/2cacfad06e652b1edc50be650f7ec3be08c5e5a6f6d12d035c440a42a8cc028e60a5b99ca08a77ab4d6b1346da7d971915828f33cdab730d3d42f08242d09baa
+  languageName: node
+  linkType: hard
+
+"import-local@npm:3.1.0, import-local@npm:^3.0.2":
+  version: 3.1.0
+  resolution: "import-local@npm:3.1.0"
+  dependencies:
+    pkg-dir: "npm:^4.2.0"
+    resolve-cwd: "npm:^3.0.0"
+  bin:
+    import-local-fixture: fixtures/cli.js
+  checksum: 10/bfcdb63b5e3c0e245e347f3107564035b128a414c4da1172a20dc67db2504e05ede4ac2eee1252359f78b0bfd7b19ef180aec427c2fce6493ae782d73a04cddd
+  languageName: node
+  linkType: hard
+
+"imurmurhash@npm:^0.1.4":
+  version: 0.1.4
+  resolution: "imurmurhash@npm:0.1.4"
+  checksum: 10/2d30b157a91fe1c1d7c6f653cbf263f039be6c5bfa959245a16d4ee191fc0f2af86c08545b6e6beeb041c56b574d2d5b9f95343d378ab49c0f37394d541e7fc8
+  languageName: node
+  linkType: hard
+
+"indent-string@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "indent-string@npm:4.0.0"
+  checksum: 10/cd3f5cbc9ca2d624c6a1f53f12e6b341659aba0e2d3254ae2b4464aaea8b4294cdb09616abbc59458f980531f2429784ed6a420d48d245bcad0811980c9efae9
   languageName: node
   linkType: hard
 
@@ -1737,30 +5300,145 @@ __metadata:
   version: 1.0.6
   resolution: "inflight@npm:1.0.6"
   dependencies:
-    once: ^1.3.0
-    wrappy: 1
-  checksum: f4f76aa072ce19fae87ce1ef7d221e709afb59d445e05d47fba710e85470923a75de35bfae47da6de1b18afc3ce83d70facf44cfb0aff89f0a3f45c0a0244dfd
+    once: "npm:^1.3.0"
+    wrappy: "npm:1"
+  checksum: 10/d2ebd65441a38c8336c223d1b80b921b9fa737e37ea466fd7e253cb000c64ae1f17fa59e68130ef5bda92cfd8d36b83d37dab0eb0a4558bcfec8e8cdfd2dcb67
   languageName: node
   linkType: hard
 
-"inherits@npm:2, inherits@npm:^2.0.3, inherits@npm:~2.0.1, inherits@npm:~2.0.3, inherits@npm:~2.0.4":
+"inherits@npm:2, inherits@npm:^2.0.3, inherits@npm:^2.0.4, inherits@npm:~2.0.1, inherits@npm:~2.0.3, inherits@npm:~2.0.4":
   version: 2.0.4
   resolution: "inherits@npm:2.0.4"
-  checksum: 4a48a733847879d6cf6691860a6b1e3f0f4754176e4d71494c41f3475553768b10f84b5ce1d40fbd0e34e6bfbb864ee35858ad4dd2cf31e02fc4a154b724d7f1
+  checksum: 10/cd45e923bee15186c07fa4c89db0aace24824c482fb887b528304694b2aa6ff8a898da8657046a5dcf3e46cd6db6c61629551f9215f208d7c3f157cf9b290521
   languageName: node
   linkType: hard
 
 "inherits@npm:2.0.3":
   version: 2.0.3
   resolution: "inherits@npm:2.0.3"
-  checksum: 78cb8d7d850d20a5e9a7f3620db31483aa00ad5f722ce03a55b110e5a723539b3716a3b463e2b96ce3fe286f33afc7c131fa2f91407528ba80cea98a7545d4c0
+  checksum: 10/8771303d66c51be433b564427c16011a8e3fbc3449f1f11ea50efb30a4369495f1d0e89f0fc12bdec0bd7e49102ced5d137e031d39ea09821cb3c717fcf21e69
+  languageName: node
+  linkType: hard
+
+"ini@npm:^1.3.2, ini@npm:^1.3.8":
+  version: 1.3.8
+  resolution: "ini@npm:1.3.8"
+  checksum: 10/314ae176e8d4deb3def56106da8002b462221c174ddb7ce0c49ee72c8cd1f9044f7b10cc555a7d8850982c3b9ca96fc212122749f5234bc2b6fb05fb942ed566
+  languageName: node
+  linkType: hard
+
+"init-package-json@npm:5.0.0":
+  version: 5.0.0
+  resolution: "init-package-json@npm:5.0.0"
+  dependencies:
+    npm-package-arg: "npm:^10.0.0"
+    promzard: "npm:^1.0.0"
+    read: "npm:^2.0.0"
+    read-package-json: "npm:^6.0.0"
+    semver: "npm:^7.3.5"
+    validate-npm-package-license: "npm:^3.0.4"
+    validate-npm-package-name: "npm:^5.0.0"
+  checksum: 10/2816821b4962ef9c090076de9abe12d4ca4ec210056999f97e5c143a8f67acaad67e4cf7d056f9131a6d859ad45d1d0d9cdb4b8e7347cb275d55a6d61b4389ef
+  languageName: node
+  linkType: hard
+
+"inquirer@npm:^8.2.4":
+  version: 8.2.6
+  resolution: "inquirer@npm:8.2.6"
+  dependencies:
+    ansi-escapes: "npm:^4.2.1"
+    chalk: "npm:^4.1.1"
+    cli-cursor: "npm:^3.1.0"
+    cli-width: "npm:^3.0.0"
+    external-editor: "npm:^3.0.3"
+    figures: "npm:^3.0.0"
+    lodash: "npm:^4.17.21"
+    mute-stream: "npm:0.0.8"
+    ora: "npm:^5.4.1"
+    run-async: "npm:^2.4.0"
+    rxjs: "npm:^7.5.5"
+    string-width: "npm:^4.1.0"
+    strip-ansi: "npm:^6.0.0"
+    through: "npm:^2.3.6"
+    wrap-ansi: "npm:^6.0.1"
+  checksum: 10/f642b9e5a94faaba54f277bdda2af0e0a6b592bd7f88c60e1614b5795b19336c7025e0c2923915d5f494f600a02fe8517413779a794415bb79a9563b061d68ab
   languageName: node
   linkType: hard
 
 "invert-kv@npm:^1.0.0":
   version: 1.0.0
   resolution: "invert-kv@npm:1.0.0"
-  checksum: aebeee31dda3b3d25ffd242e9a050926e7fe5df642d60953ab183aca1a7d1ffb39922eb2618affb0e850cf2923116f0da1345367759d88d097df5da1f1e1590e
+  checksum: 10/0820af99ca21818fa4a78815a8d06cf621a831306a5db57d7558234624b4891a89bb19a95fc3a868db4e754384c0ee38b70a00b75d81a0a46ee3937184a7cf6d
+  languageName: node
+  linkType: hard
+
+"ip-address@npm:^9.0.5":
+  version: 9.0.5
+  resolution: "ip-address@npm:9.0.5"
+  dependencies:
+    jsbn: "npm:1.1.0"
+    sprintf-js: "npm:^1.1.3"
+  checksum: 10/1ed81e06721af012306329b31f532b5e24e00cb537be18ddc905a84f19fe8f83a09a1699862bf3a1ec4b9dea93c55a3fa5faf8b5ea380431469df540f38b092c
+  languageName: node
+  linkType: hard
+
+"is-arguments@npm:^1.0.4":
+  version: 1.1.1
+  resolution: "is-arguments@npm:1.1.1"
+  dependencies:
+    call-bind: "npm:^1.0.2"
+    has-tostringtag: "npm:^1.0.0"
+  checksum: 10/a170c7e26082e10de9be6e96d32ae3db4d5906194051b792e85fae3393b53cf2cb5b3557863e5c8ccbab55e2fd8f2f75aa643d437613f72052cf0356615c34be
+  languageName: node
+  linkType: hard
+
+"is-arrayish@npm:^0.2.1":
+  version: 0.2.1
+  resolution: "is-arrayish@npm:0.2.1"
+  checksum: 10/73ced84fa35e59e2c57da2d01e12cd01479f381d7f122ce41dcbb713f09dbfc651315832cd2bf8accba7681a69e4d6f1e03941d94dd10040d415086360e7005e
+  languageName: node
+  linkType: hard
+
+"is-callable@npm:^1.1.3":
+  version: 1.2.7
+  resolution: "is-callable@npm:1.2.7"
+  checksum: 10/48a9297fb92c99e9df48706241a189da362bff3003354aea4048bd5f7b2eb0d823cd16d0a383cece3d76166ba16d85d9659165ac6fcce1ac12e6c649d66dbdb9
+  languageName: node
+  linkType: hard
+
+"is-ci@npm:3.0.1":
+  version: 3.0.1
+  resolution: "is-ci@npm:3.0.1"
+  dependencies:
+    ci-info: "npm:^3.2.0"
+  bin:
+    is-ci: bin.js
+  checksum: 10/192c66dc7826d58f803ecae624860dccf1899fc1f3ac5505284c0a5cf5f889046ffeb958fa651e5725d5705c5bcb14f055b79150ea5fcad7456a9569de60260e
+  languageName: node
+  linkType: hard
+
+"is-core-module@npm:^2.13.0, is-core-module@npm:^2.5.0, is-core-module@npm:^2.8.1":
+  version: 2.13.1
+  resolution: "is-core-module@npm:2.13.1"
+  dependencies:
+    hasown: "npm:^2.0.0"
+  checksum: 10/d53bd0cc24b0a0351fb4b206ee3908f71b9bbf1c47e9c9e14e5f06d292af1663704d2abd7e67700d6487b2b7864e0d0f6f10a1edf1892864bdffcb197d1845a2
+  languageName: node
+  linkType: hard
+
+"is-docker@npm:^2.0.0, is-docker@npm:^2.1.1":
+  version: 2.2.1
+  resolution: "is-docker@npm:2.2.1"
+  bin:
+    is-docker: cli.js
+  checksum: 10/3fef7ddbf0be25958e8991ad941901bf5922ab2753c46980b60b05c1bf9c9c2402d35e6dc32e4380b980ef5e1970a5d9d5e5aa2e02d77727c3b6b5e918474c56
+  languageName: node
+  linkType: hard
+
+"is-extglob@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "is-extglob@npm:2.1.1"
+  checksum: 10/df033653d06d0eb567461e58a7a8c9f940bd8c22274b94bf7671ab36df5719791aae15eef6d83bbb5e23283967f2f984b8914559d4449efda578c775c4be6f85
   languageName: node
   linkType: hard
 
@@ -1768,67 +5446,876 @@ __metadata:
   version: 1.0.0
   resolution: "is-fullwidth-code-point@npm:1.0.0"
   dependencies:
-    number-is-nan: ^1.0.0
-  checksum: 4d46a7465a66a8aebcc5340d3b63a56602133874af576a9ca42c6f0f4bd787a743605771c5f246db77da96605fefeffb65fc1dbe862dcc7328f4b4d03edf5a57
-  languageName: node
-  linkType: hard
-
-"is-fullwidth-code-point@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "is-fullwidth-code-point@npm:2.0.0"
-  checksum: eef9c6e15f68085fec19ff6a978a6f1b8f48018fd1265035552078ee945573594933b09bbd6f562553e2a241561439f1ef5339276eba68d272001343084cfab8
+    number-is-nan: "npm:^1.0.0"
+  checksum: 10/4d46a7465a66a8aebcc5340d3b63a56602133874af576a9ca42c6f0f4bd787a743605771c5f246db77da96605fefeffb65fc1dbe862dcc7328f4b4d03edf5a57
   languageName: node
   linkType: hard
 
 "is-fullwidth-code-point@npm:^3.0.0":
   version: 3.0.0
   resolution: "is-fullwidth-code-point@npm:3.0.0"
-  checksum: 44a30c29457c7fb8f00297bce733f0a64cd22eca270f83e58c105e0d015e45c019491a4ab2faef91ab51d4738c670daff901c799f6a700e27f7314029e99e348
+  checksum: 10/44a30c29457c7fb8f00297bce733f0a64cd22eca270f83e58c105e0d015e45c019491a4ab2faef91ab51d4738c670daff901c799f6a700e27f7314029e99e348
+  languageName: node
+  linkType: hard
+
+"is-generator-fn@npm:^2.0.0":
+  version: 2.1.0
+  resolution: "is-generator-fn@npm:2.1.0"
+  checksum: 10/a6ad5492cf9d1746f73b6744e0c43c0020510b59d56ddcb78a91cbc173f09b5e6beff53d75c9c5a29feb618bfef2bf458e025ecf3a57ad2268e2fb2569f56215
+  languageName: node
+  linkType: hard
+
+"is-generator-function@npm:^1.0.7":
+  version: 1.0.10
+  resolution: "is-generator-function@npm:1.0.10"
+  dependencies:
+    has-tostringtag: "npm:^1.0.0"
+  checksum: 10/499a3ce6361064c3bd27fbff5c8000212d48506ebe1977842bbd7b3e708832d0deb1f4cc69186ece3640770e8c4f1287b24d99588a0b8058b2dbdd344bc1f47f
+  languageName: node
+  linkType: hard
+
+"is-glob@npm:^4.0.1":
+  version: 4.0.3
+  resolution: "is-glob@npm:4.0.3"
+  dependencies:
+    is-extglob: "npm:^2.1.1"
+  checksum: 10/3ed74f2b0cdf4f401f38edb0442ddfde3092d79d7d35c9919c86641efdbcbb32e45aa3c0f70ce5eecc946896cd5a0f26e4188b9f2b881876f7cb6c505b82da11
+  languageName: node
+  linkType: hard
+
+"is-interactive@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "is-interactive@npm:1.0.0"
+  checksum: 10/824808776e2d468b2916cdd6c16acacebce060d844c35ca6d82267da692e92c3a16fdba624c50b54a63f38bdc4016055b6f443ce57d7147240de4f8cdabaf6f9
+  languageName: node
+  linkType: hard
+
+"is-lambda@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "is-lambda@npm:1.0.1"
+  checksum: 10/93a32f01940220532e5948538699ad610d5924ac86093fcee83022252b363eb0cc99ba53ab084a04e4fb62bf7b5731f55496257a4c38adf87af9c4d352c71c35
+  languageName: node
+  linkType: hard
+
+"is-number@npm:^7.0.0":
+  version: 7.0.0
+  resolution: "is-number@npm:7.0.0"
+  checksum: 10/6a6c3383f68afa1e05b286af866017c78f1226d43ac8cb064e115ff9ed85eb33f5c4f7216c96a71e4dfea289ef52c5da3aef5bbfade8ffe47a0465d70c0c8e86
+  languageName: node
+  linkType: hard
+
+"is-obj@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "is-obj@npm:2.0.0"
+  checksum: 10/c9916ac8f4621962a42f5e80e7ffdb1d79a3fab7456ceaeea394cd9e0858d04f985a9ace45be44433bf605673c8be8810540fe4cc7f4266fc7526ced95af5a08
+  languageName: node
+  linkType: hard
+
+"is-plain-obj@npm:^1.0.0, is-plain-obj@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "is-plain-obj@npm:1.1.0"
+  checksum: 10/0ee04807797aad50859652a7467481816cbb57e5cc97d813a7dcd8915da8195dc68c436010bf39d195226cde6a2d352f4b815f16f26b7bf486a5754290629931
+  languageName: node
+  linkType: hard
+
+"is-plain-object@npm:^2.0.4":
+  version: 2.0.4
+  resolution: "is-plain-object@npm:2.0.4"
+  dependencies:
+    isobject: "npm:^3.0.1"
+  checksum: 10/2a401140cfd86cabe25214956ae2cfee6fbd8186809555cd0e84574f88de7b17abacb2e477a6a658fa54c6083ecbda1e6ae404c7720244cd198903848fca70ca
+  languageName: node
+  linkType: hard
+
+"is-plain-object@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "is-plain-object@npm:5.0.0"
+  checksum: 10/e32d27061eef62c0847d303125440a38660517e586f2f3db7c9d179ae5b6674ab0f469d519b2e25c147a1a3bc87156d0d5f4d8821e0ce4a9ee7fe1fcf11ce45c
+  languageName: node
+  linkType: hard
+
+"is-ssh@npm:^1.4.0":
+  version: 1.4.0
+  resolution: "is-ssh@npm:1.4.0"
+  dependencies:
+    protocols: "npm:^2.0.1"
+  checksum: 10/e2d17d74a19b4368cc06ce5c76d4f625952442da337098d670a9840e1db5334c646aa0a6ed3a01e9d396901e22c755174ce64e74c3139bb10e5df03d5a6fb3fa
+  languageName: node
+  linkType: hard
+
+"is-stream@npm:2.0.0":
+  version: 2.0.0
+  resolution: "is-stream@npm:2.0.0"
+  checksum: 10/4dc47738e26bc4f1b3be9070b6b9e39631144f204fc6f87db56961220add87c10a999ba26cf81699f9ef9610426f69cb08a4713feff8deb7d8cadac907826935
+  languageName: node
+  linkType: hard
+
+"is-stream@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "is-stream@npm:2.0.1"
+  checksum: 10/b8e05ccdf96ac330ea83c12450304d4a591f9958c11fd17bed240af8d5ffe08aedafa4c0f4cfccd4d28dc9d4d129daca1023633d5c11601a6cbc77521f6fae66
+  languageName: node
+  linkType: hard
+
+"is-text-path@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "is-text-path@npm:1.0.1"
+  dependencies:
+    text-extensions: "npm:^1.0.0"
+  checksum: 10/fb5d78752c22b3f73a7c9540768f765ffcfa38c9e421e2b9af869565307fa1ae5e3d3a2ba016a43549742856846566d327da406e94a5846ec838a288b1704fd2
+  languageName: node
+  linkType: hard
+
+"is-typed-array@npm:^1.1.3":
+  version: 1.1.13
+  resolution: "is-typed-array@npm:1.1.13"
+  dependencies:
+    which-typed-array: "npm:^1.1.14"
+  checksum: 10/f850ba08286358b9a11aee6d93d371a45e3c59b5953549ee1c1a9a55ba5c1dd1bd9952488ae194ad8f32a9cf5e79c8fa5f0cc4d78c00720aa0bbcf238b38062d
+  languageName: node
+  linkType: hard
+
+"is-unicode-supported@npm:^0.1.0":
+  version: 0.1.0
+  resolution: "is-unicode-supported@npm:0.1.0"
+  checksum: 10/a2aab86ee7712f5c2f999180daaba5f361bdad1efadc9610ff5b8ab5495b86e4f627839d085c6530363c6d6d4ecbde340fb8e54bdb83da4ba8e0865ed5513c52
   languageName: node
   linkType: hard
 
 "is-utf8@npm:^0.2.1":
   version: 0.2.1
   resolution: "is-utf8@npm:0.2.1"
-  checksum: 167ccd2be869fc228cc62c1a28df4b78c6b5485d15a29027d3b5dceb09b383e86a3522008b56dcac14b592b22f0a224388718c2505027a994fd8471465de54b3
+  checksum: 10/167ccd2be869fc228cc62c1a28df4b78c6b5485d15a29027d3b5dceb09b383e86a3522008b56dcac14b592b22f0a224388718c2505027a994fd8471465de54b3
+  languageName: node
+  linkType: hard
+
+"is-wsl@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "is-wsl@npm:2.2.0"
+  dependencies:
+    is-docker: "npm:^2.0.0"
+  checksum: 10/20849846ae414997d290b75e16868e5261e86ff5047f104027026fd61d8b5a9b0b3ade16239f35e1a067b3c7cc02f70183cb661010ed16f4b6c7c93dad1b19d8
   languageName: node
   linkType: hard
 
 "isarray@npm:0.0.1":
   version: 0.0.1
   resolution: "isarray@npm:0.0.1"
-  checksum: 49191f1425681df4a18c2f0f93db3adb85573bcdd6a4482539d98eac9e705d8961317b01175627e860516a2fc45f8f9302db26e5a380a97a520e272e2a40a8d4
+  checksum: 10/49191f1425681df4a18c2f0f93db3adb85573bcdd6a4482539d98eac9e705d8961317b01175627e860516a2fc45f8f9302db26e5a380a97a520e272e2a40a8d4
   languageName: node
   linkType: hard
 
 "isarray@npm:~1.0.0":
   version: 1.0.0
   resolution: "isarray@npm:1.0.0"
-  checksum: f032df8e02dce8ec565cf2eb605ea939bdccea528dbcf565cdf92bfa2da9110461159d86a537388ef1acef8815a330642d7885b29010e8f7eac967c9993b65ab
+  checksum: 10/f032df8e02dce8ec565cf2eb605ea939bdccea528dbcf565cdf92bfa2da9110461159d86a537388ef1acef8815a330642d7885b29010e8f7eac967c9993b65ab
   languageName: node
   linkType: hard
 
-"jshint@npm:^2.9.6":
-  version: 2.13.5
-  resolution: "jshint@npm:2.13.5"
+"isexe@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "isexe@npm:2.0.0"
+  checksum: 10/7c9f715c03aff08f35e98b1fadae1b9267b38f0615d501824f9743f3aab99ef10e303ce7db3f186763a0b70a19de5791ebfc854ff884d5a8c4d92211f642ec92
+  languageName: node
+  linkType: hard
+
+"isexe@npm:^3.1.1":
+  version: 3.1.1
+  resolution: "isexe@npm:3.1.1"
+  checksum: 10/7fe1931ee4e88eb5aa524cd3ceb8c882537bc3a81b02e438b240e47012eef49c86904d0f0e593ea7c3a9996d18d0f1f3be8d3eaa92333977b0c3a9d353d5563e
+  languageName: node
+  linkType: hard
+
+"isobject@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "isobject@npm:3.0.1"
+  checksum: 10/db85c4c970ce30693676487cca0e61da2ca34e8d4967c2e1309143ff910c207133a969f9e4ddb2dc6aba670aabce4e0e307146c310350b298e74a31f7d464703
+  languageName: node
+  linkType: hard
+
+"istanbul-lib-coverage@npm:^3.0.0, istanbul-lib-coverage@npm:^3.2.0":
+  version: 3.2.2
+  resolution: "istanbul-lib-coverage@npm:3.2.2"
+  checksum: 10/40bbdd1e937dfd8c830fa286d0f665e81b7a78bdabcd4565f6d5667c99828bda3db7fb7ac6b96a3e2e8a2461ddbc5452d9f8bc7d00cb00075fa6a3e99f5b6a81
+  languageName: node
+  linkType: hard
+
+"istanbul-lib-instrument@npm:^5.0.4":
+  version: 5.2.1
+  resolution: "istanbul-lib-instrument@npm:5.2.1"
   dependencies:
-    cli: ~1.0.0
-    console-browserify: 1.1.x
-    exit: 0.1.x
-    htmlparser2: 3.8.x
-    lodash: ~4.17.21
-    minimatch: ~3.0.2
-    strip-json-comments: 1.0.x
+    "@babel/core": "npm:^7.12.3"
+    "@babel/parser": "npm:^7.14.7"
+    "@istanbuljs/schema": "npm:^0.1.2"
+    istanbul-lib-coverage: "npm:^3.2.0"
+    semver: "npm:^6.3.0"
+  checksum: 10/bbc4496c2f304d799f8ec22202ab38c010ac265c441947f075c0f7d46bd440b45c00e46017cf9053453d42182d768b1d6ed0e70a142c95ab00df9843aa5ab80e
+  languageName: node
+  linkType: hard
+
+"istanbul-lib-instrument@npm:^6.0.0":
+  version: 6.0.2
+  resolution: "istanbul-lib-instrument@npm:6.0.2"
+  dependencies:
+    "@babel/core": "npm:^7.23.9"
+    "@babel/parser": "npm:^7.23.9"
+    "@istanbuljs/schema": "npm:^0.1.3"
+    istanbul-lib-coverage: "npm:^3.2.0"
+    semver: "npm:^7.5.4"
+  checksum: 10/3aee19be199350182827679a137e1df142a306e9d7e20bb5badfd92ecc9023a7d366bc68e7c66e36983654a02a67401d75d8debf29fc6d4b83670fde69a594fc
+  languageName: node
+  linkType: hard
+
+"istanbul-lib-report@npm:^3.0.0":
+  version: 3.0.1
+  resolution: "istanbul-lib-report@npm:3.0.1"
+  dependencies:
+    istanbul-lib-coverage: "npm:^3.0.0"
+    make-dir: "npm:^4.0.0"
+    supports-color: "npm:^7.1.0"
+  checksum: 10/86a83421ca1cf2109a9f6d193c06c31ef04a45e72a74579b11060b1e7bb9b6337a4e6f04abfb8857e2d569c271273c65e855ee429376a0d7c91ad91db42accd1
+  languageName: node
+  linkType: hard
+
+"istanbul-lib-source-maps@npm:^4.0.0":
+  version: 4.0.1
+  resolution: "istanbul-lib-source-maps@npm:4.0.1"
+  dependencies:
+    debug: "npm:^4.1.1"
+    istanbul-lib-coverage: "npm:^3.0.0"
+    source-map: "npm:^0.6.1"
+  checksum: 10/5526983462799aced011d776af166e350191b816821ea7bcf71cab3e5272657b062c47dc30697a22a43656e3ced78893a42de677f9ccf276a28c913190953b82
+  languageName: node
+  linkType: hard
+
+"istanbul-reports@npm:^3.1.3":
+  version: 3.1.7
+  resolution: "istanbul-reports@npm:3.1.7"
+  dependencies:
+    html-escaper: "npm:^2.0.0"
+    istanbul-lib-report: "npm:^3.0.0"
+  checksum: 10/f1faaa4684efaf57d64087776018d7426312a59aa6eeb4e0e3a777347d23cd286ad18f427e98f0e3dee666103d7404c9d7abc5f240406a912fa16bd6695437fa
+  languageName: node
+  linkType: hard
+
+"jackspeak@npm:^2.3.6":
+  version: 2.3.6
+  resolution: "jackspeak@npm:2.3.6"
+  dependencies:
+    "@isaacs/cliui": "npm:^8.0.2"
+    "@pkgjs/parseargs": "npm:^0.11.0"
+  dependenciesMeta:
+    "@pkgjs/parseargs":
+      optional: true
+  checksum: 10/6e6490d676af8c94a7b5b29b8fd5629f21346911ebe2e32931c2a54210134408171c24cee1a109df2ec19894ad04a429402a8438cbf5cc2794585d35428ace76
+  languageName: node
+  linkType: hard
+
+"jake@npm:^10.8.5":
+  version: 10.9.1
+  resolution: "jake@npm:10.9.1"
+  dependencies:
+    async: "npm:^3.2.3"
+    chalk: "npm:^4.0.2"
+    filelist: "npm:^1.0.4"
+    minimatch: "npm:^3.1.2"
+  bin:
+    jake: bin/cli.js
+  checksum: 10/82603513de5a61bc12360d2b8ba2be9f6bb52495b73f4d1b541cdfef9e43314b132ca10e73d2b41e3c1ea16bf79ec30a64afc9b9e2d2c72a4d4575a8db61cbc8
+  languageName: node
+  linkType: hard
+
+"jest-changed-files@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "jest-changed-files@npm:29.7.0"
+  dependencies:
+    execa: "npm:^5.0.0"
+    jest-util: "npm:^29.7.0"
+    p-limit: "npm:^3.1.0"
+  checksum: 10/3d93742e56b1a73a145d55b66e96711fbf87ef89b96c2fab7cfdfba8ec06612591a982111ca2b712bb853dbc16831ec8b43585a2a96b83862d6767de59cbf83d
+  languageName: node
+  linkType: hard
+
+"jest-circus@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "jest-circus@npm:29.7.0"
+  dependencies:
+    "@jest/environment": "npm:^29.7.0"
+    "@jest/expect": "npm:^29.7.0"
+    "@jest/test-result": "npm:^29.7.0"
+    "@jest/types": "npm:^29.6.3"
+    "@types/node": "npm:*"
+    chalk: "npm:^4.0.0"
+    co: "npm:^4.6.0"
+    dedent: "npm:^1.0.0"
+    is-generator-fn: "npm:^2.0.0"
+    jest-each: "npm:^29.7.0"
+    jest-matcher-utils: "npm:^29.7.0"
+    jest-message-util: "npm:^29.7.0"
+    jest-runtime: "npm:^29.7.0"
+    jest-snapshot: "npm:^29.7.0"
+    jest-util: "npm:^29.7.0"
+    p-limit: "npm:^3.1.0"
+    pretty-format: "npm:^29.7.0"
+    pure-rand: "npm:^6.0.0"
+    slash: "npm:^3.0.0"
+    stack-utils: "npm:^2.0.3"
+  checksum: 10/716a8e3f40572fd0213bcfc1da90274bf30d856e5133af58089a6ce45089b63f4d679bd44e6be9d320e8390483ebc3ae9921981993986d21639d9019b523123d
+  languageName: node
+  linkType: hard
+
+"jest-cli@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "jest-cli@npm:29.7.0"
+  dependencies:
+    "@jest/core": "npm:^29.7.0"
+    "@jest/test-result": "npm:^29.7.0"
+    "@jest/types": "npm:^29.6.3"
+    chalk: "npm:^4.0.0"
+    create-jest: "npm:^29.7.0"
+    exit: "npm:^0.1.2"
+    import-local: "npm:^3.0.2"
+    jest-config: "npm:^29.7.0"
+    jest-util: "npm:^29.7.0"
+    jest-validate: "npm:^29.7.0"
+    yargs: "npm:^17.3.1"
+  peerDependencies:
+    node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+  peerDependenciesMeta:
+    node-notifier:
+      optional: true
+  bin:
+    jest: bin/jest.js
+  checksum: 10/6cc62b34d002c034203065a31e5e9a19e7c76d9e8ef447a6f70f759c0714cb212c6245f75e270ba458620f9c7b26063cd8cf6cd1f7e3afd659a7cc08add17307
+  languageName: node
+  linkType: hard
+
+"jest-config@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "jest-config@npm:29.7.0"
+  dependencies:
+    "@babel/core": "npm:^7.11.6"
+    "@jest/test-sequencer": "npm:^29.7.0"
+    "@jest/types": "npm:^29.6.3"
+    babel-jest: "npm:^29.7.0"
+    chalk: "npm:^4.0.0"
+    ci-info: "npm:^3.2.0"
+    deepmerge: "npm:^4.2.2"
+    glob: "npm:^7.1.3"
+    graceful-fs: "npm:^4.2.9"
+    jest-circus: "npm:^29.7.0"
+    jest-environment-node: "npm:^29.7.0"
+    jest-get-type: "npm:^29.6.3"
+    jest-regex-util: "npm:^29.6.3"
+    jest-resolve: "npm:^29.7.0"
+    jest-runner: "npm:^29.7.0"
+    jest-util: "npm:^29.7.0"
+    jest-validate: "npm:^29.7.0"
+    micromatch: "npm:^4.0.4"
+    parse-json: "npm:^5.2.0"
+    pretty-format: "npm:^29.7.0"
+    slash: "npm:^3.0.0"
+    strip-json-comments: "npm:^3.1.1"
+  peerDependencies:
+    "@types/node": "*"
+    ts-node: ">=9.0.0"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+    ts-node:
+      optional: true
+  checksum: 10/6bdf570e9592e7d7dd5124fc0e21f5fe92bd15033513632431b211797e3ab57eaa312f83cc6481b3094b72324e369e876f163579d60016677c117ec4853cf02b
+  languageName: node
+  linkType: hard
+
+"jest-diff@npm:>=29.4.3 < 30, jest-diff@npm:^29.4.1, jest-diff@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "jest-diff@npm:29.7.0"
+  dependencies:
+    chalk: "npm:^4.0.0"
+    diff-sequences: "npm:^29.6.3"
+    jest-get-type: "npm:^29.6.3"
+    pretty-format: "npm:^29.7.0"
+  checksum: 10/6f3a7eb9cd9de5ea9e5aa94aed535631fa6f80221832952839b3cb59dd419b91c20b73887deb0b62230d06d02d6b6cf34ebb810b88d904bb4fe1e2e4f0905c98
+  languageName: node
+  linkType: hard
+
+"jest-docblock@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "jest-docblock@npm:29.7.0"
+  dependencies:
+    detect-newline: "npm:^3.0.0"
+  checksum: 10/8d48818055bc96c9e4ec2e217a5a375623c0d0bfae8d22c26e011074940c202aa2534a3362294c81d981046885c05d304376afba9f2874143025981148f3e96d
+  languageName: node
+  linkType: hard
+
+"jest-each@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "jest-each@npm:29.7.0"
+  dependencies:
+    "@jest/types": "npm:^29.6.3"
+    chalk: "npm:^4.0.0"
+    jest-get-type: "npm:^29.6.3"
+    jest-util: "npm:^29.7.0"
+    pretty-format: "npm:^29.7.0"
+  checksum: 10/bd1a077654bdaa013b590deb5f7e7ade68f2e3289180a8c8f53bc8a49f3b40740c0ec2d3a3c1aee906f682775be2bebbac37491d80b634d15276b0aa0f2e3fda
+  languageName: node
+  linkType: hard
+
+"jest-environment-node@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "jest-environment-node@npm:29.7.0"
+  dependencies:
+    "@jest/environment": "npm:^29.7.0"
+    "@jest/fake-timers": "npm:^29.7.0"
+    "@jest/types": "npm:^29.6.3"
+    "@types/node": "npm:*"
+    jest-mock: "npm:^29.7.0"
+    jest-util: "npm:^29.7.0"
+  checksum: 10/9cf7045adf2307cc93aed2f8488942e39388bff47ec1df149a997c6f714bfc66b2056768973770d3f8b1bf47396c19aa564877eb10ec978b952c6018ed1bd637
+  languageName: node
+  linkType: hard
+
+"jest-get-type@npm:^29.6.3":
+  version: 29.6.3
+  resolution: "jest-get-type@npm:29.6.3"
+  checksum: 10/88ac9102d4679d768accae29f1e75f592b760b44277df288ad76ce5bf038c3f5ce3719dea8aa0f035dac30e9eb034b848ce716b9183ad7cc222d029f03e92205
+  languageName: node
+  linkType: hard
+
+"jest-haste-map@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "jest-haste-map@npm:29.7.0"
+  dependencies:
+    "@jest/types": "npm:^29.6.3"
+    "@types/graceful-fs": "npm:^4.1.3"
+    "@types/node": "npm:*"
+    anymatch: "npm:^3.0.3"
+    fb-watchman: "npm:^2.0.0"
+    fsevents: "npm:^2.3.2"
+    graceful-fs: "npm:^4.2.9"
+    jest-regex-util: "npm:^29.6.3"
+    jest-util: "npm:^29.7.0"
+    jest-worker: "npm:^29.7.0"
+    micromatch: "npm:^4.0.4"
+    walker: "npm:^1.0.8"
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  checksum: 10/8531b42003581cb18a69a2774e68c456fb5a5c3280b1b9b77475af9e346b6a457250f9d756bfeeae2fe6cbc9ef28434c205edab9390ee970a919baddfa08bb85
+  languageName: node
+  linkType: hard
+
+"jest-leak-detector@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "jest-leak-detector@npm:29.7.0"
+  dependencies:
+    jest-get-type: "npm:^29.6.3"
+    pretty-format: "npm:^29.7.0"
+  checksum: 10/e3950e3ddd71e1d0c22924c51a300a1c2db6cf69ec1e51f95ccf424bcc070f78664813bef7aed4b16b96dfbdeea53fe358f8aeaaea84346ae15c3735758f1605
+  languageName: node
+  linkType: hard
+
+"jest-matcher-utils@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "jest-matcher-utils@npm:29.7.0"
+  dependencies:
+    chalk: "npm:^4.0.0"
+    jest-diff: "npm:^29.7.0"
+    jest-get-type: "npm:^29.6.3"
+    pretty-format: "npm:^29.7.0"
+  checksum: 10/981904a494299cf1e3baed352f8a3bd8b50a8c13a662c509b6a53c31461f94ea3bfeffa9d5efcfeb248e384e318c87de7e3baa6af0f79674e987482aa189af40
+  languageName: node
+  linkType: hard
+
+"jest-message-util@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "jest-message-util@npm:29.7.0"
+  dependencies:
+    "@babel/code-frame": "npm:^7.12.13"
+    "@jest/types": "npm:^29.6.3"
+    "@types/stack-utils": "npm:^2.0.0"
+    chalk: "npm:^4.0.0"
+    graceful-fs: "npm:^4.2.9"
+    micromatch: "npm:^4.0.4"
+    pretty-format: "npm:^29.7.0"
+    slash: "npm:^3.0.0"
+    stack-utils: "npm:^2.0.3"
+  checksum: 10/31d53c6ed22095d86bab9d14c0fa70c4a92c749ea6ceece82cf30c22c9c0e26407acdfbdb0231435dc85a98d6d65ca0d9cbcd25cd1abb377fe945e843fb770b9
+  languageName: node
+  linkType: hard
+
+"jest-mock@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "jest-mock@npm:29.7.0"
+  dependencies:
+    "@jest/types": "npm:^29.6.3"
+    "@types/node": "npm:*"
+    jest-util: "npm:^29.7.0"
+  checksum: 10/ae51d1b4f898724be5e0e52b2268a68fcd876d9b20633c864a6dd6b1994cbc48d62402b0f40f3a1b669b30ebd648821f086c26c08ffde192ced951ff4670d51c
+  languageName: node
+  linkType: hard
+
+"jest-pnp-resolver@npm:^1.2.2":
+  version: 1.2.3
+  resolution: "jest-pnp-resolver@npm:1.2.3"
+  peerDependencies:
+    jest-resolve: "*"
+  peerDependenciesMeta:
+    jest-resolve:
+      optional: true
+  checksum: 10/db1a8ab2cb97ca19c01b1cfa9a9c8c69a143fde833c14df1fab0766f411b1148ff0df878adea09007ac6a2085ec116ba9a996a6ad104b1e58c20adbf88eed9b2
+  languageName: node
+  linkType: hard
+
+"jest-regex-util@npm:^29.6.3":
+  version: 29.6.3
+  resolution: "jest-regex-util@npm:29.6.3"
+  checksum: 10/0518beeb9bf1228261695e54f0feaad3606df26a19764bc19541e0fc6e2a3737191904607fb72f3f2ce85d9c16b28df79b7b1ec9443aa08c3ef0e9efda6f8f2a
+  languageName: node
+  linkType: hard
+
+"jest-resolve-dependencies@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "jest-resolve-dependencies@npm:29.7.0"
+  dependencies:
+    jest-regex-util: "npm:^29.6.3"
+    jest-snapshot: "npm:^29.7.0"
+  checksum: 10/1e206f94a660d81e977bcfb1baae6450cb4a81c92e06fad376cc5ea16b8e8c6ea78c383f39e95591a9eb7f925b6a1021086c38941aa7c1b8a6a813c2f6e93675
+  languageName: node
+  linkType: hard
+
+"jest-resolve@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "jest-resolve@npm:29.7.0"
+  dependencies:
+    chalk: "npm:^4.0.0"
+    graceful-fs: "npm:^4.2.9"
+    jest-haste-map: "npm:^29.7.0"
+    jest-pnp-resolver: "npm:^1.2.2"
+    jest-util: "npm:^29.7.0"
+    jest-validate: "npm:^29.7.0"
+    resolve: "npm:^1.20.0"
+    resolve.exports: "npm:^2.0.0"
+    slash: "npm:^3.0.0"
+  checksum: 10/faa466fd9bc69ea6c37a545a7c6e808e073c66f46ab7d3d8a6ef084f8708f201b85d5fe1799789578b8b47fa1de47b9ee47b414d1863bc117a49e032ba77b7c7
+  languageName: node
+  linkType: hard
+
+"jest-runner@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "jest-runner@npm:29.7.0"
+  dependencies:
+    "@jest/console": "npm:^29.7.0"
+    "@jest/environment": "npm:^29.7.0"
+    "@jest/test-result": "npm:^29.7.0"
+    "@jest/transform": "npm:^29.7.0"
+    "@jest/types": "npm:^29.6.3"
+    "@types/node": "npm:*"
+    chalk: "npm:^4.0.0"
+    emittery: "npm:^0.13.1"
+    graceful-fs: "npm:^4.2.9"
+    jest-docblock: "npm:^29.7.0"
+    jest-environment-node: "npm:^29.7.0"
+    jest-haste-map: "npm:^29.7.0"
+    jest-leak-detector: "npm:^29.7.0"
+    jest-message-util: "npm:^29.7.0"
+    jest-resolve: "npm:^29.7.0"
+    jest-runtime: "npm:^29.7.0"
+    jest-util: "npm:^29.7.0"
+    jest-watcher: "npm:^29.7.0"
+    jest-worker: "npm:^29.7.0"
+    p-limit: "npm:^3.1.0"
+    source-map-support: "npm:0.5.13"
+  checksum: 10/9d8748a494bd90f5c82acea99be9e99f21358263ce6feae44d3f1b0cd90991b5df5d18d607e73c07be95861ee86d1cbab2a3fc6ca4b21805f07ac29d47c1da1e
+  languageName: node
+  linkType: hard
+
+"jest-runtime@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "jest-runtime@npm:29.7.0"
+  dependencies:
+    "@jest/environment": "npm:^29.7.0"
+    "@jest/fake-timers": "npm:^29.7.0"
+    "@jest/globals": "npm:^29.7.0"
+    "@jest/source-map": "npm:^29.6.3"
+    "@jest/test-result": "npm:^29.7.0"
+    "@jest/transform": "npm:^29.7.0"
+    "@jest/types": "npm:^29.6.3"
+    "@types/node": "npm:*"
+    chalk: "npm:^4.0.0"
+    cjs-module-lexer: "npm:^1.0.0"
+    collect-v8-coverage: "npm:^1.0.0"
+    glob: "npm:^7.1.3"
+    graceful-fs: "npm:^4.2.9"
+    jest-haste-map: "npm:^29.7.0"
+    jest-message-util: "npm:^29.7.0"
+    jest-mock: "npm:^29.7.0"
+    jest-regex-util: "npm:^29.6.3"
+    jest-resolve: "npm:^29.7.0"
+    jest-snapshot: "npm:^29.7.0"
+    jest-util: "npm:^29.7.0"
+    slash: "npm:^3.0.0"
+    strip-bom: "npm:^4.0.0"
+  checksum: 10/59eb58eb7e150e0834a2d0c0d94f2a0b963ae7182cfa6c63f2b49b9c6ef794e5193ef1634e01db41420c36a94cefc512cdd67a055cd3e6fa2f41eaf0f82f5a20
+  languageName: node
+  linkType: hard
+
+"jest-snapshot@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "jest-snapshot@npm:29.7.0"
+  dependencies:
+    "@babel/core": "npm:^7.11.6"
+    "@babel/generator": "npm:^7.7.2"
+    "@babel/plugin-syntax-jsx": "npm:^7.7.2"
+    "@babel/plugin-syntax-typescript": "npm:^7.7.2"
+    "@babel/types": "npm:^7.3.3"
+    "@jest/expect-utils": "npm:^29.7.0"
+    "@jest/transform": "npm:^29.7.0"
+    "@jest/types": "npm:^29.6.3"
+    babel-preset-current-node-syntax: "npm:^1.0.0"
+    chalk: "npm:^4.0.0"
+    expect: "npm:^29.7.0"
+    graceful-fs: "npm:^4.2.9"
+    jest-diff: "npm:^29.7.0"
+    jest-get-type: "npm:^29.6.3"
+    jest-matcher-utils: "npm:^29.7.0"
+    jest-message-util: "npm:^29.7.0"
+    jest-util: "npm:^29.7.0"
+    natural-compare: "npm:^1.4.0"
+    pretty-format: "npm:^29.7.0"
+    semver: "npm:^7.5.3"
+  checksum: 10/cb19a3948256de5f922d52f251821f99657339969bf86843bd26cf3332eae94883e8260e3d2fba46129a27c3971c1aa522490e460e16c7fad516e82d10bbf9f8
+  languageName: node
+  linkType: hard
+
+"jest-util@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "jest-util@npm:29.7.0"
+  dependencies:
+    "@jest/types": "npm:^29.6.3"
+    "@types/node": "npm:*"
+    chalk: "npm:^4.0.0"
+    ci-info: "npm:^3.2.0"
+    graceful-fs: "npm:^4.2.9"
+    picomatch: "npm:^2.2.3"
+  checksum: 10/30d58af6967e7d42bd903ccc098f3b4d3859ed46238fbc88d4add6a3f10bea00c226b93660285f058bc7a65f6f9529cf4eb80f8d4707f79f9e3a23686b4ab8f3
+  languageName: node
+  linkType: hard
+
+"jest-validate@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "jest-validate@npm:29.7.0"
+  dependencies:
+    "@jest/types": "npm:^29.6.3"
+    camelcase: "npm:^6.2.0"
+    chalk: "npm:^4.0.0"
+    jest-get-type: "npm:^29.6.3"
+    leven: "npm:^3.1.0"
+    pretty-format: "npm:^29.7.0"
+  checksum: 10/8ee1163666d8eaa16d90a989edba2b4a3c8ab0ffaa95ad91b08ca42b015bfb70e164b247a5b17f9de32d096987cada63ed8491ab82761bfb9a28bc34b27ae161
+  languageName: node
+  linkType: hard
+
+"jest-watcher@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "jest-watcher@npm:29.7.0"
+  dependencies:
+    "@jest/test-result": "npm:^29.7.0"
+    "@jest/types": "npm:^29.6.3"
+    "@types/node": "npm:*"
+    ansi-escapes: "npm:^4.2.1"
+    chalk: "npm:^4.0.0"
+    emittery: "npm:^0.13.1"
+    jest-util: "npm:^29.7.0"
+    string-length: "npm:^4.0.1"
+  checksum: 10/4f616e0345676631a7034b1d94971aaa719f0cd4a6041be2aa299be437ea047afd4fe05c48873b7963f5687a2f6c7cbf51244be8b14e313b97bfe32b1e127e55
+  languageName: node
+  linkType: hard
+
+"jest-worker@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "jest-worker@npm:29.7.0"
+  dependencies:
+    "@types/node": "npm:*"
+    jest-util: "npm:^29.7.0"
+    merge-stream: "npm:^2.0.0"
+    supports-color: "npm:^8.0.0"
+  checksum: 10/364cbaef00d8a2729fc760227ad34b5e60829e0869bd84976bdfbd8c0d0f9c2f22677b3e6dd8afa76ed174765351cd12bae3d4530c62eefb3791055127ca9745
+  languageName: node
+  linkType: hard
+
+"jest@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "jest@npm:29.7.0"
+  dependencies:
+    "@jest/core": "npm:^29.7.0"
+    "@jest/types": "npm:^29.6.3"
+    import-local: "npm:^3.0.2"
+    jest-cli: "npm:^29.7.0"
+  peerDependencies:
+    node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+  peerDependenciesMeta:
+    node-notifier:
+      optional: true
+  bin:
+    jest: bin/jest.js
+  checksum: 10/97023d78446098c586faaa467fbf2c6b07ff06e2c85a19e3926adb5b0effe9ac60c4913ae03e2719f9c01ae8ffd8d92f6b262cedb9555ceeb5d19263d8c6362a
+  languageName: node
+  linkType: hard
+
+"js-tokens@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "js-tokens@npm:4.0.0"
+  checksum: 10/af37d0d913fb56aec6dc0074c163cc71cd23c0b8aad5c2350747b6721d37ba118af35abdd8b33c47ec2800de07dedb16a527ca9c530ee004093e04958bd0cbf2
+  languageName: node
+  linkType: hard
+
+"js-yaml@npm:4.1.0, js-yaml@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "js-yaml@npm:4.1.0"
+  dependencies:
+    argparse: "npm:^2.0.1"
+  bin:
+    js-yaml: bin/js-yaml.js
+  checksum: 10/c138a34a3fd0d08ebaf71273ad4465569a483b8a639e0b118ff65698d257c2791d3199e3f303631f2cb98213fa7b5f5d6a4621fd0fff819421b990d30d967140
+  languageName: node
+  linkType: hard
+
+"js-yaml@npm:^3.10.0, js-yaml@npm:^3.13.1":
+  version: 3.14.1
+  resolution: "js-yaml@npm:3.14.1"
+  dependencies:
+    argparse: "npm:^1.0.7"
+    esprima: "npm:^4.0.0"
+  bin:
+    js-yaml: bin/js-yaml.js
+  checksum: 10/9e22d80b4d0105b9899135365f746d47466ed53ef4223c529b3c0f7a39907743fdbd3c4379f94f1106f02755b5e90b2faaf84801a891135544e1ea475d1a1379
+  languageName: node
+  linkType: hard
+
+"jsbn@npm:1.1.0":
+  version: 1.1.0
+  resolution: "jsbn@npm:1.1.0"
+  checksum: 10/bebe7ae829bbd586ce8cbe83501dd8cb8c282c8902a8aeeed0a073a89dc37e8103b1244f3c6acd60278bcbfe12d93a3f83c9ac396868a3b3bbc3c5e5e3b648ef
+  languageName: node
+  linkType: hard
+
+"jsesc@npm:^2.5.1":
+  version: 2.5.2
+  resolution: "jsesc@npm:2.5.2"
+  bin:
+    jsesc: bin/jsesc
+  checksum: 10/d2096abdcdec56969764b40ffc91d4a23408aa2f351b4d1c13f736f25476643238c43fdbaf38a191c26b1b78fd856d965f5d4d0dde7b89459cd94025190cdf13
+  languageName: node
+  linkType: hard
+
+"jshint@npm:^2.13.6":
+  version: 2.13.6
+  resolution: "jshint@npm:2.13.6"
+  dependencies:
+    cli: "npm:~1.0.0"
+    console-browserify: "npm:1.1.x"
+    exit: "npm:0.1.x"
+    htmlparser2: "npm:3.8.x"
+    lodash: "npm:~4.17.21"
+    minimatch: "npm:~3.0.2"
+    strip-json-comments: "npm:1.0.x"
   bin:
     jshint: bin/jshint
-  checksum: 2d1920855d21cd98dde2293e4c91da64d9154c00f8f8e27de17b7ddce3ab7cb45b25e8a395e809c12da11634c3284f95c9dbd9b05c8984a10c7a79e58f5c2e0f
+  checksum: 10/ead3bcd21c03e685babf69e5fa99ab05a859826dbab99d032089ef7d4fe11e464d292387594c58a8b1153ae5279eefba3af529cc65cdf071e3dc5731ed4a38d5
+  languageName: node
+  linkType: hard
+
+"json-parse-better-errors@npm:^1.0.1":
+  version: 1.0.2
+  resolution: "json-parse-better-errors@npm:1.0.2"
+  checksum: 10/5553232045359b767b0f2039a6777fede1a8d7dca1a0ffb1f9ef73a7519489ae7f566b2e040f2b4c38edb8e35e37ae07af7f0a52420902f869ee0dbf5dc6c784
+  languageName: node
+  linkType: hard
+
+"json-parse-even-better-errors@npm:^2.3.0":
+  version: 2.3.1
+  resolution: "json-parse-even-better-errors@npm:2.3.1"
+  checksum: 10/5f3a99009ed5f2a5a67d06e2f298cc97bc86d462034173308156f15b43a6e850be8511dc204b9b94566305da2947f7d90289657237d210351a39059ff9d666cf
+  languageName: node
+  linkType: hard
+
+"json-parse-even-better-errors@npm:^3.0.0":
+  version: 3.0.2
+  resolution: "json-parse-even-better-errors@npm:3.0.2"
+  checksum: 10/6f04ea6c9ccb783630a59297959247e921cc90b917b8351197ca7fd058fccc7079268fd9362be21ba876fc26aa5039369dd0a2280aae49aae425784794a94927
   languageName: node
   linkType: hard
 
 "json-schema-traverse@npm:^0.4.1":
   version: 0.4.1
   resolution: "json-schema-traverse@npm:0.4.1"
-  checksum: 7486074d3ba247769fda17d5181b345c9fb7d12e0da98b22d1d71a5db9698d8b4bd900a3ec1a4ffdd60846fc2556274a5c894d0c48795f14cb03aeae7b55260b
+  checksum: 10/7486074d3ba247769fda17d5181b345c9fb7d12e0da98b22d1d71a5db9698d8b4bd900a3ec1a4ffdd60846fc2556274a5c894d0c48795f14cb03aeae7b55260b
+  languageName: node
+  linkType: hard
+
+"json-schema-traverse@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "json-schema-traverse@npm:1.0.0"
+  checksum: 10/02f2f466cdb0362558b2f1fd5e15cce82ef55d60cd7f8fa828cf35ba74330f8d767fcae5c5c2adb7851fa811766c694b9405810879bc4e1ddd78a7c0e03658ad
+  languageName: node
+  linkType: hard
+
+"json-stringify-safe@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "json-stringify-safe@npm:5.0.1"
+  checksum: 10/59169a081e4eeb6f9559ae1f938f656191c000e0512aa6df9f3c8b2437a4ab1823819c6b9fd1818a4e39593ccfd72e9a051fdd3e2d1e340ed913679e888ded8c
+  languageName: node
+  linkType: hard
+
+"json5@npm:^2.2.2, json5@npm:^2.2.3":
+  version: 2.2.3
+  resolution: "json5@npm:2.2.3"
+  bin:
+    json5: lib/cli.js
+  checksum: 10/1db67b853ff0de3534085d630691d3247de53a2ed1390ba0ddff681ea43e9b3e30ecbdb65c5e9aab49435e44059c23dbd6fee8ee619419ba37465bb0dd7135da
+  languageName: node
+  linkType: hard
+
+"jsonc-parser@npm:3.2.0":
+  version: 3.2.0
+  resolution: "jsonc-parser@npm:3.2.0"
+  checksum: 10/bd68b902e5f9394f01da97921f49c5084b2dc03a0c5b4fdb2a429f8d6f292686c1bf87badaeb0a8148d024192a88f5ad2e57b2918ba43fe25cf15f3371db64d4
+  languageName: node
+  linkType: hard
+
+"jsonfile@npm:^6.0.1":
+  version: 6.1.0
+  resolution: "jsonfile@npm:6.1.0"
+  dependencies:
+    graceful-fs: "npm:^4.1.6"
+    universalify: "npm:^2.0.0"
+  dependenciesMeta:
+    graceful-fs:
+      optional: true
+  checksum: 10/03014769e7dc77d4cf05fa0b534907270b60890085dd5e4d60a382ff09328580651da0b8b4cdf44d91e4c8ae64d91791d965f05707beff000ed494a38b6fec85
+  languageName: node
+  linkType: hard
+
+"jsonparse@npm:^1.2.0, jsonparse@npm:^1.3.1":
+  version: 1.3.1
+  resolution: "jsonparse@npm:1.3.1"
+  checksum: 10/24531e956f0f19d79e22c157cebd81b37af3486ae22f9bc1028f8c2a4d1b70df48b168ff86f8568d9c2248182de9b6da9f50f685d5e4b9d1d2d339d2a29d15bc
+  languageName: node
+  linkType: hard
+
+"kind-of@npm:^6.0.2, kind-of@npm:^6.0.3":
+  version: 6.0.3
+  resolution: "kind-of@npm:6.0.3"
+  checksum: 10/5873d303fb36aad875b7538798867da2ae5c9e328d67194b0162a3659a627d22f742fc9c4ae95cd1704132a24b00cae5041fc00c0f6ef937dc17080dc4dbb962
+  languageName: node
+  linkType: hard
+
+"kleur@npm:^3.0.3":
+  version: 3.0.3
+  resolution: "kleur@npm:3.0.3"
+  checksum: 10/0c0ecaf00a5c6173d25059c7db2113850b5457016dfa1d0e3ef26da4704fbb186b4938d7611246d86f0ddf1bccf26828daa5877b1f232a65e7373d0122a83e7f
   languageName: node
   linkType: hard
 
@@ -1836,15 +6323,229 @@ __metadata:
   version: 1.0.0
   resolution: "lcid@npm:1.0.0"
   dependencies:
-    invert-kv: ^1.0.0
-  checksum: e8c7a4db07663068c5c44b650938a2bc41aa992037eebb69376214320f202c1250e70b50c32f939e28345fd30c2d35b8e8cd9a19d5932c398246a864ce54843d
+    invert-kv: "npm:^1.0.0"
+  checksum: 10/e8c7a4db07663068c5c44b650938a2bc41aa992037eebb69376214320f202c1250e70b50c32f939e28345fd30c2d35b8e8cd9a19d5932c398246a864ce54843d
   languageName: node
   linkType: hard
 
-"lodash@npm:^4.17.14, lodash@npm:^4.17.21, lodash@npm:~4.17.21":
+"lerna@npm:^8.1.2":
+  version: 8.1.3
+  resolution: "lerna@npm:8.1.3"
+  dependencies:
+    "@lerna/create": "npm:8.1.3"
+    "@npmcli/run-script": "npm:7.0.2"
+    "@nx/devkit": "npm:>=17.1.2 < 20"
+    "@octokit/plugin-enterprise-rest": "npm:6.0.1"
+    "@octokit/rest": "npm:19.0.11"
+    byte-size: "npm:8.1.1"
+    chalk: "npm:4.1.0"
+    clone-deep: "npm:4.0.1"
+    cmd-shim: "npm:6.0.1"
+    columnify: "npm:1.6.0"
+    conventional-changelog-angular: "npm:7.0.0"
+    conventional-changelog-core: "npm:5.0.1"
+    conventional-recommended-bump: "npm:7.0.1"
+    cosmiconfig: "npm:^8.2.0"
+    dedent: "npm:0.7.0"
+    envinfo: "npm:7.8.1"
+    execa: "npm:5.0.0"
+    fs-extra: "npm:^11.1.1"
+    get-port: "npm:5.1.1"
+    get-stream: "npm:6.0.0"
+    git-url-parse: "npm:13.1.0"
+    glob-parent: "npm:5.1.2"
+    globby: "npm:11.1.0"
+    graceful-fs: "npm:4.2.11"
+    has-unicode: "npm:2.0.1"
+    import-local: "npm:3.1.0"
+    ini: "npm:^1.3.8"
+    init-package-json: "npm:5.0.0"
+    inquirer: "npm:^8.2.4"
+    is-ci: "npm:3.0.1"
+    is-stream: "npm:2.0.0"
+    jest-diff: "npm:>=29.4.3 < 30"
+    js-yaml: "npm:4.1.0"
+    libnpmaccess: "npm:7.0.2"
+    libnpmpublish: "npm:7.3.0"
+    load-json-file: "npm:6.2.0"
+    lodash: "npm:^4.17.21"
+    make-dir: "npm:4.0.0"
+    minimatch: "npm:3.0.5"
+    multimatch: "npm:5.0.0"
+    node-fetch: "npm:2.6.7"
+    npm-package-arg: "npm:8.1.1"
+    npm-packlist: "npm:5.1.1"
+    npm-registry-fetch: "npm:^14.0.5"
+    npmlog: "npm:^6.0.2"
+    nx: "npm:>=17.1.2 < 20"
+    p-map: "npm:4.0.0"
+    p-map-series: "npm:2.1.0"
+    p-pipe: "npm:3.1.0"
+    p-queue: "npm:6.6.2"
+    p-reduce: "npm:2.1.0"
+    p-waterfall: "npm:2.1.1"
+    pacote: "npm:^17.0.5"
+    pify: "npm:5.0.0"
+    read-cmd-shim: "npm:4.0.0"
+    read-package-json: "npm:6.0.4"
+    resolve-from: "npm:5.0.0"
+    rimraf: "npm:^4.4.1"
+    semver: "npm:^7.3.8"
+    signal-exit: "npm:3.0.7"
+    slash: "npm:3.0.0"
+    ssri: "npm:^9.0.1"
+    strong-log-transformer: "npm:2.1.0"
+    tar: "npm:6.2.1"
+    temp-dir: "npm:1.0.0"
+    typescript: "npm:>=3 < 6"
+    upath: "npm:2.0.1"
+    uuid: "npm:^9.0.0"
+    validate-npm-package-license: "npm:3.0.4"
+    validate-npm-package-name: "npm:5.0.0"
+    write-file-atomic: "npm:5.0.1"
+    write-pkg: "npm:4.0.0"
+    yargs: "npm:17.7.2"
+    yargs-parser: "npm:21.1.1"
+  bin:
+    lerna: dist/cli.js
+  checksum: 10/822268c86fedba07e7ecf27d219237c8e381c47d33c83ea8c19da7ccb03c0aa051dc86297d5af3244485e18d0de8933b3266b7241349f9fce66d2fc1884a1a9a
+  languageName: node
+  linkType: hard
+
+"leven@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "leven@npm:3.1.0"
+  checksum: 10/638401d534585261b6003db9d99afd244dfe82d75ddb6db5c0df412842d5ab30b2ef18de471aaec70fe69a46f17b4ae3c7f01d8a4e6580ef7adb9f4273ad1e55
+  languageName: node
+  linkType: hard
+
+"libnpmaccess@npm:7.0.2":
+  version: 7.0.2
+  resolution: "libnpmaccess@npm:7.0.2"
+  dependencies:
+    npm-package-arg: "npm:^10.1.0"
+    npm-registry-fetch: "npm:^14.0.3"
+  checksum: 10/73d49f39391173276c46c12e32f503709338efd867d255d062ae9bc9e9f464d61240747f42bdd6dc6003a5dc275a27352ebfc11ed4cb424091463f302d823f23
+  languageName: node
+  linkType: hard
+
+"libnpmpublish@npm:7.3.0":
+  version: 7.3.0
+  resolution: "libnpmpublish@npm:7.3.0"
+  dependencies:
+    ci-info: "npm:^3.6.1"
+    normalize-package-data: "npm:^5.0.0"
+    npm-package-arg: "npm:^10.1.0"
+    npm-registry-fetch: "npm:^14.0.3"
+    proc-log: "npm:^3.0.0"
+    semver: "npm:^7.3.7"
+    sigstore: "npm:^1.4.0"
+    ssri: "npm:^10.0.1"
+  checksum: 10/89c8b8810897f9bb584ab9c7b4aa5438636590ddfe482989b3440a4ea47f95969e395f7fe5af1a7a0364faf70a2b1680fa1d8a37002597f33acd9f3bcd6d555a
+  languageName: node
+  linkType: hard
+
+"lines-and-columns@npm:^1.1.6":
+  version: 1.2.4
+  resolution: "lines-and-columns@npm:1.2.4"
+  checksum: 10/0c37f9f7fa212b38912b7145e1cd16a5f3cd34d782441c3e6ca653485d326f58b3caccda66efce1c5812bde4961bbde3374fae4b0d11bf1226152337f3894aa5
+  languageName: node
+  linkType: hard
+
+"lines-and-columns@npm:~2.0.3":
+  version: 2.0.4
+  resolution: "lines-and-columns@npm:2.0.4"
+  checksum: 10/81ac2f943f5428a46bd4ea2561c74ba674a107d8e6cc70cd317d16892a36ff3ba0dc6e599aca8b6f8668d26c85288394c6edf7a40e985ca843acab3701b80d4c
+  languageName: node
+  linkType: hard
+
+"load-json-file@npm:6.2.0":
+  version: 6.2.0
+  resolution: "load-json-file@npm:6.2.0"
+  dependencies:
+    graceful-fs: "npm:^4.1.15"
+    parse-json: "npm:^5.0.0"
+    strip-bom: "npm:^4.0.0"
+    type-fest: "npm:^0.6.0"
+  checksum: 10/4429e430ebb99375fc7cd936348e4f7ba729486080ced4272091c1e386a7f5f738ea3337d8ffd4b01c2f5bc3ddde92f2c780045b66838fe98bdb79f901884643
+  languageName: node
+  linkType: hard
+
+"load-json-file@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "load-json-file@npm:4.0.0"
+  dependencies:
+    graceful-fs: "npm:^4.1.2"
+    parse-json: "npm:^4.0.0"
+    pify: "npm:^3.0.0"
+    strip-bom: "npm:^3.0.0"
+  checksum: 10/8f5d6d93ba64a9620445ee9bde4d98b1eac32cf6c8c2d20d44abfa41a6945e7969456ab5f1ca2fb06ee32e206c9769a20eec7002fe290de462e8c884b6b8b356
+  languageName: node
+  linkType: hard
+
+"locate-path@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "locate-path@npm:2.0.0"
+  dependencies:
+    p-locate: "npm:^2.0.0"
+    path-exists: "npm:^3.0.0"
+  checksum: 10/02d581edbbbb0fa292e28d96b7de36b5b62c2fa8b5a7e82638ebb33afa74284acf022d3b1e9ae10e3ffb7658fbc49163fcd5e76e7d1baaa7801c3e05a81da755
+  languageName: node
+  linkType: hard
+
+"locate-path@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "locate-path@npm:5.0.0"
+  dependencies:
+    p-locate: "npm:^4.1.0"
+  checksum: 10/83e51725e67517287d73e1ded92b28602e3ae5580b301fe54bfb76c0c723e3f285b19252e375712316774cf52006cb236aed5704692c32db0d5d089b69696e30
+  languageName: node
+  linkType: hard
+
+"lodash.ismatch@npm:^4.4.0":
+  version: 4.4.0
+  resolution: "lodash.ismatch@npm:4.4.0"
+  checksum: 10/946a7176cdf4048f7b624378defda00dc0d01a2dad9933c54dad11fbecc253716df4210fbbfcd7d042e6fdb7603463cfe48e0ef576e20bf60d43f7deb1a2fe04
+  languageName: node
+  linkType: hard
+
+"lodash.truncate@npm:^4.4.2":
+  version: 4.4.2
+  resolution: "lodash.truncate@npm:4.4.2"
+  checksum: 10/7a495616121449e5d2288c606b1025d42ab9979e8c93ba885e5c5802ffd4f1ebad4428c793ccc12f73e73237e85a9f5b67dd6415757546fbd5a4653ba83e25ac
+  languageName: node
+  linkType: hard
+
+"lodash@npm:^4.17.21, lodash@npm:~4.17.21":
   version: 4.17.21
   resolution: "lodash@npm:4.17.21"
-  checksum: eb835a2e51d381e561e508ce932ea50a8e5a68f4ebdd771ea240d3048244a8d13658acbd502cd4829768c56f2e16bdd4340b9ea141297d472517b83868e677f7
+  checksum: 10/c08619c038846ea6ac754abd6dd29d2568aa705feb69339e836dfa8d8b09abbb2f859371e86863eda41848221f9af43714491467b5b0299122431e202bb0c532
+  languageName: node
+  linkType: hard
+
+"log-symbols@npm:^4.0.0, log-symbols@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "log-symbols@npm:4.1.0"
+  dependencies:
+    chalk: "npm:^4.1.0"
+    is-unicode-supported: "npm:^0.1.0"
+  checksum: 10/fce1497b3135a0198803f9f07464165e9eb83ed02ceb2273930a6f8a508951178d8cf4f0378e9d28300a2ed2bc49050995d2bd5f53ab716bb15ac84d58c6ef74
+  languageName: node
+  linkType: hard
+
+"lru-cache@npm:^10.0.1, lru-cache@npm:^10.2.0":
+  version: 10.2.2
+  resolution: "lru-cache@npm:10.2.2"
+  checksum: 10/ff1a496d30b5eaec2c9079080965bb0cede203cf878371f7033a007f1e54cd4aa13cc8abf7ccec4c994a83a22ed5476e83a55bb57cc07e6c1547a42937e42c37
+  languageName: node
+  linkType: hard
+
+"lru-cache@npm:^5.1.1":
+  version: 5.1.1
+  resolution: "lru-cache@npm:5.1.1"
+  dependencies:
+    yallist: "npm:^3.0.2"
+  checksum: 10/951d2673dcc64a7fb888bf3d13bc2fdf923faca97d89cdb405ba3dfff77e2b26e5798d405e78fcd7094c9e7b8b4dab2ddc5a4f8a11928af24a207b7c738ca3f8
   languageName: node
   linkType: hard
 
@@ -1852,15 +6553,150 @@ __metadata:
   version: 6.0.0
   resolution: "lru-cache@npm:6.0.0"
   dependencies:
-    yallist: ^4.0.0
-  checksum: f97f499f898f23e4585742138a22f22526254fdba6d75d41a1c2526b3b6cc5747ef59c5612ba7375f42aca4f8461950e925ba08c991ead0651b4918b7c978297
+    yallist: "npm:^4.0.0"
+  checksum: 10/fc1fe2ee205f7c8855fa0f34c1ab0bcf14b6229e35579ec1fd1079f31d6fc8ef8eb6fd17f2f4d99788d7e339f50e047555551ebd5e434dda503696e7c6591825
+  languageName: node
+  linkType: hard
+
+"lru-cache@npm:^7.5.1, lru-cache@npm:^7.7.1":
+  version: 7.18.3
+  resolution: "lru-cache@npm:7.18.3"
+  checksum: 10/6029ca5aba3aacb554e919d7ef804fffd4adfc4c83db00fac8248c7c78811fb6d4b6f70f7fd9d55032b3823446546a007edaa66ad1f2377ae833bd983fac5d98
+  languageName: node
+  linkType: hard
+
+"make-dir@npm:4.0.0, make-dir@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "make-dir@npm:4.0.0"
+  dependencies:
+    semver: "npm:^7.5.3"
+  checksum: 10/bf0731a2dd3aab4db6f3de1585cea0b746bb73eb5a02e3d8d72757e376e64e6ada190b1eddcde5b2f24a81b688a9897efd5018737d05e02e2a671dda9cff8a8a
+  languageName: node
+  linkType: hard
+
+"make-dir@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "make-dir@npm:2.1.0"
+  dependencies:
+    pify: "npm:^4.0.1"
+    semver: "npm:^5.6.0"
+  checksum: 10/043548886bfaf1820323c6a2997e6d2fa51ccc2586ac14e6f14634f7458b4db2daf15f8c310e2a0abd3e0cddc64df1890d8fc7263033602c47bb12cbfcf86aab
+  languageName: node
+  linkType: hard
+
+"make-fetch-happen@npm:^11.0.0, make-fetch-happen@npm:^11.0.1, make-fetch-happen@npm:^11.1.1":
+  version: 11.1.1
+  resolution: "make-fetch-happen@npm:11.1.1"
+  dependencies:
+    agentkeepalive: "npm:^4.2.1"
+    cacache: "npm:^17.0.0"
+    http-cache-semantics: "npm:^4.1.1"
+    http-proxy-agent: "npm:^5.0.0"
+    https-proxy-agent: "npm:^5.0.0"
+    is-lambda: "npm:^1.0.1"
+    lru-cache: "npm:^7.7.1"
+    minipass: "npm:^5.0.0"
+    minipass-fetch: "npm:^3.0.0"
+    minipass-flush: "npm:^1.0.5"
+    minipass-pipeline: "npm:^1.2.4"
+    negotiator: "npm:^0.6.3"
+    promise-retry: "npm:^2.0.1"
+    socks-proxy-agent: "npm:^7.0.0"
+    ssri: "npm:^10.0.0"
+  checksum: 10/b4b442cfaaec81db159f752a5f2e3ee3d7aa682782868fa399200824ec6298502e01bdc456e443dc219bcd5546c8e4471644d54109c8599841dc961d17a805fa
+  languageName: node
+  linkType: hard
+
+"make-fetch-happen@npm:^13.0.0, make-fetch-happen@npm:^13.0.1":
+  version: 13.0.1
+  resolution: "make-fetch-happen@npm:13.0.1"
+  dependencies:
+    "@npmcli/agent": "npm:^2.0.0"
+    cacache: "npm:^18.0.0"
+    http-cache-semantics: "npm:^4.1.1"
+    is-lambda: "npm:^1.0.1"
+    minipass: "npm:^7.0.2"
+    minipass-fetch: "npm:^3.0.0"
+    minipass-flush: "npm:^1.0.5"
+    minipass-pipeline: "npm:^1.2.4"
+    negotiator: "npm:^0.6.3"
+    proc-log: "npm:^4.2.0"
+    promise-retry: "npm:^2.0.1"
+    ssri: "npm:^10.0.0"
+  checksum: 10/11bae5ad6ac59b654dbd854f30782f9de052186c429dfce308eda42374528185a100ee40ac9ffdc36a2b6c821ecaba43913e4730a12f06f15e895ea9cb23fa59
+  languageName: node
+  linkType: hard
+
+"makeerror@npm:1.0.12":
+  version: 1.0.12
+  resolution: "makeerror@npm:1.0.12"
+  dependencies:
+    tmpl: "npm:1.0.5"
+  checksum: 10/4c66ddfc654537333da952c084f507fa4c30c707b1635344eb35be894d797ba44c901a9cebe914aa29a7f61357543ba09b09dddbd7f65b4aee756b450f169f40
+  languageName: node
+  linkType: hard
+
+"map-obj@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "map-obj@npm:1.0.1"
+  checksum: 10/f8e6fc7f6137329c376c4524f6d25b3c243c17019bc8f621d15a2dcb855919e482a9298a78ae58b00dbd0e76b640bf6533aa343a9e993cfc16e0346a2507e7f8
+  languageName: node
+  linkType: hard
+
+"map-obj@npm:^4.0.0":
+  version: 4.3.0
+  resolution: "map-obj@npm:4.3.0"
+  checksum: 10/fbc554934d1a27a1910e842bc87b177b1a556609dd803747c85ece420692380827c6ae94a95cce4407c054fa0964be3bf8226f7f2cb2e9eeee432c7c1985684e
+  languageName: node
+  linkType: hard
+
+"meow@npm:^8.1.2":
+  version: 8.1.2
+  resolution: "meow@npm:8.1.2"
+  dependencies:
+    "@types/minimist": "npm:^1.2.0"
+    camelcase-keys: "npm:^6.2.2"
+    decamelize-keys: "npm:^1.1.0"
+    hard-rejection: "npm:^2.1.0"
+    minimist-options: "npm:4.1.0"
+    normalize-package-data: "npm:^3.0.0"
+    read-pkg-up: "npm:^7.0.1"
+    redent: "npm:^3.0.0"
+    trim-newlines: "npm:^3.0.0"
+    type-fest: "npm:^0.18.0"
+    yargs-parser: "npm:^20.2.3"
+  checksum: 10/d4770f90135c0ef4d0f4fa4f4310a18c07bbbe408221fa79a68fda93944134001ffc24ed605e7668f61e920dd8db30936548e927d2331b0e30699d56247f9873
+  languageName: node
+  linkType: hard
+
+"merge-stream@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "merge-stream@npm:2.0.0"
+  checksum: 10/6fa4dcc8d86629705cea944a4b88ef4cb0e07656ebf223fa287443256414283dd25d91c1cd84c77987f2aec5927af1a9db6085757cb43d90eb170ebf4b47f4f4
+  languageName: node
+  linkType: hard
+
+"merge2@npm:^1.3.0, merge2@npm:^1.4.1":
+  version: 1.4.1
+  resolution: "merge2@npm:1.4.1"
+  checksum: 10/7268db63ed5169466540b6fb947aec313200bcf6d40c5ab722c22e242f651994619bcd85601602972d3c85bd2cc45a358a4c61937e9f11a061919a1da569b0c2
+  languageName: node
+  linkType: hard
+
+"micromatch@npm:^4.0.4":
+  version: 4.0.5
+  resolution: "micromatch@npm:4.0.5"
+  dependencies:
+    braces: "npm:^3.0.2"
+    picomatch: "npm:^2.3.1"
+  checksum: 10/a749888789fc15cac0e03273844dbd749f9f8e8d64e70c564bcf06a033129554c789bb9e30d7566d7ff6596611a08e58ac12cf2a05f6e3c9c47c50c4c7e12fa2
   languageName: node
   linkType: hard
 
 "mime-db@npm:1.52.0":
   version: 1.52.0
   resolution: "mime-db@npm:1.52.0"
-  checksum: 0d99a03585f8b39d68182803b12ac601d9c01abfa28ec56204fa330bc9f3d1c5e14beb049bafadb3dbdf646dfb94b87e24d4ec7b31b7279ef906a8ea9b6a513f
+  checksum: 10/54bb60bf39e6f8689f6622784e668a3d7f8bed6b0d886f5c3c446cb3284be28b30bf707ed05d0fe44a036f8469976b2629bbea182684977b084de9da274694d7
   languageName: node
   linkType: hard
 
@@ -1868,8 +6704,22 @@ __metadata:
   version: 2.1.35
   resolution: "mime-types@npm:2.1.35"
   dependencies:
-    mime-db: 1.52.0
-  checksum: 89a5b7f1def9f3af5dad6496c5ed50191ae4331cc5389d7c521c8ad28d5fdad2d06fd81baf38fed813dc4e46bb55c8145bb0ff406330818c9cf712fb2e9b3836
+    mime-db: "npm:1.52.0"
+  checksum: 10/89aa9651b67644035de2784a6e665fc685d79aba61857e02b9c8758da874a754aed4a9aced9265f5ed1171fd934331e5516b84a7f0218031b6fa0270eca1e51a
+  languageName: node
+  linkType: hard
+
+"mimic-fn@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "mimic-fn@npm:2.1.0"
+  checksum: 10/d2421a3444848ce7f84bd49115ddacff29c15745db73f54041edc906c14b131a38d05298dae3081667627a59b2eb1ca4b436ff2e1b80f69679522410418b478a
+  languageName: node
+  linkType: hard
+
+"min-indent@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "min-indent@npm:1.0.1"
+  checksum: 10/bfc6dd03c5eaf623a4963ebd94d087f6f4bbbfd8c41329a7f09706b0cb66969c4ddd336abeb587bc44bc6f08e13bf90f0b374f9d71f9f01e04adc2cd6f083ef1
   languageName: node
   linkType: hard
 
@@ -1877,17 +6727,53 @@ __metadata:
   version: 3.0.5
   resolution: "minimatch@npm:3.0.5"
   dependencies:
-    brace-expansion: ^1.1.7
-  checksum: a3b84b426eafca947741b864502cee02860c4e7b145de11ad98775cfcf3066fef422583bc0ffce0952ddf4750c1ccf4220b1556430d4ce10139f66247d87d69e
+    brace-expansion: "npm:^1.1.7"
+  checksum: 10/8f9707491183a07a9542b8cf45aacb3745ba9fe6c611173fb225d7bf191e55416779aee31e17673a516a178af02d8d3d71ddd36ae3d5cc2495f627977ad1a012
   languageName: node
   linkType: hard
 
-"minimatch@npm:^3.1.1":
+"minimatch@npm:9.0.3":
+  version: 9.0.3
+  resolution: "minimatch@npm:9.0.3"
+  dependencies:
+    brace-expansion: "npm:^2.0.1"
+  checksum: 10/c81b47d28153e77521877649f4bab48348d10938df9e8147a58111fe00ef89559a2938de9f6632910c4f7bf7bb5cd81191a546167e58d357f0cfb1e18cecc1c5
+  languageName: node
+  linkType: hard
+
+"minimatch@npm:^3.0.4, minimatch@npm:^3.1.1, minimatch@npm:^3.1.2":
   version: 3.1.2
   resolution: "minimatch@npm:3.1.2"
   dependencies:
-    brace-expansion: ^1.1.7
-  checksum: c154e566406683e7bcb746e000b84d74465b3a832c45d59912b9b55cd50dee66e5c4b1e5566dba26154040e51672f9aa450a9aef0c97cfc7336b78b7afb9540a
+    brace-expansion: "npm:^1.1.7"
+  checksum: 10/e0b25b04cd4ec6732830344e5739b13f8690f8a012d73445a4a19fbc623f5dd481ef7a5827fde25954cd6026fede7574cc54dc4643c99d6c6b653d6203f94634
+  languageName: node
+  linkType: hard
+
+"minimatch@npm:^5.0.1":
+  version: 5.1.6
+  resolution: "minimatch@npm:5.1.6"
+  dependencies:
+    brace-expansion: "npm:^2.0.1"
+  checksum: 10/126b36485b821daf96d33b5c821dac600cc1ab36c87e7a532594f9b1652b1fa89a1eebcaad4dff17c764dce1a7ac1531327f190fed5f97d8f6e5f889c116c429
+  languageName: node
+  linkType: hard
+
+"minimatch@npm:^8.0.2":
+  version: 8.0.4
+  resolution: "minimatch@npm:8.0.4"
+  dependencies:
+    brace-expansion: "npm:^2.0.1"
+  checksum: 10/aef05598ee565e1013bc8a10f53410ac681561f901c1a084b8ecfd016c9ed919f58f4bbd5b63e05643189dfb26e8106a84f0e1ff12e4a263aa37e1cae7ce9828
+  languageName: node
+  linkType: hard
+
+"minimatch@npm:^9.0.0, minimatch@npm:^9.0.1, minimatch@npm:^9.0.4":
+  version: 9.0.4
+  resolution: "minimatch@npm:9.0.4"
+  dependencies:
+    brace-expansion: "npm:^2.0.1"
+  checksum: 10/4cdc18d112b164084513e890d6323370db14c22249d536ad1854539577a895e690a27513dc346392f61a4a50afbbd8abc88f3f25558bfbbbb862cd56508b20f5
   languageName: node
   linkType: hard
 
@@ -1895,8 +6781,281 @@ __metadata:
   version: 3.0.8
   resolution: "minimatch@npm:3.0.8"
   dependencies:
-    brace-expansion: ^1.1.7
-  checksum: 850cca179cad715133132693e6963b0db64ab0988c4d211415b087fc23a3e46321e2c5376a01bf5623d8782aba8bdf43c571e2e902e51fdce7175c7215c29f8b
+    brace-expansion: "npm:^1.1.7"
+  checksum: 10/6df5373cb1ea79020beb6887ff5576c58cfabcfd32c5a65c2cf58f326e4ee8eae84f129e5fa50b8a4347fa1d1e583f931285c9fb3040d984bdfb5109ef6607ec
+  languageName: node
+  linkType: hard
+
+"minimist-options@npm:4.1.0":
+  version: 4.1.0
+  resolution: "minimist-options@npm:4.1.0"
+  dependencies:
+    arrify: "npm:^1.0.1"
+    is-plain-obj: "npm:^1.1.0"
+    kind-of: "npm:^6.0.3"
+  checksum: 10/8c040b3068811e79de1140ca2b708d3e203c8003eb9a414c1ab3cd467fc5f17c9ca02a5aef23bedc51a7f8bfbe77f87e9a7e31ec81fba304cda675b019496f4e
+  languageName: node
+  linkType: hard
+
+"minimist@npm:^1.2.0, minimist@npm:^1.2.5, minimist@npm:^1.2.6":
+  version: 1.2.8
+  resolution: "minimist@npm:1.2.8"
+  checksum: 10/908491b6cc15a6c440ba5b22780a0ba89b9810e1aea684e253e43c4e3b8d56ec1dcdd7ea96dde119c29df59c936cde16062159eae4225c691e19c70b432b6e6f
+  languageName: node
+  linkType: hard
+
+"minipass-collect@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "minipass-collect@npm:1.0.2"
+  dependencies:
+    minipass: "npm:^3.0.0"
+  checksum: 10/14df761028f3e47293aee72888f2657695ec66bd7d09cae7ad558da30415fdc4752bbfee66287dcc6fd5e6a2fa3466d6c484dc1cbd986525d9393b9523d97f10
+  languageName: node
+  linkType: hard
+
+"minipass-collect@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "minipass-collect@npm:2.0.1"
+  dependencies:
+    minipass: "npm:^7.0.3"
+  checksum: 10/b251bceea62090f67a6cced7a446a36f4cd61ee2d5cea9aee7fff79ba8030e416327a1c5aa2908dc22629d06214b46d88fdab8c51ac76bacbf5703851b5ad342
+  languageName: node
+  linkType: hard
+
+"minipass-fetch@npm:^3.0.0":
+  version: 3.0.5
+  resolution: "minipass-fetch@npm:3.0.5"
+  dependencies:
+    encoding: "npm:^0.1.13"
+    minipass: "npm:^7.0.3"
+    minipass-sized: "npm:^1.0.3"
+    minizlib: "npm:^2.1.2"
+  dependenciesMeta:
+    encoding:
+      optional: true
+  checksum: 10/c669948bec1373313aaa8f104b962a3ced9f45c49b26366a4b0ae27ccdfa9c5740d72c8a84d3f8623d7a61c5fc7afdfda44789008c078f61a62441142efc4a97
+  languageName: node
+  linkType: hard
+
+"minipass-flush@npm:^1.0.5":
+  version: 1.0.5
+  resolution: "minipass-flush@npm:1.0.5"
+  dependencies:
+    minipass: "npm:^3.0.0"
+  checksum: 10/56269a0b22bad756a08a94b1ffc36b7c9c5de0735a4dd1ab2b06c066d795cfd1f0ac44a0fcae13eece5589b908ecddc867f04c745c7009be0b566421ea0944cf
+  languageName: node
+  linkType: hard
+
+"minipass-json-stream@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "minipass-json-stream@npm:1.0.1"
+  dependencies:
+    jsonparse: "npm:^1.3.1"
+    minipass: "npm:^3.0.0"
+  checksum: 10/3c65482c630b063c3fa86c853f324a50d9484f2eb6c3034f9c86c0b22f44181668848088f2c869cc764f8a9b8adc8f617f93762cd9d11521f563b8a71c5b815d
+  languageName: node
+  linkType: hard
+
+"minipass-pipeline@npm:^1.2.4":
+  version: 1.2.4
+  resolution: "minipass-pipeline@npm:1.2.4"
+  dependencies:
+    minipass: "npm:^3.0.0"
+  checksum: 10/b14240dac0d29823c3d5911c286069e36d0b81173d7bdf07a7e4a91ecdef92cdff4baaf31ea3746f1c61e0957f652e641223970870e2353593f382112257971b
+  languageName: node
+  linkType: hard
+
+"minipass-sized@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "minipass-sized@npm:1.0.3"
+  dependencies:
+    minipass: "npm:^3.0.0"
+  checksum: 10/40982d8d836a52b0f37049a0a7e5d0f089637298e6d9b45df9c115d4f0520682a78258905e5c8b180fb41b593b0a82cc1361d2c74b45f7ada66334f84d1ecfdd
+  languageName: node
+  linkType: hard
+
+"minipass@npm:^3.0.0, minipass@npm:^3.1.1":
+  version: 3.3.6
+  resolution: "minipass@npm:3.3.6"
+  dependencies:
+    yallist: "npm:^4.0.0"
+  checksum: 10/a5c6ef069f70d9a524d3428af39f2b117ff8cd84172e19b754e7264a33df460873e6eb3d6e55758531580970de50ae950c496256bb4ad3691a2974cddff189f0
+  languageName: node
+  linkType: hard
+
+"minipass@npm:^4.2.4":
+  version: 4.2.8
+  resolution: "minipass@npm:4.2.8"
+  checksum: 10/e148eb6dcb85c980234cad889139ef8ddf9d5bdac534f4f0268446c8792dd4c74f4502479be48de3c1cce2f6450f6da4d0d4a86405a8a12be04c1c36b339569a
+  languageName: node
+  linkType: hard
+
+"minipass@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "minipass@npm:5.0.0"
+  checksum: 10/61682162d29f45d3152b78b08bab7fb32ca10899bc5991ffe98afc18c9e9543bd1e3be94f8b8373ba6262497db63607079dc242ea62e43e7b2270837b7347c93
+  languageName: node
+  linkType: hard
+
+"minipass@npm:^5.0.0 || ^6.0.2 || ^7.0.0, minipass@npm:^7.0.2, minipass@npm:^7.0.3, minipass@npm:^7.0.4":
+  version: 7.1.1
+  resolution: "minipass@npm:7.1.1"
+  checksum: 10/6f4f920f1b5ea585d08fa3739b9bd81726cd85a0c972fb371c0fa6c1544d468813fb1694c7bc64ad81f138fd8abf665e2af0f406de9ba5741d8e4a377ed346b1
+  languageName: node
+  linkType: hard
+
+"minizlib@npm:^2.1.1, minizlib@npm:^2.1.2":
+  version: 2.1.2
+  resolution: "minizlib@npm:2.1.2"
+  dependencies:
+    minipass: "npm:^3.0.0"
+    yallist: "npm:^4.0.0"
+  checksum: 10/ae0f45436fb51344dcb87938446a32fbebb540d0e191d63b35e1c773d47512e17307bf54aa88326cc6d176594d00e4423563a091f7266c2f9a6872cdc1e234d1
+  languageName: node
+  linkType: hard
+
+"mkdirp@npm:^1.0.3":
+  version: 1.0.4
+  resolution: "mkdirp@npm:1.0.4"
+  bin:
+    mkdirp: bin/cmd.js
+  checksum: 10/d71b8dcd4b5af2fe13ecf3bd24070263489404fe216488c5ba7e38ece1f54daf219e72a833a3a2dc404331e870e9f44963a33399589490956bff003a3404d3b2
+  languageName: node
+  linkType: hard
+
+"modify-values@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "modify-values@npm:1.0.1"
+  checksum: 10/16fa93f7ddb2540a8e82c99738ae4ed0e8e8cae57c96e13a0db9d68dfad074fd2eec542929b62ebbb18b357bbb3e4680b92d3a4099baa7aeb32360cb1c8f0247
+  languageName: node
+  linkType: hard
+
+"ms@npm:2.1.2":
+  version: 2.1.2
+  resolution: "ms@npm:2.1.2"
+  checksum: 10/673cdb2c3133eb050c745908d8ce632ed2c02d85640e2edb3ace856a2266a813b30c613569bf3354fdf4ea7d1a1494add3bfa95e2713baa27d0c2c71fc44f58f
+  languageName: node
+  linkType: hard
+
+"ms@npm:^2.0.0":
+  version: 2.1.3
+  resolution: "ms@npm:2.1.3"
+  checksum: 10/aa92de608021b242401676e35cfa5aa42dd70cbdc082b916da7fb925c542173e36bce97ea3e804923fe92c0ad991434e4a38327e15a1b5b5f945d66df615ae6d
+  languageName: node
+  linkType: hard
+
+"multimatch@npm:5.0.0":
+  version: 5.0.0
+  resolution: "multimatch@npm:5.0.0"
+  dependencies:
+    "@types/minimatch": "npm:^3.0.3"
+    array-differ: "npm:^3.0.0"
+    array-union: "npm:^2.1.0"
+    arrify: "npm:^2.0.1"
+    minimatch: "npm:^3.0.4"
+  checksum: 10/82c8030a53af965cab48da22f1b0f894ef99e16ee680dabdfbd38d2dfacc3c8208c475203d747afd9e26db44118ed0221d5a0d65268c864f06d6efc7ac6df812
+  languageName: node
+  linkType: hard
+
+"mute-stream@npm:0.0.8":
+  version: 0.0.8
+  resolution: "mute-stream@npm:0.0.8"
+  checksum: 10/a2d2e79dde87e3424ffc8c334472c7f3d17b072137734ca46e6f221131f1b014201cc593b69a38062e974fb2394d3d1cb4349f80f012bbf8b8ac1b28033e515f
+  languageName: node
+  linkType: hard
+
+"mute-stream@npm:^1.0.0, mute-stream@npm:~1.0.0":
+  version: 1.0.0
+  resolution: "mute-stream@npm:1.0.0"
+  checksum: 10/36fc968b0e9c9c63029d4f9dc63911950a3bdf55c9a87f58d3a266289b67180201cade911e7699f8b2fa596b34c9db43dad37649e3f7fdd13c3bb9edb0017ee7
+  languageName: node
+  linkType: hard
+
+"nanoid@npm:^3.3.6":
+  version: 3.3.7
+  resolution: "nanoid@npm:3.3.7"
+  bin:
+    nanoid: bin/nanoid.cjs
+  checksum: 10/ac1eb60f615b272bccb0e2b9cd933720dad30bf9708424f691b8113826bb91aca7e9d14ef5d9415a6ba15c266b37817256f58d8ce980c82b0ba3185352565679
+  languageName: node
+  linkType: hard
+
+"natural-compare@npm:^1.4.0":
+  version: 1.4.0
+  resolution: "natural-compare@npm:1.4.0"
+  checksum: 10/23ad088b08f898fc9b53011d7bb78ec48e79de7627e01ab5518e806033861bef68d5b0cd0e2205c2f36690ac9571ff6bcb05eb777ced2eeda8d4ac5b44592c3d
+  languageName: node
+  linkType: hard
+
+"negotiator@npm:^0.6.3":
+  version: 0.6.3
+  resolution: "negotiator@npm:0.6.3"
+  checksum: 10/2723fb822a17ad55c93a588a4bc44d53b22855bf4be5499916ca0cab1e7165409d0b288ba2577d7b029f10ce18cf2ed8e703e5af31c984e1e2304277ef979837
+  languageName: node
+  linkType: hard
+
+"neo-async@npm:^2.6.2":
+  version: 2.6.2
+  resolution: "neo-async@npm:2.6.2"
+  checksum: 10/1a7948fea86f2b33ec766bc899c88796a51ba76a4afc9026764aedc6e7cde692a09067031e4a1bf6db4f978ccd99e7f5b6c03fe47ad9865c3d4f99050d67e002
+  languageName: node
+  linkType: hard
+
+"next@npm:14.2.3":
+  version: 14.2.3
+  resolution: "next@npm:14.2.3"
+  dependencies:
+    "@next/env": "npm:14.2.3"
+    "@next/swc-darwin-arm64": "npm:14.2.3"
+    "@next/swc-darwin-x64": "npm:14.2.3"
+    "@next/swc-linux-arm64-gnu": "npm:14.2.3"
+    "@next/swc-linux-arm64-musl": "npm:14.2.3"
+    "@next/swc-linux-x64-gnu": "npm:14.2.3"
+    "@next/swc-linux-x64-musl": "npm:14.2.3"
+    "@next/swc-win32-arm64-msvc": "npm:14.2.3"
+    "@next/swc-win32-ia32-msvc": "npm:14.2.3"
+    "@next/swc-win32-x64-msvc": "npm:14.2.3"
+    "@swc/helpers": "npm:0.5.5"
+    busboy: "npm:1.6.0"
+    caniuse-lite: "npm:^1.0.30001579"
+    graceful-fs: "npm:^4.2.11"
+    postcss: "npm:8.4.31"
+    styled-jsx: "npm:5.1.1"
+  peerDependencies:
+    "@opentelemetry/api": ^1.1.0
+    "@playwright/test": ^1.41.2
+    react: ^18.2.0
+    react-dom: ^18.2.0
+    sass: ^1.3.0
+  dependenciesMeta:
+    "@next/swc-darwin-arm64":
+      optional: true
+    "@next/swc-darwin-x64":
+      optional: true
+    "@next/swc-linux-arm64-gnu":
+      optional: true
+    "@next/swc-linux-arm64-musl":
+      optional: true
+    "@next/swc-linux-x64-gnu":
+      optional: true
+    "@next/swc-linux-x64-musl":
+      optional: true
+    "@next/swc-win32-arm64-msvc":
+      optional: true
+    "@next/swc-win32-ia32-msvc":
+      optional: true
+    "@next/swc-win32-x64-msvc":
+      optional: true
+  peerDependenciesMeta:
+    "@opentelemetry/api":
+      optional: true
+    "@playwright/test":
+      optional: true
+    sass:
+      optional: true
+  bin:
+    next: dist/bin/next
+  checksum: 10/666c9770206ce693732a6d772297f1ddb3ce72f59862fa4cd104c5536da596026f758c4c9256ea790cf22d1bb8a15e27e5ea9455c948f72a9e3ca61fb745b0f5
   languageName: node
   linkType: hard
 
@@ -1904,11 +7063,11 @@ __metadata:
   version: 1.0.1
   resolution: "nifti-js@npm:1.0.1"
   dependencies:
-    yargs: ^3.29.0
+    yargs: "npm:^3.29.0"
   dependenciesMeta:
     yargs:
       optional: true
-  checksum: 1a0c96aadb7954aada2e91f7a9dfbea2410d8a6dac9e06320a1c76091972eab84ac5b0fd0f97b4634534f753ce2079ac1a8315faead656fc42c7f5b757570a18
+  checksum: 10/3cdf6277e0f1181a7bd7f2a0d2b95f04e74a4467b6ab321e7ed2b13335271597ed97f975d736b4af27fe71427a440da18559f88fc51c72cf575b621ed27fe3ff
   languageName: node
   linkType: hard
 
@@ -1916,36 +7075,450 @@ __metadata:
   version: 2.6.7
   resolution: "node-fetch@npm:2.6.7"
   dependencies:
-    whatwg-url: ^5.0.0
+    whatwg-url: "npm:^5.0.0"
   peerDependencies:
     encoding: ^0.1.0
   peerDependenciesMeta:
     encoding:
       optional: true
-  checksum: 8d816ffd1ee22cab8301c7756ef04f3437f18dace86a1dae22cf81db8ef29c0bf6655f3215cb0cdb22b420b6fe141e64b26905e7f33f9377a7fa59135ea3e10b
+  checksum: 10/4bc9245383db92c35601a798c9a992fdf38d99920ceac11e0e6512ef3014d188b3807ccb060bc6c4bdb57a145030c73f5b5fd6730f665979f9264bc43ca3afea
+  languageName: node
+  linkType: hard
+
+"node-fetch@npm:^2.6.12, node-fetch@npm:^2.6.7":
+  version: 2.7.0
+  resolution: "node-fetch@npm:2.7.0"
+  dependencies:
+    whatwg-url: "npm:^5.0.0"
+  peerDependencies:
+    encoding: ^0.1.0
+  peerDependenciesMeta:
+    encoding:
+      optional: true
+  checksum: 10/b24f8a3dc937f388192e59bcf9d0857d7b6940a2496f328381641cb616efccc9866e89ec43f2ec956bbd6c3d3ee05524ce77fe7b29ccd34692b3a16f237d6676
+  languageName: node
+  linkType: hard
+
+"node-gyp@npm:^10.0.0, node-gyp@npm:latest":
+  version: 10.1.0
+  resolution: "node-gyp@npm:10.1.0"
+  dependencies:
+    env-paths: "npm:^2.2.0"
+    exponential-backoff: "npm:^3.1.1"
+    glob: "npm:^10.3.10"
+    graceful-fs: "npm:^4.2.6"
+    make-fetch-happen: "npm:^13.0.0"
+    nopt: "npm:^7.0.0"
+    proc-log: "npm:^3.0.0"
+    semver: "npm:^7.3.5"
+    tar: "npm:^6.1.2"
+    which: "npm:^4.0.0"
+  bin:
+    node-gyp: bin/node-gyp.js
+  checksum: 10/89e105e495e66cd4568af3cf79cdeb67d670eb069e33163c7781d3366470a30367c9bd8dea59e46db16370020139e5bf78b1fbc03284cb571754dfaa59744db5
+  languageName: node
+  linkType: hard
+
+"node-int64@npm:^0.4.0":
+  version: 0.4.0
+  resolution: "node-int64@npm:0.4.0"
+  checksum: 10/b7afc2b65e56f7035b1a2eec57ae0fbdee7d742b1cdcd0f4387562b6527a011ab1cbe9f64cc8b3cca61e3297c9637c8bf61cec2e6b8d3a711d4b5267dfafbe02
+  languageName: node
+  linkType: hard
+
+"node-machine-id@npm:1.1.12":
+  version: 1.1.12
+  resolution: "node-machine-id@npm:1.1.12"
+  checksum: 10/46bf3d4fab8d0e63b24c42bcec2b6975c7ec5bc16e53d7a589d095668d0fdf0bfcbcdc28246dd1ef74cf95a37fbd774cd4b17b41f518d79dfad7fdc99f995903
+  languageName: node
+  linkType: hard
+
+"node-releases@npm:^2.0.14":
+  version: 2.0.14
+  resolution: "node-releases@npm:2.0.14"
+  checksum: 10/0f7607ec7db5ef1dc616899a5f24ae90c869b6a54c2d4f36ff6d84a282ab9343c7ff3ca3670fe4669171bb1e8a9b3e286e1ef1c131f09a83d70554f855d54f24
+  languageName: node
+  linkType: hard
+
+"nopt@npm:^7.0.0":
+  version: 7.2.1
+  resolution: "nopt@npm:7.2.1"
+  dependencies:
+    abbrev: "npm:^2.0.0"
+  bin:
+    nopt: bin/nopt.js
+  checksum: 10/95a1f6dec8a81cd18cdc2fed93e6f0b4e02cf6bdb4501c848752c6e34f9883d9942f036a5e3b21a699047d8a448562d891e67492df68ec9c373e6198133337ae
+  languageName: node
+  linkType: hard
+
+"normalize-package-data@npm:^2.3.2, normalize-package-data@npm:^2.5.0":
+  version: 2.5.0
+  resolution: "normalize-package-data@npm:2.5.0"
+  dependencies:
+    hosted-git-info: "npm:^2.1.4"
+    resolve: "npm:^1.10.0"
+    semver: "npm:2 || 3 || 4 || 5"
+    validate-npm-package-license: "npm:^3.0.1"
+  checksum: 10/644f830a8bb9b7cc9bf2f6150618727659ee27cdd0840d1c1f97e8e6cab0803a098a2c19f31c6247ad9d3a0792e61521a13a6e8cd87cc6bb676e3150612c03d4
+  languageName: node
+  linkType: hard
+
+"normalize-package-data@npm:^3.0.0, normalize-package-data@npm:^3.0.3":
+  version: 3.0.3
+  resolution: "normalize-package-data@npm:3.0.3"
+  dependencies:
+    hosted-git-info: "npm:^4.0.1"
+    is-core-module: "npm:^2.5.0"
+    semver: "npm:^7.3.4"
+    validate-npm-package-license: "npm:^3.0.1"
+  checksum: 10/3cd3b438c9c7b15d72ed2d1bbf0f8cc2d07bfe27702fc9e95d039f0af4e069dc75c0646e75068f9f9255a8aae64b59aa4fe2177e65787145fb996c3d38d48acb
+  languageName: node
+  linkType: hard
+
+"normalize-package-data@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "normalize-package-data@npm:5.0.0"
+  dependencies:
+    hosted-git-info: "npm:^6.0.0"
+    is-core-module: "npm:^2.8.1"
+    semver: "npm:^7.3.5"
+    validate-npm-package-license: "npm:^3.0.4"
+  checksum: 10/477344ee99c6c81afbc4359f9dc7a3a219cc29a37fe0220a4595bbdb7e1e5fa9e3c195e99900228b72d8676edf99eb99fd3b66aa94b4b8ab74d516f2ff60e510
+  languageName: node
+  linkType: hard
+
+"normalize-package-data@npm:^6.0.0":
+  version: 6.0.1
+  resolution: "normalize-package-data@npm:6.0.1"
+  dependencies:
+    hosted-git-info: "npm:^7.0.0"
+    is-core-module: "npm:^2.8.1"
+    semver: "npm:^7.3.5"
+    validate-npm-package-license: "npm:^3.0.4"
+  checksum: 10/eb0b1815a105adcba09df26befc35da1dc1c3149784b8ddbcaa90c581925b7a9f1d94aefd344b6020eb0261a5f0575a8a9ef8e92c57eb86182de9a510282c2b2
+  languageName: node
+  linkType: hard
+
+"normalize-path@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "normalize-path@npm:3.0.0"
+  checksum: 10/88eeb4da891e10b1318c4b2476b6e2ecbeb5ff97d946815ffea7794c31a89017c70d7f34b3c2ebf23ef4e9fc9fb99f7dffe36da22011b5b5c6ffa34f4873ec20
+  languageName: node
+  linkType: hard
+
+"npm-bundled@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "npm-bundled@npm:1.1.2"
+  dependencies:
+    npm-normalize-package-bin: "npm:^1.0.1"
+  checksum: 10/722154cb5e9792abc2aa0112f8a5ac62885224f2e01f010d4e1a32233522a8b7849a716a9184bbf7d6ba865177da337fafeaf41bd32800785067093133a380e3
+  languageName: node
+  linkType: hard
+
+"npm-bundled@npm:^3.0.0":
+  version: 3.0.1
+  resolution: "npm-bundled@npm:3.0.1"
+  dependencies:
+    npm-normalize-package-bin: "npm:^3.0.0"
+  checksum: 10/113c9a35526d9a563694e9bda401dbda592f664fa146d365028bef1e3bfdc2a7b60ac9315a727529ef7e8e8d80b8d9e217742ccc2808e0db99c2204a3e33a465
+  languageName: node
+  linkType: hard
+
+"npm-install-checks@npm:^6.0.0":
+  version: 6.3.0
+  resolution: "npm-install-checks@npm:6.3.0"
+  dependencies:
+    semver: "npm:^7.1.1"
+  checksum: 10/6c20dadb878a0d2f1f777405217b6b63af1299d0b43e556af9363ee6eefaa98a17dfb7b612a473a473e96faf7e789c58b221e0d8ffdc1d34903c4f71618df3b4
+  languageName: node
+  linkType: hard
+
+"npm-normalize-package-bin@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "npm-normalize-package-bin@npm:1.0.1"
+  checksum: 10/b61593d1afc2b05258afe791043d1b665376ec91ae56dfcf6c67bb802acfc2c249136d3fb600f356562ef013f9e46a009c5e4769693bf13bcabf99fb5e806e6a
+  languageName: node
+  linkType: hard
+
+"npm-normalize-package-bin@npm:^3.0.0":
+  version: 3.0.1
+  resolution: "npm-normalize-package-bin@npm:3.0.1"
+  checksum: 10/de416d720ab22137a36292ff8a333af499ea0933ef2320a8c6f56a73b0f0448227fec4db5c890d702e26d21d04f271415eab6580b5546456861cc0c19498a4bf
+  languageName: node
+  linkType: hard
+
+"npm-package-arg@npm:8.1.1":
+  version: 8.1.1
+  resolution: "npm-package-arg@npm:8.1.1"
+  dependencies:
+    hosted-git-info: "npm:^3.0.6"
+    semver: "npm:^7.0.0"
+    validate-npm-package-name: "npm:^3.0.0"
+  checksum: 10/b50b130680997f37c97fd6a4b100e447739eb5615a7f06e8c8010c2cc6ba61ba91e370d481cea06a90febc89816197a900189a9f91dab7b860171dda2334b320
+  languageName: node
+  linkType: hard
+
+"npm-package-arg@npm:^10.0.0, npm-package-arg@npm:^10.1.0":
+  version: 10.1.0
+  resolution: "npm-package-arg@npm:10.1.0"
+  dependencies:
+    hosted-git-info: "npm:^6.0.0"
+    proc-log: "npm:^3.0.0"
+    semver: "npm:^7.3.5"
+    validate-npm-package-name: "npm:^5.0.0"
+  checksum: 10/3bbb5f081099f73e852b4d3a3a10f78d495bdf21e050ca5c78dc134921c99ec856d1555ff6ba9c1c15b7475ad976ce803ef53fdda34abec622fe8f5d76421319
+  languageName: node
+  linkType: hard
+
+"npm-package-arg@npm:^11.0.0":
+  version: 11.0.2
+  resolution: "npm-package-arg@npm:11.0.2"
+  dependencies:
+    hosted-git-info: "npm:^7.0.0"
+    proc-log: "npm:^4.0.0"
+    semver: "npm:^7.3.5"
+    validate-npm-package-name: "npm:^5.0.0"
+  checksum: 10/ce4c51900a73aadb408c9830c38a61b1930e1ab08509ec5ebbcf625ad14326ee33b014df289c942039bd28071ab17e813368f68d26a4ccad0eb6e9928f8ad03c
+  languageName: node
+  linkType: hard
+
+"npm-packlist@npm:5.1.1":
+  version: 5.1.1
+  resolution: "npm-packlist@npm:5.1.1"
+  dependencies:
+    glob: "npm:^8.0.1"
+    ignore-walk: "npm:^5.0.1"
+    npm-bundled: "npm:^1.1.2"
+    npm-normalize-package-bin: "npm:^1.0.1"
+  bin:
+    npm-packlist: bin/index.js
+  checksum: 10/938299a48c7d2435199c8245f3ed79ad38c26f2256fe223d8654702d5e84d91a4193ee552333cf66d1716a94bc19a03b8ba43e1c5cd0535323de958b8dc7049e
+  languageName: node
+  linkType: hard
+
+"npm-packlist@npm:^8.0.0":
+  version: 8.0.2
+  resolution: "npm-packlist@npm:8.0.2"
+  dependencies:
+    ignore-walk: "npm:^6.0.4"
+  checksum: 10/707206e5c09a1b8aa04e590592715ba5ab8732add1bbb5eeaff54b9c6b2740764c9e94c99e390c13245970b51c2cc92b8d44594c2784fcd96f255c7109622322
+  languageName: node
+  linkType: hard
+
+"npm-pick-manifest@npm:^9.0.0":
+  version: 9.0.1
+  resolution: "npm-pick-manifest@npm:9.0.1"
+  dependencies:
+    npm-install-checks: "npm:^6.0.0"
+    npm-normalize-package-bin: "npm:^3.0.0"
+    npm-package-arg: "npm:^11.0.0"
+    semver: "npm:^7.3.5"
+  checksum: 10/870053b63c8765a5d22df3aabcf09505342dd30398c68e15a57cc32e9da629c361b12285d72bd0bac100786623d2f2dc5ced16270f39dda7c14660fae677590e
+  languageName: node
+  linkType: hard
+
+"npm-registry-fetch@npm:^14.0.3, npm-registry-fetch@npm:^14.0.5":
+  version: 14.0.5
+  resolution: "npm-registry-fetch@npm:14.0.5"
+  dependencies:
+    make-fetch-happen: "npm:^11.0.0"
+    minipass: "npm:^5.0.0"
+    minipass-fetch: "npm:^3.0.0"
+    minipass-json-stream: "npm:^1.0.1"
+    minizlib: "npm:^2.1.2"
+    npm-package-arg: "npm:^10.0.0"
+    proc-log: "npm:^3.0.0"
+  checksum: 10/63026b22d6a6afe5cb3a02dca96db783b88d3acc68be94f3485f25a5e4932800fdeff08145a77b35b8f61987033346462d4b3e710c0729a9735357ff97596062
+  languageName: node
+  linkType: hard
+
+"npm-registry-fetch@npm:^16.0.0":
+  version: 16.2.1
+  resolution: "npm-registry-fetch@npm:16.2.1"
+  dependencies:
+    "@npmcli/redact": "npm:^1.1.0"
+    make-fetch-happen: "npm:^13.0.0"
+    minipass: "npm:^7.0.2"
+    minipass-fetch: "npm:^3.0.0"
+    minipass-json-stream: "npm:^1.0.1"
+    minizlib: "npm:^2.1.2"
+    npm-package-arg: "npm:^11.0.0"
+    proc-log: "npm:^4.0.0"
+  checksum: 10/eb5a939f8f1c187b8d739e41bbc37f5d376480e2479f61a4f55af5aa00262a9a55e0053a0cd673d2945716863aaef6afbf97ebbb33fb194259573151c4dff37b
+  languageName: node
+  linkType: hard
+
+"npm-run-path@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "npm-run-path@npm:4.0.1"
+  dependencies:
+    path-key: "npm:^3.0.0"
+  checksum: 10/5374c0cea4b0bbfdfae62da7bbdf1e1558d338335f4cacf2515c282ff358ff27b2ecb91ffa5330a8b14390ac66a1e146e10700440c1ab868208430f56b5f4d23
+  languageName: node
+  linkType: hard
+
+"npmlog@npm:^6.0.2":
+  version: 6.0.2
+  resolution: "npmlog@npm:6.0.2"
+  dependencies:
+    are-we-there-yet: "npm:^3.0.0"
+    console-control-strings: "npm:^1.1.0"
+    gauge: "npm:^4.0.3"
+    set-blocking: "npm:^2.0.0"
+  checksum: 10/82b123677e62deb9e7472e27b92386c09e6e254ee6c8bcd720b3011013e4168bc7088e984f4fbd53cb6e12f8b4690e23e4fa6132689313e0d0dc4feea45489bb
   languageName: node
   linkType: hard
 
 "number-is-nan@npm:^1.0.0":
   version: 1.0.1
   resolution: "number-is-nan@npm:1.0.1"
-  checksum: 13656bc9aa771b96cef209ffca31c31a03b507ca6862ba7c3f638a283560620d723d52e626d57892c7fff475f4c36ac07f0600f14544692ff595abff214b9ffb
+  checksum: 10/13656bc9aa771b96cef209ffca31c31a03b507ca6862ba7c3f638a283560620d723d52e626d57892c7fff475f4c36ac07f0600f14544692ff595abff214b9ffb
   languageName: node
   linkType: hard
 
-"object-inspect@npm:^1.9.0":
-  version: 1.12.2
-  resolution: "object-inspect@npm:1.12.2"
-  checksum: a534fc1b8534284ed71f25ce3a496013b7ea030f3d1b77118f6b7b1713829262be9e6243acbcb3ef8c626e2b64186112cb7f6db74e37b2789b9c789ca23048b2
+"nx@npm:19.0.3, nx@npm:>=17.1.2 < 20":
+  version: 19.0.3
+  resolution: "nx@npm:19.0.3"
+  dependencies:
+    "@nrwl/tao": "npm:19.0.3"
+    "@nx/nx-darwin-arm64": "npm:19.0.3"
+    "@nx/nx-darwin-x64": "npm:19.0.3"
+    "@nx/nx-freebsd-x64": "npm:19.0.3"
+    "@nx/nx-linux-arm-gnueabihf": "npm:19.0.3"
+    "@nx/nx-linux-arm64-gnu": "npm:19.0.3"
+    "@nx/nx-linux-arm64-musl": "npm:19.0.3"
+    "@nx/nx-linux-x64-gnu": "npm:19.0.3"
+    "@nx/nx-linux-x64-musl": "npm:19.0.3"
+    "@nx/nx-win32-arm64-msvc": "npm:19.0.3"
+    "@nx/nx-win32-x64-msvc": "npm:19.0.3"
+    "@yarnpkg/lockfile": "npm:^1.1.0"
+    "@yarnpkg/parsers": "npm:3.0.0-rc.46"
+    "@zkochan/js-yaml": "npm:0.0.6"
+    axios: "npm:^1.6.0"
+    chalk: "npm:^4.1.0"
+    cli-cursor: "npm:3.1.0"
+    cli-spinners: "npm:2.6.1"
+    cliui: "npm:^8.0.1"
+    dotenv: "npm:~16.3.1"
+    dotenv-expand: "npm:~10.0.0"
+    enquirer: "npm:~2.3.6"
+    figures: "npm:3.2.0"
+    flat: "npm:^5.0.2"
+    fs-extra: "npm:^11.1.0"
+    ignore: "npm:^5.0.4"
+    jest-diff: "npm:^29.4.1"
+    js-yaml: "npm:4.1.0"
+    jsonc-parser: "npm:3.2.0"
+    lines-and-columns: "npm:~2.0.3"
+    minimatch: "npm:9.0.3"
+    node-machine-id: "npm:1.1.12"
+    npm-run-path: "npm:^4.0.1"
+    open: "npm:^8.4.0"
+    ora: "npm:5.3.0"
+    semver: "npm:^7.5.3"
+    string-width: "npm:^4.2.3"
+    strong-log-transformer: "npm:^2.1.0"
+    tar-stream: "npm:~2.2.0"
+    tmp: "npm:~0.2.1"
+    tsconfig-paths: "npm:^4.1.2"
+    tslib: "npm:^2.3.0"
+    yargs: "npm:^17.6.2"
+    yargs-parser: "npm:21.1.1"
+  peerDependencies:
+    "@swc-node/register": ^1.8.0
+    "@swc/core": ^1.3.85
+  dependenciesMeta:
+    "@nx/nx-darwin-arm64":
+      optional: true
+    "@nx/nx-darwin-x64":
+      optional: true
+    "@nx/nx-freebsd-x64":
+      optional: true
+    "@nx/nx-linux-arm-gnueabihf":
+      optional: true
+    "@nx/nx-linux-arm64-gnu":
+      optional: true
+    "@nx/nx-linux-arm64-musl":
+      optional: true
+    "@nx/nx-linux-x64-gnu":
+      optional: true
+    "@nx/nx-linux-x64-musl":
+      optional: true
+    "@nx/nx-win32-arm64-msvc":
+      optional: true
+    "@nx/nx-win32-x64-msvc":
+      optional: true
+  peerDependenciesMeta:
+    "@swc-node/register":
+      optional: true
+    "@swc/core":
+      optional: true
+  bin:
+    nx: bin/nx.js
+    nx-cloud: bin/nx-cloud.js
+  checksum: 10/06198a6f1b0c4a14796a800abd056c8a5a1893a1240aeba26fb45d5fdf2c097e801434212809c5906a8a42e92ea44c1564355fa7fa42692b90d891d3228beacd
   languageName: node
   linkType: hard
 
-"once@npm:^1.3.0":
+"once@npm:^1.3.0, once@npm:^1.4.0":
   version: 1.4.0
   resolution: "once@npm:1.4.0"
   dependencies:
-    wrappy: 1
-  checksum: cd0a88501333edd640d95f0d2700fbde6bff20b3d4d9bdc521bdd31af0656b5706570d6c6afe532045a20bb8dc0849f8332d6f2a416e0ba6d3d3b98806c7db68
+    wrappy: "npm:1"
+  checksum: 10/cd0a88501333edd640d95f0d2700fbde6bff20b3d4d9bdc521bdd31af0656b5706570d6c6afe532045a20bb8dc0849f8332d6f2a416e0ba6d3d3b98806c7db68
+  languageName: node
+  linkType: hard
+
+"onetime@npm:^5.1.0, onetime@npm:^5.1.2":
+  version: 5.1.2
+  resolution: "onetime@npm:5.1.2"
+  dependencies:
+    mimic-fn: "npm:^2.1.0"
+  checksum: 10/e9fd0695a01cf226652f0385bf16b7a24153dbbb2039f764c8ba6d2306a8506b0e4ce570de6ad99c7a6eb49520743afdb66edd95ee979c1a342554ed49a9aadd
+  languageName: node
+  linkType: hard
+
+"open@npm:^8.4.0":
+  version: 8.4.2
+  resolution: "open@npm:8.4.2"
+  dependencies:
+    define-lazy-prop: "npm:^2.0.0"
+    is-docker: "npm:^2.1.1"
+    is-wsl: "npm:^2.2.0"
+  checksum: 10/acd81a1d19879c818acb3af2d2e8e9d81d17b5367561e623248133deb7dd3aefaed527531df2677d3e6aaf0199f84df57b6b2262babff8bf46ea0029aac536c9
+  languageName: node
+  linkType: hard
+
+"ora@npm:5.3.0":
+  version: 5.3.0
+  resolution: "ora@npm:5.3.0"
+  dependencies:
+    bl: "npm:^4.0.3"
+    chalk: "npm:^4.1.0"
+    cli-cursor: "npm:^3.1.0"
+    cli-spinners: "npm:^2.5.0"
+    is-interactive: "npm:^1.0.0"
+    log-symbols: "npm:^4.0.0"
+    strip-ansi: "npm:^6.0.0"
+    wcwidth: "npm:^1.0.1"
+  checksum: 10/989a075b596c297acfee647010e555709bd657dedd9eee9ff99d923cbc65c68b6189c2c9ea58167675b101433509f87d1674a84047c7b766babab15d9220f1d5
+  languageName: node
+  linkType: hard
+
+"ora@npm:^5.4.1":
+  version: 5.4.1
+  resolution: "ora@npm:5.4.1"
+  dependencies:
+    bl: "npm:^4.1.0"
+    chalk: "npm:^4.1.0"
+    cli-cursor: "npm:^3.1.0"
+    cli-spinners: "npm:^2.5.0"
+    is-interactive: "npm:^1.0.0"
+    is-unicode-supported: "npm:^0.1.0"
+    log-symbols: "npm:^4.1.0"
+    strip-ansi: "npm:^6.0.0"
+    wcwidth: "npm:^1.0.1"
+  checksum: 10/8d071828f40090a8e1c6e8f350c6eb065808e9ab2b3e57fa37e0d5ae78cb46dac00117c8f12c3c8b8da2923454afbd8265e08c10b69881170c5b269f451e7fef
   languageName: node
   linkType: hard
 
@@ -1953,45 +7526,284 @@ __metadata:
   version: 1.4.0
   resolution: "os-locale@npm:1.4.0"
   dependencies:
-    lcid: ^1.0.0
-  checksum: 0161a1b6b5a8492f99f4b47fe465df9fc521c55ba5414fce6444c45e2500487b8ed5b40a47a98a2363fe83ff04ab033785300ed8df717255ec4c3b625e55b1fb
+    lcid: "npm:^1.0.0"
+  checksum: 10/0161a1b6b5a8492f99f4b47fe465df9fc521c55ba5414fce6444c45e2500487b8ed5b40a47a98a2363fe83ff04ab033785300ed8df717255ec4c3b625e55b1fb
   languageName: node
   linkType: hard
 
-"p-limit@npm:^2.1.0":
+"os-tmpdir@npm:~1.0.2":
+  version: 1.0.2
+  resolution: "os-tmpdir@npm:1.0.2"
+  checksum: 10/5666560f7b9f10182548bf7013883265be33620b1c1b4a4d405c25be2636f970c5488ff3e6c48de75b55d02bde037249fe5dbfbb4c0fb7714953d56aed062e6d
+  languageName: node
+  linkType: hard
+
+"p-finally@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "p-finally@npm:1.0.0"
+  checksum: 10/93a654c53dc805dd5b5891bab16eb0ea46db8f66c4bfd99336ae929323b1af2b70a8b0654f8f1eae924b2b73d037031366d645f1fd18b3d30cbd15950cc4b1d4
+  languageName: node
+  linkType: hard
+
+"p-limit@npm:^1.1.0":
+  version: 1.3.0
+  resolution: "p-limit@npm:1.3.0"
+  dependencies:
+    p-try: "npm:^1.0.0"
+  checksum: 10/eb9d9bc378d48ab1998d2a2b2962a99eddd3e3726c82d3258ecc1a475f22907968edea4fec2736586d100366a001c6bb449a2abe6cd65e252e9597394f01e789
+  languageName: node
+  linkType: hard
+
+"p-limit@npm:^2.1.0, p-limit@npm:^2.2.0":
   version: 2.3.0
   resolution: "p-limit@npm:2.3.0"
   dependencies:
-    p-try: ^2.0.0
-  checksum: 84ff17f1a38126c3314e91ecfe56aecbf36430940e2873dadaa773ffe072dc23b7af8e46d4b6485d302a11673fe94c6b67ca2cfbb60c989848b02100d0594ac1
+    p-try: "npm:^2.0.0"
+  checksum: 10/84ff17f1a38126c3314e91ecfe56aecbf36430940e2873dadaa773ffe072dc23b7af8e46d4b6485d302a11673fe94c6b67ca2cfbb60c989848b02100d0594ac1
+  languageName: node
+  linkType: hard
+
+"p-limit@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "p-limit@npm:3.1.0"
+  dependencies:
+    yocto-queue: "npm:^0.1.0"
+  checksum: 10/7c3690c4dbf62ef625671e20b7bdf1cbc9534e83352a2780f165b0d3ceba21907e77ad63401708145ca4e25bfc51636588d89a8c0aeb715e6c37d1c066430360
+  languageName: node
+  linkType: hard
+
+"p-locate@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "p-locate@npm:2.0.0"
+  dependencies:
+    p-limit: "npm:^1.1.0"
+  checksum: 10/e2dceb9b49b96d5513d90f715780f6f4972f46987dc32a0e18bc6c3fc74a1a5d73ec5f81b1398af5e58b99ea1ad03fd41e9181c01fa81b4af2833958696e3081
+  languageName: node
+  linkType: hard
+
+"p-locate@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "p-locate@npm:4.1.0"
+  dependencies:
+    p-limit: "npm:^2.2.0"
+  checksum: 10/513bd14a455f5da4ebfcb819ef706c54adb09097703de6aeaa5d26fe5ea16df92b48d1ac45e01e3944ce1e6aa2a66f7f8894742b8c9d6e276e16cd2049a2b870
+  languageName: node
+  linkType: hard
+
+"p-map-series@npm:2.1.0":
+  version: 2.1.0
+  resolution: "p-map-series@npm:2.1.0"
+  checksum: 10/69d4efbb6951c0dd62591d5a18c3af0af78496eae8b55791e049da239d70011aa3af727dece3fc9943e0bb3fd4fa64d24177cfbecc46efaf193179f0feeac486
+  languageName: node
+  linkType: hard
+
+"p-map@npm:4.0.0, p-map@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "p-map@npm:4.0.0"
+  dependencies:
+    aggregate-error: "npm:^3.0.0"
+  checksum: 10/7ba4a2b1e24c05e1fc14bbaea0fc6d85cf005ae7e9c9425d4575550f37e2e584b1af97bcde78eacd7559208f20995988d52881334db16cf77bc1bcf68e48ed7c
+  languageName: node
+  linkType: hard
+
+"p-pipe@npm:3.1.0":
+  version: 3.1.0
+  resolution: "p-pipe@npm:3.1.0"
+  checksum: 10/d4ef73801a99bd6ca6f1bd0f46c7992c4d006421d653de387893b72d91373ab93fca75ffaacba6199b1ce5bb5ff51d715f1c669541186afbb0a11b4aebb032b3
+  languageName: node
+  linkType: hard
+
+"p-queue@npm:6.6.2":
+  version: 6.6.2
+  resolution: "p-queue@npm:6.6.2"
+  dependencies:
+    eventemitter3: "npm:^4.0.4"
+    p-timeout: "npm:^3.2.0"
+  checksum: 10/60fe227ffce59fbc5b1b081305b61a2f283ff145005853702b7d4d3f99a0176bd21bb126c99a962e51fe1e01cb8aa10f0488b7bbe73b5dc2e84b5cc650b8ffd2
+  languageName: node
+  linkType: hard
+
+"p-reduce@npm:2.1.0, p-reduce@npm:^2.0.0, p-reduce@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "p-reduce@npm:2.1.0"
+  checksum: 10/99b26d36066a921982f25c575e78355824da0787c486e3dd9fc867460e8bf17d5fb3ce98d006b41bdc81ffc0aa99edf5faee53d11fe282a20291fb721b0cb1c7
+  languageName: node
+  linkType: hard
+
+"p-timeout@npm:^3.2.0":
+  version: 3.2.0
+  resolution: "p-timeout@npm:3.2.0"
+  dependencies:
+    p-finally: "npm:^1.0.0"
+  checksum: 10/3dd0eaa048780a6f23e5855df3dd45c7beacff1f820476c1d0d1bcd6648e3298752ba2c877aa1c92f6453c7dd23faaf13d9f5149fc14c0598a142e2c5e8d649c
+  languageName: node
+  linkType: hard
+
+"p-try@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "p-try@npm:1.0.0"
+  checksum: 10/20d9735f57258158df50249f172c77fe800d31e80f11a3413ac9e68ccbe6b11798acb3f48f2df8cea7ba2b56b753ce695a4fe2a2987c3c7691c44226b6d82b6f
   languageName: node
   linkType: hard
 
 "p-try@npm:^2.0.0":
   version: 2.2.0
   resolution: "p-try@npm:2.2.0"
-  checksum: f8a8e9a7693659383f06aec604ad5ead237c7a261c18048a6e1b5b85a5f8a067e469aa24f5bc009b991ea3b058a87f5065ef4176793a200d4917349881216cae
+  checksum: 10/f8a8e9a7693659383f06aec604ad5ead237c7a261c18048a6e1b5b85a5f8a067e469aa24f5bc009b991ea3b058a87f5065ef4176793a200d4917349881216cae
+  languageName: node
+  linkType: hard
+
+"p-waterfall@npm:2.1.1":
+  version: 2.1.1
+  resolution: "p-waterfall@npm:2.1.1"
+  dependencies:
+    p-reduce: "npm:^2.0.0"
+  checksum: 10/3ab6762f3cf913eb0462e0016b242df679e4ace946cdfaab48999288c5b6fed9c6c6c5e050e08e777aa658f94e02fbab72349c59135d5a608d887293c5b16299
+  languageName: node
+  linkType: hard
+
+"pacote@npm:^17.0.5":
+  version: 17.0.7
+  resolution: "pacote@npm:17.0.7"
+  dependencies:
+    "@npmcli/git": "npm:^5.0.0"
+    "@npmcli/installed-package-contents": "npm:^2.0.1"
+    "@npmcli/promise-spawn": "npm:^7.0.0"
+    "@npmcli/run-script": "npm:^7.0.0"
+    cacache: "npm:^18.0.0"
+    fs-minipass: "npm:^3.0.0"
+    minipass: "npm:^7.0.2"
+    npm-package-arg: "npm:^11.0.0"
+    npm-packlist: "npm:^8.0.0"
+    npm-pick-manifest: "npm:^9.0.0"
+    npm-registry-fetch: "npm:^16.0.0"
+    proc-log: "npm:^4.0.0"
+    promise-retry: "npm:^2.0.1"
+    read-package-json: "npm:^7.0.0"
+    read-package-json-fast: "npm:^3.0.0"
+    sigstore: "npm:^2.2.0"
+    ssri: "npm:^10.0.0"
+    tar: "npm:^6.1.11"
+  bin:
+    pacote: lib/bin.js
+  checksum: 10/6aa223428e0c8273d48d2e49d7bf3fbe03ea3f6b418a56f7c6d52f3f628d71608a4b4a4cb04f3de0b67fface556df34e47ca1f840c771e24b5e4f57cdbc3f4d4
   languageName: node
   linkType: hard
 
 "pako@npm:^1.0.6":
   version: 1.0.11
   resolution: "pako@npm:1.0.11"
-  checksum: 1be2bfa1f807608c7538afa15d6f25baa523c30ec870a3228a89579e474a4d992f4293859524e46d5d87fd30fa17c5edf34dbef0671251d9749820b488660b16
+  checksum: 10/1ad07210e894472685564c4d39a08717e84c2a68a70d3c1d9e657d32394ef1670e22972a433cbfe48976cb98b154ba06855dcd3fcfba77f60f1777634bec48c0
   languageName: node
   linkType: hard
 
-"parse-cache-control@npm:^1.0.1":
+"parent-module@npm:^1.0.0":
   version: 1.0.1
-  resolution: "parse-cache-control@npm:1.0.1"
-  checksum: 5a70868792124eb07c2dd07a78fcb824102e972e908254e9e59ce59a4796c51705ff28196d2b20d3b7353d14e9f98e65ed0e4eda9be072cc99b5297dc0466fee
+  resolution: "parent-module@npm:1.0.1"
+  dependencies:
+    callsites: "npm:^3.0.0"
+  checksum: 10/6ba8b255145cae9470cf5551eb74be2d22281587af787a2626683a6c20fbb464978784661478dd2a3f1dad74d1e802d403e1b03c1a31fab310259eec8ac560ff
+  languageName: node
+  linkType: hard
+
+"parse-json@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "parse-json@npm:4.0.0"
+  dependencies:
+    error-ex: "npm:^1.3.1"
+    json-parse-better-errors: "npm:^1.0.1"
+  checksum: 10/0fe227d410a61090c247e34fa210552b834613c006c2c64d9a05cfe9e89cf8b4246d1246b1a99524b53b313e9ac024438d0680f67e33eaed7e6f38db64cfe7b5
+  languageName: node
+  linkType: hard
+
+"parse-json@npm:^5.0.0, parse-json@npm:^5.2.0":
+  version: 5.2.0
+  resolution: "parse-json@npm:5.2.0"
+  dependencies:
+    "@babel/code-frame": "npm:^7.0.0"
+    error-ex: "npm:^1.3.1"
+    json-parse-even-better-errors: "npm:^2.3.0"
+    lines-and-columns: "npm:^1.1.6"
+  checksum: 10/62085b17d64da57f40f6afc2ac1f4d95def18c4323577e1eced571db75d9ab59b297d1d10582920f84b15985cbfc6b6d450ccbf317644cfa176f3ed982ad87e2
+  languageName: node
+  linkType: hard
+
+"parse-path@npm:^7.0.0":
+  version: 7.0.0
+  resolution: "parse-path@npm:7.0.0"
+  dependencies:
+    protocols: "npm:^2.0.0"
+  checksum: 10/2e6eadae5aff97a8b6373c1c08440bfeed814f65452674a139dc606c7c410e8e48b7983fe451aedc59802a2814121b40415ca00675c1546ff75cb73ad0c1df5a
+  languageName: node
+  linkType: hard
+
+"parse-url@npm:^8.1.0":
+  version: 8.1.0
+  resolution: "parse-url@npm:8.1.0"
+  dependencies:
+    parse-path: "npm:^7.0.0"
+  checksum: 10/ceb51dc474568092a50d6d936036dfe438a87aa45bcf20947c8fcdf1544ee9c50255608abae604644e718e91e0b83cfbea4675e8b2fd90bc197432f6d9be263c
+  languageName: node
+  linkType: hard
+
+"path-exists@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "path-exists@npm:3.0.0"
+  checksum: 10/96e92643aa34b4b28d0de1cd2eba52a1c5313a90c6542d03f62750d82480e20bfa62bc865d5cfc6165f5fcd5aeb0851043c40a39be5989646f223300021bae0a
+  languageName: node
+  linkType: hard
+
+"path-exists@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "path-exists@npm:4.0.0"
+  checksum: 10/505807199dfb7c50737b057dd8d351b82c033029ab94cb10a657609e00c1bc53b951cfdbccab8de04c5584d5eff31128ce6afd3db79281874a5ef2adbba55ed1
   languageName: node
   linkType: hard
 
 "path-is-absolute@npm:^1.0.0":
   version: 1.0.1
   resolution: "path-is-absolute@npm:1.0.1"
-  checksum: 060840f92cf8effa293bcc1bea81281bd7d363731d214cbe5c227df207c34cd727430f70c6037b5159c8a870b9157cba65e775446b0ab06fd5ecc7e54615a3b8
+  checksum: 10/060840f92cf8effa293bcc1bea81281bd7d363731d214cbe5c227df207c34cd727430f70c6037b5159c8a870b9157cba65e775446b0ab06fd5ecc7e54615a3b8
+  languageName: node
+  linkType: hard
+
+"path-key@npm:^3.0.0, path-key@npm:^3.1.0":
+  version: 3.1.1
+  resolution: "path-key@npm:3.1.1"
+  checksum: 10/55cd7a9dd4b343412a8386a743f9c746ef196e57c823d90ca3ab917f90ab9f13dd0ded27252ba49dbdfcab2b091d998bc446f6220cd3cea65db407502a740020
+  languageName: node
+  linkType: hard
+
+"path-parse@npm:^1.0.7":
+  version: 1.0.7
+  resolution: "path-parse@npm:1.0.7"
+  checksum: 10/49abf3d81115642938a8700ec580da6e830dde670be21893c62f4e10bd7dd4c3742ddc603fe24f898cba7eb0c6bc1777f8d9ac14185d34540c6d4d80cd9cae8a
+  languageName: node
+  linkType: hard
+
+"path-scurry@npm:^1.11.0, path-scurry@npm:^1.6.1":
+  version: 1.11.1
+  resolution: "path-scurry@npm:1.11.1"
+  dependencies:
+    lru-cache: "npm:^10.2.0"
+    minipass: "npm:^5.0.0 || ^6.0.2 || ^7.0.0"
+  checksum: 10/5e8845c159261adda6f09814d7725683257fcc85a18f329880ab4d7cc1d12830967eae5d5894e453f341710d5484b8fdbbd4d75181b4d6e1eb2f4dc7aeadc434
+  languageName: node
+  linkType: hard
+
+"path-type@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "path-type@npm:3.0.0"
+  dependencies:
+    pify: "npm:^3.0.0"
+  checksum: 10/735b35e256bad181f38fa021033b1c33cfbe62ead42bb2222b56c210e42938eecb272ae1949f3b6db4ac39597a61b44edd8384623ec4d79bfdc9a9c0f12537a6
+  languageName: node
+  linkType: hard
+
+"path-type@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "path-type@npm:4.0.0"
+  checksum: 10/5b1e2daa247062061325b8fdbfd1fb56dde0a448fb1455453276ea18c60685bdad23a445dc148cf87bc216be1573357509b7d4060494a6fd768c7efad833ee45
   languageName: node
   linkType: hard
 
@@ -1999,55 +7811,319 @@ __metadata:
   version: 0.12.7
   resolution: "path@npm:0.12.7"
   dependencies:
-    process: ^0.11.1
-    util: ^0.10.3
-  checksum: 5dedb71e78fc008fcba797defc0b4e1cf06c1f18e0a631e03ba5bb505136f587ff017afc14f9a3d481cbe77aeedff7dc0c1d2ce4d820c1ebf3c4281ca49423a1
+    process: "npm:^0.11.1"
+    util: "npm:^0.10.3"
+  checksum: 10/d49d101f9596613cf4cd1d4ebc4e64ba9a9df5d9cd75a410cfe87a88ce4bf0e2617ff44b92025376f7ecb02e88a6308b27f7f39d810f2335a5126f762487adfb
+  languageName: node
+  linkType: hard
+
+"picocolors@npm:^1.0.0, picocolors@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "picocolors@npm:1.0.1"
+  checksum: 10/fa68166d1f56009fc02a34cdfd112b0dd3cf1ef57667ac57281f714065558c01828cdf4f18600ad6851cbe0093952ed0660b1e0156bddf2184b6aaf5817553a5
+  languageName: node
+  linkType: hard
+
+"picomatch@npm:^2.0.4, picomatch@npm:^2.2.3, picomatch@npm:^2.3.1":
+  version: 2.3.1
+  resolution: "picomatch@npm:2.3.1"
+  checksum: 10/60c2595003b05e4535394d1da94850f5372c9427ca4413b71210f437f7b2ca091dbd611c45e8b37d10036fa8eade25c1b8951654f9d3973bfa66a2ff4d3b08bc
+  languageName: node
+  linkType: hard
+
+"pify@npm:5.0.0":
+  version: 5.0.0
+  resolution: "pify@npm:5.0.0"
+  checksum: 10/443e3e198ad6bfa8c0c533764cf75c9d5bc976387a163792fb553ffe6ce923887cf14eebf5aea9b7caa8eab930da8c33612990ae85bd8c2bc18bedb9eae94ecb
+  languageName: node
+  linkType: hard
+
+"pify@npm:^2.3.0":
+  version: 2.3.0
+  resolution: "pify@npm:2.3.0"
+  checksum: 10/9503aaeaf4577acc58642ad1d25c45c6d90288596238fb68f82811c08104c800e5a7870398e9f015d82b44ecbcbef3dc3d4251a1cbb582f6e5959fe09884b2ba
+  languageName: node
+  linkType: hard
+
+"pify@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "pify@npm:3.0.0"
+  checksum: 10/668c1dc8d9fc1b34b9ce3b16ba59deb39d4dc743527bf2ed908d2b914cb8ba40aa5ba6960b27c417c241531c5aafd0598feeac2d50cb15278cf9863fa6b02a77
+  languageName: node
+  linkType: hard
+
+"pify@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "pify@npm:4.0.1"
+  checksum: 10/8b97cbf9dc6d4c1320cc238a2db0fc67547f9dc77011729ff353faf34f1936ea1a4d7f3c63b2f4980b253be77bcc72ea1e9e76ee3fd53cce2aafb6a8854d07ec
+  languageName: node
+  linkType: hard
+
+"pirates@npm:^4.0.4":
+  version: 4.0.6
+  resolution: "pirates@npm:4.0.6"
+  checksum: 10/d02dda76f4fec1cbdf395c36c11cf26f76a644f9f9a1bfa84d3167d0d3154d5289aacc72677aa20d599bb4a6937a471de1b65c995e2aea2d8687cbcd7e43ea5f
+  languageName: node
+  linkType: hard
+
+"pkg-dir@npm:^4.2.0":
+  version: 4.2.0
+  resolution: "pkg-dir@npm:4.2.0"
+  dependencies:
+    find-up: "npm:^4.0.0"
+  checksum: 10/9863e3f35132bf99ae1636d31ff1e1e3501251d480336edb1c211133c8d58906bed80f154a1d723652df1fda91e01c7442c2eeaf9dc83157c7ae89087e43c8d6
   languageName: node
   linkType: hard
 
 "pluralize@npm:^8.0.0":
   version: 8.0.0
   resolution: "pluralize@npm:8.0.0"
-  checksum: 08931d4a6a4a5561a7f94f67a31c17e6632cb21e459ab3ff4f6f629d9a822984cf8afef2311d2005fbea5d7ef26016ebb090db008e2d8bce39d0a9a9d218736e
+  checksum: 10/17877fdfdb7ddb3639ce257ad73a7c51a30a966091e40f56ea9f2f545b5727ce548d4928f8cb3ce38e7dc0c5150407d318af6a4ed0ea5265d378473b4c2c61ec
+  languageName: node
+  linkType: hard
+
+"possible-typed-array-names@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "possible-typed-array-names@npm:1.0.0"
+  checksum: 10/8ed3e96dfeea1c5880c1f4c9cb707e5fb26e8be22f14f82ef92df20fd2004e635c62ba47fbe8f2bb63bfd80dac1474be2fb39798da8c2feba2815435d1f749af
+  languageName: node
+  linkType: hard
+
+"postcss@npm:8.4.31":
+  version: 8.4.31
+  resolution: "postcss@npm:8.4.31"
+  dependencies:
+    nanoid: "npm:^3.3.6"
+    picocolors: "npm:^1.0.0"
+    source-map-js: "npm:^1.0.2"
+  checksum: 10/1a6653e72105907377f9d4f2cd341d8d90e3fde823a5ddea1e2237aaa56933ea07853f0f2758c28892a1d70c53bbaca200eb8b80f8ed55f13093003dbec5afa0
+  languageName: node
+  linkType: hard
+
+"pretty-format@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "pretty-format@npm:29.7.0"
+  dependencies:
+    "@jest/schemas": "npm:^29.6.3"
+    ansi-styles: "npm:^5.0.0"
+    react-is: "npm:^18.0.0"
+  checksum: 10/dea96bc83c83cd91b2bfc55757b6b2747edcaac45b568e46de29deee80742f17bc76fe8898135a70d904f4928eafd8bb693cd1da4896e8bdd3c5e82cadf1d2bb
+  languageName: node
+  linkType: hard
+
+"proc-log@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "proc-log@npm:3.0.0"
+  checksum: 10/02b64e1b3919e63df06f836b98d3af002b5cd92655cab18b5746e37374bfb73e03b84fe305454614b34c25b485cc687a9eebdccf0242cda8fda2475dd2c97e02
+  languageName: node
+  linkType: hard
+
+"proc-log@npm:^4.0.0, proc-log@npm:^4.2.0":
+  version: 4.2.0
+  resolution: "proc-log@npm:4.2.0"
+  checksum: 10/4e1394491b717f6c1ade15c570ecd4c2b681698474d3ae2d303c1e4b6ab9455bd5a81566211e82890d5a5ae9859718cc6954d5150bb18b09b72ecb297beae90a
   languageName: node
   linkType: hard
 
 "process-nextick-args@npm:~2.0.0":
   version: 2.0.1
   resolution: "process-nextick-args@npm:2.0.1"
-  checksum: 1d38588e520dab7cea67cbbe2efdd86a10cc7a074c09657635e34f035277b59fbb57d09d8638346bf7090f8e8ebc070c96fa5fd183b777fff4f5edff5e9466cf
+  checksum: 10/1d38588e520dab7cea67cbbe2efdd86a10cc7a074c09657635e34f035277b59fbb57d09d8638346bf7090f8e8ebc070c96fa5fd183b777fff4f5edff5e9466cf
   languageName: node
   linkType: hard
 
 "process@npm:^0.11.1":
   version: 0.11.10
   resolution: "process@npm:0.11.10"
-  checksum: bfcce49814f7d172a6e6a14d5fa3ac92cc3d0c3b9feb1279774708a719e19acd673995226351a082a9ae99978254e320ccda4240ddc474ba31a76c79491ca7c3
+  checksum: 10/dbaa7e8d1d5cf375c36963ff43116772a989ef2bb47c9bdee20f38fd8fc061119cf38140631cf90c781aca4d3f0f0d2c834711952b728953f04fd7d238f59f5b
   languageName: node
   linkType: hard
 
-"promise@npm:^8.0.0":
-  version: 8.2.0
-  resolution: "promise@npm:8.2.0"
+"promise-inflight@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "promise-inflight@npm:1.0.1"
+  checksum: 10/1560d413ea20c5a74f3631d39ba8cbd1972b9228072a755d01e1f5ca5110382d9af76a1582d889445adc6e75bb5ac4886b56dc4b6eae51b30145d7bb1ac7505b
+  languageName: node
+  linkType: hard
+
+"promise-retry@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "promise-retry@npm:2.0.1"
   dependencies:
-    asap: ~2.0.6
-  checksum: 45d65ffe4fbd9172ef848f790ac1366822e63f063a5ef42a14e75b577ffa3c37870a9d8472729d9d429d7c8a770428f9d13650b52aafaa361dcc69cf84873b20
+    err-code: "npm:^2.0.2"
+    retry: "npm:^0.12.0"
+  checksum: 10/96e1a82453c6c96eef53a37a1d6134c9f2482f94068f98a59145d0986ca4e497bf110a410adf73857e588165eab3899f0ebcf7b3890c1b3ce802abc0d65967d4
+  languageName: node
+  linkType: hard
+
+"prompts@npm:^2.0.1":
+  version: 2.4.2
+  resolution: "prompts@npm:2.4.2"
+  dependencies:
+    kleur: "npm:^3.0.3"
+    sisteransi: "npm:^1.0.5"
+  checksum: 10/c52536521a4d21eff4f2f2aa4572446cad227464066365a7167e52ccf8d9839c099f9afec1aba0eed3d5a2514b3e79e0b3e7a1dc326b9acde6b75d27ed74b1a9
+  languageName: node
+  linkType: hard
+
+"promzard@npm:^1.0.0":
+  version: 1.0.2
+  resolution: "promzard@npm:1.0.2"
+  dependencies:
+    read: "npm:^3.0.1"
+  checksum: 10/08dee9179e79d4a6446f707cce46fb3e8e8d93ec8b8d722ddc1ec4043c4c07e2e88dc90c64326a58f83d1a7e2b0d6b3bdf11b8b2687b9c74bfb410bafe630ad8
+  languageName: node
+  linkType: hard
+
+"protocols@npm:^2.0.0, protocols@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "protocols@npm:2.0.1"
+  checksum: 10/0cd08a55b9cb7cc96fed7a528255320428a7c86fd5f3f35965845285436433b7836178893168f80584efdf86391cd7c0a837b6f6bc5ddac3029c76be61118ba5
+  languageName: node
+  linkType: hard
+
+"proxy-from-env@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "proxy-from-env@npm:1.1.0"
+  checksum: 10/f0bb4a87cfd18f77bc2fba23ae49c3b378fb35143af16cc478171c623eebe181678f09439707ad80081d340d1593cd54a33a0113f3ccb3f4bc9451488780ee23
   languageName: node
   linkType: hard
 
 "punycode@npm:^2.1.0":
   version: 2.1.1
   resolution: "punycode@npm:2.1.1"
-  checksum: 823bf443c6dd14f669984dea25757b37993f67e8d94698996064035edd43bed8a5a17a9f12e439c2b35df1078c6bec05a6c86e336209eb1061e8025c481168e8
+  checksum: 10/939daa010c2cacebdb060c40ecb52fef0a739324a66f7fffe0f94353a1ee83e3b455e9032054c4a0c4977b0a28e27086f2171c392832b59a01bd948fd8e20914
   languageName: node
   linkType: hard
 
-"qs@npm:^6.4.0":
-  version: 6.11.0
-  resolution: "qs@npm:6.11.0"
+"pure-rand@npm:^6.0.0":
+  version: 6.1.0
+  resolution: "pure-rand@npm:6.1.0"
+  checksum: 10/256aa4bcaf9297256f552914e03cbdb0039c8fe1db11fa1e6d3f80790e16e563eb0a859a1e61082a95e224fc0c608661839439f8ecc6a3db4e48d46d99216ee4
+  languageName: node
+  linkType: hard
+
+"queue-microtask@npm:^1.2.2":
+  version: 1.2.3
+  resolution: "queue-microtask@npm:1.2.3"
+  checksum: 10/72900df0616e473e824202113c3df6abae59150dfb73ed13273503127235320e9c8ca4aaaaccfd58cf417c6ca92a6e68ee9a5c3182886ae949a768639b388a7b
+  languageName: node
+  linkType: hard
+
+"quick-lru@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "quick-lru@npm:4.0.1"
+  checksum: 10/5c7c75f1c696750f619b165cc9957382f919e4207dabf04597a64f0298861391cdc5ee91a1dde1a5d460ecf7ee1af7fc36fef6d155bef2be66f05d43fd63d4f0
+  languageName: node
+  linkType: hard
+
+"react-is@npm:^18.0.0":
+  version: 18.3.1
+  resolution: "react-is@npm:18.3.1"
+  checksum: 10/d5f60c87d285af24b1e1e7eaeb123ec256c3c8bdea7061ab3932e3e14685708221bf234ec50b21e10dd07f008f1b966a2730a0ce4ff67905b3872ff2042aec22
+  languageName: node
+  linkType: hard
+
+"read-cmd-shim@npm:4.0.0":
+  version: 4.0.0
+  resolution: "read-cmd-shim@npm:4.0.0"
+  checksum: 10/69a83acf0a3e2357762d5944a6f4a3f3c5527d0f9fe8a5c9362225aaf702ccfa580ff3bc0b84809c99e88861a5e5be147629717f02ff9befdac68fca1ccc7664
+  languageName: node
+  linkType: hard
+
+"read-package-json-fast@npm:^3.0.0":
+  version: 3.0.2
+  resolution: "read-package-json-fast@npm:3.0.2"
   dependencies:
-    side-channel: ^1.0.4
-  checksum: 6e1f29dd5385f7488ec74ac7b6c92f4d09a90408882d0c208414a34dd33badc1a621019d4c799a3df15ab9b1d0292f97c1dd71dc7c045e69f81a8064e5af7297
+    json-parse-even-better-errors: "npm:^3.0.0"
+    npm-normalize-package-bin: "npm:^3.0.0"
+  checksum: 10/8d406869f045f1d76e2a99865a8fd1c1af9c1dc06200b94d2b07eef87ed734b22703a8d72e1cd36ea36cc48e22020bdd187f88243c7dd0563f72114d38c17072
+  languageName: node
+  linkType: hard
+
+"read-package-json@npm:6.0.4, read-package-json@npm:^6.0.0":
+  version: 6.0.4
+  resolution: "read-package-json@npm:6.0.4"
+  dependencies:
+    glob: "npm:^10.2.2"
+    json-parse-even-better-errors: "npm:^3.0.0"
+    normalize-package-data: "npm:^5.0.0"
+    npm-normalize-package-bin: "npm:^3.0.0"
+  checksum: 10/2c72fc86745ffd303177ec1490a809fb916d36720cec145900ec92ca5dd159d6f096dd7842ad92dfa01eeea5509e076960a5395e8d5ce31984a4e9070018915a
+  languageName: node
+  linkType: hard
+
+"read-package-json@npm:^7.0.0":
+  version: 7.0.1
+  resolution: "read-package-json@npm:7.0.1"
+  dependencies:
+    glob: "npm:^10.2.2"
+    json-parse-even-better-errors: "npm:^3.0.0"
+    normalize-package-data: "npm:^6.0.0"
+    npm-normalize-package-bin: "npm:^3.0.0"
+  checksum: 10/4b5684f4ee96ff29d0ec62452d2b1ed2b3fb7e452cd1a1f40869d896082816a231a1e157fa3e72137e140ca961cbe7eeabc952658fc38235c85b202c91f2e584
+  languageName: node
+  linkType: hard
+
+"read-pkg-up@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "read-pkg-up@npm:3.0.0"
+  dependencies:
+    find-up: "npm:^2.0.0"
+    read-pkg: "npm:^3.0.0"
+  checksum: 10/16175573f2914ab9788897bcbe2a62b5728d0075e62285b3680cebe97059e2911e0134a062cf6e51ebe3e3775312bc788ac2039ed6af38ec68d2c10c6f2b30fb
+  languageName: node
+  linkType: hard
+
+"read-pkg-up@npm:^7.0.1":
+  version: 7.0.1
+  resolution: "read-pkg-up@npm:7.0.1"
+  dependencies:
+    find-up: "npm:^4.1.0"
+    read-pkg: "npm:^5.2.0"
+    type-fest: "npm:^0.8.1"
+  checksum: 10/e4e93ce70e5905b490ca8f883eb9e48b5d3cebc6cd4527c25a0d8f3ae2903bd4121c5ab9c5a3e217ada0141098eeb661313c86fa008524b089b8ed0b7f165e44
+  languageName: node
+  linkType: hard
+
+"read-pkg@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "read-pkg@npm:3.0.0"
+  dependencies:
+    load-json-file: "npm:^4.0.0"
+    normalize-package-data: "npm:^2.3.2"
+    path-type: "npm:^3.0.0"
+  checksum: 10/398903ebae6c7e9965419a1062924436cc0b6f516c42c4679a90290d2f87448ed8f977e7aa2dbba4aa1ac09248628c43e493ac25b2bc76640e946035200e34c6
+  languageName: node
+  linkType: hard
+
+"read-pkg@npm:^5.2.0":
+  version: 5.2.0
+  resolution: "read-pkg@npm:5.2.0"
+  dependencies:
+    "@types/normalize-package-data": "npm:^2.4.0"
+    normalize-package-data: "npm:^2.5.0"
+    parse-json: "npm:^5.0.0"
+    type-fest: "npm:^0.6.0"
+  checksum: 10/eb696e60528b29aebe10e499ba93f44991908c57d70f2d26f369e46b8b9afc208ef11b4ba64f67630f31df8b6872129e0a8933c8c53b7b4daf0eace536901222
+  languageName: node
+  linkType: hard
+
+"read@npm:^2.0.0":
+  version: 2.1.0
+  resolution: "read@npm:2.1.0"
+  dependencies:
+    mute-stream: "npm:~1.0.0"
+  checksum: 10/90a525c7612ca2fc21b44a0c0e39840541f208b5907112d9db00697559396c0fb682321594fb802eaf1d501ec294d810f88b4f76477e082552ee306dc6d4ba0e
+  languageName: node
+  linkType: hard
+
+"read@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "read@npm:3.0.1"
+  dependencies:
+    mute-stream: "npm:^1.0.0"
+  checksum: 10/446b463d04fc3fa82ed2ad9c924aef9174c9ea912ffc6a38b7b9e7b8fa10d6ce4735bcbd0dcc3b9833e9b8f561c182fa57cf6cdb9ca39c8c032ca3070d89baaa
   languageName: node
   linkType: hard
 
@@ -2055,26 +8131,22 @@ __metadata:
   version: 1.1.14
   resolution: "readable-stream@npm:1.1.14"
   dependencies:
-    core-util-is: ~1.0.0
-    inherits: ~2.0.1
-    isarray: 0.0.1
-    string_decoder: ~0.10.x
-  checksum: 17dfeae3e909945a4a1abc5613ea92d03269ef54c49288599507fc98ff4615988a1c39a999dcf9aacba70233d9b7040bc11a5f2bfc947e262dedcc0a8b32b5a0
+    core-util-is: "npm:~1.0.0"
+    inherits: "npm:~2.0.1"
+    isarray: "npm:0.0.1"
+    string_decoder: "npm:~0.10.x"
+  checksum: 10/1aa2cf4bd02f9ab3e1d57842a43a413b52be5300aa089ad1f2e3cea00684532d73edc6a2ba52b0c3210d8b57eb20a695a6d2b96d1c6085ee979c6021ad48ad20
   languageName: node
   linkType: hard
 
-"readable-stream@npm:^2.2.2":
-  version: 2.3.7
-  resolution: "readable-stream@npm:2.3.7"
+"readable-stream@npm:^3.0.0, readable-stream@npm:^3.0.2, readable-stream@npm:^3.1.1, readable-stream@npm:^3.4.0, readable-stream@npm:^3.6.0":
+  version: 3.6.2
+  resolution: "readable-stream@npm:3.6.2"
   dependencies:
-    core-util-is: ~1.0.0
-    inherits: ~2.0.3
-    isarray: ~1.0.0
-    process-nextick-args: ~2.0.0
-    safe-buffer: ~5.1.1
-    string_decoder: ~1.1.1
-    util-deprecate: ~1.0.1
-  checksum: e4920cf7549a60f8aaf694d483a0e61b2a878b969d224f89b3bc788b8d920075132c4b55a7494ee944c7b6a9a0eada28a7f6220d80b0312ece70bbf08eeca755
+    inherits: "npm:^2.0.3"
+    string_decoder: "npm:^1.1.1"
+    util-deprecate: "npm:^1.0.1"
+  checksum: 10/d9e3e53193adcdb79d8f10f2a1f6989bd4389f5936c6f8b870e77570853561c362bee69feca2bbb7b32368ce96a85504aa4cedf7cf80f36e6a9de30d64244048
   languageName: node
   linkType: hard
 
@@ -2082,17 +8154,140 @@ __metadata:
   version: 3.6.0
   resolution: "readable-stream@npm:3.6.0"
   dependencies:
-    inherits: ^2.0.3
-    string_decoder: ^1.1.1
-    util-deprecate: ^1.0.1
-  checksum: d4ea81502d3799439bb955a3a5d1d808592cf3133350ed352aeaa499647858b27b1c4013984900238b0873ec8d0d8defce72469fb7a83e61d53f5ad61cb80dc8
+    inherits: "npm:^2.0.3"
+    string_decoder: "npm:^1.1.1"
+    util-deprecate: "npm:^1.0.1"
+  checksum: 10/b80b3e6a7fafb1c79de7db541de357f4a5ee73bd70c21672f5a7c840d27bb27bdb0151e7ba2fd82c4a888df22ce0c501b0d9f3e4dfe51688876701c437d59536
+  languageName: node
+  linkType: hard
+
+"readable-stream@npm:~2.3.6":
+  version: 2.3.8
+  resolution: "readable-stream@npm:2.3.8"
+  dependencies:
+    core-util-is: "npm:~1.0.0"
+    inherits: "npm:~2.0.3"
+    isarray: "npm:~1.0.0"
+    process-nextick-args: "npm:~2.0.0"
+    safe-buffer: "npm:~5.1.1"
+    string_decoder: "npm:~1.1.1"
+    util-deprecate: "npm:~1.0.1"
+  checksum: 10/8500dd3a90e391d6c5d889256d50ec6026c059fadee98ae9aa9b86757d60ac46fff24fafb7a39fa41d54cb39d8be56cc77be202ebd4cd8ffcf4cb226cbaa40d4
+  languageName: node
+  linkType: hard
+
+"redent@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "redent@npm:3.0.0"
+  dependencies:
+    indent-string: "npm:^4.0.0"
+    strip-indent: "npm:^3.0.0"
+  checksum: 10/fa1ef20404a2d399235e83cc80bd55a956642e37dd197b4b612ba7327bf87fa32745aeb4a1634b2bab25467164ab4ed9c15be2c307923dd08b0fe7c52431ae6b
   languageName: node
   linkType: hard
 
 "require-directory@npm:^2.1.1":
   version: 2.1.1
   resolution: "require-directory@npm:2.1.1"
-  checksum: fb47e70bf0001fdeabdc0429d431863e9475e7e43ea5f94ad86503d918423c1543361cc5166d713eaa7029dd7a3d34775af04764bebff99ef413111a5af18c80
+  checksum: 10/a72468e2589270d91f06c7d36ec97a88db53ae5d6fe3787fadc943f0b0276b10347f89b363b2a82285f650bdcc135ad4a257c61bdd4d00d6df1fa24875b0ddaf
+  languageName: node
+  linkType: hard
+
+"require-from-string@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "require-from-string@npm:2.0.2"
+  checksum: 10/839a3a890102a658f4cb3e7b2aa13a1f80a3a976b512020c3d1efc418491c48a886b6e481ea56afc6c4cb5eef678f23b2a4e70575e7534eccadf5e30ed2e56eb
+  languageName: node
+  linkType: hard
+
+"resolve-cwd@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "resolve-cwd@npm:3.0.0"
+  dependencies:
+    resolve-from: "npm:^5.0.0"
+  checksum: 10/546e0816012d65778e580ad62b29e975a642989108d9a3c5beabfb2304192fa3c9f9146fbdfe213563c6ff51975ae41bac1d3c6e047dd9572c94863a057b4d81
+  languageName: node
+  linkType: hard
+
+"resolve-from@npm:5.0.0, resolve-from@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "resolve-from@npm:5.0.0"
+  checksum: 10/be18a5e4d76dd711778664829841cde690971d02b6cbae277735a09c1c28f407b99ef6ef3cd585a1e6546d4097b28df40ed32c4a287b9699dcf6d7f208495e23
+  languageName: node
+  linkType: hard
+
+"resolve-from@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "resolve-from@npm:4.0.0"
+  checksum: 10/91eb76ce83621eea7bbdd9b55121a5c1c4a39e54a9ce04a9ad4517f102f8b5131c2cf07622c738a6683991bf54f2ce178f5a42803ecbd527ddc5105f362cc9e3
+  languageName: node
+  linkType: hard
+
+"resolve.exports@npm:^2.0.0":
+  version: 2.0.2
+  resolution: "resolve.exports@npm:2.0.2"
+  checksum: 10/f1cc0b6680f9a7e0345d783e0547f2a5110d8336b3c2a4227231dd007271ffd331fd722df934f017af90bae0373920ca0d4005da6f76cb3176c8ae426370f893
+  languageName: node
+  linkType: hard
+
+"resolve@npm:^1.10.0, resolve@npm:^1.20.0":
+  version: 1.22.8
+  resolution: "resolve@npm:1.22.8"
+  dependencies:
+    is-core-module: "npm:^2.13.0"
+    path-parse: "npm:^1.0.7"
+    supports-preserve-symlinks-flag: "npm:^1.0.0"
+  bin:
+    resolve: bin/resolve
+  checksum: 10/c473506ee01eb45cbcfefb68652ae5759e092e6b0fb64547feadf9736a6394f258fbc6f88e00c5ca36d5477fbb65388b272432a3600fa223062e54333c156753
+  languageName: node
+  linkType: hard
+
+"resolve@patch:resolve@npm%3A^1.10.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.20.0#optional!builtin<compat/resolve>":
+  version: 1.22.8
+  resolution: "resolve@patch:resolve@npm%3A1.22.8#optional!builtin<compat/resolve>::version=1.22.8&hash=c3c19d"
+  dependencies:
+    is-core-module: "npm:^2.13.0"
+    path-parse: "npm:^1.0.7"
+    supports-preserve-symlinks-flag: "npm:^1.0.0"
+  bin:
+    resolve: bin/resolve
+  checksum: 10/f345cd37f56a2c0275e3fe062517c650bb673815d885e7507566df589375d165bbbf4bdb6aa95600a9bc55f4744b81f452b5a63f95b9f10a72787dba3c90890a
+  languageName: node
+  linkType: hard
+
+"restore-cursor@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "restore-cursor@npm:3.1.0"
+  dependencies:
+    onetime: "npm:^5.1.0"
+    signal-exit: "npm:^3.0.2"
+  checksum: 10/f877dd8741796b909f2a82454ec111afb84eb45890eb49ac947d87991379406b3b83ff9673a46012fca0d7844bb989f45cc5b788254cf1a39b6b5a9659de0630
+  languageName: node
+  linkType: hard
+
+"retry@npm:^0.12.0":
+  version: 0.12.0
+  resolution: "retry@npm:0.12.0"
+  checksum: 10/1f914879f97e7ee931ad05fe3afa629bd55270fc6cf1c1e589b6a99fab96d15daad0fa1a52a00c729ec0078045fe3e399bd4fd0c93bcc906957bdc17f89cb8e6
+  languageName: node
+  linkType: hard
+
+"reusify@npm:^1.0.4":
+  version: 1.0.4
+  resolution: "reusify@npm:1.0.4"
+  checksum: 10/14222c9e1d3f9ae01480c50d96057228a8524706db79cdeb5a2ce5bb7070dd9f409a6f84a02cbef8cdc80d39aef86f2dd03d155188a1300c599b05437dcd2ffb
+  languageName: node
+  linkType: hard
+
+"rimraf@npm:^4.4.1":
+  version: 4.4.1
+  resolution: "rimraf@npm:4.4.1"
+  dependencies:
+    glob: "npm:^9.2.0"
+  bin:
+    rimraf: dist/cjs/src/bin.js
+  checksum: 10/218ef9122145ccce9d0a71124d36a3894537de46600b37fae7dba26ccff973251eaa98aa63c2c5855a05fa04bca7cbbd7a92d4b29f2875d2203e72530ecf6ede
   languageName: node
   linkType: hard
 
@@ -2100,61 +8295,377 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "root-workspace-0b6124@workspace:."
   dependencies:
-    bids-validator: 1.10.0
+    bids-validator: "npm:1.14.6"
   languageName: unknown
   linkType: soft
+
+"run-async@npm:^2.4.0":
+  version: 2.4.1
+  resolution: "run-async@npm:2.4.1"
+  checksum: 10/c79551224dafa26ecc281cb1efad3510c82c79116aaf681f8a931ce70fdf4ca880d58f97d3b930a38992c7aad7955a08e065b32ec194e1dd49d7790c874ece50
+  languageName: node
+  linkType: hard
+
+"run-parallel@npm:^1.1.9":
+  version: 1.2.0
+  resolution: "run-parallel@npm:1.2.0"
+  dependencies:
+    queue-microtask: "npm:^1.2.2"
+  checksum: 10/cb4f97ad25a75ebc11a8ef4e33bb962f8af8516bb2001082ceabd8902e15b98f4b84b4f8a9b222e5d57fc3bd1379c483886ed4619367a7680dad65316993021d
+  languageName: node
+  linkType: hard
+
+"rxjs@npm:^7.5.5":
+  version: 7.8.1
+  resolution: "rxjs@npm:7.8.1"
+  dependencies:
+    tslib: "npm:^2.1.0"
+  checksum: 10/b10cac1a5258f885e9dd1b70d23c34daeb21b61222ee735d2ec40a8685bdca40429000703a44f0e638c27a684ac139e1c37e835d2a0dc16f6fc061a138ae3abb
+  languageName: node
+  linkType: hard
 
 "safe-buffer@npm:~5.1.0, safe-buffer@npm:~5.1.1":
   version: 5.1.2
   resolution: "safe-buffer@npm:5.1.2"
-  checksum: f2f1f7943ca44a594893a852894055cf619c1fbcb611237fc39e461ae751187e7baf4dc391a72125e0ac4fb2d8c5c0b3c71529622e6a58f46b960211e704903c
+  checksum: 10/7eb5b48f2ed9a594a4795677d5a150faa7eb54483b2318b568dc0c4fc94092a6cce5be02c7288a0500a156282f5276d5688bce7259299568d1053b2150ef374a
   languageName: node
   linkType: hard
 
 "safe-buffer@npm:~5.2.0":
   version: 5.2.1
   resolution: "safe-buffer@npm:5.2.1"
-  checksum: b99c4b41fdd67a6aaf280fcd05e9ffb0813654894223afb78a31f14a19ad220bba8aba1cb14eddce1fcfb037155fe6de4e861784eb434f7d11ed58d1e70dd491
+  checksum: 10/32872cd0ff68a3ddade7a7617b8f4c2ae8764d8b7d884c651b74457967a9e0e886267d3ecc781220629c44a865167b61c375d2da6c720c840ecd73f45d5d9451
+  languageName: node
+  linkType: hard
+
+"safer-buffer@npm:>= 2.1.2 < 3, safer-buffer@npm:>= 2.1.2 < 3.0.0":
+  version: 2.1.2
+  resolution: "safer-buffer@npm:2.1.2"
+  checksum: 10/7eaf7a0cf37cc27b42fb3ef6a9b1df6e93a1c6d98c6c6702b02fe262d5fcbd89db63320793b99b21cb5348097d0a53de81bd5f4e8b86e20cc9412e3f1cfb4e83
   languageName: node
   linkType: hard
 
 "sax@npm:>=0.6.0":
   version: 1.2.4
   resolution: "sax@npm:1.2.4"
-  checksum: d3df7d32b897a2c2f28e941f732c71ba90e27c24f62ee918bd4d9a8cfb3553f2f81e5493c7f0be94a11c1911b643a9108f231dd6f60df3fa9586b5d2e3e9e1fe
+  checksum: 10/09b79ff6dc09689a24323352117c94593c69db348997b2af0edbd82fa08aba47d778055bf9616b57285bb73d25d790900c044bf631a8f10c8252412e3f3fe5dd
   languageName: node
   linkType: hard
 
-"semver@npm:^7.3.2, semver@npm:^7.3.4":
+"semver@npm:2 || 3 || 4 || 5, semver@npm:^5.6.0":
+  version: 5.7.2
+  resolution: "semver@npm:5.7.2"
+  bin:
+    semver: bin/semver
+  checksum: 10/fca14418a174d4b4ef1fecb32c5941e3412d52a4d3d85165924ce3a47fbc7073372c26faf7484ceb4bbc2bde25880c6b97e492473dc7e9708fdfb1c6a02d546e
+  languageName: node
+  linkType: hard
+
+"semver@npm:^6.3.0, semver@npm:^6.3.1":
+  version: 6.3.1
+  resolution: "semver@npm:6.3.1"
+  bin:
+    semver: bin/semver.js
+  checksum: 10/1ef3a85bd02a760c6ef76a45b8c1ce18226de40831e02a00bad78485390b98b6ccaa31046245fc63bba4a47a6a592b6c7eedc65cc47126e60489f9cc1ce3ed7e
+  languageName: node
+  linkType: hard
+
+"semver@npm:^7.0.0, semver@npm:^7.1.1, semver@npm:^7.3.5, semver@npm:^7.3.7, semver@npm:^7.3.8, semver@npm:^7.5.3, semver@npm:^7.5.4, semver@npm:^7.6.0":
+  version: 7.6.2
+  resolution: "semver@npm:7.6.2"
+  bin:
+    semver: bin/semver.js
+  checksum: 10/296b17d027f57a87ef645e9c725bff4865a38dfc9caf29b26aa084b85820972fbe7372caea1ba6857162fa990702c6d9c1d82297cecb72d56c78ab29070d2ca2
+  languageName: node
+  linkType: hard
+
+"semver@npm:^7.3.4":
   version: 7.5.4
   resolution: "semver@npm:7.5.4"
   dependencies:
-    lru-cache: ^6.0.0
+    lru-cache: "npm:^6.0.0"
   bin:
     semver: bin/semver.js
-  checksum: 12d8ad952fa353b0995bf180cdac205a4068b759a140e5d3c608317098b3575ac2f1e09182206bf2eb26120e1c0ed8fb92c48c592f6099680de56bb071423ca3
+  checksum: 10/985dec0d372370229a262c737063860fabd4a1c730662c1ea3200a2f649117761a42184c96df62a0e885e76fbd5dace41087d6c1ac0351b13c0df5d6bcb1b5ac
   languageName: node
   linkType: hard
 
-"side-channel@npm:^1.0.4":
-  version: 1.0.4
-  resolution: "side-channel@npm:1.0.4"
-  dependencies:
-    call-bind: ^1.0.0
-    get-intrinsic: ^1.0.2
-    object-inspect: ^1.9.0
-  checksum: 351e41b947079c10bd0858364f32bb3a7379514c399edb64ab3dce683933483fc63fb5e4efe0a15a2e8a7e3c436b6a91736ddb8d8c6591b0460a24bb4a1ee245
+"set-blocking@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "set-blocking@npm:2.0.0"
+  checksum: 10/8980ebf7ae9eb945bb036b6e283c547ee783a1ad557a82babf758a065e2fb6ea337fd82cac30dd565c1e606e423f30024a19fff7afbf4977d784720c4026a8ef
   languageName: node
   linkType: hard
 
-"slice-ansi@npm:^2.1.0":
-  version: 2.1.0
-  resolution: "slice-ansi@npm:2.1.0"
+"set-function-length@npm:^1.2.1":
+  version: 1.2.2
+  resolution: "set-function-length@npm:1.2.2"
   dependencies:
-    ansi-styles: ^3.2.0
-    astral-regex: ^1.0.0
-    is-fullwidth-code-point: ^2.0.0
-  checksum: 4e82995aa59cef7eb03ef232d73c2239a15efa0ace87a01f3012ebb942e963fbb05d448ce7391efcd52ab9c32724164aba2086f5143e0445c969221dde3b6b1e
+    define-data-property: "npm:^1.1.4"
+    es-errors: "npm:^1.3.0"
+    function-bind: "npm:^1.1.2"
+    get-intrinsic: "npm:^1.2.4"
+    gopd: "npm:^1.0.1"
+    has-property-descriptors: "npm:^1.0.2"
+  checksum: 10/505d62b8e088468917ca4e3f8f39d0e29f9a563b97dbebf92f4bd2c3172ccfb3c5b8e4566d5fcd00784a00433900e7cb8fbc404e2dbd8c3818ba05bb9d4a8a6d
+  languageName: node
+  linkType: hard
+
+"shallow-clone@npm:^3.0.0":
+  version: 3.0.1
+  resolution: "shallow-clone@npm:3.0.1"
+  dependencies:
+    kind-of: "npm:^6.0.2"
+  checksum: 10/e066bd540cfec5e1b0f78134853e0d892d1c8945fb9a926a579946052e7cb0c70ca4fc34f875a8083aa7910d751805d36ae64af250a6de6f3d28f9fa7be6c21b
+  languageName: node
+  linkType: hard
+
+"shebang-command@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "shebang-command@npm:2.0.0"
+  dependencies:
+    shebang-regex: "npm:^3.0.0"
+  checksum: 10/6b52fe87271c12968f6a054e60f6bde5f0f3d2db483a1e5c3e12d657c488a15474121a1d55cd958f6df026a54374ec38a4a963988c213b7570e1d51575cea7fa
+  languageName: node
+  linkType: hard
+
+"shebang-regex@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "shebang-regex@npm:3.0.0"
+  checksum: 10/1a2bcae50de99034fcd92ad4212d8e01eedf52c7ec7830eedcf886622804fe36884278f2be8be0ea5fde3fd1c23911643a4e0f726c8685b61871c8908af01222
+  languageName: node
+  linkType: hard
+
+"signal-exit@npm:3.0.7, signal-exit@npm:^3.0.2, signal-exit@npm:^3.0.3, signal-exit@npm:^3.0.7":
+  version: 3.0.7
+  resolution: "signal-exit@npm:3.0.7"
+  checksum: 10/a2f098f247adc367dffc27845853e9959b9e88b01cb301658cfe4194352d8d2bb32e18467c786a7fe15f1d44b233ea35633d076d5e737870b7139949d1ab6318
+  languageName: node
+  linkType: hard
+
+"signal-exit@npm:^4.0.1":
+  version: 4.1.0
+  resolution: "signal-exit@npm:4.1.0"
+  checksum: 10/c9fa63bbbd7431066174a48ba2dd9986dfd930c3a8b59de9c29d7b6854ec1c12a80d15310869ea5166d413b99f041bfa3dd80a7947bcd44ea8e6eb3ffeabfa1f
+  languageName: node
+  linkType: hard
+
+"sigstore@npm:^1.4.0":
+  version: 1.9.0
+  resolution: "sigstore@npm:1.9.0"
+  dependencies:
+    "@sigstore/bundle": "npm:^1.1.0"
+    "@sigstore/protobuf-specs": "npm:^0.2.0"
+    "@sigstore/sign": "npm:^1.0.0"
+    "@sigstore/tuf": "npm:^1.0.3"
+    make-fetch-happen: "npm:^11.0.1"
+  bin:
+    sigstore: bin/sigstore.js
+  checksum: 10/7ff59f6bbc6fbf4e11f99df36562cdfd8f27f74650e1794942b0f9b567c6facdd0a6c245375111c464a0c367e617793a1c1787ec1dea9784ad2fb698932b9fb9
+  languageName: node
+  linkType: hard
+
+"sigstore@npm:^2.2.0":
+  version: 2.3.0
+  resolution: "sigstore@npm:2.3.0"
+  dependencies:
+    "@sigstore/bundle": "npm:^2.3.1"
+    "@sigstore/core": "npm:^1.0.0"
+    "@sigstore/protobuf-specs": "npm:^0.3.1"
+    "@sigstore/sign": "npm:^2.3.0"
+    "@sigstore/tuf": "npm:^2.3.1"
+    "@sigstore/verify": "npm:^1.2.0"
+  checksum: 10/881c6ee139231c167ff7a33b743ef884f4813e897afe7b48a2929fb06b6c74a0b032c8875f836b0a70cad5327252f77755ca26ab6cf639d00adf7fa55e7dc424
+  languageName: node
+  linkType: hard
+
+"sisteransi@npm:^1.0.5":
+  version: 1.0.5
+  resolution: "sisteransi@npm:1.0.5"
+  checksum: 10/aba6438f46d2bfcef94cf112c835ab395172c75f67453fe05c340c770d3c402363018ae1ab4172a1026a90c47eaccf3af7b6ff6fa749a680c2929bd7fa2b37a4
+  languageName: node
+  linkType: hard
+
+"slash@npm:3.0.0, slash@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "slash@npm:3.0.0"
+  checksum: 10/94a93fff615f25a999ad4b83c9d5e257a7280c90a32a7cb8b4a87996e4babf322e469c42b7f649fd5796edd8687652f3fb452a86dc97a816f01113183393f11c
+  languageName: node
+  linkType: hard
+
+"slice-ansi@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "slice-ansi@npm:4.0.0"
+  dependencies:
+    ansi-styles: "npm:^4.0.0"
+    astral-regex: "npm:^2.0.0"
+    is-fullwidth-code-point: "npm:^3.0.0"
+  checksum: 10/4a82d7f085b0e1b070e004941ada3c40d3818563ac44766cca4ceadd2080427d337554f9f99a13aaeb3b4a94d9964d9466c807b3d7b7541d1ec37ee32d308756
+  languageName: node
+  linkType: hard
+
+"smart-buffer@npm:^4.2.0":
+  version: 4.2.0
+  resolution: "smart-buffer@npm:4.2.0"
+  checksum: 10/927484aa0b1640fd9473cee3e0a0bcad6fce93fd7bbc18bac9ad0c33686f5d2e2c422fba24b5899c184524af01e11dd2bd051c2bf2b07e47aff8ca72cbfc60d2
+  languageName: node
+  linkType: hard
+
+"socks-proxy-agent@npm:^7.0.0":
+  version: 7.0.0
+  resolution: "socks-proxy-agent@npm:7.0.0"
+  dependencies:
+    agent-base: "npm:^6.0.2"
+    debug: "npm:^4.3.3"
+    socks: "npm:^2.6.2"
+  checksum: 10/26c75d9c62a9ed3fd494df60e65e88da442f78e0d4bc19bfd85ac37bd2c67470d6d4bba5202e804561cda6674db52864c9e2a2266775f879bc8d89c1445a5f4c
+  languageName: node
+  linkType: hard
+
+"socks-proxy-agent@npm:^8.0.3":
+  version: 8.0.3
+  resolution: "socks-proxy-agent@npm:8.0.3"
+  dependencies:
+    agent-base: "npm:^7.1.1"
+    debug: "npm:^4.3.4"
+    socks: "npm:^2.7.1"
+  checksum: 10/c2112c66d6322e497d68e913c3780f3683237fd394bfd480b9283486a86e36095d0020db96145d88f8ccd9cc73261b98165b461f9c1bf5dc17abfe75c18029ce
+  languageName: node
+  linkType: hard
+
+"socks@npm:^2.6.2, socks@npm:^2.7.1":
+  version: 2.8.3
+  resolution: "socks@npm:2.8.3"
+  dependencies:
+    ip-address: "npm:^9.0.5"
+    smart-buffer: "npm:^4.2.0"
+  checksum: 10/ffcb622c22481dfcd7589aae71fbfd71ca34334064d181df64bf8b7feaeee19706aba4cffd1de35cc7bbaeeaa0af96be2d7f40fcbc7bc0ab69533a7ae9ffc4fb
+  languageName: node
+  linkType: hard
+
+"sort-keys@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "sort-keys@npm:2.0.0"
+  dependencies:
+    is-plain-obj: "npm:^1.0.0"
+  checksum: 10/255f9fb393ef60a3db508e0cc5b18ef401127dbb2376b205ae27d168e245fc0d6b35267dde98fab6410dde684c9321f7fc8bf71f2b051761973231617753380d
+  languageName: node
+  linkType: hard
+
+"source-map-js@npm:^1.0.2":
+  version: 1.2.0
+  resolution: "source-map-js@npm:1.2.0"
+  checksum: 10/74f331cfd2d121c50790c8dd6d3c9de6be21926de80583b23b37029b0f37aefc3e019fa91f9a10a5e120c08135297e1ecf312d561459c45908cb1e0e365f49e5
+  languageName: node
+  linkType: hard
+
+"source-map-support@npm:0.5.13":
+  version: 0.5.13
+  resolution: "source-map-support@npm:0.5.13"
+  dependencies:
+    buffer-from: "npm:^1.0.0"
+    source-map: "npm:^0.6.0"
+  checksum: 10/d1514a922ac9c7e4786037eeff6c3322f461cd25da34bb9fefb15387b3490531774e6e31d95ab6d5b84a3e139af9c3a570ccaee6b47bd7ea262691ed3a8bc34e
+  languageName: node
+  linkType: hard
+
+"source-map@npm:^0.6.0, source-map@npm:^0.6.1":
+  version: 0.6.1
+  resolution: "source-map@npm:0.6.1"
+  checksum: 10/59ef7462f1c29d502b3057e822cdbdae0b0e565302c4dd1a95e11e793d8d9d62006cdc10e0fd99163ca33ff2071360cf50ee13f90440806e7ed57d81cba2f7ff
+  languageName: node
+  linkType: hard
+
+"spdx-correct@npm:^3.0.0":
+  version: 3.2.0
+  resolution: "spdx-correct@npm:3.2.0"
+  dependencies:
+    spdx-expression-parse: "npm:^3.0.0"
+    spdx-license-ids: "npm:^3.0.0"
+  checksum: 10/cc2e4dbef822f6d12142116557d63f5facf3300e92a6bd24e907e4865e17b7e1abd0ee6b67f305cae6790fc2194175a24dc394bfcc01eea84e2bdad728e9ae9a
+  languageName: node
+  linkType: hard
+
+"spdx-exceptions@npm:^2.1.0":
+  version: 2.5.0
+  resolution: "spdx-exceptions@npm:2.5.0"
+  checksum: 10/bb127d6e2532de65b912f7c99fc66097cdea7d64c10d3ec9b5e96524dbbd7d20e01cba818a6ddb2ae75e62bb0c63d5e277a7e555a85cbc8ab40044984fa4ae15
+  languageName: node
+  linkType: hard
+
+"spdx-expression-parse@npm:^3.0.0":
+  version: 3.0.1
+  resolution: "spdx-expression-parse@npm:3.0.1"
+  dependencies:
+    spdx-exceptions: "npm:^2.1.0"
+    spdx-license-ids: "npm:^3.0.0"
+  checksum: 10/a1c6e104a2cbada7a593eaa9f430bd5e148ef5290d4c0409899855ce8b1c39652bcc88a725259491a82601159d6dc790bedefc9016c7472f7de8de7361f8ccde
+  languageName: node
+  linkType: hard
+
+"spdx-license-ids@npm:^3.0.0":
+  version: 3.0.17
+  resolution: "spdx-license-ids@npm:3.0.17"
+  checksum: 10/8f6c6ae02ebb25b4ca658b8990d9e8a8f8d8a95e1d8b9fd84d87eed80a7dc8f8073d6a8d50b8a0295c0e8399e1f8814f5c00e2985e6bf3731540a16f7241cbf1
+  languageName: node
+  linkType: hard
+
+"split2@npm:^3.2.2":
+  version: 3.2.2
+  resolution: "split2@npm:3.2.2"
+  dependencies:
+    readable-stream: "npm:^3.0.0"
+  checksum: 10/a426e1e6718e2f7e50f102d5ec3525063d885e3d9cec021a81175fd3497fdb8b867a89c99e70bef4daeef4f2f5e544f7b92df8c1a30b4254e10a9cfdcc3dae87
+  languageName: node
+  linkType: hard
+
+"split@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "split@npm:1.0.1"
+  dependencies:
+    through: "npm:2"
+  checksum: 10/12f4554a5792c7e98bb3e22b53c63bfa5ef89aa704353e1db608a55b51f5b12afaad6e4a8ecf7843c15f273f43cdadd67b3705cc43d48a75c2cf4641d51f7e7a
+  languageName: node
+  linkType: hard
+
+"sprintf-js@npm:^1.1.3":
+  version: 1.1.3
+  resolution: "sprintf-js@npm:1.1.3"
+  checksum: 10/e7587128c423f7e43cc625fe2f87e6affdf5ca51c1cc468e910d8aaca46bb44a7fbcfa552f787b1d3987f7043aeb4527d1b99559e6621e01b42b3f45e5a24cbb
+  languageName: node
+  linkType: hard
+
+"sprintf-js@npm:~1.0.2":
+  version: 1.0.3
+  resolution: "sprintf-js@npm:1.0.3"
+  checksum: 10/c34828732ab8509c2741e5fd1af6b767c3daf2c642f267788f933a65b1614943c282e74c4284f4fa749c264b18ee016a0d37a3e5b73aee446da46277d3a85daa
+  languageName: node
+  linkType: hard
+
+"ssri@npm:^10.0.0, ssri@npm:^10.0.1":
+  version: 10.0.6
+  resolution: "ssri@npm:10.0.6"
+  dependencies:
+    minipass: "npm:^7.0.3"
+  checksum: 10/f92c1b3cc9bfd0a925417412d07d999935917bc87049f43ebec41074661d64cf720315661844106a77da9f8204b6d55ae29f9514e673083cae39464343af2a8b
+  languageName: node
+  linkType: hard
+
+"ssri@npm:^9.0.1":
+  version: 9.0.1
+  resolution: "ssri@npm:9.0.1"
+  dependencies:
+    minipass: "npm:^3.1.1"
+  checksum: 10/7638a61e91432510718e9265d48d0438a17d53065e5184f1336f234ef6aa3479663942e41e97df56cda06bb24d9d0b5ef342c10685add3cac7267a82d7fa6718
+  languageName: node
+  linkType: hard
+
+"stack-utils@npm:^2.0.3":
+  version: 2.0.6
+  resolution: "stack-utils@npm:2.0.6"
+  dependencies:
+    escape-string-regexp: "npm:^2.0.0"
+  checksum: 10/cdc988acbc99075b4b036ac6014e5f1e9afa7e564482b687da6384eee6a1909d7eaffde85b0a17ffbe186c5247faf6c2b7544e802109f63b72c7be69b13151bb
   languageName: node
   linkType: hard
 
@@ -2162,9 +8673,37 @@ __metadata:
   version: 3.0.0
   resolution: "stream-browserify@npm:3.0.0"
   dependencies:
-    inherits: ~2.0.4
-    readable-stream: ^3.5.0
-  checksum: 4c47ef64d6f03815a9ca3874e2319805e8e8a85f3550776c47ce523b6f4c6cd57f40e46ec6a9ab8ad260fde61863c2718f250d3bedb3fe9052444eb9abfd9921
+    inherits: "npm:~2.0.4"
+    readable-stream: "npm:^3.5.0"
+  checksum: 10/05a3cd0a0ce2d568dbdeb69914557c26a1b0a9d871839666b692eae42b96189756a3ed685affc90dab64ff588a8524c8aec6d85072c07905a1f0d941ea68f956
+  languageName: node
+  linkType: hard
+
+"streamsearch@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "streamsearch@npm:1.1.0"
+  checksum: 10/612c2b2a7dbcc859f74597112f80a42cbe4d448d03da790d5b7b39673c1197dd3789e91cd67210353e58857395d32c1e955a9041c4e6d5bae723436b3ed9ed14
+  languageName: node
+  linkType: hard
+
+"string-length@npm:^4.0.1":
+  version: 4.0.2
+  resolution: "string-length@npm:4.0.2"
+  dependencies:
+    char-regex: "npm:^1.0.2"
+    strip-ansi: "npm:^6.0.0"
+  checksum: 10/ce85533ef5113fcb7e522bcf9e62cb33871aa99b3729cec5595f4447f660b0cefd542ca6df4150c97a677d58b0cb727a3fe09ac1de94071d05526c73579bf505
+  languageName: node
+  linkType: hard
+
+"string-width-cjs@npm:string-width@^4.2.0, string-width@npm:^1.0.2 || 2 || 3 || 4, string-width@npm:^4.1.0, string-width@npm:^4.2.0, string-width@npm:^4.2.3":
+  version: 4.2.3
+  resolution: "string-width@npm:4.2.3"
+  dependencies:
+    emoji-regex: "npm:^8.0.0"
+    is-fullwidth-code-point: "npm:^3.0.0"
+    strip-ansi: "npm:^6.0.1"
+  checksum: 10/e52c10dc3fbfcd6c3a15f159f54a90024241d0f149cf8aed2982a2d801d2e64df0bf1dc351cf8e95c3319323f9f220c16e740b06faecd53e2462df1d2b5443fb
   languageName: node
   linkType: hard
 
@@ -2172,48 +8711,37 @@ __metadata:
   version: 1.0.2
   resolution: "string-width@npm:1.0.2"
   dependencies:
-    code-point-at: ^1.0.0
-    is-fullwidth-code-point: ^1.0.0
-    strip-ansi: ^3.0.0
-  checksum: 5c79439e95bc3bd7233a332c5f5926ab2ee90b23816ed4faa380ce3b2576d7800b0a5bb15ae88ed28737acc7ea06a518c2eef39142dd727adad0e45c776cd37e
+    code-point-at: "npm:^1.0.0"
+    is-fullwidth-code-point: "npm:^1.0.0"
+    strip-ansi: "npm:^3.0.0"
+  checksum: 10/5c79439e95bc3bd7233a332c5f5926ab2ee90b23816ed4faa380ce3b2576d7800b0a5bb15ae88ed28737acc7ea06a518c2eef39142dd727adad0e45c776cd37e
   languageName: node
   linkType: hard
 
-"string-width@npm:^3.0.0":
-  version: 3.1.0
-  resolution: "string-width@npm:3.1.0"
+"string-width@npm:^5.0.1, string-width@npm:^5.1.2":
+  version: 5.1.2
+  resolution: "string-width@npm:5.1.2"
   dependencies:
-    emoji-regex: ^7.0.1
-    is-fullwidth-code-point: ^2.0.0
-    strip-ansi: ^5.1.0
-  checksum: 57f7ca73d201682816d573dc68bd4bb8e1dff8dc9fcf10470fdfc3474135c97175fec12ea6a159e67339b41e86963112355b64529489af6e7e70f94a7caf08b2
+    eastasianwidth: "npm:^0.2.0"
+    emoji-regex: "npm:^9.2.2"
+    strip-ansi: "npm:^7.0.1"
+  checksum: 10/7369deaa29f21dda9a438686154b62c2c5f661f8dda60449088f9f980196f7908fc39fdd1803e3e01541970287cf5deae336798337e9319a7055af89dafa7193
   languageName: node
   linkType: hard
 
-"string-width@npm:^4.1.0, string-width@npm:^4.2.0":
-  version: 4.2.3
-  resolution: "string-width@npm:4.2.3"
-  dependencies:
-    emoji-regex: ^8.0.0
-    is-fullwidth-code-point: ^3.0.0
-    strip-ansi: ^6.0.1
-  checksum: e52c10dc3fbfcd6c3a15f159f54a90024241d0f149cf8aed2982a2d801d2e64df0bf1dc351cf8e95c3319323f9f220c16e740b06faecd53e2462df1d2b5443fb
-  languageName: node
-  linkType: hard
-
-"string_decoder@npm:^1.1.1":
+"string_decoder@npm:^1.1.1, string_decoder@npm:^1.3.0":
   version: 1.3.0
   resolution: "string_decoder@npm:1.3.0"
   dependencies:
-    safe-buffer: ~5.2.0
-  checksum: 8417646695a66e73aefc4420eb3b84cc9ffd89572861fe004e6aeb13c7bc00e2f616247505d2dbbef24247c372f70268f594af7126f43548565c68c117bdeb56
+    safe-buffer: "npm:~5.2.0"
+  checksum: 10/54d23f4a6acae0e93f999a585e673be9e561b65cd4cca37714af1e893ab8cd8dfa52a9e4f58f48f87b4a44918d3a9254326cb80ed194bf2e4c226e2b21767e56
   languageName: node
   linkType: hard
 
 "string_decoder@npm:~0.10.x":
   version: 0.10.31
   resolution: "string_decoder@npm:0.10.31"
-  checksum: fe00f8e303647e5db919948ccb5ce0da7dea209ab54702894dd0c664edd98e5d4df4b80d6fabf7b9e92b237359d21136c95bf068b2f7760b772ca974ba970202
+  checksum: 10/cc43e6b1340d4c7843da0e37d4c87a4084c2342fc99dcf6563c3ec273bb082f0cbd4ebf25d5da19b04fb16400d393885fda830be5128e1c416c73b5a6165f175
   languageName: node
   linkType: hard
 
@@ -2221,8 +8749,17 @@ __metadata:
   version: 1.1.1
   resolution: "string_decoder@npm:1.1.1"
   dependencies:
-    safe-buffer: ~5.1.0
-  checksum: 9ab7e56f9d60a28f2be697419917c50cac19f3e8e6c28ef26ed5f4852289fe0de5d6997d29becf59028556f2c62983790c1d9ba1e2a3cc401768ca12d5183a5b
+    safe-buffer: "npm:~5.1.0"
+  checksum: 10/7c41c17ed4dea105231f6df208002ebddd732e8e9e2d619d133cecd8e0087ddfd9587d2feb3c8caf3213cbd841ada6d057f5142cae68a4e62d3540778d9819b4
+  languageName: node
+  linkType: hard
+
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1, strip-ansi@npm:^6.0.0, strip-ansi@npm:^6.0.1":
+  version: 6.0.1
+  resolution: "strip-ansi@npm:6.0.1"
+  dependencies:
+    ansi-regex: "npm:^5.0.1"
+  checksum: 10/ae3b5436d34fadeb6096367626ce987057713c566e1e7768818797e00ac5d62023d0f198c4e681eae9e20701721980b26a64a8f5b91238869592a9c6800719a2
   languageName: node
   linkType: hard
 
@@ -2230,26 +8767,47 @@ __metadata:
   version: 3.0.1
   resolution: "strip-ansi@npm:3.0.1"
   dependencies:
-    ansi-regex: ^2.0.0
-  checksum: 9b974de611ce5075c70629c00fa98c46144043db92ae17748fb780f706f7a789e9989fd10597b7c2053ae8d1513fd707816a91f1879b2f71e6ac0b6a863db465
+    ansi-regex: "npm:^2.0.0"
+  checksum: 10/9b974de611ce5075c70629c00fa98c46144043db92ae17748fb780f706f7a789e9989fd10597b7c2053ae8d1513fd707816a91f1879b2f71e6ac0b6a863db465
   languageName: node
   linkType: hard
 
-"strip-ansi@npm:^5.1.0":
-  version: 5.2.0
-  resolution: "strip-ansi@npm:5.2.0"
+"strip-ansi@npm:^7.0.1":
+  version: 7.1.0
+  resolution: "strip-ansi@npm:7.1.0"
   dependencies:
-    ansi-regex: ^4.1.0
-  checksum: bdb5f76ade97062bd88e7723aa019adbfacdcba42223b19ccb528ffb9fb0b89a5be442c663c4a3fb25268eaa3f6ea19c7c3fbae830bd1562d55adccae1fcec46
+    ansi-regex: "npm:^6.0.1"
+  checksum: 10/475f53e9c44375d6e72807284024ac5d668ee1d06010740dec0b9744f2ddf47de8d7151f80e5f6190fc8f384e802fdf9504b76a7e9020c9faee7103623338be2
   languageName: node
   linkType: hard
 
-"strip-ansi@npm:^6.0.0, strip-ansi@npm:^6.0.1":
-  version: 6.0.1
-  resolution: "strip-ansi@npm:6.0.1"
+"strip-bom@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "strip-bom@npm:3.0.0"
+  checksum: 10/8d50ff27b7ebe5ecc78f1fe1e00fcdff7af014e73cf724b46fb81ef889eeb1015fc5184b64e81a2efe002180f3ba431bdd77e300da5c6685d702780fbf0c8d5b
+  languageName: node
+  linkType: hard
+
+"strip-bom@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "strip-bom@npm:4.0.0"
+  checksum: 10/9dbcfbaf503c57c06af15fe2c8176fb1bf3af5ff65003851a102749f875a6dbe0ab3b30115eccf6e805e9d756830d3e40ec508b62b3f1ddf3761a20ebe29d3f3
+  languageName: node
+  linkType: hard
+
+"strip-final-newline@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "strip-final-newline@npm:2.0.0"
+  checksum: 10/69412b5e25731e1938184b5d489c32e340605bb611d6140344abc3421b7f3c6f9984b21dff296dfcf056681b82caa3bb4cc996a965ce37bcfad663e92eae9c64
+  languageName: node
+  linkType: hard
+
+"strip-indent@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "strip-indent@npm:3.0.0"
   dependencies:
-    ansi-regex: ^5.0.1
-  checksum: f3cd25890aef3ba6e1a74e20896c21a46f482e93df4a06567cebf2b57edabb15133f1f94e57434e0a958d61186087b1008e89c94875d019910a213181a14fc8c
+    min-indent: "npm:^1.0.0"
+  checksum: 10/18f045d57d9d0d90cd16f72b2313d6364fd2cb4bf85b9f593523ad431c8720011a4d5f08b6591c9d580f446e78855c5334a30fb91aa1560f5d9f95ed1b4a0530
   languageName: node
   linkType: hard
 
@@ -2258,82 +8816,420 @@ __metadata:
   resolution: "strip-json-comments@npm:1.0.4"
   bin:
     strip-json-comments: cli.js
-  checksum: 8a6487da5db2f5cf75630bc7c0185e13ece71b180b9dd1f786c1737c88a685080ca680b776443fce862867f3bd0b41145304a1c17f6f6ce7e495459523d31392
+  checksum: 10/44152ba179c0d269885606061727893b419c2a7d598eeb3eadefcdf7e39a7930bf27ec125c0044b2d5d90f630f30d9984da8506dc1fdd1b6bc6b448a477d7bee
   languageName: node
   linkType: hard
 
-"table@npm:^5.2.3":
-  version: 5.4.6
-  resolution: "table@npm:5.4.6"
-  dependencies:
-    ajv: ^6.10.2
-    lodash: ^4.17.14
-    slice-ansi: ^2.1.0
-    string-width: ^3.0.0
-  checksum: 9e35d3efa788edc17237eef8852f8e4b9178efd65a7d115141777b2ee77df4b7796c05f4ed3712d858f98894ac5935a481ceeb6dcb9895e2f67a61cce0e63b6c
+"strip-json-comments@npm:^3.1.1":
+  version: 3.1.1
+  resolution: "strip-json-comments@npm:3.1.1"
+  checksum: 10/492f73e27268f9b1c122733f28ecb0e7e8d8a531a6662efbd08e22cccb3f9475e90a1b82cab06a392f6afae6d2de636f977e231296400d0ec5304ba70f166443
   languageName: node
   linkType: hard
 
-"then-request@npm:^6.0.2":
-  version: 6.0.2
-  resolution: "then-request@npm:6.0.2"
+"strnum@npm:^1.0.5":
+  version: 1.0.5
+  resolution: "strnum@npm:1.0.5"
+  checksum: 10/d3117975db8372d4d7b2c07601ed2f65bf21cc48d741f37a8617b76370d228f2ec26336e53791ebc3638264d23ca54e6c241f57f8c69bd4941c63c79440525ca
+  languageName: node
+  linkType: hard
+
+"strong-log-transformer@npm:2.1.0, strong-log-transformer@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "strong-log-transformer@npm:2.1.0"
   dependencies:
-    "@types/concat-stream": ^1.6.0
-    "@types/form-data": 0.0.33
-    "@types/node": ^8.0.0
-    "@types/qs": ^6.2.31
-    caseless: ~0.12.0
-    concat-stream: ^1.6.0
-    form-data: ^2.2.0
-    http-basic: ^8.1.1
-    http-response-object: ^3.0.1
-    promise: ^8.0.0
-    qs: ^6.4.0
-  checksum: a24a4fc95dd8591966bf3752f024f5cd4d53c2b2c29b23b4e40c3322df6a432d939bc17b589d8e9d760b90e92ab860f6f361a4dfcfe3542019e1615fb51afccc
+    duplexer: "npm:^0.1.1"
+    minimist: "npm:^1.2.0"
+    through: "npm:^2.3.4"
+  bin:
+    sl-log-transformer: bin/sl-log-transformer.js
+  checksum: 10/2fd14eb0a68893fdadefd89f964df404e3d637729c48aca015eb12d1c47455dee28b2522ad7150de23f7a57cce503656585e7644c9cd8532023ea572f8cc5a80
+  languageName: node
+  linkType: hard
+
+"styled-jsx@npm:5.1.1":
+  version: 5.1.1
+  resolution: "styled-jsx@npm:5.1.1"
+  dependencies:
+    client-only: "npm:0.0.1"
+  peerDependencies:
+    react: ">= 16.8.0 || 17.x.x || ^18.0.0-0"
+  peerDependenciesMeta:
+    "@babel/core":
+      optional: true
+    babel-plugin-macros:
+      optional: true
+  checksum: 10/4f6a5d0010770fdeea1183d919d528fd46c484e23c0535ef3e1dd49488116f639c594f3bd4440e3bc8a8686c9f8d53c5761599870ff039ede11a5c3bfe08a4be
+  languageName: node
+  linkType: hard
+
+"supports-color@npm:^5.3.0":
+  version: 5.5.0
+  resolution: "supports-color@npm:5.5.0"
+  dependencies:
+    has-flag: "npm:^3.0.0"
+  checksum: 10/5f505c6fa3c6e05873b43af096ddeb22159831597649881aeb8572d6fe3b81e798cc10840d0c9735e0026b250368851b7f77b65e84f4e4daa820a4f69947f55b
+  languageName: node
+  linkType: hard
+
+"supports-color@npm:^7.1.0":
+  version: 7.2.0
+  resolution: "supports-color@npm:7.2.0"
+  dependencies:
+    has-flag: "npm:^4.0.0"
+  checksum: 10/c8bb7afd564e3b26b50ca6ee47572c217526a1389fe018d00345856d4a9b08ffbd61fadaf283a87368d94c3dcdb8f5ffe2650a5a65863e21ad2730ca0f05210a
+  languageName: node
+  linkType: hard
+
+"supports-color@npm:^8.0.0":
+  version: 8.1.1
+  resolution: "supports-color@npm:8.1.1"
+  dependencies:
+    has-flag: "npm:^4.0.0"
+  checksum: 10/157b534df88e39c5518c5e78c35580c1eca848d7dbaf31bbe06cdfc048e22c7ff1a9d046ae17b25691128f631a51d9ec373c1b740c12ae4f0de6e292037e4282
+  languageName: node
+  linkType: hard
+
+"supports-preserve-symlinks-flag@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "supports-preserve-symlinks-flag@npm:1.0.0"
+  checksum: 10/a9dc19ae2220c952bd2231d08ddeecb1b0328b61e72071ff4000c8384e145cc07c1c0bdb3b5a1cb06e186a7b2790f1dee793418b332f6ddf320de25d9125be7e
+  languageName: node
+  linkType: hard
+
+"table@npm:^6.8.2":
+  version: 6.8.2
+  resolution: "table@npm:6.8.2"
+  dependencies:
+    ajv: "npm:^8.0.1"
+    lodash.truncate: "npm:^4.4.2"
+    slice-ansi: "npm:^4.0.0"
+    string-width: "npm:^4.2.3"
+    strip-ansi: "npm:^6.0.1"
+  checksum: 10/2946162eb87a91b9bf4283214d26830db96f09cf517eff18e7501d47a4770c529b432bb54c9394337c3dfd6c8dbf66581f76edb37e9838beb6ec394080af4ac2
+  languageName: node
+  linkType: hard
+
+"tar-stream@npm:~2.2.0":
+  version: 2.2.0
+  resolution: "tar-stream@npm:2.2.0"
+  dependencies:
+    bl: "npm:^4.0.3"
+    end-of-stream: "npm:^1.4.1"
+    fs-constants: "npm:^1.0.0"
+    inherits: "npm:^2.0.3"
+    readable-stream: "npm:^3.1.1"
+  checksum: 10/1a52a51d240c118cbcd30f7368ea5e5baef1eac3e6b793fb1a41e6cd7319296c79c0264ccc5859f5294aa80f8f00b9239d519e627b9aade80038de6f966fec6a
+  languageName: node
+  linkType: hard
+
+"tar@npm:6.2.1, tar@npm:^6.1.11, tar@npm:^6.1.2":
+  version: 6.2.1
+  resolution: "tar@npm:6.2.1"
+  dependencies:
+    chownr: "npm:^2.0.0"
+    fs-minipass: "npm:^2.0.0"
+    minipass: "npm:^5.0.0"
+    minizlib: "npm:^2.1.1"
+    mkdirp: "npm:^1.0.3"
+    yallist: "npm:^4.0.0"
+  checksum: 10/bfbfbb2861888077fc1130b84029cdc2721efb93d1d1fb80f22a7ac3a98ec6f8972f29e564103bbebf5e97be67ebc356d37fa48dbc4960600a1eb7230fbd1ea0
+  languageName: node
+  linkType: hard
+
+"temp-dir@npm:1.0.0":
+  version: 1.0.0
+  resolution: "temp-dir@npm:1.0.0"
+  checksum: 10/cb2b58ddfb12efa83e939091386ad73b425c9a8487ea0095fe4653192a40d49184a771a1beba99045fbd011e389fd563122d79f54f82be86a55620667e08a6b2
+  languageName: node
+  linkType: hard
+
+"test-exclude@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "test-exclude@npm:6.0.0"
+  dependencies:
+    "@istanbuljs/schema": "npm:^0.1.2"
+    glob: "npm:^7.1.4"
+    minimatch: "npm:^3.0.4"
+  checksum: 10/8fccb2cb6c8fcb6bb4115394feb833f8b6cf4b9503ec2485c2c90febf435cac62abe882a0c5c51a37b9bbe70640cdd05acf5f45e486ac4583389f4b0855f69e5
+  languageName: node
+  linkType: hard
+
+"text-extensions@npm:^1.0.0":
+  version: 1.9.0
+  resolution: "text-extensions@npm:1.9.0"
+  checksum: 10/56a9962c1b62d39b2bcb369b7558ca85c1b55e554b38dfd725edcc0a1babe5815782a60c17ff6b839093b163dfebb92b804208aaaea616ec7571c8059ae0cf44
+  languageName: node
+  linkType: hard
+
+"through2@npm:^2.0.0":
+  version: 2.0.5
+  resolution: "through2@npm:2.0.5"
+  dependencies:
+    readable-stream: "npm:~2.3.6"
+    xtend: "npm:~4.0.1"
+  checksum: 10/cd71f7dcdc7a8204fea003a14a433ef99384b7d4e31f5497e1f9f622b3cf3be3691f908455f98723bdc80922a53af7fa10c3b7abbe51c6fd3d536dbc7850e2c4
+  languageName: node
+  linkType: hard
+
+"through@npm:2, through@npm:>=2.2.7 <3, through@npm:^2.3.4, through@npm:^2.3.6":
+  version: 2.3.8
+  resolution: "through@npm:2.3.8"
+  checksum: 10/5da78346f70139a7d213b65a0106f3c398d6bc5301f9248b5275f420abc2c4b1e77c2abc72d218dedc28c41efb2e7c312cb76a7730d04f9c2d37d247da3f4198
+  languageName: node
+  linkType: hard
+
+"tmp@npm:^0.0.33":
+  version: 0.0.33
+  resolution: "tmp@npm:0.0.33"
+  dependencies:
+    os-tmpdir: "npm:~1.0.2"
+  checksum: 10/09c0abfd165cff29b32be42bc35e80b8c64727d97dedde6550022e88fa9fd39a084660415ed8e3ebaa2aca1ee142f86df8b31d4196d4f81c774a3a20fd4b6abf
+  languageName: node
+  linkType: hard
+
+"tmp@npm:~0.2.1":
+  version: 0.2.3
+  resolution: "tmp@npm:0.2.3"
+  checksum: 10/7b13696787f159c9754793a83aa79a24f1522d47b87462ddb57c18ee93ff26c74cbb2b8d9138f571d2e0e765c728fb2739863a672b280528512c6d83d511c6fa
+  languageName: node
+  linkType: hard
+
+"tmpl@npm:1.0.5":
+  version: 1.0.5
+  resolution: "tmpl@npm:1.0.5"
+  checksum: 10/cd922d9b853c00fe414c5a774817be65b058d54a2d01ebb415840960406c669a0fc632f66df885e24cb022ec812739199ccbdb8d1164c3e513f85bfca5ab2873
+  languageName: node
+  linkType: hard
+
+"to-fast-properties@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "to-fast-properties@npm:2.0.0"
+  checksum: 10/be2de62fe58ead94e3e592680052683b1ec986c72d589e7b21e5697f8744cdbf48c266fa72f6c15932894c10187b5f54573a3bcf7da0bfd964d5caf23d436168
+  languageName: node
+  linkType: hard
+
+"to-regex-range@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "to-regex-range@npm:5.0.1"
+  dependencies:
+    is-number: "npm:^7.0.0"
+  checksum: 10/10dda13571e1f5ad37546827e9b6d4252d2e0bc176c24a101252153ef435d83696e2557fe128c4678e4e78f5f01e83711c703eef9814eb12dab028580d45980a
   languageName: node
   linkType: hard
 
 "tr46@npm:~0.0.3":
   version: 0.0.3
   resolution: "tr46@npm:0.0.3"
-  checksum: 726321c5eaf41b5002e17ffbd1fb7245999a073e8979085dacd47c4b4e8068ff5777142fc6726d6ca1fd2ff16921b48788b87225cbc57c72636f6efa8efbffe3
+  checksum: 10/8f1f5aa6cb232f9e1bdc86f485f916b7aa38caee8a778b378ffec0b70d9307873f253f5cbadbe2955ece2ac5c83d0dc14a77513166ccd0a0c7fe197e21396695
+  languageName: node
+  linkType: hard
+
+"trim-newlines@npm:^3.0.0":
+  version: 3.0.1
+  resolution: "trim-newlines@npm:3.0.1"
+  checksum: 10/b530f3fadf78e570cf3c761fb74fef655beff6b0f84b29209bac6c9622db75ad1417f4a7b5d54c96605dcd72734ad44526fef9f396807b90839449eb543c6206
+  languageName: node
+  linkType: hard
+
+"tsconfig-paths@npm:^4.1.2":
+  version: 4.2.0
+  resolution: "tsconfig-paths@npm:4.2.0"
+  dependencies:
+    json5: "npm:^2.2.2"
+    minimist: "npm:^1.2.6"
+    strip-bom: "npm:^3.0.0"
+  checksum: 10/5e55cc2fb6b800eb72011522e10edefccb45b1f9af055681a51354c9b597d1390c6fa9cc356b8c7529f195ac8a90a78190d563159f3a1eed10e01bbd4d01a8ab
   languageName: node
   linkType: hard
 
 "tslib@npm:^1.11.1":
   version: 1.14.1
   resolution: "tslib@npm:1.14.1"
-  checksum: dbe628ef87f66691d5d2959b3e41b9ca0045c3ee3c7c7b906cc1e328b39f199bb1ad9e671c39025bd56122ac57dfbf7385a94843b1cc07c60a4db74795829acd
+  checksum: 10/7dbf34e6f55c6492637adb81b555af5e3b4f9cc6b998fb440dac82d3b42bdc91560a35a5fb75e20e24a076c651438234da6743d139e4feabf0783f3cdfe1dddb
+  languageName: node
+  linkType: hard
+
+"tslib@npm:^2.1.0, tslib@npm:^2.3.0, tslib@npm:^2.4.0, tslib@npm:^2.6.2":
+  version: 2.6.2
+  resolution: "tslib@npm:2.6.2"
+  checksum: 10/bd26c22d36736513980091a1e356378e8b662ded04204453d353a7f34a4c21ed0afc59b5f90719d4ba756e581a162ecbf93118dc9c6be5acf70aa309188166ca
   languageName: node
   linkType: hard
 
 "tslib@npm:^2.3.1":
   version: 2.4.0
   resolution: "tslib@npm:2.4.0"
-  checksum: 8c4aa6a3c5a754bf76aefc38026134180c053b7bd2f81338cb5e5ebf96fefa0f417bff221592bf801077f5bf990562f6264fecbc42cd3309b33872cb6fc3b113
+  checksum: 10/d8379e68b36caf082c1905ec25d17df8261e1d68ddc1abfd6c91158a064f6e4402039ae7c02cf4c81d12e3a2a2c7cd8ea2f57b233eb80136a2e3e7279daf2911
+  languageName: node
+  linkType: hard
+
+"tuf-js@npm:^1.1.7":
+  version: 1.1.7
+  resolution: "tuf-js@npm:1.1.7"
+  dependencies:
+    "@tufjs/models": "npm:1.0.4"
+    debug: "npm:^4.3.4"
+    make-fetch-happen: "npm:^11.1.1"
+  checksum: 10/8ce0061b76a9dc89fc6e53bc1870afeb8e70083a751910273f959c5d0d574ba9b037a22d944ff97623e58eefa16b051f0ac678bd2da973d2f6b57359604fee31
+  languageName: node
+  linkType: hard
+
+"tuf-js@npm:^2.2.1":
+  version: 2.2.1
+  resolution: "tuf-js@npm:2.2.1"
+  dependencies:
+    "@tufjs/models": "npm:2.0.1"
+    debug: "npm:^4.3.4"
+    make-fetch-happen: "npm:^13.0.1"
+  checksum: 10/4c057f4f0cfb183d8634c026a592f4fb29fd4e3d88260e32949642deedf87a1ae407645bae4cca58299458679a1cb7721245cde1885d466c2dbc1fbac0bc008a
+  languageName: node
+  linkType: hard
+
+"type-detect@npm:4.0.8":
+  version: 4.0.8
+  resolution: "type-detect@npm:4.0.8"
+  checksum: 10/5179e3b8ebc51fce1b13efb75fdea4595484433f9683bbc2dca6d99789dba4e602ab7922d2656f2ce8383987467f7770131d4a7f06a26287db0615d2f4c4ce7d
+  languageName: node
+  linkType: hard
+
+"type-fest@npm:^0.18.0":
+  version: 0.18.1
+  resolution: "type-fest@npm:0.18.1"
+  checksum: 10/08844377058435c2b0e633ba01bab6102dba0ed63d85417d8e18feff265eed6f5c9f8f9a25d405ea9db88a41a569be73a3c4c0d4e29150bf89fb145bb23114a2
+  languageName: node
+  linkType: hard
+
+"type-fest@npm:^0.21.3":
+  version: 0.21.3
+  resolution: "type-fest@npm:0.21.3"
+  checksum: 10/f4254070d9c3d83a6e573bcb95173008d73474ceadbbf620dd32d273940ca18734dff39c2b2480282df9afe5d1675ebed5499a00d791758748ea81f61a38961f
+  languageName: node
+  linkType: hard
+
+"type-fest@npm:^0.4.1":
+  version: 0.4.1
+  resolution: "type-fest@npm:0.4.1"
+  checksum: 10/ee6c77378ab0e5b1cb5a408671b03e3edda52bbba6976dc10daf966e5919adbf9553eb597dd23ff3cdfbed7370e9641441a579369d9de94fe9cc12b14b29ccaf
+  languageName: node
+  linkType: hard
+
+"type-fest@npm:^0.6.0":
+  version: 0.6.0
+  resolution: "type-fest@npm:0.6.0"
+  checksum: 10/9ecbf4ba279402b14c1a0614b6761bbe95626fab11377291fecd7e32b196109551e0350dcec6af74d97ced1b000ba8060a23eca33157091e642b409c2054ba82
+  languageName: node
+  linkType: hard
+
+"type-fest@npm:^0.8.1":
+  version: 0.8.1
+  resolution: "type-fest@npm:0.8.1"
+  checksum: 10/fd4a91bfb706aeeb0d326ebd2e9a8ea5263979e5dec8d16c3e469a5bd3a946e014a062ef76c02e3086d3d1c7209a56a20a4caafd0e9f9a5c2ab975084ea3d388
   languageName: node
   linkType: hard
 
 "typedarray@npm:^0.0.6":
   version: 0.0.6
   resolution: "typedarray@npm:0.0.6"
-  checksum: 33b39f3d0e8463985eeaeeacc3cb2e28bc3dfaf2a5ed219628c0b629d5d7b810b0eb2165f9f607c34871d5daa92ba1dc69f49051cf7d578b4cbd26c340b9d1b1
+  checksum: 10/2cc1bcf7d8c1237f6a16c04efc06637b2c5f2d74e58e84665445cf87668b85a21ab18dd751fa49eee6ae024b70326635d7b79ad37b1c370ed2fec6aeeeb52714
   languageName: node
   linkType: hard
 
-"uri-js@npm:^4.2.2":
+"typescript@npm:>=3 < 6":
+  version: 5.4.5
+  resolution: "typescript@npm:5.4.5"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 10/d04a9e27e6d83861f2126665aa8d84847e8ebabcea9125b9ebc30370b98cb38b5dff2508d74e2326a744938191a83a69aa9fddab41f193ffa43eabfdf3f190a5
+  languageName: node
+  linkType: hard
+
+"typescript@patch:typescript@npm%3A>=3 < 6#optional!builtin<compat/typescript>":
+  version: 5.4.5
+  resolution: "typescript@patch:typescript@npm%3A5.4.5#optional!builtin<compat/typescript>::version=5.4.5&hash=5adc0c"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 10/760f7d92fb383dbf7dee2443bf902f4365db2117f96f875cf809167f6103d55064de973db9f78fe8f31ec08fff52b2c969aee0d310939c0a3798ec75d0bca2e1
+  languageName: node
+  linkType: hard
+
+"uglify-js@npm:^3.1.4":
+  version: 3.17.4
+  resolution: "uglify-js@npm:3.17.4"
+  bin:
+    uglifyjs: bin/uglifyjs
+  checksum: 10/4c0b800e0ff192079d2c3ce8414fd3b656a570028c7c79af5c29c53d5c532b68bbcae4ad47307f89c2ee124d11826fff7a136b59d5c5bb18422bcdf5568afe1e
+  languageName: node
+  linkType: hard
+
+"unique-filename@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "unique-filename@npm:3.0.0"
+  dependencies:
+    unique-slug: "npm:^4.0.0"
+  checksum: 10/8e2f59b356cb2e54aab14ff98a51ac6c45781d15ceaab6d4f1c2228b780193dc70fae4463ce9e1df4479cb9d3304d7c2043a3fb905bdeca71cc7e8ce27e063df
+  languageName: node
+  linkType: hard
+
+"unique-slug@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "unique-slug@npm:4.0.0"
+  dependencies:
+    imurmurhash: "npm:^0.1.4"
+  checksum: 10/40912a8963fc02fb8b600cf50197df4a275c602c60de4cac4f75879d3c48558cfac48de08a25cc10df8112161f7180b3bbb4d662aadb711568602f9eddee54f0
+  languageName: node
+  linkType: hard
+
+"universal-user-agent@npm:^6.0.0":
+  version: 6.0.1
+  resolution: "universal-user-agent@npm:6.0.1"
+  checksum: 10/fdc8e1ae48a05decfc7ded09b62071f571c7fe0bd793d700704c80cea316101d4eac15cc27ed2bb64f4ce166d2684777c3198b9ab16034f547abea0d3aa1c93c
+  languageName: node
+  linkType: hard
+
+"universalify@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "universalify@npm:2.0.1"
+  checksum: 10/ecd8469fe0db28e7de9e5289d32bd1b6ba8f7183db34f3bfc4ca53c49891c2d6aa05f3fb3936a81285a905cc509fb641a0c3fc131ec786167eff41236ae32e60
+  languageName: node
+  linkType: hard
+
+"upath@npm:2.0.1":
+  version: 2.0.1
+  resolution: "upath@npm:2.0.1"
+  checksum: 10/7b98a83559a295d59f87f7a8d615c7549d19e4aec4dd9d52be2bf1ba93e1d6ee7d8f2188cdecbf303a22cea3768abff4268b960350152a0264125f577d9ed79e
+  languageName: node
+  linkType: hard
+
+"update-browserslist-db@npm:^1.0.13":
+  version: 1.0.16
+  resolution: "update-browserslist-db@npm:1.0.16"
+  dependencies:
+    escalade: "npm:^3.1.2"
+    picocolors: "npm:^1.0.1"
+  peerDependencies:
+    browserslist: ">= 4.21.0"
+  bin:
+    update-browserslist-db: cli.js
+  checksum: 10/071bf0b2fb8568db6cd42ee2598ac9b87c794a7229fcbf1b035ae7f883e770c07143f16a5371525d5bcb94b99f9a1b279036142b0195ffd4cf5a0008fc4a500e
+  languageName: node
+  linkType: hard
+
+"uri-js@npm:^4.2.2, uri-js@npm:^4.4.1":
   version: 4.4.1
   resolution: "uri-js@npm:4.4.1"
   dependencies:
-    punycode: ^2.1.0
-  checksum: 7167432de6817fe8e9e0c9684f1d2de2bb688c94388f7569f7dbdb1587c9f4ca2a77962f134ec90be0cc4d004c939ff0d05acc9f34a0db39a3c797dada262633
+    punycode: "npm:^2.1.0"
+  checksum: 10/b271ca7e3d46b7160222e3afa3e531505161c9a4e097febae9664e4b59912f4cbe94861361a4175edac3a03fee99d91e44b6a58c17a634bc5a664b19fc76fbcb
   languageName: node
   linkType: hard
 
 "util-deprecate@npm:^1.0.1, util-deprecate@npm:~1.0.1":
   version: 1.0.2
   resolution: "util-deprecate@npm:1.0.2"
-  checksum: 474acf1146cb2701fe3b074892217553dfcf9a031280919ba1b8d651a068c9b15d863b7303cb15bd00a862b498e6cf4ad7b4a08fb134edd5a6f7641681cb54a2
+  checksum: 10/474acf1146cb2701fe3b074892217553dfcf9a031280919ba1b8d651a068c9b15d863b7303cb15bd00a862b498e6cf4ad7b4a08fb134edd5a6f7641681cb54a2
   languageName: node
   linkType: hard
 
@@ -2341,24 +9237,101 @@ __metadata:
   version: 0.10.4
   resolution: "util@npm:0.10.4"
   dependencies:
-    inherits: 2.0.3
-  checksum: 913f9a90d05a60e91f91af01b8bd37e06bca4cc02d7b49e01089f9d5b78be2fffd61fb1a41b517de7238c5fc7337fa939c62d1fb4eb82e014894c7bee6637aaf
+    inherits: "npm:2.0.3"
+  checksum: 10/1200a1ca2b474758342b3a0c5261c56f14ef09ad7eeaec3e6f449f5776ecdfce09a153cad62652b823e74647cdcfd2918552eadd2434783dfb58dabc5061803a
   languageName: node
   linkType: hard
 
-"uuid@npm:^8.3.2":
-  version: 8.3.2
-  resolution: "uuid@npm:8.3.2"
+"util@npm:^0.12.5":
+  version: 0.12.5
+  resolution: "util@npm:0.12.5"
+  dependencies:
+    inherits: "npm:^2.0.3"
+    is-arguments: "npm:^1.0.4"
+    is-generator-function: "npm:^1.0.7"
+    is-typed-array: "npm:^1.1.3"
+    which-typed-array: "npm:^1.1.2"
+  checksum: 10/61a10de7753353dd4d744c917f74cdd7d21b8b46379c1e48e1c4fd8e83f8190e6bd9978fc4e5102ab6a10ebda6019d1b36572fa4a325e175ec8b789a121f6147
+  languageName: node
+  linkType: hard
+
+"uuid@npm:^9.0.0, uuid@npm:^9.0.1":
+  version: 9.0.1
+  resolution: "uuid@npm:9.0.1"
   bin:
     uuid: dist/bin/uuid
-  checksum: 5575a8a75c13120e2f10e6ddc801b2c7ed7d8f3c8ac22c7ed0c7b2ba6383ec0abda88c905085d630e251719e0777045ae3236f04c812184b7c765f63a70e58df
+  checksum: 10/9d0b6adb72b736e36f2b1b53da0d559125ba3e39d913b6072f6f033e0c87835b414f0836b45bcfaf2bdf698f92297fea1c3cc19b0b258bc182c9c43cc0fab9f2
+  languageName: node
+  linkType: hard
+
+"v8-to-istanbul@npm:^9.0.1":
+  version: 9.2.0
+  resolution: "v8-to-istanbul@npm:9.2.0"
+  dependencies:
+    "@jridgewell/trace-mapping": "npm:^0.3.12"
+    "@types/istanbul-lib-coverage": "npm:^2.0.1"
+    convert-source-map: "npm:^2.0.0"
+  checksum: 10/18dd8cebfb6790f27f4e41e7cff77c7ab1c8904085f354dd7875e2eb65f4261c4cf40939132502875779d92304bfea46b8336346ecb40b6f33c3a3979e6f5729
+  languageName: node
+  linkType: hard
+
+"validate-npm-package-license@npm:3.0.4, validate-npm-package-license@npm:^3.0.1, validate-npm-package-license@npm:^3.0.4":
+  version: 3.0.4
+  resolution: "validate-npm-package-license@npm:3.0.4"
+  dependencies:
+    spdx-correct: "npm:^3.0.0"
+    spdx-expression-parse: "npm:^3.0.0"
+  checksum: 10/86242519b2538bb8aeb12330edebb61b4eb37fd35ef65220ab0b03a26c0592c1c8a7300d32da3cde5abd08d18d95e8dabfad684b5116336f6de9e6f207eec224
+  languageName: node
+  linkType: hard
+
+"validate-npm-package-name@npm:5.0.0":
+  version: 5.0.0
+  resolution: "validate-npm-package-name@npm:5.0.0"
+  dependencies:
+    builtins: "npm:^5.0.0"
+  checksum: 10/5342a994986199b3c28e53a8452a14b2bb5085727691ea7aa0d284a6606b127c371e0925ae99b3f1ef7cc7d2c9de75f52eb61a3d1cc45e39bca1e3a9444cbb4e
+  languageName: node
+  linkType: hard
+
+"validate-npm-package-name@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "validate-npm-package-name@npm:3.0.0"
+  dependencies:
+    builtins: "npm:^1.0.3"
+  checksum: 10/6f89bcc91bb0d46e3c756eec2fd33887eeb76c85d20e5d3e452b69fe3ffbd37062704a4e8422735ea82d69fd963451b4f85501a4dc856f384138411ec42608fa
+  languageName: node
+  linkType: hard
+
+"validate-npm-package-name@npm:^5.0.0":
+  version: 5.0.1
+  resolution: "validate-npm-package-name@npm:5.0.1"
+  checksum: 10/0d583a1af23aeffea7748742cf22b6802458736fb8b60323ba5949763824d46f796474b0e1b9206beb716f9d75269e19dbd7795d6b038b29d561be95dd827381
+  languageName: node
+  linkType: hard
+
+"walker@npm:^1.0.8":
+  version: 1.0.8
+  resolution: "walker@npm:1.0.8"
+  dependencies:
+    makeerror: "npm:1.0.12"
+  checksum: 10/ad7a257ea1e662e57ef2e018f97b3c02a7240ad5093c392186ce0bcf1f1a60bbadd520d073b9beb921ed99f64f065efb63dfc8eec689a80e569f93c1c5d5e16c
+  languageName: node
+  linkType: hard
+
+"wcwidth@npm:^1.0.0, wcwidth@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "wcwidth@npm:1.0.1"
+  dependencies:
+    defaults: "npm:^1.0.3"
+  checksum: 10/182ebac8ca0b96845fae6ef44afd4619df6987fe5cf552fdee8396d3daa1fb9b8ec5c6c69855acb7b3c1231571393bd1f0a4cdc4028d421575348f64bb0a8817
   languageName: node
   linkType: hard
 
 "webidl-conversions@npm:^3.0.0":
   version: 3.0.1
   resolution: "webidl-conversions@npm:3.0.1"
-  checksum: c92a0a6ab95314bde9c32e1d0a6dfac83b578f8fa5f21e675bc2706ed6981bc26b7eb7e6a1fab158e5ce4adf9caa4a0aee49a52505d4d13c7be545f15021b17c
+  checksum: 10/b65b9f8d6854572a84a5c69615152b63371395f0c5dcd6729c45789052296df54314db2bc3e977df41705eacb8bc79c247cee139a63fa695192f95816ed528ad
   languageName: node
   linkType: hard
 
@@ -2366,9 +9339,53 @@ __metadata:
   version: 5.0.0
   resolution: "whatwg-url@npm:5.0.0"
   dependencies:
-    tr46: ~0.0.3
-    webidl-conversions: ^3.0.0
-  checksum: b8daed4ad3356cc4899048a15b2c143a9aed0dfae1f611ebd55073310c7b910f522ad75d727346ad64203d7e6c79ef25eafd465f4d12775ca44b90fa82ed9e2c
+    tr46: "npm:~0.0.3"
+    webidl-conversions: "npm:^3.0.0"
+  checksum: 10/f95adbc1e80820828b45cc671d97da7cd5e4ef9deb426c31bcd5ab00dc7103042291613b3ef3caec0a2335ed09e0d5ed026c940755dbb6d404e2b27f940fdf07
+  languageName: node
+  linkType: hard
+
+"which-typed-array@npm:^1.1.14, which-typed-array@npm:^1.1.2":
+  version: 1.1.15
+  resolution: "which-typed-array@npm:1.1.15"
+  dependencies:
+    available-typed-arrays: "npm:^1.0.7"
+    call-bind: "npm:^1.0.7"
+    for-each: "npm:^0.3.3"
+    gopd: "npm:^1.0.1"
+    has-tostringtag: "npm:^1.0.2"
+  checksum: 10/c3b6a99beadc971baa53c3ee5b749f2b9bdfa3b3b9a70650dd8511a48b61d877288b498d424712e9991d16019633086bd8b5923369460d93463c5825fa36c448
+  languageName: node
+  linkType: hard
+
+"which@npm:^2.0.1":
+  version: 2.0.2
+  resolution: "which@npm:2.0.2"
+  dependencies:
+    isexe: "npm:^2.0.0"
+  bin:
+    node-which: ./bin/node-which
+  checksum: 10/4782f8a1d6b8fc12c65e968fea49f59752bf6302dc43036c3bf87da718a80710f61a062516e9764c70008b487929a73546125570acea95c5b5dcc8ac3052c70f
+  languageName: node
+  linkType: hard
+
+"which@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "which@npm:4.0.0"
+  dependencies:
+    isexe: "npm:^3.1.1"
+  bin:
+    node-which: bin/which.js
+  checksum: 10/f17e84c042592c21e23c8195108cff18c64050b9efb8459589116999ea9da6dd1509e6a1bac3aeebefd137be00fabbb61b5c2bc0aa0f8526f32b58ee2f545651
+  languageName: node
+  linkType: hard
+
+"wide-align@npm:^1.1.5":
+  version: 1.1.5
+  resolution: "wide-align@npm:1.1.5"
+  dependencies:
+    string-width: "npm:^1.0.2 || 2 || 3 || 4"
+  checksum: 10/d5f8027b9a8255a493a94e4ec1b74a27bff6679d5ffe29316a3215e4712945c84ef73ca4045c7e20ae7d0c72f5f57f296e04a4928e773d4276a2f1222e4c2e99
   languageName: node
   linkType: hard
 
@@ -2377,7 +9394,25 @@ __metadata:
   resolution: "window-size@npm:0.1.4"
   bin:
     window-size: cli.js
-  checksum: 409accca0b1373c69897400e3cc6a56a2acc8a6ba9009f0cd8e4adda4ebf308e50425d3bd375c0c08efb803c8f0b09d84d7266faa05422b3fadfe6ee422d0aef
+  checksum: 10/26f86538be4975be7c8cb8f7aeb518dfb25473e7506baf1e90780758766f734df50cfbee289b645baf39b1e21100f4a86ef199538422a638b248ebacfbf8719b
+  languageName: node
+  linkType: hard
+
+"wordwrap@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "wordwrap@npm:1.0.0"
+  checksum: 10/497d40beb2bdb08e6d38754faa17ce20b0bf1306327f80cb777927edb23f461ee1f6bc659b3c3c93f26b08e1cf4b46acc5bae8fda1f0be3b5ab9a1a0211034cd
+  languageName: node
+  linkType: hard
+
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0, wrap-ansi@npm:^7.0.0":
+  version: 7.0.0
+  resolution: "wrap-ansi@npm:7.0.0"
+  dependencies:
+    ansi-styles: "npm:^4.0.0"
+    string-width: "npm:^4.1.0"
+    strip-ansi: "npm:^6.0.0"
+  checksum: 10/cebdaeca3a6880da410f75209e68cd05428580de5ad24535f22696d7d9cab134d1f8498599f344c3cf0fb37c1715807a183778d8c648d6cc0cb5ff2bb4236540
   languageName: node
   linkType: hard
 
@@ -2385,79 +9420,184 @@ __metadata:
   version: 2.1.0
   resolution: "wrap-ansi@npm:2.1.0"
   dependencies:
-    string-width: ^1.0.1
-    strip-ansi: ^3.0.1
-  checksum: 2dacd4b3636f7a53ee13d4d0fe7fa2ed9ad81e9967e17231924ea88a286ec4619a78288de8d41881ee483f4449ab2c0287cde8154ba1bd0126c10271101b2ee3
+    string-width: "npm:^1.0.1"
+    strip-ansi: "npm:^3.0.1"
+  checksum: 10/cf66d33f62f2edf0aac52685da98194e47ddf4ceb81d9f98f294b46ffbbf8662caa72a905b343aeab8d6a16cade982be5fc45df99235b07f781ebf68f051ca98
   languageName: node
   linkType: hard
 
-"wrap-ansi@npm:^7.0.0":
-  version: 7.0.0
-  resolution: "wrap-ansi@npm:7.0.0"
+"wrap-ansi@npm:^6.0.1":
+  version: 6.2.0
+  resolution: "wrap-ansi@npm:6.2.0"
   dependencies:
-    ansi-styles: ^4.0.0
-    string-width: ^4.1.0
-    strip-ansi: ^6.0.0
-  checksum: a790b846fd4505de962ba728a21aaeda189b8ee1c7568ca5e817d85930e06ef8d1689d49dbf0e881e8ef84436af3a88bc49115c2e2788d841ff1b8b5b51a608b
+    ansi-styles: "npm:^4.0.0"
+    string-width: "npm:^4.1.0"
+    strip-ansi: "npm:^6.0.0"
+  checksum: 10/0d64f2d438e0b555e693b95aee7b2689a12c3be5ac458192a1ce28f542a6e9e59ddfecc37520910c2c88eb1f82a5411260566dba5064e8f9895e76e169e76187
+  languageName: node
+  linkType: hard
+
+"wrap-ansi@npm:^8.1.0":
+  version: 8.1.0
+  resolution: "wrap-ansi@npm:8.1.0"
+  dependencies:
+    ansi-styles: "npm:^6.1.0"
+    string-width: "npm:^5.0.1"
+    strip-ansi: "npm:^7.0.1"
+  checksum: 10/7b1e4b35e9bb2312d2ee9ee7dc95b8cb5f8b4b5a89f7dde5543fe66c1e3715663094defa50d75454ac900bd210f702d575f15f3f17fa9ec0291806d2578d1ddf
   languageName: node
   linkType: hard
 
 "wrappy@npm:1":
   version: 1.0.2
   resolution: "wrappy@npm:1.0.2"
-  checksum: 159da4805f7e84a3d003d8841557196034155008f817172d4e986bd591f74aa82aa7db55929a54222309e01079a65a92a9e6414da5a6aa4b01ee44a511ac3ee5
+  checksum: 10/159da4805f7e84a3d003d8841557196034155008f817172d4e986bd591f74aa82aa7db55929a54222309e01079a65a92a9e6414da5a6aa4b01ee44a511ac3ee5
   languageName: node
   linkType: hard
 
-"xml2js@npm:^0.4.23":
-  version: 0.4.23
-  resolution: "xml2js@npm:0.4.23"
+"write-file-atomic@npm:5.0.1":
+  version: 5.0.1
+  resolution: "write-file-atomic@npm:5.0.1"
   dependencies:
-    sax: ">=0.6.0"
-    xmlbuilder: ~11.0.0
-  checksum: ca0cf2dfbf6deeaae878a891c8fbc0db6fd04398087084edf143cdc83d0509ad0fe199b890f62f39c4415cf60268a27a6aed0d343f0658f8779bd7add690fa98
+    imurmurhash: "npm:^0.1.4"
+    signal-exit: "npm:^4.0.1"
+  checksum: 10/648efddba54d478d0e4330ab6f239976df3b9752b123db5dc9405d9b5af768fa9d70ce60c52fdbe61d1200d24350bc4fbcbaf09288496c2be050de126bd95b7e
+  languageName: node
+  linkType: hard
+
+"write-file-atomic@npm:^2.4.2":
+  version: 2.4.3
+  resolution: "write-file-atomic@npm:2.4.3"
+  dependencies:
+    graceful-fs: "npm:^4.1.11"
+    imurmurhash: "npm:^0.1.4"
+    signal-exit: "npm:^3.0.2"
+  checksum: 10/15ce863dce07075d0decedd7c9094f4461e46139d28a758c53162f24c0791c16cd2e7a76baa5b47b1a851fbb51e16f2fab739afb156929b22628f3225437135c
+  languageName: node
+  linkType: hard
+
+"write-file-atomic@npm:^4.0.2":
+  version: 4.0.2
+  resolution: "write-file-atomic@npm:4.0.2"
+  dependencies:
+    imurmurhash: "npm:^0.1.4"
+    signal-exit: "npm:^3.0.7"
+  checksum: 10/3be1f5508a46c190619d5386b1ac8f3af3dbe951ed0f7b0b4a0961eed6fc626bd84b50cf4be768dabc0a05b672f5d0c5ee7f42daa557b14415d18c3a13c7d246
+  languageName: node
+  linkType: hard
+
+"write-json-file@npm:^3.2.0":
+  version: 3.2.0
+  resolution: "write-json-file@npm:3.2.0"
+  dependencies:
+    detect-indent: "npm:^5.0.0"
+    graceful-fs: "npm:^4.1.15"
+    make-dir: "npm:^2.1.0"
+    pify: "npm:^4.0.1"
+    sort-keys: "npm:^2.0.0"
+    write-file-atomic: "npm:^2.4.2"
+  checksum: 10/2b97ce2027d53c28a33e4a8e7b0d565faf785988b3776f9e0c68d36477c1fb12639fd0d70877d92a861820707966c62ea9c5f7a36a165d615fd47ca8e24c8371
+  languageName: node
+  linkType: hard
+
+"write-pkg@npm:4.0.0":
+  version: 4.0.0
+  resolution: "write-pkg@npm:4.0.0"
+  dependencies:
+    sort-keys: "npm:^2.0.0"
+    type-fest: "npm:^0.4.1"
+    write-json-file: "npm:^3.2.0"
+  checksum: 10/7864d44370f42a6761f6898d07ee2818c7a2faad45116580cf779f3adaf94e4bea5557612533a6c421c32323253ecb63b50615094960a637aeaef5df0fd2d6cd
+  languageName: node
+  linkType: hard
+
+"xml2js@npm:^0.6.2":
+  version: 0.6.2
+  resolution: "xml2js@npm:0.6.2"
+  dependencies:
+    sax: "npm:>=0.6.0"
+    xmlbuilder: "npm:~11.0.0"
+  checksum: 10/df29de8eeedb762c367d87945c39bcf54db19a2c522607491c266ed6184b5a749e37ff29cfaed0ac149da9ba332ac3dcf8e5ff2bd0a206be3343eca95faa941d
   languageName: node
   linkType: hard
 
 "xmlbuilder@npm:~11.0.0":
   version: 11.0.1
   resolution: "xmlbuilder@npm:11.0.1"
-  checksum: 7152695e16f1a9976658215abab27e55d08b1b97bca901d58b048d2b6e106b5af31efccbdecf9b07af37c8377d8e7e821b494af10b3a68b0ff4ae60331b415b0
+  checksum: 10/c8c3d208783718db5b285101a736cd8e6b69a5c265199a0739abaa93d1a1b7de5489fd16df4e776e18b2c98cb91f421a7349e99fd8c1ebeb44ecfed72a25091a
+  languageName: node
+  linkType: hard
+
+"xtend@npm:~4.0.1":
+  version: 4.0.2
+  resolution: "xtend@npm:4.0.2"
+  checksum: 10/ac5dfa738b21f6e7f0dd6e65e1b3155036d68104e67e5d5d1bde74892e327d7e5636a076f625599dc394330a731861e87343ff184b0047fef1360a7ec0a5a36a
   languageName: node
   linkType: hard
 
 "y18n@npm:^3.2.0":
   version: 3.2.2
   resolution: "y18n@npm:3.2.2"
-  checksum: 6154fd7544f8bbf5b18cdf77692ed88d389be49c87238ecb4e0d6a5276446cd2a5c29cc4bdbdddfc7e4e498b08df9d7e38df4a1453cf75eecfead392246ea74a
+  checksum: 10/42ee58e321252ac87f85ccc7cee01c2e3e224737531e9e543963264194255132ce406e02993904b84ea974050d53b8959dcf9da695408553c32f2a8b4b59a667
   languageName: node
   linkType: hard
 
 "y18n@npm:^5.0.5":
   version: 5.0.8
   resolution: "y18n@npm:5.0.8"
-  checksum: 54f0fb95621ee60898a38c572c515659e51cc9d9f787fb109cef6fde4befbe1c4602dc999d30110feee37456ad0f1660fa2edcfde6a9a740f86a290999550d30
+  checksum: 10/5f1b5f95e3775de4514edbb142398a2c37849ccfaf04a015be5d75521e9629d3be29bd4432d23c57f37e5b61ade592fb0197022e9993f81a06a5afbdcda9346d
+  languageName: node
+  linkType: hard
+
+"yallist@npm:^3.0.2":
+  version: 3.1.1
+  resolution: "yallist@npm:3.1.1"
+  checksum: 10/9af0a4329c3c6b779ac4736c69fae4190ac03029fa27c1aef4e6bcc92119b73dea6fe5db5fe881fb0ce2a0e9539a42cdf60c7c21eda04d1a0b8c082e38509efb
   languageName: node
   linkType: hard
 
 "yallist@npm:^4.0.0":
   version: 4.0.0
   resolution: "yallist@npm:4.0.0"
-  checksum: 343617202af32df2a15a3be36a5a8c0c8545208f3d3dfbc6bb7c3e3b7e8c6f8e7485432e4f3b88da3031a6e20afa7c711eded32ddfb122896ac5d914e75848d5
+  checksum: 10/4cb02b42b8a93b5cf50caf5d8e9beb409400a8a4d85e83bb0685c1457e9ac0b7a00819e9f5991ac25ffabb56a78e2f017c1acc010b3a1babfe6de690ba531abd
   languageName: node
   linkType: hard
 
-"yaml@npm:^1.10.2":
-  version: 1.10.2
-  resolution: "yaml@npm:1.10.2"
-  checksum: ce4ada136e8a78a0b08dc10b4b900936912d15de59905b2bf415b4d33c63df1d555d23acb2a41b23cf9fb5da41c256441afca3d6509de7247daa062fd2c5ea5f
+"yaml@npm:^2.3.1":
+  version: 2.4.2
+  resolution: "yaml@npm:2.4.2"
+  bin:
+    yaml: bin.mjs
+  checksum: 10/6eafbcd68dead734035f6f72af21bd820c29214caf7d8e40c595671a3c908535cef8092b9660a1c055c5833aa148aa640e0c5fa4adb5af2dacd6d28296ccd81c
   languageName: node
   linkType: hard
 
-"yargs-parser@npm:^20.2.2":
+"yargs-parser@npm:21.1.1, yargs-parser@npm:^21.1.1":
+  version: 21.1.1
+  resolution: "yargs-parser@npm:21.1.1"
+  checksum: 10/9dc2c217ea3bf8d858041252d43e074f7166b53f3d010a8c711275e09cd3d62a002969a39858b92bbda2a6a63a585c7127014534a560b9c69ed2d923d113406e
+  languageName: node
+  linkType: hard
+
+"yargs-parser@npm:^20.2.2, yargs-parser@npm:^20.2.3":
   version: 20.2.9
   resolution: "yargs-parser@npm:20.2.9"
-  checksum: 8bb69015f2b0ff9e17b2c8e6bfe224ab463dd00ca211eece72a4cd8a906224d2703fb8a326d36fdd0e68701e201b2a60ed7cf81ce0fd9b3799f9fe7745977ae3
+  checksum: 10/0188f430a0f496551d09df6719a9132a3469e47fe2747208b1dd0ab2bb0c512a95d0b081628bbca5400fb20dbf2fabe63d22badb346cecadffdd948b049f3fcc
+  languageName: node
+  linkType: hard
+
+"yargs@npm:17.7.2, yargs@npm:^17.3.1, yargs@npm:^17.6.2, yargs@npm:^17.7.2":
+  version: 17.7.2
+  resolution: "yargs@npm:17.7.2"
+  dependencies:
+    cliui: "npm:^8.0.1"
+    escalade: "npm:^3.1.1"
+    get-caller-file: "npm:^2.0.5"
+    require-directory: "npm:^2.1.1"
+    string-width: "npm:^4.2.3"
+    y18n: "npm:^5.0.5"
+    yargs-parser: "npm:^21.1.1"
+  checksum: 10/abb3e37678d6e38ea85485ed86ebe0d1e3464c640d7d9069805ea0da12f69d5a32df8e5625e370f9c96dd1c2dc088ab2d0a4dd32af18222ef3c4224a19471576
   languageName: node
   linkType: hard
 
@@ -2465,14 +9605,14 @@ __metadata:
   version: 16.2.0
   resolution: "yargs@npm:16.2.0"
   dependencies:
-    cliui: ^7.0.2
-    escalade: ^3.1.1
-    get-caller-file: ^2.0.5
-    require-directory: ^2.1.1
-    string-width: ^4.2.0
-    y18n: ^5.0.5
-    yargs-parser: ^20.2.2
-  checksum: b14afbb51e3251a204d81937c86a7e9d4bdbf9a2bcee38226c900d00f522969ab675703bee2a6f99f8e20103f608382936034e64d921b74df82b63c07c5e8f59
+    cliui: "npm:^7.0.2"
+    escalade: "npm:^3.1.1"
+    get-caller-file: "npm:^2.0.5"
+    require-directory: "npm:^2.1.1"
+    string-width: "npm:^4.2.0"
+    y18n: "npm:^5.0.5"
+    yargs-parser: "npm:^20.2.2"
+  checksum: 10/807fa21211d2117135d557f95fcd3c3d390530cda2eca0c840f1d95f0f40209dcfeb5ec18c785a1f3425896e623e3b2681e8bb7b6600060eda1c3f4804e7957e
   languageName: node
   linkType: hard
 
@@ -2480,13 +9620,20 @@ __metadata:
   version: 3.32.0
   resolution: "yargs@npm:3.32.0"
   dependencies:
-    camelcase: ^2.0.1
-    cliui: ^3.0.3
-    decamelize: ^1.1.1
-    os-locale: ^1.4.0
-    string-width: ^1.0.1
-    window-size: ^0.1.4
-    y18n: ^3.2.0
-  checksum: 3e0f7fc1bc2052bcaaa7354cbd33d05a86fc0f236432d107ecd088989fbd175174c562d17e762727acbf25d04e8520d43625f7581b2a6ce55ce10034e80675fc
+    camelcase: "npm:^2.0.1"
+    cliui: "npm:^3.0.3"
+    decamelize: "npm:^1.1.1"
+    os-locale: "npm:^1.4.0"
+    string-width: "npm:^1.0.1"
+    window-size: "npm:^0.1.4"
+    y18n: "npm:^3.2.0"
+  checksum: 10/bcf0bc61e77d104260838c757c5d83d9763030149cb4bc5c2bf60fbfbfdfb43393d92d0689f470047af6e41c72d8f680329c97615448c80748166ef60cc1eaaf
+  languageName: node
+  linkType: hard
+
+"yocto-queue@npm:^0.1.0":
+  version: 0.1.0
+  resolution: "yocto-queue@npm:0.1.0"
+  checksum: 10/f77b3d8d00310def622123df93d4ee654fc6a0096182af8bd60679ddcdfb3474c56c6c7190817c84a2785648cdee9d721c0154eb45698c62176c322fb46fc700
   languageName: node
   linkType: hard

--- a/yarn.lock
+++ b/yarn.lock
@@ -562,128 +562,69 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/client-s3@npm:^3.391.0":
-  version: 3.412.0
-  resolution: "@aws-sdk/client-s3@npm:3.412.0"
+"@aws-sdk/client-s3@npm:^3.556.0":
+  version: 3.575.0
+  resolution: "@aws-sdk/client-s3@npm:3.575.0"
   dependencies:
     "@aws-crypto/sha1-browser": "npm:3.0.0"
     "@aws-crypto/sha256-browser": "npm:3.0.0"
     "@aws-crypto/sha256-js": "npm:3.0.0"
-    "@aws-sdk/client-sts": "npm:3.410.0"
-    "@aws-sdk/credential-provider-node": "npm:3.410.0"
-    "@aws-sdk/middleware-bucket-endpoint": "npm:3.410.0"
-    "@aws-sdk/middleware-expect-continue": "npm:3.410.0"
-    "@aws-sdk/middleware-flexible-checksums": "npm:3.410.0"
-    "@aws-sdk/middleware-host-header": "npm:3.410.0"
-    "@aws-sdk/middleware-location-constraint": "npm:3.410.0"
-    "@aws-sdk/middleware-logger": "npm:3.410.0"
-    "@aws-sdk/middleware-recursion-detection": "npm:3.410.0"
-    "@aws-sdk/middleware-sdk-s3": "npm:3.410.0"
-    "@aws-sdk/middleware-signing": "npm:3.410.0"
-    "@aws-sdk/middleware-ssec": "npm:3.410.0"
-    "@aws-sdk/middleware-user-agent": "npm:3.410.0"
-    "@aws-sdk/signature-v4-multi-region": "npm:3.412.0"
-    "@aws-sdk/types": "npm:3.410.0"
-    "@aws-sdk/util-endpoints": "npm:3.410.0"
-    "@aws-sdk/util-user-agent-browser": "npm:3.410.0"
-    "@aws-sdk/util-user-agent-node": "npm:3.410.0"
-    "@aws-sdk/xml-builder": "npm:3.310.0"
-    "@smithy/config-resolver": "npm:^2.0.7"
-    "@smithy/eventstream-serde-browser": "npm:^2.0.6"
-    "@smithy/eventstream-serde-config-resolver": "npm:^2.0.6"
-    "@smithy/eventstream-serde-node": "npm:^2.0.6"
-    "@smithy/fetch-http-handler": "npm:^2.1.2"
-    "@smithy/hash-blob-browser": "npm:^2.0.6"
-    "@smithy/hash-node": "npm:^2.0.6"
-    "@smithy/hash-stream-node": "npm:^2.0.6"
-    "@smithy/invalid-dependency": "npm:^2.0.6"
-    "@smithy/md5-js": "npm:^2.0.6"
-    "@smithy/middleware-content-length": "npm:^2.0.8"
-    "@smithy/middleware-endpoint": "npm:^2.0.6"
-    "@smithy/middleware-retry": "npm:^2.0.9"
-    "@smithy/middleware-serde": "npm:^2.0.6"
-    "@smithy/middleware-stack": "npm:^2.0.0"
-    "@smithy/node-config-provider": "npm:^2.0.9"
-    "@smithy/node-http-handler": "npm:^2.1.2"
-    "@smithy/protocol-http": "npm:^3.0.2"
-    "@smithy/smithy-client": "npm:^2.1.3"
-    "@smithy/types": "npm:^2.3.0"
-    "@smithy/url-parser": "npm:^2.0.6"
-    "@smithy/util-base64": "npm:^2.0.0"
-    "@smithy/util-body-length-browser": "npm:^2.0.0"
-    "@smithy/util-body-length-node": "npm:^2.1.0"
-    "@smithy/util-defaults-mode-browser": "npm:^2.0.7"
-    "@smithy/util-defaults-mode-node": "npm:^2.0.9"
-    "@smithy/util-retry": "npm:^2.0.0"
-    "@smithy/util-stream": "npm:^2.0.9"
-    "@smithy/util-utf8": "npm:^2.0.0"
-    "@smithy/util-waiter": "npm:^2.0.6"
-    fast-xml-parser: "npm:4.2.5"
-    tslib: "npm:^2.5.0"
-  checksum: 10/71fa2c9f4ce8b8382e2d30bf60ece51d1e8a0cd2dfb46dd049efe49bf1f01b4305ea6a7149f77223f92aacab5ce7f9a24f864604c3d9b01571315e50475c06d7
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/client-s3@npm:^3.9.0":
-  version: 3.418.0
-  resolution: "@aws-sdk/client-s3@npm:3.418.0"
-  dependencies:
-    "@aws-crypto/sha1-browser": "npm:3.0.0"
-    "@aws-crypto/sha256-browser": "npm:3.0.0"
-    "@aws-crypto/sha256-js": "npm:3.0.0"
-    "@aws-sdk/client-sts": "npm:3.418.0"
-    "@aws-sdk/credential-provider-node": "npm:3.418.0"
-    "@aws-sdk/middleware-bucket-endpoint": "npm:3.418.0"
-    "@aws-sdk/middleware-expect-continue": "npm:3.418.0"
-    "@aws-sdk/middleware-flexible-checksums": "npm:3.418.0"
-    "@aws-sdk/middleware-host-header": "npm:3.418.0"
-    "@aws-sdk/middleware-location-constraint": "npm:3.418.0"
-    "@aws-sdk/middleware-logger": "npm:3.418.0"
-    "@aws-sdk/middleware-recursion-detection": "npm:3.418.0"
-    "@aws-sdk/middleware-sdk-s3": "npm:3.418.0"
-    "@aws-sdk/middleware-signing": "npm:3.418.0"
-    "@aws-sdk/middleware-ssec": "npm:3.418.0"
-    "@aws-sdk/middleware-user-agent": "npm:3.418.0"
-    "@aws-sdk/region-config-resolver": "npm:3.418.0"
-    "@aws-sdk/signature-v4-multi-region": "npm:3.418.0"
-    "@aws-sdk/types": "npm:3.418.0"
-    "@aws-sdk/util-endpoints": "npm:3.418.0"
-    "@aws-sdk/util-user-agent-browser": "npm:3.418.0"
-    "@aws-sdk/util-user-agent-node": "npm:3.418.0"
-    "@aws-sdk/xml-builder": "npm:3.310.0"
-    "@smithy/config-resolver": "npm:^2.0.10"
-    "@smithy/eventstream-serde-browser": "npm:^2.0.9"
-    "@smithy/eventstream-serde-config-resolver": "npm:^2.0.9"
-    "@smithy/eventstream-serde-node": "npm:^2.0.9"
-    "@smithy/fetch-http-handler": "npm:^2.1.5"
-    "@smithy/hash-blob-browser": "npm:^2.0.9"
-    "@smithy/hash-node": "npm:^2.0.9"
-    "@smithy/hash-stream-node": "npm:^2.0.9"
-    "@smithy/invalid-dependency": "npm:^2.0.9"
-    "@smithy/md5-js": "npm:^2.0.9"
-    "@smithy/middleware-content-length": "npm:^2.0.11"
-    "@smithy/middleware-endpoint": "npm:^2.0.9"
-    "@smithy/middleware-retry": "npm:^2.0.12"
-    "@smithy/middleware-serde": "npm:^2.0.9"
-    "@smithy/middleware-stack": "npm:^2.0.2"
-    "@smithy/node-config-provider": "npm:^2.0.12"
-    "@smithy/node-http-handler": "npm:^2.1.5"
-    "@smithy/protocol-http": "npm:^3.0.5"
-    "@smithy/smithy-client": "npm:^2.1.6"
-    "@smithy/types": "npm:^2.3.3"
-    "@smithy/url-parser": "npm:^2.0.9"
-    "@smithy/util-base64": "npm:^2.0.0"
-    "@smithy/util-body-length-browser": "npm:^2.0.0"
-    "@smithy/util-body-length-node": "npm:^2.1.0"
-    "@smithy/util-defaults-mode-browser": "npm:^2.0.10"
-    "@smithy/util-defaults-mode-node": "npm:^2.0.12"
-    "@smithy/util-retry": "npm:^2.0.2"
-    "@smithy/util-stream": "npm:^2.0.12"
-    "@smithy/util-utf8": "npm:^2.0.0"
-    "@smithy/util-waiter": "npm:^2.0.9"
-    fast-xml-parser: "npm:4.2.5"
-    tslib: "npm:^2.5.0"
-  checksum: 10/30f81d680a394cbf81123f90e7284fc39b95d681bc3511c8616ecd68af1a2c48fd0fb25af961299153d7afa4c80e88e9bf2bbd37b82c7450f0f2d0406113a3ef
+    "@aws-sdk/client-sso-oidc": "npm:3.575.0"
+    "@aws-sdk/client-sts": "npm:3.575.0"
+    "@aws-sdk/core": "npm:3.575.0"
+    "@aws-sdk/credential-provider-node": "npm:3.575.0"
+    "@aws-sdk/middleware-bucket-endpoint": "npm:3.575.0"
+    "@aws-sdk/middleware-expect-continue": "npm:3.575.0"
+    "@aws-sdk/middleware-flexible-checksums": "npm:3.575.0"
+    "@aws-sdk/middleware-host-header": "npm:3.575.0"
+    "@aws-sdk/middleware-location-constraint": "npm:3.575.0"
+    "@aws-sdk/middleware-logger": "npm:3.575.0"
+    "@aws-sdk/middleware-recursion-detection": "npm:3.575.0"
+    "@aws-sdk/middleware-sdk-s3": "npm:3.575.0"
+    "@aws-sdk/middleware-signing": "npm:3.575.0"
+    "@aws-sdk/middleware-ssec": "npm:3.575.0"
+    "@aws-sdk/middleware-user-agent": "npm:3.575.0"
+    "@aws-sdk/region-config-resolver": "npm:3.575.0"
+    "@aws-sdk/signature-v4-multi-region": "npm:3.575.0"
+    "@aws-sdk/types": "npm:3.575.0"
+    "@aws-sdk/util-endpoints": "npm:3.575.0"
+    "@aws-sdk/util-user-agent-browser": "npm:3.575.0"
+    "@aws-sdk/util-user-agent-node": "npm:3.575.0"
+    "@aws-sdk/xml-builder": "npm:3.575.0"
+    "@smithy/config-resolver": "npm:^3.0.0"
+    "@smithy/core": "npm:^2.0.0"
+    "@smithy/eventstream-serde-browser": "npm:^3.0.0"
+    "@smithy/eventstream-serde-config-resolver": "npm:^3.0.0"
+    "@smithy/eventstream-serde-node": "npm:^3.0.0"
+    "@smithy/fetch-http-handler": "npm:^3.0.0"
+    "@smithy/hash-blob-browser": "npm:^3.0.0"
+    "@smithy/hash-node": "npm:^3.0.0"
+    "@smithy/hash-stream-node": "npm:^3.0.0"
+    "@smithy/invalid-dependency": "npm:^3.0.0"
+    "@smithy/md5-js": "npm:^3.0.0"
+    "@smithy/middleware-content-length": "npm:^3.0.0"
+    "@smithy/middleware-endpoint": "npm:^3.0.0"
+    "@smithy/middleware-retry": "npm:^3.0.0"
+    "@smithy/middleware-serde": "npm:^3.0.0"
+    "@smithy/middleware-stack": "npm:^3.0.0"
+    "@smithy/node-config-provider": "npm:^3.0.0"
+    "@smithy/node-http-handler": "npm:^3.0.0"
+    "@smithy/protocol-http": "npm:^4.0.0"
+    "@smithy/smithy-client": "npm:^3.0.0"
+    "@smithy/types": "npm:^3.0.0"
+    "@smithy/url-parser": "npm:^3.0.0"
+    "@smithy/util-base64": "npm:^3.0.0"
+    "@smithy/util-body-length-browser": "npm:^3.0.0"
+    "@smithy/util-body-length-node": "npm:^3.0.0"
+    "@smithy/util-defaults-mode-browser": "npm:^3.0.0"
+    "@smithy/util-defaults-mode-node": "npm:^3.0.0"
+    "@smithy/util-endpoints": "npm:^2.0.0"
+    "@smithy/util-retry": "npm:^3.0.0"
+    "@smithy/util-stream": "npm:^3.0.0"
+    "@smithy/util-utf8": "npm:^3.0.0"
+    "@smithy/util-waiter": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/d44c44fd7b8d8dc7cf4a194ab19bf4f14a89c2fa1895b4e9bbdac46f0b2ab2d481d4e0192927b36a57a9f75e376e6c236688dfb423101e9b5c563e514babccf8
   languageName: node
   linkType: hard
 
@@ -727,6 +668,54 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/client-sso-oidc@npm:3.575.0":
+  version: 3.575.0
+  resolution: "@aws-sdk/client-sso-oidc@npm:3.575.0"
+  dependencies:
+    "@aws-crypto/sha256-browser": "npm:3.0.0"
+    "@aws-crypto/sha256-js": "npm:3.0.0"
+    "@aws-sdk/client-sts": "npm:3.575.0"
+    "@aws-sdk/core": "npm:3.575.0"
+    "@aws-sdk/credential-provider-node": "npm:3.575.0"
+    "@aws-sdk/middleware-host-header": "npm:3.575.0"
+    "@aws-sdk/middleware-logger": "npm:3.575.0"
+    "@aws-sdk/middleware-recursion-detection": "npm:3.575.0"
+    "@aws-sdk/middleware-user-agent": "npm:3.575.0"
+    "@aws-sdk/region-config-resolver": "npm:3.575.0"
+    "@aws-sdk/types": "npm:3.575.0"
+    "@aws-sdk/util-endpoints": "npm:3.575.0"
+    "@aws-sdk/util-user-agent-browser": "npm:3.575.0"
+    "@aws-sdk/util-user-agent-node": "npm:3.575.0"
+    "@smithy/config-resolver": "npm:^3.0.0"
+    "@smithy/core": "npm:^2.0.0"
+    "@smithy/fetch-http-handler": "npm:^3.0.0"
+    "@smithy/hash-node": "npm:^3.0.0"
+    "@smithy/invalid-dependency": "npm:^3.0.0"
+    "@smithy/middleware-content-length": "npm:^3.0.0"
+    "@smithy/middleware-endpoint": "npm:^3.0.0"
+    "@smithy/middleware-retry": "npm:^3.0.0"
+    "@smithy/middleware-serde": "npm:^3.0.0"
+    "@smithy/middleware-stack": "npm:^3.0.0"
+    "@smithy/node-config-provider": "npm:^3.0.0"
+    "@smithy/node-http-handler": "npm:^3.0.0"
+    "@smithy/protocol-http": "npm:^4.0.0"
+    "@smithy/smithy-client": "npm:^3.0.0"
+    "@smithy/types": "npm:^3.0.0"
+    "@smithy/url-parser": "npm:^3.0.0"
+    "@smithy/util-base64": "npm:^3.0.0"
+    "@smithy/util-body-length-browser": "npm:^3.0.0"
+    "@smithy/util-body-length-node": "npm:^3.0.0"
+    "@smithy/util-defaults-mode-browser": "npm:^3.0.0"
+    "@smithy/util-defaults-mode-node": "npm:^3.0.0"
+    "@smithy/util-endpoints": "npm:^2.0.0"
+    "@smithy/util-middleware": "npm:^3.0.0"
+    "@smithy/util-retry": "npm:^3.0.0"
+    "@smithy/util-utf8": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/98cc6f57184d48a2cea4a8e8d304943dd8524e520cb5ae729568e3690927aa6fba6362473b6c3c8829e269f7d6f154557104077f708262a90f78844d1a689578
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/client-sso@npm:3.212.0":
   version: 3.212.0
   resolution: "@aws-sdk/client-sso@npm:3.212.0"
@@ -767,86 +756,49 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/client-sso@npm:3.410.0":
-  version: 3.410.0
-  resolution: "@aws-sdk/client-sso@npm:3.410.0"
+"@aws-sdk/client-sso@npm:3.575.0":
+  version: 3.575.0
+  resolution: "@aws-sdk/client-sso@npm:3.575.0"
   dependencies:
     "@aws-crypto/sha256-browser": "npm:3.0.0"
     "@aws-crypto/sha256-js": "npm:3.0.0"
-    "@aws-sdk/middleware-host-header": "npm:3.410.0"
-    "@aws-sdk/middleware-logger": "npm:3.410.0"
-    "@aws-sdk/middleware-recursion-detection": "npm:3.410.0"
-    "@aws-sdk/middleware-user-agent": "npm:3.410.0"
-    "@aws-sdk/types": "npm:3.410.0"
-    "@aws-sdk/util-endpoints": "npm:3.410.0"
-    "@aws-sdk/util-user-agent-browser": "npm:3.410.0"
-    "@aws-sdk/util-user-agent-node": "npm:3.410.0"
-    "@smithy/config-resolver": "npm:^2.0.7"
-    "@smithy/fetch-http-handler": "npm:^2.1.2"
-    "@smithy/hash-node": "npm:^2.0.6"
-    "@smithy/invalid-dependency": "npm:^2.0.6"
-    "@smithy/middleware-content-length": "npm:^2.0.8"
-    "@smithy/middleware-endpoint": "npm:^2.0.6"
-    "@smithy/middleware-retry": "npm:^2.0.9"
-    "@smithy/middleware-serde": "npm:^2.0.6"
-    "@smithy/middleware-stack": "npm:^2.0.0"
-    "@smithy/node-config-provider": "npm:^2.0.9"
-    "@smithy/node-http-handler": "npm:^2.1.2"
-    "@smithy/protocol-http": "npm:^3.0.2"
-    "@smithy/smithy-client": "npm:^2.1.3"
-    "@smithy/types": "npm:^2.3.0"
-    "@smithy/url-parser": "npm:^2.0.6"
-    "@smithy/util-base64": "npm:^2.0.0"
-    "@smithy/util-body-length-browser": "npm:^2.0.0"
-    "@smithy/util-body-length-node": "npm:^2.1.0"
-    "@smithy/util-defaults-mode-browser": "npm:^2.0.7"
-    "@smithy/util-defaults-mode-node": "npm:^2.0.9"
-    "@smithy/util-retry": "npm:^2.0.0"
-    "@smithy/util-utf8": "npm:^2.0.0"
-    tslib: "npm:^2.5.0"
-  checksum: 10/176d7700dd22045821bbdea84c5accd7567f3557d4a30d1b80580121cbb2ad6309fd86bf021917f6eabfaa54a103d00299c6154df012fed62842958a41cd53c6
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/client-sso@npm:3.418.0":
-  version: 3.418.0
-  resolution: "@aws-sdk/client-sso@npm:3.418.0"
-  dependencies:
-    "@aws-crypto/sha256-browser": "npm:3.0.0"
-    "@aws-crypto/sha256-js": "npm:3.0.0"
-    "@aws-sdk/middleware-host-header": "npm:3.418.0"
-    "@aws-sdk/middleware-logger": "npm:3.418.0"
-    "@aws-sdk/middleware-recursion-detection": "npm:3.418.0"
-    "@aws-sdk/middleware-user-agent": "npm:3.418.0"
-    "@aws-sdk/region-config-resolver": "npm:3.418.0"
-    "@aws-sdk/types": "npm:3.418.0"
-    "@aws-sdk/util-endpoints": "npm:3.418.0"
-    "@aws-sdk/util-user-agent-browser": "npm:3.418.0"
-    "@aws-sdk/util-user-agent-node": "npm:3.418.0"
-    "@smithy/config-resolver": "npm:^2.0.10"
-    "@smithy/fetch-http-handler": "npm:^2.1.5"
-    "@smithy/hash-node": "npm:^2.0.9"
-    "@smithy/invalid-dependency": "npm:^2.0.9"
-    "@smithy/middleware-content-length": "npm:^2.0.11"
-    "@smithy/middleware-endpoint": "npm:^2.0.9"
-    "@smithy/middleware-retry": "npm:^2.0.12"
-    "@smithy/middleware-serde": "npm:^2.0.9"
-    "@smithy/middleware-stack": "npm:^2.0.2"
-    "@smithy/node-config-provider": "npm:^2.0.12"
-    "@smithy/node-http-handler": "npm:^2.1.5"
-    "@smithy/protocol-http": "npm:^3.0.5"
-    "@smithy/smithy-client": "npm:^2.1.6"
-    "@smithy/types": "npm:^2.3.3"
-    "@smithy/url-parser": "npm:^2.0.9"
-    "@smithy/util-base64": "npm:^2.0.0"
-    "@smithy/util-body-length-browser": "npm:^2.0.0"
-    "@smithy/util-body-length-node": "npm:^2.1.0"
-    "@smithy/util-defaults-mode-browser": "npm:^2.0.10"
-    "@smithy/util-defaults-mode-node": "npm:^2.0.12"
-    "@smithy/util-retry": "npm:^2.0.2"
-    "@smithy/util-utf8": "npm:^2.0.0"
-    tslib: "npm:^2.5.0"
-  checksum: 10/14a046232c46f42818bb9122c64e7dad9457e9aef3ef8180dac27b844b3fec763ea706dca4126f1e4294244fa5c1069c79dfe728eabf3a34cf122689f2b5566f
+    "@aws-sdk/core": "npm:3.575.0"
+    "@aws-sdk/middleware-host-header": "npm:3.575.0"
+    "@aws-sdk/middleware-logger": "npm:3.575.0"
+    "@aws-sdk/middleware-recursion-detection": "npm:3.575.0"
+    "@aws-sdk/middleware-user-agent": "npm:3.575.0"
+    "@aws-sdk/region-config-resolver": "npm:3.575.0"
+    "@aws-sdk/types": "npm:3.575.0"
+    "@aws-sdk/util-endpoints": "npm:3.575.0"
+    "@aws-sdk/util-user-agent-browser": "npm:3.575.0"
+    "@aws-sdk/util-user-agent-node": "npm:3.575.0"
+    "@smithy/config-resolver": "npm:^3.0.0"
+    "@smithy/core": "npm:^2.0.0"
+    "@smithy/fetch-http-handler": "npm:^3.0.0"
+    "@smithy/hash-node": "npm:^3.0.0"
+    "@smithy/invalid-dependency": "npm:^3.0.0"
+    "@smithy/middleware-content-length": "npm:^3.0.0"
+    "@smithy/middleware-endpoint": "npm:^3.0.0"
+    "@smithy/middleware-retry": "npm:^3.0.0"
+    "@smithy/middleware-serde": "npm:^3.0.0"
+    "@smithy/middleware-stack": "npm:^3.0.0"
+    "@smithy/node-config-provider": "npm:^3.0.0"
+    "@smithy/node-http-handler": "npm:^3.0.0"
+    "@smithy/protocol-http": "npm:^4.0.0"
+    "@smithy/smithy-client": "npm:^3.0.0"
+    "@smithy/types": "npm:^3.0.0"
+    "@smithy/url-parser": "npm:^3.0.0"
+    "@smithy/util-base64": "npm:^3.0.0"
+    "@smithy/util-body-length-browser": "npm:^3.0.0"
+    "@smithy/util-body-length-node": "npm:^3.0.0"
+    "@smithy/util-defaults-mode-browser": "npm:^3.0.0"
+    "@smithy/util-defaults-mode-node": "npm:^3.0.0"
+    "@smithy/util-endpoints": "npm:^2.0.0"
+    "@smithy/util-middleware": "npm:^3.0.0"
+    "@smithy/util-retry": "npm:^3.0.0"
+    "@smithy/util-utf8": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/38957b3cacb9e7687595c5f76f3888ecbf3e97c669471ee015fa601b8743fe2e52e36ebe6fe8168b021e0fee3e70d3c07642f106ded5bc0c548e80e286616c70
   languageName: node
   linkType: hard
 
@@ -894,94 +846,51 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/client-sts@npm:3.410.0":
-  version: 3.410.0
-  resolution: "@aws-sdk/client-sts@npm:3.410.0"
+"@aws-sdk/client-sts@npm:3.575.0":
+  version: 3.575.0
+  resolution: "@aws-sdk/client-sts@npm:3.575.0"
   dependencies:
     "@aws-crypto/sha256-browser": "npm:3.0.0"
     "@aws-crypto/sha256-js": "npm:3.0.0"
-    "@aws-sdk/credential-provider-node": "npm:3.410.0"
-    "@aws-sdk/middleware-host-header": "npm:3.410.0"
-    "@aws-sdk/middleware-logger": "npm:3.410.0"
-    "@aws-sdk/middleware-recursion-detection": "npm:3.410.0"
-    "@aws-sdk/middleware-sdk-sts": "npm:3.410.0"
-    "@aws-sdk/middleware-signing": "npm:3.410.0"
-    "@aws-sdk/middleware-user-agent": "npm:3.410.0"
-    "@aws-sdk/types": "npm:3.410.0"
-    "@aws-sdk/util-endpoints": "npm:3.410.0"
-    "@aws-sdk/util-user-agent-browser": "npm:3.410.0"
-    "@aws-sdk/util-user-agent-node": "npm:3.410.0"
-    "@smithy/config-resolver": "npm:^2.0.7"
-    "@smithy/fetch-http-handler": "npm:^2.1.2"
-    "@smithy/hash-node": "npm:^2.0.6"
-    "@smithy/invalid-dependency": "npm:^2.0.6"
-    "@smithy/middleware-content-length": "npm:^2.0.8"
-    "@smithy/middleware-endpoint": "npm:^2.0.6"
-    "@smithy/middleware-retry": "npm:^2.0.9"
-    "@smithy/middleware-serde": "npm:^2.0.6"
-    "@smithy/middleware-stack": "npm:^2.0.0"
-    "@smithy/node-config-provider": "npm:^2.0.9"
-    "@smithy/node-http-handler": "npm:^2.1.2"
-    "@smithy/protocol-http": "npm:^3.0.2"
-    "@smithy/smithy-client": "npm:^2.1.3"
-    "@smithy/types": "npm:^2.3.0"
-    "@smithy/url-parser": "npm:^2.0.6"
-    "@smithy/util-base64": "npm:^2.0.0"
-    "@smithy/util-body-length-browser": "npm:^2.0.0"
-    "@smithy/util-body-length-node": "npm:^2.1.0"
-    "@smithy/util-defaults-mode-browser": "npm:^2.0.7"
-    "@smithy/util-defaults-mode-node": "npm:^2.0.9"
-    "@smithy/util-retry": "npm:^2.0.0"
-    "@smithy/util-utf8": "npm:^2.0.0"
-    fast-xml-parser: "npm:4.2.5"
-    tslib: "npm:^2.5.0"
-  checksum: 10/b82d6a6a14fc8c346223e6b14d094838210f05d12465b07c2de6fa260d57282c030368ee1e828db2eee5c0a9c3e043cf8674550709534a5b91a020028b7fdb37
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/client-sts@npm:3.418.0":
-  version: 3.418.0
-  resolution: "@aws-sdk/client-sts@npm:3.418.0"
-  dependencies:
-    "@aws-crypto/sha256-browser": "npm:3.0.0"
-    "@aws-crypto/sha256-js": "npm:3.0.0"
-    "@aws-sdk/credential-provider-node": "npm:3.418.0"
-    "@aws-sdk/middleware-host-header": "npm:3.418.0"
-    "@aws-sdk/middleware-logger": "npm:3.418.0"
-    "@aws-sdk/middleware-recursion-detection": "npm:3.418.0"
-    "@aws-sdk/middleware-sdk-sts": "npm:3.418.0"
-    "@aws-sdk/middleware-signing": "npm:3.418.0"
-    "@aws-sdk/middleware-user-agent": "npm:3.418.0"
-    "@aws-sdk/region-config-resolver": "npm:3.418.0"
-    "@aws-sdk/types": "npm:3.418.0"
-    "@aws-sdk/util-endpoints": "npm:3.418.0"
-    "@aws-sdk/util-user-agent-browser": "npm:3.418.0"
-    "@aws-sdk/util-user-agent-node": "npm:3.418.0"
-    "@smithy/config-resolver": "npm:^2.0.10"
-    "@smithy/fetch-http-handler": "npm:^2.1.5"
-    "@smithy/hash-node": "npm:^2.0.9"
-    "@smithy/invalid-dependency": "npm:^2.0.9"
-    "@smithy/middleware-content-length": "npm:^2.0.11"
-    "@smithy/middleware-endpoint": "npm:^2.0.9"
-    "@smithy/middleware-retry": "npm:^2.0.12"
-    "@smithy/middleware-serde": "npm:^2.0.9"
-    "@smithy/middleware-stack": "npm:^2.0.2"
-    "@smithy/node-config-provider": "npm:^2.0.12"
-    "@smithy/node-http-handler": "npm:^2.1.5"
-    "@smithy/protocol-http": "npm:^3.0.5"
-    "@smithy/smithy-client": "npm:^2.1.6"
-    "@smithy/types": "npm:^2.3.3"
-    "@smithy/url-parser": "npm:^2.0.9"
-    "@smithy/util-base64": "npm:^2.0.0"
-    "@smithy/util-body-length-browser": "npm:^2.0.0"
-    "@smithy/util-body-length-node": "npm:^2.1.0"
-    "@smithy/util-defaults-mode-browser": "npm:^2.0.10"
-    "@smithy/util-defaults-mode-node": "npm:^2.0.12"
-    "@smithy/util-retry": "npm:^2.0.2"
-    "@smithy/util-utf8": "npm:^2.0.0"
-    fast-xml-parser: "npm:4.2.5"
-    tslib: "npm:^2.5.0"
-  checksum: 10/87841ff5a85779fbf74599e523acca0745fe03544d310cf882619901530a4670760a8b27be428ab3c86f647757fc954a41c1c8632f7b70d5216fdf92704ee105
+    "@aws-sdk/client-sso-oidc": "npm:3.575.0"
+    "@aws-sdk/core": "npm:3.575.0"
+    "@aws-sdk/credential-provider-node": "npm:3.575.0"
+    "@aws-sdk/middleware-host-header": "npm:3.575.0"
+    "@aws-sdk/middleware-logger": "npm:3.575.0"
+    "@aws-sdk/middleware-recursion-detection": "npm:3.575.0"
+    "@aws-sdk/middleware-user-agent": "npm:3.575.0"
+    "@aws-sdk/region-config-resolver": "npm:3.575.0"
+    "@aws-sdk/types": "npm:3.575.0"
+    "@aws-sdk/util-endpoints": "npm:3.575.0"
+    "@aws-sdk/util-user-agent-browser": "npm:3.575.0"
+    "@aws-sdk/util-user-agent-node": "npm:3.575.0"
+    "@smithy/config-resolver": "npm:^3.0.0"
+    "@smithy/core": "npm:^2.0.0"
+    "@smithy/fetch-http-handler": "npm:^3.0.0"
+    "@smithy/hash-node": "npm:^3.0.0"
+    "@smithy/invalid-dependency": "npm:^3.0.0"
+    "@smithy/middleware-content-length": "npm:^3.0.0"
+    "@smithy/middleware-endpoint": "npm:^3.0.0"
+    "@smithy/middleware-retry": "npm:^3.0.0"
+    "@smithy/middleware-serde": "npm:^3.0.0"
+    "@smithy/middleware-stack": "npm:^3.0.0"
+    "@smithy/node-config-provider": "npm:^3.0.0"
+    "@smithy/node-http-handler": "npm:^3.0.0"
+    "@smithy/protocol-http": "npm:^4.0.0"
+    "@smithy/smithy-client": "npm:^3.0.0"
+    "@smithy/types": "npm:^3.0.0"
+    "@smithy/url-parser": "npm:^3.0.0"
+    "@smithy/util-base64": "npm:^3.0.0"
+    "@smithy/util-body-length-browser": "npm:^3.0.0"
+    "@smithy/util-body-length-node": "npm:^3.0.0"
+    "@smithy/util-defaults-mode-browser": "npm:^3.0.0"
+    "@smithy/util-defaults-mode-node": "npm:^3.0.0"
+    "@smithy/util-endpoints": "npm:^2.0.0"
+    "@smithy/util-middleware": "npm:^3.0.0"
+    "@smithy/util-retry": "npm:^3.0.0"
+    "@smithy/util-utf8": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/d37e4ac232b4a32241f8528a726baf04991304e7bb33093ffaef93d7567f1198f1a456068a9c4e535227bff9e5eb14930a41349d092f384c0ac658f9164a80e6
   languageName: node
   linkType: hard
 
@@ -995,6 +904,21 @@ __metadata:
     "@aws-sdk/util-middleware": "npm:3.212.0"
     tslib: "npm:^2.3.1"
   checksum: 10/69e4a00ab993d8cce9c541b20fd6e278fd42de91ed21bb10cf894ca8fadaa26c518276035e6b15ec64ed06570450dd897231380e76c19d476ef002aa2ba8a499
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/core@npm:3.575.0":
+  version: 3.575.0
+  resolution: "@aws-sdk/core@npm:3.575.0"
+  dependencies:
+    "@smithy/core": "npm:^2.0.0"
+    "@smithy/protocol-http": "npm:^4.0.0"
+    "@smithy/signature-v4": "npm:^3.0.0"
+    "@smithy/smithy-client": "npm:^3.0.0"
+    "@smithy/types": "npm:^3.0.0"
+    fast-xml-parser: "npm:4.2.5"
+    tslib: "npm:^2.6.2"
+  checksum: 10/9458760ba73df3ee4d135068869eb8859e91f3492354f9a2e03ce5829fdf65355f8be719effd2fc09f7bfdb3b6b242cfcd4a316dea1ad047b9cdf464c695b73a
   languageName: node
   linkType: hard
 
@@ -1021,27 +945,32 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-env@npm:3.410.0":
-  version: 3.410.0
-  resolution: "@aws-sdk/credential-provider-env@npm:3.410.0"
+"@aws-sdk/credential-provider-env@npm:3.575.0":
+  version: 3.575.0
+  resolution: "@aws-sdk/credential-provider-env@npm:3.575.0"
   dependencies:
-    "@aws-sdk/types": "npm:3.410.0"
-    "@smithy/property-provider": "npm:^2.0.0"
-    "@smithy/types": "npm:^2.3.0"
-    tslib: "npm:^2.5.0"
-  checksum: 10/3ce240be3e305d2ca92a28edceb2dc4457a69f4b98511a441d83b1380bafb69de99d81821841f3b8a332b28c061bf63e392f45ddee1c6722a02093cd506b8826
+    "@aws-sdk/types": "npm:3.575.0"
+    "@smithy/property-provider": "npm:^3.0.0"
+    "@smithy/types": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/9301c3dc80a50db85e697c13c05945f78ac4ce92189d8ddb157b84b456395e1146b46b6c06cfdc334e7231bb86de9fa4aced95ce83950a9fa76c663d80fc2d81
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-env@npm:3.418.0":
-  version: 3.418.0
-  resolution: "@aws-sdk/credential-provider-env@npm:3.418.0"
+"@aws-sdk/credential-provider-http@npm:3.575.0":
+  version: 3.575.0
+  resolution: "@aws-sdk/credential-provider-http@npm:3.575.0"
   dependencies:
-    "@aws-sdk/types": "npm:3.418.0"
-    "@smithy/property-provider": "npm:^2.0.0"
-    "@smithy/types": "npm:^2.3.3"
-    tslib: "npm:^2.5.0"
-  checksum: 10/84e0a2395d8d551f2c3bf2e79db8fa75f019ddd27af9de6b99e5e705e46b37a3f27542957910c097adc55727d4419ee0c8f0a92324e37a0a6417f996080f8529
+    "@aws-sdk/types": "npm:3.575.0"
+    "@smithy/fetch-http-handler": "npm:^3.0.0"
+    "@smithy/node-http-handler": "npm:^3.0.0"
+    "@smithy/property-provider": "npm:^3.0.0"
+    "@smithy/protocol-http": "npm:^4.0.0"
+    "@smithy/smithy-client": "npm:^3.0.0"
+    "@smithy/types": "npm:^3.0.0"
+    "@smithy/util-stream": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/fec90a520cf73049df60533170547c2725f39b8d96515e7b98a62bd174e725d9ef05153791c5851d65aa53d509b224470a8db26ddcd4eb2e0c80dc99fba82235
   languageName: node
   linkType: hard
 
@@ -1074,39 +1003,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-ini@npm:3.410.0":
-  version: 3.410.0
-  resolution: "@aws-sdk/credential-provider-ini@npm:3.410.0"
+"@aws-sdk/credential-provider-ini@npm:3.575.0":
+  version: 3.575.0
+  resolution: "@aws-sdk/credential-provider-ini@npm:3.575.0"
   dependencies:
-    "@aws-sdk/credential-provider-env": "npm:3.410.0"
-    "@aws-sdk/credential-provider-process": "npm:3.410.0"
-    "@aws-sdk/credential-provider-sso": "npm:3.410.0"
-    "@aws-sdk/credential-provider-web-identity": "npm:3.410.0"
-    "@aws-sdk/types": "npm:3.410.0"
-    "@smithy/credential-provider-imds": "npm:^2.0.0"
-    "@smithy/property-provider": "npm:^2.0.0"
-    "@smithy/shared-ini-file-loader": "npm:^2.0.6"
-    "@smithy/types": "npm:^2.3.0"
-    tslib: "npm:^2.5.0"
-  checksum: 10/0f02c6ddc49ce9d572243b20c6d762de996c9683916aea53d597373833bea7d65f63e94087deb7c2bcc22d787248f13125887ffa8832850cf1c53a3cc91fbfac
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/credential-provider-ini@npm:3.418.0":
-  version: 3.418.0
-  resolution: "@aws-sdk/credential-provider-ini@npm:3.418.0"
-  dependencies:
-    "@aws-sdk/credential-provider-env": "npm:3.418.0"
-    "@aws-sdk/credential-provider-process": "npm:3.418.0"
-    "@aws-sdk/credential-provider-sso": "npm:3.418.0"
-    "@aws-sdk/credential-provider-web-identity": "npm:3.418.0"
-    "@aws-sdk/types": "npm:3.418.0"
-    "@smithy/credential-provider-imds": "npm:^2.0.0"
-    "@smithy/property-provider": "npm:^2.0.0"
-    "@smithy/shared-ini-file-loader": "npm:^2.0.6"
-    "@smithy/types": "npm:^2.3.3"
-    tslib: "npm:^2.5.0"
-  checksum: 10/9fd7070a9958e547a444f7f30338b790beba51dff1970fda61ebc8228828c21d7d8ea7cb7ee56e10f67b0bd47fb3712bddd555abcadc3f6f4dabe6769d29d585
+    "@aws-sdk/credential-provider-env": "npm:3.575.0"
+    "@aws-sdk/credential-provider-process": "npm:3.575.0"
+    "@aws-sdk/credential-provider-sso": "npm:3.575.0"
+    "@aws-sdk/credential-provider-web-identity": "npm:3.575.0"
+    "@aws-sdk/types": "npm:3.575.0"
+    "@smithy/credential-provider-imds": "npm:^3.0.0"
+    "@smithy/property-provider": "npm:^3.0.0"
+    "@smithy/shared-ini-file-loader": "npm:^3.0.0"
+    "@smithy/types": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  peerDependencies:
+    "@aws-sdk/client-sts": 3.575.0
+  checksum: 10/d86df0977a8198570a682d1416e796912e3784002651b4433fd77385946979945e7810d45bc36b76a33f5cbd8600ee25d12d353d79cad0fcd8f4107111975e58
   languageName: node
   linkType: hard
 
@@ -1128,41 +1041,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-node@npm:3.410.0":
-  version: 3.410.0
-  resolution: "@aws-sdk/credential-provider-node@npm:3.410.0"
+"@aws-sdk/credential-provider-node@npm:3.575.0":
+  version: 3.575.0
+  resolution: "@aws-sdk/credential-provider-node@npm:3.575.0"
   dependencies:
-    "@aws-sdk/credential-provider-env": "npm:3.410.0"
-    "@aws-sdk/credential-provider-ini": "npm:3.410.0"
-    "@aws-sdk/credential-provider-process": "npm:3.410.0"
-    "@aws-sdk/credential-provider-sso": "npm:3.410.0"
-    "@aws-sdk/credential-provider-web-identity": "npm:3.410.0"
-    "@aws-sdk/types": "npm:3.410.0"
-    "@smithy/credential-provider-imds": "npm:^2.0.0"
-    "@smithy/property-provider": "npm:^2.0.0"
-    "@smithy/shared-ini-file-loader": "npm:^2.0.6"
-    "@smithy/types": "npm:^2.3.0"
-    tslib: "npm:^2.5.0"
-  checksum: 10/5a11d53533f05929e353adeb9146549ea19b2d2b7900dc3b703c4dda35d5490feff9b3457561bb61cddc1be88e09380dc4071c303569c9ec6ee542d056d55796
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/credential-provider-node@npm:3.418.0":
-  version: 3.418.0
-  resolution: "@aws-sdk/credential-provider-node@npm:3.418.0"
-  dependencies:
-    "@aws-sdk/credential-provider-env": "npm:3.418.0"
-    "@aws-sdk/credential-provider-ini": "npm:3.418.0"
-    "@aws-sdk/credential-provider-process": "npm:3.418.0"
-    "@aws-sdk/credential-provider-sso": "npm:3.418.0"
-    "@aws-sdk/credential-provider-web-identity": "npm:3.418.0"
-    "@aws-sdk/types": "npm:3.418.0"
-    "@smithy/credential-provider-imds": "npm:^2.0.0"
-    "@smithy/property-provider": "npm:^2.0.0"
-    "@smithy/shared-ini-file-loader": "npm:^2.0.6"
-    "@smithy/types": "npm:^2.3.3"
-    tslib: "npm:^2.5.0"
-  checksum: 10/1efbd7b58043657b5c6f7a2e34945eaa8da49c7f0051abd1d0103aaae54af21a2021474957170122b693a7616009caba8bc9a1d4d5e1e35174a124c851563d10
+    "@aws-sdk/credential-provider-env": "npm:3.575.0"
+    "@aws-sdk/credential-provider-http": "npm:3.575.0"
+    "@aws-sdk/credential-provider-ini": "npm:3.575.0"
+    "@aws-sdk/credential-provider-process": "npm:3.575.0"
+    "@aws-sdk/credential-provider-sso": "npm:3.575.0"
+    "@aws-sdk/credential-provider-web-identity": "npm:3.575.0"
+    "@aws-sdk/types": "npm:3.575.0"
+    "@smithy/credential-provider-imds": "npm:^3.0.0"
+    "@smithy/property-provider": "npm:^3.0.0"
+    "@smithy/shared-ini-file-loader": "npm:^3.0.0"
+    "@smithy/types": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/91f06aff0d3f24c006cc38dd642feecf8c776b8fa75a31aa8164dc5c17048200d9fc650417d9b84ad625dc4586f2f8f182a7766e0ba8a44d24b2f798fa06579b
   languageName: node
   linkType: hard
 
@@ -1178,29 +1073,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-process@npm:3.410.0":
-  version: 3.410.0
-  resolution: "@aws-sdk/credential-provider-process@npm:3.410.0"
+"@aws-sdk/credential-provider-process@npm:3.575.0":
+  version: 3.575.0
+  resolution: "@aws-sdk/credential-provider-process@npm:3.575.0"
   dependencies:
-    "@aws-sdk/types": "npm:3.410.0"
-    "@smithy/property-provider": "npm:^2.0.0"
-    "@smithy/shared-ini-file-loader": "npm:^2.0.6"
-    "@smithy/types": "npm:^2.3.0"
-    tslib: "npm:^2.5.0"
-  checksum: 10/ba3759f43fc45a22f618c92e3cbf18d07a42f899d179b504fd692e9a97fa0388e23372b552f737051f6acebd8ead618f6e332d70dd7336fc4049bc8d873fb4d4
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/credential-provider-process@npm:3.418.0":
-  version: 3.418.0
-  resolution: "@aws-sdk/credential-provider-process@npm:3.418.0"
-  dependencies:
-    "@aws-sdk/types": "npm:3.418.0"
-    "@smithy/property-provider": "npm:^2.0.0"
-    "@smithy/shared-ini-file-loader": "npm:^2.0.6"
-    "@smithy/types": "npm:^2.3.3"
-    tslib: "npm:^2.5.0"
-  checksum: 10/d9aa1d88650072f5ef6501acf3fc4505f10747084f8d47db6976dd243b4ac9c8b67423dc012b0528006a064e2e824ff9995a6dd7485b6d2c683f27cc14b6a194
+    "@aws-sdk/types": "npm:3.575.0"
+    "@smithy/property-provider": "npm:^3.0.0"
+    "@smithy/shared-ini-file-loader": "npm:^3.0.0"
+    "@smithy/types": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/a32fcc6f820399c8b02247a149f4da097e0abab4d06dde7b2b6ed394460e1e73cfa0033ed295473d5001b6e550057cb1f16e966537f927fe8d1dbc5ef0a48725
   languageName: node
   linkType: hard
 
@@ -1218,33 +1100,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-sso@npm:3.410.0":
-  version: 3.410.0
-  resolution: "@aws-sdk/credential-provider-sso@npm:3.410.0"
+"@aws-sdk/credential-provider-sso@npm:3.575.0":
+  version: 3.575.0
+  resolution: "@aws-sdk/credential-provider-sso@npm:3.575.0"
   dependencies:
-    "@aws-sdk/client-sso": "npm:3.410.0"
-    "@aws-sdk/token-providers": "npm:3.410.0"
-    "@aws-sdk/types": "npm:3.410.0"
-    "@smithy/property-provider": "npm:^2.0.0"
-    "@smithy/shared-ini-file-loader": "npm:^2.0.6"
-    "@smithy/types": "npm:^2.3.0"
-    tslib: "npm:^2.5.0"
-  checksum: 10/450fc30e648f7f879ccbbf369370b7c332e34c48defd71b8e10462ef2d1b48d978292e225cdb13cfde2bdc43c0ec95227b70e5f9cb24ac74e6088d417134f9c0
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/credential-provider-sso@npm:3.418.0":
-  version: 3.418.0
-  resolution: "@aws-sdk/credential-provider-sso@npm:3.418.0"
-  dependencies:
-    "@aws-sdk/client-sso": "npm:3.418.0"
-    "@aws-sdk/token-providers": "npm:3.418.0"
-    "@aws-sdk/types": "npm:3.418.0"
-    "@smithy/property-provider": "npm:^2.0.0"
-    "@smithy/shared-ini-file-loader": "npm:^2.0.6"
-    "@smithy/types": "npm:^2.3.3"
-    tslib: "npm:^2.5.0"
-  checksum: 10/030e2208a94a01dbc4fa27c77ebdcb1bae72406170155abd9f80dd6f49a216fb42879f1e47db0a7c93ac4aa3bca99e60a5c277cab4dfee6d15bd2a122f838100
+    "@aws-sdk/client-sso": "npm:3.575.0"
+    "@aws-sdk/token-providers": "npm:3.575.0"
+    "@aws-sdk/types": "npm:3.575.0"
+    "@smithy/property-provider": "npm:^3.0.0"
+    "@smithy/shared-ini-file-loader": "npm:^3.0.0"
+    "@smithy/types": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/e9197693fca6732c3b0644e4aa5a88b6c1dbe14af0ca3cce3322025c45042d308b54055b5397dae8a1534aa362df6868e6b49edb8576daa5adf81c1a18766cf1
   languageName: node
   linkType: hard
 
@@ -1259,27 +1126,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-web-identity@npm:3.410.0":
-  version: 3.410.0
-  resolution: "@aws-sdk/credential-provider-web-identity@npm:3.410.0"
+"@aws-sdk/credential-provider-web-identity@npm:3.575.0":
+  version: 3.575.0
+  resolution: "@aws-sdk/credential-provider-web-identity@npm:3.575.0"
   dependencies:
-    "@aws-sdk/types": "npm:3.410.0"
-    "@smithy/property-provider": "npm:^2.0.0"
-    "@smithy/types": "npm:^2.3.0"
-    tslib: "npm:^2.5.0"
-  checksum: 10/6df9fc1eb5e43652a4cdcddaf6ad4954eb73b7246aad3d59b1e7b9d43c494a16eaf380fa9cb5876dcfce78fdb3bc08b1fb7e300dcb3b2e835bc3db56c3d7003f
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/credential-provider-web-identity@npm:3.418.0":
-  version: 3.418.0
-  resolution: "@aws-sdk/credential-provider-web-identity@npm:3.418.0"
-  dependencies:
-    "@aws-sdk/types": "npm:3.418.0"
-    "@smithy/property-provider": "npm:^2.0.0"
-    "@smithy/types": "npm:^2.3.3"
-    tslib: "npm:^2.5.0"
-  checksum: 10/cc53d6c2dab188d8d378282aa60a7e2f97bfb8b9913d06770339ac9bf449ce524895b577ba225ba61f97cb789b81ebaa2d6f1c507a43c5436a1bf1e9c9b5cfe9
+    "@aws-sdk/types": "npm:3.575.0"
+    "@smithy/property-provider": "npm:^3.0.0"
+    "@smithy/types": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  peerDependencies:
+    "@aws-sdk/client-sts": 3.575.0
+  checksum: 10/05088f325d67388d06d7f43f0a69bf3acd71868065c56bbccbbe754455f57b3b1b0d16f943c74e4bc6d37ab88aa5af944dc553fa4ad4e95a56e49eaf235099cd
   languageName: node
   linkType: hard
 
@@ -1349,33 +1206,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-bucket-endpoint@npm:3.410.0":
-  version: 3.410.0
-  resolution: "@aws-sdk/middleware-bucket-endpoint@npm:3.410.0"
+"@aws-sdk/middleware-bucket-endpoint@npm:3.575.0":
+  version: 3.575.0
+  resolution: "@aws-sdk/middleware-bucket-endpoint@npm:3.575.0"
   dependencies:
-    "@aws-sdk/types": "npm:3.410.0"
-    "@aws-sdk/util-arn-parser": "npm:3.310.0"
-    "@smithy/node-config-provider": "npm:^2.0.9"
-    "@smithy/protocol-http": "npm:^3.0.2"
-    "@smithy/types": "npm:^2.3.0"
-    "@smithy/util-config-provider": "npm:^2.0.0"
-    tslib: "npm:^2.5.0"
-  checksum: 10/8f04fc1f64f1f1f60109e194c0f2cfeb02b1a880ae44f497ca88f0871ccebddae3f8882a8c836d903be47f7c932abe9af13f2f29225abd42aada929e6a19c773
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/middleware-bucket-endpoint@npm:3.418.0":
-  version: 3.418.0
-  resolution: "@aws-sdk/middleware-bucket-endpoint@npm:3.418.0"
-  dependencies:
-    "@aws-sdk/types": "npm:3.418.0"
-    "@aws-sdk/util-arn-parser": "npm:3.310.0"
-    "@smithy/node-config-provider": "npm:^2.0.12"
-    "@smithy/protocol-http": "npm:^3.0.5"
-    "@smithy/types": "npm:^2.3.3"
-    "@smithy/util-config-provider": "npm:^2.0.0"
-    tslib: "npm:^2.5.0"
-  checksum: 10/be70a317ba7a1198845657ef9a14f6860dc83a6e86faa4647b615b3ca788b3f09cf10a600cf42bdf7b913d4597b9ed72aca58fc29a3f81b3edc9fd169ab4fee6
+    "@aws-sdk/types": "npm:3.575.0"
+    "@aws-sdk/util-arn-parser": "npm:3.568.0"
+    "@smithy/node-config-provider": "npm:^3.0.0"
+    "@smithy/protocol-http": "npm:^4.0.0"
+    "@smithy/types": "npm:^3.0.0"
+    "@smithy/util-config-provider": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/8e41eba73b3ede72da3a132132828c2dabaaff726523cc1da31904e84bf526aa68bedbf8e72bfb5a934ad6db455886223cb47bfc4af38ab3a17b4408bc9bc258
   languageName: node
   linkType: hard
 
@@ -1406,59 +1248,31 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-expect-continue@npm:3.410.0":
-  version: 3.410.0
-  resolution: "@aws-sdk/middleware-expect-continue@npm:3.410.0"
+"@aws-sdk/middleware-expect-continue@npm:3.575.0":
+  version: 3.575.0
+  resolution: "@aws-sdk/middleware-expect-continue@npm:3.575.0"
   dependencies:
-    "@aws-sdk/types": "npm:3.410.0"
-    "@smithy/protocol-http": "npm:^3.0.2"
-    "@smithy/types": "npm:^2.3.0"
-    tslib: "npm:^2.5.0"
-  checksum: 10/b4facc2588f63d603cf4b942b8621d48f1eb3044d98bfa54292226d84e41cb425590b6ab3ae91499cf1d212fd5aa32d8941ed1e1790a53fe1fd56ccdf6d9f42b
+    "@aws-sdk/types": "npm:3.575.0"
+    "@smithy/protocol-http": "npm:^4.0.0"
+    "@smithy/types": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/8836b2c9c83cb1d839d4b58c32904f9194c78fba0e27f4c82d991bffea1b64124238413a28aaf15bb26ba9aa741bdc9d2250023581817e6a4efb53d351166891
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-expect-continue@npm:3.418.0":
-  version: 3.418.0
-  resolution: "@aws-sdk/middleware-expect-continue@npm:3.418.0"
-  dependencies:
-    "@aws-sdk/types": "npm:3.418.0"
-    "@smithy/protocol-http": "npm:^3.0.5"
-    "@smithy/types": "npm:^2.3.3"
-    tslib: "npm:^2.5.0"
-  checksum: 10/0d0cc77de86f304dc9e36d3488d76b86fa16f1919d7447d7a2dd2825e217a83f3e440ce53fe2718064e2ff8e9f72de751c5bc9e500567c1b45b902270f2c5cc2
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/middleware-flexible-checksums@npm:3.410.0":
-  version: 3.410.0
-  resolution: "@aws-sdk/middleware-flexible-checksums@npm:3.410.0"
+"@aws-sdk/middleware-flexible-checksums@npm:3.575.0":
+  version: 3.575.0
+  resolution: "@aws-sdk/middleware-flexible-checksums@npm:3.575.0"
   dependencies:
     "@aws-crypto/crc32": "npm:3.0.0"
     "@aws-crypto/crc32c": "npm:3.0.0"
-    "@aws-sdk/types": "npm:3.410.0"
-    "@smithy/is-array-buffer": "npm:^2.0.0"
-    "@smithy/protocol-http": "npm:^3.0.2"
-    "@smithy/types": "npm:^2.3.0"
-    "@smithy/util-utf8": "npm:^2.0.0"
-    tslib: "npm:^2.5.0"
-  checksum: 10/e95c67dc48742b7f3c670514c70eb658889abd16aa808dc48a5fe97b0abaa3c3914be98873c2f415b7d679f6ab592fec6a7482831b9a22e0468b30b2d46227e1
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/middleware-flexible-checksums@npm:3.418.0":
-  version: 3.418.0
-  resolution: "@aws-sdk/middleware-flexible-checksums@npm:3.418.0"
-  dependencies:
-    "@aws-crypto/crc32": "npm:3.0.0"
-    "@aws-crypto/crc32c": "npm:3.0.0"
-    "@aws-sdk/types": "npm:3.418.0"
-    "@smithy/is-array-buffer": "npm:^2.0.0"
-    "@smithy/protocol-http": "npm:^3.0.5"
-    "@smithy/types": "npm:^2.3.3"
-    "@smithy/util-utf8": "npm:^2.0.0"
-    tslib: "npm:^2.5.0"
-  checksum: 10/ab1c6675a6231e36b43cf3eec9efdee0697a0e91ad283eb85ca18a63fe39db19bd740e99586418fe8f75328ef73f925c3a4f37dff916fb9e0c062e1159818765
+    "@aws-sdk/types": "npm:3.575.0"
+    "@smithy/is-array-buffer": "npm:^3.0.0"
+    "@smithy/protocol-http": "npm:^4.0.0"
+    "@smithy/types": "npm:^3.0.0"
+    "@smithy/util-utf8": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/eb30799caaf2fed7687de0838d2779894c1e5db84c2ea806ce1c5d07ffae48ca1800065626e05d35a8063d6e33b8750f6f3ea9702576eb85bbd883cf6ef7d61e
   languageName: node
   linkType: hard
 
@@ -1473,49 +1287,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-host-header@npm:3.410.0":
-  version: 3.410.0
-  resolution: "@aws-sdk/middleware-host-header@npm:3.410.0"
+"@aws-sdk/middleware-host-header@npm:3.575.0":
+  version: 3.575.0
+  resolution: "@aws-sdk/middleware-host-header@npm:3.575.0"
   dependencies:
-    "@aws-sdk/types": "npm:3.410.0"
-    "@smithy/protocol-http": "npm:^3.0.2"
-    "@smithy/types": "npm:^2.3.0"
-    tslib: "npm:^2.5.0"
-  checksum: 10/63ac263f3951175454f195748a2f5069111f8135ef1a66e0e84c387908f2c80c05f6b4349f329104637743923278a9f13196b62b9202c4acb5986aa4e28cdf68
+    "@aws-sdk/types": "npm:3.575.0"
+    "@smithy/protocol-http": "npm:^4.0.0"
+    "@smithy/types": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/8c5478db6b02629b6a6f3273fbb88a16b379c677dff8103a4b856b9d3842d3c4a2ec200726671a4655b201f575b961b398eff76163602046ee41a39cc483510b
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-host-header@npm:3.418.0":
-  version: 3.418.0
-  resolution: "@aws-sdk/middleware-host-header@npm:3.418.0"
+"@aws-sdk/middleware-location-constraint@npm:3.575.0":
+  version: 3.575.0
+  resolution: "@aws-sdk/middleware-location-constraint@npm:3.575.0"
   dependencies:
-    "@aws-sdk/types": "npm:3.418.0"
-    "@smithy/protocol-http": "npm:^3.0.5"
-    "@smithy/types": "npm:^2.3.3"
-    tslib: "npm:^2.5.0"
-  checksum: 10/5cdfa1d7254362bec676053f143a6b24b152275de855be9e788e91e2cf45b2c6b0628bdd98abc935e67f20e29776d2702698cfde08fdee4a29e4fe539155e8af
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/middleware-location-constraint@npm:3.410.0":
-  version: 3.410.0
-  resolution: "@aws-sdk/middleware-location-constraint@npm:3.410.0"
-  dependencies:
-    "@aws-sdk/types": "npm:3.410.0"
-    "@smithy/types": "npm:^2.3.0"
-    tslib: "npm:^2.5.0"
-  checksum: 10/4735e6598f6eeb1f6f52e7ba11516f81ba2927d9dd223aadff3a469aa67e7eb1d6b47d53d8076bbde66f21222260d0493633ee7c46bdc2e42b58d08f80e236aa
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/middleware-location-constraint@npm:3.418.0":
-  version: 3.418.0
-  resolution: "@aws-sdk/middleware-location-constraint@npm:3.418.0"
-  dependencies:
-    "@aws-sdk/types": "npm:3.418.0"
-    "@smithy/types": "npm:^2.3.3"
-    tslib: "npm:^2.5.0"
-  checksum: 10/8cdd394c5a7df2bcab8b8aca318454fc0c0366fb58cc8a72d0609f9673ff4ce62f60d8146cd46ea9a78f0eccf07f7daf6d6fc0f68a69dde18d346c6e34ace66c
+    "@aws-sdk/types": "npm:3.575.0"
+    "@smithy/types": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/690c3628270317748119f7955dd395e837de18aa8e9960422d8b3faf10aaf51e379719c22391f43dcf1daf52dd53273e9e1b0e4f14ad1a3566c4b8ff68202ff9
   languageName: node
   linkType: hard
 
@@ -1529,25 +1320,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-logger@npm:3.410.0":
-  version: 3.410.0
-  resolution: "@aws-sdk/middleware-logger@npm:3.410.0"
+"@aws-sdk/middleware-logger@npm:3.575.0":
+  version: 3.575.0
+  resolution: "@aws-sdk/middleware-logger@npm:3.575.0"
   dependencies:
-    "@aws-sdk/types": "npm:3.410.0"
-    "@smithy/types": "npm:^2.3.0"
-    tslib: "npm:^2.5.0"
-  checksum: 10/56e30b3a16c9d543308c13296fea9e8f411f70540db38bb06b86755389423631f7c769a399031bc882e3721cb74b3614d16c13832c3c18f447afc8c9eec17c0c
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/middleware-logger@npm:3.418.0":
-  version: 3.418.0
-  resolution: "@aws-sdk/middleware-logger@npm:3.418.0"
-  dependencies:
-    "@aws-sdk/types": "npm:3.418.0"
-    "@smithy/types": "npm:^2.3.3"
-    tslib: "npm:^2.5.0"
-  checksum: 10/5733dc9b960456b677fab926b85857249eed6af1b9358bb3fd8cf22a15250c8285d1a208cef1a79e2ca96798ae53968ab7a7b41139d244d93972131e418a5380
+    "@aws-sdk/types": "npm:3.575.0"
+    "@smithy/types": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/30b6b986d6669afddbbc307649d6cbcb8387c160756ce43e9977b4e2bc083954945bb6e48fdaa7b433b4d022b5e6cc318d2384895c0c9bbb7d5fa586c59201eb
   languageName: node
   linkType: hard
 
@@ -1562,27 +1342,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-recursion-detection@npm:3.410.0":
-  version: 3.410.0
-  resolution: "@aws-sdk/middleware-recursion-detection@npm:3.410.0"
+"@aws-sdk/middleware-recursion-detection@npm:3.575.0":
+  version: 3.575.0
+  resolution: "@aws-sdk/middleware-recursion-detection@npm:3.575.0"
   dependencies:
-    "@aws-sdk/types": "npm:3.410.0"
-    "@smithy/protocol-http": "npm:^3.0.2"
-    "@smithy/types": "npm:^2.3.0"
-    tslib: "npm:^2.5.0"
-  checksum: 10/464c729db23001b639b31dc70d2cbe36b6c56e2633ca2c6e131018f982807dc15f0950056b4d0729633f511e6bd0ce04abf7c0d4ed32bf6dbf84f336161667c4
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/middleware-recursion-detection@npm:3.418.0":
-  version: 3.418.0
-  resolution: "@aws-sdk/middleware-recursion-detection@npm:3.418.0"
-  dependencies:
-    "@aws-sdk/types": "npm:3.418.0"
-    "@smithy/protocol-http": "npm:^3.0.5"
-    "@smithy/types": "npm:^2.3.3"
-    tslib: "npm:^2.5.0"
-  checksum: 10/cb497658121607e84b1cb6732c67d6147406a3e30dc2d1a1b20668fbab75c198c7677eb4e098de93b1cabc7e4d2347cde4b45efb5fcfa4a08e38f52abadfb682
+    "@aws-sdk/types": "npm:3.575.0"
+    "@smithy/protocol-http": "npm:^4.0.0"
+    "@smithy/types": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/a80a3b7aec195866b9a01e06c0e11f2d635943aeedd5a674d699b124cd05832c4ef238cedf9a268cd74a4bb6e74f617dc0478b3e87731521d5db0bf6bd432332
   languageName: node
   linkType: hard
 
@@ -1600,30 +1368,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-sdk-s3@npm:3.410.0":
-  version: 3.410.0
-  resolution: "@aws-sdk/middleware-sdk-s3@npm:3.410.0"
+"@aws-sdk/middleware-sdk-s3@npm:3.575.0":
+  version: 3.575.0
+  resolution: "@aws-sdk/middleware-sdk-s3@npm:3.575.0"
   dependencies:
-    "@aws-sdk/types": "npm:3.410.0"
-    "@aws-sdk/util-arn-parser": "npm:3.310.0"
-    "@smithy/protocol-http": "npm:^3.0.2"
-    "@smithy/types": "npm:^2.3.0"
-    tslib: "npm:^2.5.0"
-  checksum: 10/9200c14d4d39ce99f982d18d7a0f768518dcb0e9c9f35acf93c35126438c7c12bb54e5e0abd8bf1136f048fc291aaf7cd3b98613d711aa530fadbf41f452f990
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/middleware-sdk-s3@npm:3.418.0":
-  version: 3.418.0
-  resolution: "@aws-sdk/middleware-sdk-s3@npm:3.418.0"
-  dependencies:
-    "@aws-sdk/types": "npm:3.418.0"
-    "@aws-sdk/util-arn-parser": "npm:3.310.0"
-    "@smithy/protocol-http": "npm:^3.0.5"
-    "@smithy/smithy-client": "npm:^2.1.6"
-    "@smithy/types": "npm:^2.3.3"
-    tslib: "npm:^2.5.0"
-  checksum: 10/205dd2399a163e213a0a07d85a5f49d36db5fc0bdea4a46ed5e8bc617e7394cb8cfc070974fdb4202842b6835326c2678f1576888bc66000d01b8aabfd84d5b9
+    "@aws-sdk/types": "npm:3.575.0"
+    "@aws-sdk/util-arn-parser": "npm:3.568.0"
+    "@smithy/node-config-provider": "npm:^3.0.0"
+    "@smithy/protocol-http": "npm:^4.0.0"
+    "@smithy/signature-v4": "npm:^3.0.0"
+    "@smithy/smithy-client": "npm:^3.0.0"
+    "@smithy/types": "npm:^3.0.0"
+    "@smithy/util-config-provider": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/52c666f794cd8a705b55d1c2686580db6a3720b2b265fd1cd0f7053d72f3c2e043577bd0ea34ee884d7903abde1f4a956230c2bf556c9db9fbf7905cae6c3f06
   languageName: node
   linkType: hard
 
@@ -1638,30 +1396,6 @@ __metadata:
     "@aws-sdk/types": "npm:3.212.0"
     tslib: "npm:^2.3.1"
   checksum: 10/edd71e258e0227124729e1a438ef7ae2a9fa980a680a4b3c884e9604f0b530bdc42884e2aad7d78b0a3ad55fe4727c1a3951afb6377dda2dbf77eed8e26bb711
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/middleware-sdk-sts@npm:3.410.0":
-  version: 3.410.0
-  resolution: "@aws-sdk/middleware-sdk-sts@npm:3.410.0"
-  dependencies:
-    "@aws-sdk/middleware-signing": "npm:3.410.0"
-    "@aws-sdk/types": "npm:3.410.0"
-    "@smithy/types": "npm:^2.3.0"
-    tslib: "npm:^2.5.0"
-  checksum: 10/b426e50edec835baefe243b02edf35c688e62f84606f1141081a31d01d85087b960dd2ad0fd085687237687870967da1519d2c37e3ae11a221ebd72fb4f7c220
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/middleware-sdk-sts@npm:3.418.0":
-  version: 3.418.0
-  resolution: "@aws-sdk/middleware-sdk-sts@npm:3.418.0"
-  dependencies:
-    "@aws-sdk/middleware-signing": "npm:3.418.0"
-    "@aws-sdk/types": "npm:3.418.0"
-    "@smithy/types": "npm:^2.3.3"
-    tslib: "npm:^2.5.0"
-  checksum: 10/6b571248202a50440e3422be7b3c5151547aef526c8d9a1250313212e3574a9c7e01e7f255fac408b1f6641dfddbdd62f78819bca7a3029fd851e1b3b1a2cf20
   languageName: node
   linkType: hard
 
@@ -1689,55 +1423,29 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-signing@npm:3.410.0":
-  version: 3.410.0
-  resolution: "@aws-sdk/middleware-signing@npm:3.410.0"
+"@aws-sdk/middleware-signing@npm:3.575.0":
+  version: 3.575.0
+  resolution: "@aws-sdk/middleware-signing@npm:3.575.0"
   dependencies:
-    "@aws-sdk/types": "npm:3.410.0"
-    "@smithy/property-provider": "npm:^2.0.0"
-    "@smithy/protocol-http": "npm:^3.0.2"
-    "@smithy/signature-v4": "npm:^2.0.0"
-    "@smithy/types": "npm:^2.3.0"
-    "@smithy/util-middleware": "npm:^2.0.0"
-    tslib: "npm:^2.5.0"
-  checksum: 10/479dfe7ece42992b23d0c3d1e85f6d0de10b56be3aa1fba81872948bedcc1c8515173be1aa6fbd2ac2ebfc00bdacd574b40445db0b07b7b307d8e650e1ca8aa0
+    "@aws-sdk/types": "npm:3.575.0"
+    "@smithy/property-provider": "npm:^3.0.0"
+    "@smithy/protocol-http": "npm:^4.0.0"
+    "@smithy/signature-v4": "npm:^3.0.0"
+    "@smithy/types": "npm:^3.0.0"
+    "@smithy/util-middleware": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/d7adaafbc239457229e3a8195cae539f007449720a9c7404853955b2c46e56a1d2dbd5632946c6cffcb10c877792fbfd2e03390f5996d6ea65f4666f1d827043
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-signing@npm:3.418.0":
-  version: 3.418.0
-  resolution: "@aws-sdk/middleware-signing@npm:3.418.0"
+"@aws-sdk/middleware-ssec@npm:3.575.0":
+  version: 3.575.0
+  resolution: "@aws-sdk/middleware-ssec@npm:3.575.0"
   dependencies:
-    "@aws-sdk/types": "npm:3.418.0"
-    "@smithy/property-provider": "npm:^2.0.0"
-    "@smithy/protocol-http": "npm:^3.0.5"
-    "@smithy/signature-v4": "npm:^2.0.0"
-    "@smithy/types": "npm:^2.3.3"
-    "@smithy/util-middleware": "npm:^2.0.2"
-    tslib: "npm:^2.5.0"
-  checksum: 10/bbfcac0f93388ed07d3cc3c5156a11716622790f347b1f0178c7acf6d44dfd43b59b0e13287e334b8d92a8856304684bbe04c23cbdcaa1dbf4a606890d6af8fd
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/middleware-ssec@npm:3.410.0":
-  version: 3.410.0
-  resolution: "@aws-sdk/middleware-ssec@npm:3.410.0"
-  dependencies:
-    "@aws-sdk/types": "npm:3.410.0"
-    "@smithy/types": "npm:^2.3.0"
-    tslib: "npm:^2.5.0"
-  checksum: 10/1f9b37da907c848179b2cc61423a517fb1e9dd7f7195a308d048287f766e1faa51bd6d6ec17e8f1a5d18c6ce39eb8400e12ffbf7b760990f54d521ff6ab9ea46
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/middleware-ssec@npm:3.418.0":
-  version: 3.418.0
-  resolution: "@aws-sdk/middleware-ssec@npm:3.418.0"
-  dependencies:
-    "@aws-sdk/types": "npm:3.418.0"
-    "@smithy/types": "npm:^2.3.3"
-    tslib: "npm:^2.5.0"
-  checksum: 10/31d45ed605c81a80129005452152c37e2091b8e1e13bef6d3894dab024b51bb97f4725b7da11b7d9ae6135d11ef16181072105034abaf71da1ac80f0a492dc9f
+    "@aws-sdk/types": "npm:3.575.0"
+    "@smithy/types": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/ec7a0dd5fea799fcee509b4647a3967e8e813f99638760620ef4297beb47e97a3a01e19a992938c74c461229ec115227871630b726fa53531a186474696b9687
   languageName: node
   linkType: hard
 
@@ -1761,29 +1469,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-user-agent@npm:3.410.0":
-  version: 3.410.0
-  resolution: "@aws-sdk/middleware-user-agent@npm:3.410.0"
+"@aws-sdk/middleware-user-agent@npm:3.575.0":
+  version: 3.575.0
+  resolution: "@aws-sdk/middleware-user-agent@npm:3.575.0"
   dependencies:
-    "@aws-sdk/types": "npm:3.410.0"
-    "@aws-sdk/util-endpoints": "npm:3.410.0"
-    "@smithy/protocol-http": "npm:^3.0.2"
-    "@smithy/types": "npm:^2.3.0"
-    tslib: "npm:^2.5.0"
-  checksum: 10/cd631597b57f881725624fc881862da2502d6dd0b050b86ea0ebe9652b338f004494e56a055305595f79b740a21826750ed4b3dc82a7226a94230d85a6479127
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/middleware-user-agent@npm:3.418.0":
-  version: 3.418.0
-  resolution: "@aws-sdk/middleware-user-agent@npm:3.418.0"
-  dependencies:
-    "@aws-sdk/types": "npm:3.418.0"
-    "@aws-sdk/util-endpoints": "npm:3.418.0"
-    "@smithy/protocol-http": "npm:^3.0.5"
-    "@smithy/types": "npm:^2.3.3"
-    tslib: "npm:^2.5.0"
-  checksum: 10/992229cfb793b06df3872e42be6a6ad3ac520b8989af7187a5844978761799e7b91b9d61bd211b346f5c7af0c079f982222285a85f8f4c0bf353e952c0a411f5
+    "@aws-sdk/types": "npm:3.575.0"
+    "@aws-sdk/util-endpoints": "npm:3.575.0"
+    "@smithy/protocol-http": "npm:^4.0.0"
+    "@smithy/types": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/2c2b9b840abc167b4845d02b043fb176514dfa251f1eab946e9951918814c61b9af3150ffe646a442b33890528f26e5c33b8a30cc451bec01c645650a755b162
   languageName: node
   linkType: hard
 
@@ -1853,16 +1548,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/region-config-resolver@npm:3.418.0":
-  version: 3.418.0
-  resolution: "@aws-sdk/region-config-resolver@npm:3.418.0"
+"@aws-sdk/region-config-resolver@npm:3.575.0":
+  version: 3.575.0
+  resolution: "@aws-sdk/region-config-resolver@npm:3.575.0"
   dependencies:
-    "@smithy/node-config-provider": "npm:^2.0.12"
-    "@smithy/types": "npm:^2.3.3"
-    "@smithy/util-config-provider": "npm:^2.0.0"
-    "@smithy/util-middleware": "npm:^2.0.2"
-    tslib: "npm:^2.5.0"
-  checksum: 10/48e033415845ce817171de8fe22ff29c750ee29206b2f9aa07a135d6858289eb69673d3c33283967174f49ed3f5cb89f5d09319858ad8d5b4a494af62a9d6d67
+    "@aws-sdk/types": "npm:3.575.0"
+    "@smithy/node-config-provider": "npm:^3.0.0"
+    "@smithy/types": "npm:^3.0.0"
+    "@smithy/util-config-provider": "npm:^3.0.0"
+    "@smithy/util-middleware": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/92c4550fd5b002cce5db05be2a77e1aa323eccebc6797835d27e7be7c2a230b2efbba8b1a8aee8a2a6bdbaa41af84bc55b397da0d0546987e003948ce7e47bb2
   languageName: node
   linkType: hard
 
@@ -1883,29 +1579,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/signature-v4-multi-region@npm:3.412.0":
-  version: 3.412.0
-  resolution: "@aws-sdk/signature-v4-multi-region@npm:3.412.0"
+"@aws-sdk/signature-v4-multi-region@npm:3.575.0":
+  version: 3.575.0
+  resolution: "@aws-sdk/signature-v4-multi-region@npm:3.575.0"
   dependencies:
-    "@aws-sdk/types": "npm:3.410.0"
-    "@smithy/protocol-http": "npm:^3.0.2"
-    "@smithy/signature-v4": "npm:^2.0.0"
-    "@smithy/types": "npm:^2.3.0"
-    tslib: "npm:^2.5.0"
-  checksum: 10/ecdbecf029142e6556bc3987febbee4d810fbb110b869b42bd0819e63b73925800a5262c4adfa9ee82c8cdc3ec433c6737fcaa9f40540df59af14b567ea7d731
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/signature-v4-multi-region@npm:3.418.0":
-  version: 3.418.0
-  resolution: "@aws-sdk/signature-v4-multi-region@npm:3.418.0"
-  dependencies:
-    "@aws-sdk/types": "npm:3.418.0"
-    "@smithy/protocol-http": "npm:^3.0.5"
-    "@smithy/signature-v4": "npm:^2.0.0"
-    "@smithy/types": "npm:^2.3.3"
-    tslib: "npm:^2.5.0"
-  checksum: 10/133e5d71f41114920c90010d39afb84c2792dfa151b48c9ae2129c471db339e89ceeb28e3a38a0297f8b3b069bcf3c3415e54df9bb79afbf43a58861e3b0d12b
+    "@aws-sdk/middleware-sdk-s3": "npm:3.575.0"
+    "@aws-sdk/types": "npm:3.575.0"
+    "@smithy/protocol-http": "npm:^4.0.0"
+    "@smithy/signature-v4": "npm:^3.0.0"
+    "@smithy/types": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/c41791cdb218e959d7fa6716d761467044ccedc16868a80eaa08db15755717f8a56d4c044bc35ce8bd3143cd51d0eb506e0634f987184043e517d26ed2f035e2
   languageName: node
   linkType: hard
 
@@ -1947,89 +1631,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/token-providers@npm:3.410.0":
-  version: 3.410.0
-  resolution: "@aws-sdk/token-providers@npm:3.410.0"
+"@aws-sdk/token-providers@npm:3.575.0":
+  version: 3.575.0
+  resolution: "@aws-sdk/token-providers@npm:3.575.0"
   dependencies:
-    "@aws-crypto/sha256-browser": "npm:3.0.0"
-    "@aws-crypto/sha256-js": "npm:3.0.0"
-    "@aws-sdk/middleware-host-header": "npm:3.410.0"
-    "@aws-sdk/middleware-logger": "npm:3.410.0"
-    "@aws-sdk/middleware-recursion-detection": "npm:3.410.0"
-    "@aws-sdk/middleware-user-agent": "npm:3.410.0"
-    "@aws-sdk/types": "npm:3.410.0"
-    "@aws-sdk/util-endpoints": "npm:3.410.0"
-    "@aws-sdk/util-user-agent-browser": "npm:3.410.0"
-    "@aws-sdk/util-user-agent-node": "npm:3.410.0"
-    "@smithy/config-resolver": "npm:^2.0.7"
-    "@smithy/fetch-http-handler": "npm:^2.1.2"
-    "@smithy/hash-node": "npm:^2.0.6"
-    "@smithy/invalid-dependency": "npm:^2.0.6"
-    "@smithy/middleware-content-length": "npm:^2.0.8"
-    "@smithy/middleware-endpoint": "npm:^2.0.6"
-    "@smithy/middleware-retry": "npm:^2.0.9"
-    "@smithy/middleware-serde": "npm:^2.0.6"
-    "@smithy/middleware-stack": "npm:^2.0.0"
-    "@smithy/node-config-provider": "npm:^2.0.9"
-    "@smithy/node-http-handler": "npm:^2.1.2"
-    "@smithy/property-provider": "npm:^2.0.0"
-    "@smithy/protocol-http": "npm:^3.0.2"
-    "@smithy/shared-ini-file-loader": "npm:^2.0.6"
-    "@smithy/smithy-client": "npm:^2.1.3"
-    "@smithy/types": "npm:^2.3.0"
-    "@smithy/url-parser": "npm:^2.0.6"
-    "@smithy/util-base64": "npm:^2.0.0"
-    "@smithy/util-body-length-browser": "npm:^2.0.0"
-    "@smithy/util-body-length-node": "npm:^2.1.0"
-    "@smithy/util-defaults-mode-browser": "npm:^2.0.7"
-    "@smithy/util-defaults-mode-node": "npm:^2.0.9"
-    "@smithy/util-retry": "npm:^2.0.0"
-    "@smithy/util-utf8": "npm:^2.0.0"
-    tslib: "npm:^2.5.0"
-  checksum: 10/5e117ada022a7f964565649044b1196f5076df28b23e223a453e2630f90431c9c8de8d706a66dfc08044e12e1d90336f913a829d201a5b107f0cd0a756892577
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/token-providers@npm:3.418.0":
-  version: 3.418.0
-  resolution: "@aws-sdk/token-providers@npm:3.418.0"
-  dependencies:
-    "@aws-crypto/sha256-browser": "npm:3.0.0"
-    "@aws-crypto/sha256-js": "npm:3.0.0"
-    "@aws-sdk/middleware-host-header": "npm:3.418.0"
-    "@aws-sdk/middleware-logger": "npm:3.418.0"
-    "@aws-sdk/middleware-recursion-detection": "npm:3.418.0"
-    "@aws-sdk/middleware-user-agent": "npm:3.418.0"
-    "@aws-sdk/types": "npm:3.418.0"
-    "@aws-sdk/util-endpoints": "npm:3.418.0"
-    "@aws-sdk/util-user-agent-browser": "npm:3.418.0"
-    "@aws-sdk/util-user-agent-node": "npm:3.418.0"
-    "@smithy/config-resolver": "npm:^2.0.10"
-    "@smithy/fetch-http-handler": "npm:^2.1.5"
-    "@smithy/hash-node": "npm:^2.0.9"
-    "@smithy/invalid-dependency": "npm:^2.0.9"
-    "@smithy/middleware-content-length": "npm:^2.0.11"
-    "@smithy/middleware-endpoint": "npm:^2.0.9"
-    "@smithy/middleware-retry": "npm:^2.0.12"
-    "@smithy/middleware-serde": "npm:^2.0.9"
-    "@smithy/middleware-stack": "npm:^2.0.2"
-    "@smithy/node-config-provider": "npm:^2.0.12"
-    "@smithy/node-http-handler": "npm:^2.1.5"
-    "@smithy/property-provider": "npm:^2.0.0"
-    "@smithy/protocol-http": "npm:^3.0.5"
-    "@smithy/shared-ini-file-loader": "npm:^2.0.6"
-    "@smithy/smithy-client": "npm:^2.1.6"
-    "@smithy/types": "npm:^2.3.3"
-    "@smithy/url-parser": "npm:^2.0.9"
-    "@smithy/util-base64": "npm:^2.0.0"
-    "@smithy/util-body-length-browser": "npm:^2.0.0"
-    "@smithy/util-body-length-node": "npm:^2.1.0"
-    "@smithy/util-defaults-mode-browser": "npm:^2.0.10"
-    "@smithy/util-defaults-mode-node": "npm:^2.0.12"
-    "@smithy/util-retry": "npm:^2.0.2"
-    "@smithy/util-utf8": "npm:^2.0.0"
-    tslib: "npm:^2.5.0"
-  checksum: 10/08a33eae8c3d4e253c19c58fec5c54fc8f6212011270627c7c1380d7642a73e4875d23553619d3857be1bcbaa3795892f9a812de73dcc68b20a624c54338bead
+    "@aws-sdk/types": "npm:3.575.0"
+    "@smithy/property-provider": "npm:^3.0.0"
+    "@smithy/shared-ini-file-loader": "npm:^3.0.0"
+    "@smithy/types": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  peerDependencies:
+    "@aws-sdk/client-sso-oidc": 3.575.0
+  checksum: 10/ce6735c15487027dc4a380609166281df7cec824ac74b7ebeb7a307285342366612eca93831c5fd3ad806417ffd2ff5b4928911170504f8a769a90493145b6ec
   languageName: node
   linkType: hard
 
@@ -2040,23 +1653,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/types@npm:3.410.0, @aws-sdk/types@npm:^3.222.0":
-  version: 3.410.0
-  resolution: "@aws-sdk/types@npm:3.410.0"
+"@aws-sdk/types@npm:3.575.0":
+  version: 3.575.0
+  resolution: "@aws-sdk/types@npm:3.575.0"
   dependencies:
-    "@smithy/types": "npm:^2.3.0"
-    tslib: "npm:^2.5.0"
-  checksum: 10/25fc3a188c3d963269941a74c3cd5dbbcff08b331316224675c6e092d9fa142fc651b2bf0a0fb13c23b488126b2ac42d93d39e2c6110ee1c88277c552d76c97c
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/types@npm:3.418.0":
-  version: 3.418.0
-  resolution: "@aws-sdk/types@npm:3.418.0"
-  dependencies:
-    "@smithy/types": "npm:^2.3.3"
-    tslib: "npm:^2.5.0"
-  checksum: 10/627955c2c92f7dd80ab5ac0fd23b6f5d5ff7a8cbc3dcc6f8b86b702f73b844219c3192990dc7048bbca9b36e2e46cdb48d21a8dc3eaf36861623348c1c1427a1
+    "@smithy/types": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/e6243ad1ebc63b9ad19f8aa5dbfdd295b4b55a8c09dcb54313c4f624faf414b1b030cf2e6b1cbab312d3771c3e33d412a479f8f3d856cff3182b51512733a47d
   languageName: node
   linkType: hard
 
@@ -2064,6 +1667,16 @@ __metadata:
   version: 3.32.0
   resolution: "@aws-sdk/types@npm:3.32.0"
   checksum: 10/292720e50658b076afeddb951d02f259a953b3d2d01bd07d969140b47bb706c003f851fdb015c7af4b0f93d077d74112ea51b48c685217587cc88f6fa6bb6a78
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/types@npm:^3.222.0":
+  version: 3.410.0
+  resolution: "@aws-sdk/types@npm:3.410.0"
+  dependencies:
+    "@smithy/types": "npm:^2.3.0"
+    tslib: "npm:^2.5.0"
+  checksum: 10/25fc3a188c3d963269941a74c3cd5dbbcff08b331316224675c6e092d9fa142fc651b2bf0a0fb13c23b488126b2ac42d93d39e2c6110ee1c88277c552d76c97c
   languageName: node
   linkType: hard
 
@@ -2078,12 +1691,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-arn-parser@npm:3.310.0":
-  version: 3.310.0
-  resolution: "@aws-sdk/util-arn-parser@npm:3.310.0"
+"@aws-sdk/util-arn-parser@npm:3.568.0":
+  version: 3.568.0
+  resolution: "@aws-sdk/util-arn-parser@npm:3.568.0"
   dependencies:
-    tslib: "npm:^2.5.0"
-  checksum: 10/909d76befcde663b263f28804f7702816f14aa10bd57ec77fda89cb9477e217af6f8a84ac6fa8b051b1b4701c5fe47f4931d0acafb2c6ff01ca432f5f63f15d9
+    tslib: "npm:^2.6.2"
+  checksum: 10/b1a7f93b4f47136ee8d71bcbbd2d5d19581007f0684aff252d3bee6b9ccc7c56e765255bb1bea847171b40cdbd2eca0fb102f24cba857d1c79c54747e8ee0855
   languageName: node
   linkType: hard
 
@@ -2170,23 +1783,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-endpoints@npm:3.410.0":
-  version: 3.410.0
-  resolution: "@aws-sdk/util-endpoints@npm:3.410.0"
+"@aws-sdk/util-endpoints@npm:3.575.0":
+  version: 3.575.0
+  resolution: "@aws-sdk/util-endpoints@npm:3.575.0"
   dependencies:
-    "@aws-sdk/types": "npm:3.410.0"
-    tslib: "npm:^2.5.0"
-  checksum: 10/af8c47df011eb75f39e042a295e0df07cb3e3a9295bd545b942db4134b022716af29e11b33eb2c960bdf7e470ab35691c09aeccfc7cf478461891120c947b7d0
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/util-endpoints@npm:3.418.0":
-  version: 3.418.0
-  resolution: "@aws-sdk/util-endpoints@npm:3.418.0"
-  dependencies:
-    "@aws-sdk/types": "npm:3.418.0"
-    tslib: "npm:^2.5.0"
-  checksum: 10/8ed0c67b5650c0ad4454fd67c0e94e35872ef3da867e7f33411676d95d53402561b615f849083c00d4180158308908e8511d9be2557fdf1c21cf8f4318ef0b86
+    "@aws-sdk/types": "npm:3.575.0"
+    "@smithy/types": "npm:^3.0.0"
+    "@smithy/util-endpoints": "npm:^2.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/51e88aaede9fecf9ac1c4ce3976876eb5997bda67b14b22129604ea11ec6d3131e97b7184c899114f9587c2930f1616ba1e9051ded10a853a5ea6047fbe21eca
   languageName: node
   linkType: hard
 
@@ -2237,27 +1842,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-user-agent-browser@npm:3.410.0":
-  version: 3.410.0
-  resolution: "@aws-sdk/util-user-agent-browser@npm:3.410.0"
+"@aws-sdk/util-user-agent-browser@npm:3.575.0":
+  version: 3.575.0
+  resolution: "@aws-sdk/util-user-agent-browser@npm:3.575.0"
   dependencies:
-    "@aws-sdk/types": "npm:3.410.0"
-    "@smithy/types": "npm:^2.3.0"
+    "@aws-sdk/types": "npm:3.575.0"
+    "@smithy/types": "npm:^3.0.0"
     bowser: "npm:^2.11.0"
-    tslib: "npm:^2.5.0"
-  checksum: 10/b427a90669463119b2eed8dfc0e14c69351cef81494eb896b4fa3f05419f5097725396eea4d5e3ea9572d2999f89d732aefafeae31a5b8b5de89fea5e66ca0c2
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/util-user-agent-browser@npm:3.418.0":
-  version: 3.418.0
-  resolution: "@aws-sdk/util-user-agent-browser@npm:3.418.0"
-  dependencies:
-    "@aws-sdk/types": "npm:3.418.0"
-    "@smithy/types": "npm:^2.3.3"
-    bowser: "npm:^2.11.0"
-    tslib: "npm:^2.5.0"
-  checksum: 10/a2e53033a067dee2a95c5709eb0170cff3e668ff82cef99d047da9d2acbe58fff666956f086008ca6bec1a6c6b1e939c9c56bb251380f6ce49eb9058bba2b40b
+    tslib: "npm:^2.6.2"
+  checksum: 10/c0d8b3bce25c72f0f05c8d0333a485482d76c81c1b6732472c0b6ed9281e9eea68e806611581de09f45f6c0465ef2e0f1f605bc4dbf5f1c037135354dc07d79c
   languageName: node
   linkType: hard
 
@@ -2277,37 +1870,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-user-agent-node@npm:3.410.0":
-  version: 3.410.0
-  resolution: "@aws-sdk/util-user-agent-node@npm:3.410.0"
+"@aws-sdk/util-user-agent-node@npm:3.575.0":
+  version: 3.575.0
+  resolution: "@aws-sdk/util-user-agent-node@npm:3.575.0"
   dependencies:
-    "@aws-sdk/types": "npm:3.410.0"
-    "@smithy/node-config-provider": "npm:^2.0.9"
-    "@smithy/types": "npm:^2.3.0"
-    tslib: "npm:^2.5.0"
+    "@aws-sdk/types": "npm:3.575.0"
+    "@smithy/node-config-provider": "npm:^3.0.0"
+    "@smithy/types": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
   peerDependencies:
     aws-crt: ">=1.0.0"
   peerDependenciesMeta:
     aws-crt:
       optional: true
-  checksum: 10/ea815d4150bd7cfa4b8262c8178951c8418fa262a70d3e51342c62cadda77d9d908583225991e4e1996414675b46dcc3baf58b609f08ec390d686d02fe67729a
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/util-user-agent-node@npm:3.418.0":
-  version: 3.418.0
-  resolution: "@aws-sdk/util-user-agent-node@npm:3.418.0"
-  dependencies:
-    "@aws-sdk/types": "npm:3.418.0"
-    "@smithy/node-config-provider": "npm:^2.0.12"
-    "@smithy/types": "npm:^2.3.3"
-    tslib: "npm:^2.5.0"
-  peerDependencies:
-    aws-crt: ">=1.0.0"
-  peerDependenciesMeta:
-    aws-crt:
-      optional: true
-  checksum: 10/c950f87158d905ca98a2c4047b13cfeb282a9f895d8a39553257afe6f1a9b04eb1a559c1144909a7805503b524dc62e60ea0cd9fdaf54c9bc156424831ec6064
+  checksum: 10/70123dde6108720184544adfd888eeaa0b9d5bcb293126be91bd278ab9c22d68282657781de5d05088356c26f5533701ac9ceb558a32bebd6715edbff43952c7
   languageName: node
   linkType: hard
 
@@ -2339,12 +1915,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/xml-builder@npm:3.310.0":
-  version: 3.310.0
-  resolution: "@aws-sdk/xml-builder@npm:3.310.0"
+"@aws-sdk/xml-builder@npm:3.575.0":
+  version: 3.575.0
+  resolution: "@aws-sdk/xml-builder@npm:3.575.0"
   dependencies:
-    tslib: "npm:^2.5.0"
-  checksum: 10/d6bcb30b5fe04723ddb3fb7e6dc9564dd1112e5abed527335a584014161cf9706012f85f9672ab50b8904370f90827ca26d1016c6911aec745dc1bc56469d76d
+    "@smithy/types": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/b1ca3cca6d49a10453d9b82242a4fbf2e5867d22c6238ea44f4210bdb64a2a48996b36d3662718995a76308bf4af7a834df7ba8498fba4d5aaabd2f7362f36f1
   languageName: node
   linkType: hard
 
@@ -2811,15 +2388,6 @@ __metadata:
   dependencies:
     regenerator-runtime: "npm:^0.13.11"
   checksum: 10/1d2f56797f548b009910bddf3dc04f980a9701193233145dc923f3ea87c8f88121a3c3ef1d449e9cb52a370d7d025a2243c748882d5546ff079ddf5ffe29f240
-  languageName: node
-  linkType: hard
-
-"@babel/runtime@npm:^7.21.0":
-  version: 7.22.15
-  resolution: "@babel/runtime@npm:7.22.15"
-  dependencies:
-    regenerator-runtime: "npm:^0.14.0"
-  checksum: 10/9670da63b77ea6d8234117c55a6d9888be5cf220b91a5954d7faefe7a537e06fa8992e11d36b7cff2ab0ef5301fe6effb3d41bec8b4e0bae10d386b7c377568b
   languageName: node
   linkType: hard
 
@@ -4144,17 +3712,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@lerna/child-process@npm:7.3.0":
-  version: 7.3.0
-  resolution: "@lerna/child-process@npm:7.3.0"
-  dependencies:
-    chalk: "npm:^4.1.0"
-    execa: "npm:^5.0.0"
-    strong-log-transformer: "npm:^2.1.0"
-  checksum: 10/f0c4782bb27ebb1c0c368616a25d2b05f35c242ccd16fc20fefb00e0f1a73e5e126c450af23eab5bd60b99c762531e9fb44e465db5d04a50df8946ff0afce2d6
-  languageName: node
-  linkType: hard
-
 "@lerna/clean@npm:3.20.0":
   version: 3.20.0
   resolution: "@lerna/clean@npm:3.20.0"
@@ -4282,13 +3839,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@lerna/create@npm:7.3.0":
-  version: 7.3.0
-  resolution: "@lerna/create@npm:7.3.0"
+"@lerna/create@npm:8.1.3":
+  version: 8.1.3
+  resolution: "@lerna/create@npm:8.1.3"
   dependencies:
-    "@lerna/child-process": "npm:7.3.0"
-    "@npmcli/run-script": "npm:6.0.2"
-    "@nx/devkit": "npm:>=16.5.1 < 17"
+    "@npmcli/run-script": "npm:7.0.2"
+    "@nx/devkit": "npm:>=17.1.2 < 20"
     "@octokit/plugin-enterprise-rest": "npm:6.0.1"
     "@octokit/rest": "npm:19.0.11"
     byte-size: "npm:8.1.1"
@@ -4325,12 +3881,12 @@ __metadata:
     npm-packlist: "npm:5.1.1"
     npm-registry-fetch: "npm:^14.0.5"
     npmlog: "npm:^6.0.2"
-    nx: "npm:>=16.5.1 < 17"
+    nx: "npm:>=17.1.2 < 20"
     p-map: "npm:4.0.0"
     p-map-series: "npm:2.1.0"
     p-queue: "npm:6.6.2"
     p-reduce: "npm:^2.1.0"
-    pacote: "npm:^15.2.0"
+    pacote: "npm:^17.0.5"
     pify: "npm:5.0.0"
     read-cmd-shim: "npm:4.0.0"
     read-package-json: "npm:6.0.4"
@@ -4341,7 +3897,7 @@ __metadata:
     slash: "npm:^3.0.0"
     ssri: "npm:^9.0.1"
     strong-log-transformer: "npm:2.1.0"
-    tar: "npm:6.1.11"
+    tar: "npm:6.2.1"
     temp-dir: "npm:1.0.0"
     upath: "npm:2.0.1"
     uuid: "npm:^9.0.0"
@@ -4349,9 +3905,9 @@ __metadata:
     validate-npm-package-name: "npm:5.0.0"
     write-file-atomic: "npm:5.0.1"
     write-pkg: "npm:4.0.0"
-    yargs: "npm:16.2.0"
-    yargs-parser: "npm:20.2.4"
-  checksum: 10/db6f3b6b7aa4860b9d100fd4cc797c5af3447a1e3f1952c2a8eb4c4ace260bdad7781d083555a3dc93eb4303ef4716cf92a9d46e9e0d3fd6a4988069f6e514d6
+    yargs: "npm:17.7.2"
+    yargs-parser: "npm:21.1.1"
+  checksum: 10/52cc1ce736bd1a30ee7f6c24ded1dbf26fe369927fa1e3923d4b829808249e0e018a9f204d1d69c36352b69b973ab2f5e6fad696aee4c62cfa4ecbe443e91a9a
   languageName: node
   linkType: hard
 
@@ -4976,72 +4532,72 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@next/env@npm:13.4.19":
-  version: 13.4.19
-  resolution: "@next/env@npm:13.4.19"
-  checksum: 10/9454485caf50292d4b1b4ffdd4794d408a07c43ac3e4688bcca023cd10980232a0a283f6fc48129ae4f3c21ad547b8404beeb84b5e1883815f940cb36a18c2fa
+"@next/env@npm:14.2.3":
+  version: 14.2.3
+  resolution: "@next/env@npm:14.2.3"
+  checksum: 10/82b445331d46b4896dc86c0e33a7eaaa6f6abfd2408d49e1cb90fbfd6b26c698ea8e69c911ffe597e30fd8294db4e3445cde44b0771eabbfcd13663a9832a397
   languageName: node
   linkType: hard
 
-"@next/swc-darwin-arm64@npm:13.4.19":
-  version: 13.4.19
-  resolution: "@next/swc-darwin-arm64@npm:13.4.19"
+"@next/swc-darwin-arm64@npm:14.2.3":
+  version: 14.2.3
+  resolution: "@next/swc-darwin-arm64@npm:14.2.3"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@next/swc-darwin-x64@npm:13.4.19":
-  version: 13.4.19
-  resolution: "@next/swc-darwin-x64@npm:13.4.19"
+"@next/swc-darwin-x64@npm:14.2.3":
+  version: 14.2.3
+  resolution: "@next/swc-darwin-x64@npm:14.2.3"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@next/swc-linux-arm64-gnu@npm:13.4.19":
-  version: 13.4.19
-  resolution: "@next/swc-linux-arm64-gnu@npm:13.4.19"
+"@next/swc-linux-arm64-gnu@npm:14.2.3":
+  version: 14.2.3
+  resolution: "@next/swc-linux-arm64-gnu@npm:14.2.3"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@next/swc-linux-arm64-musl@npm:13.4.19":
-  version: 13.4.19
-  resolution: "@next/swc-linux-arm64-musl@npm:13.4.19"
+"@next/swc-linux-arm64-musl@npm:14.2.3":
+  version: 14.2.3
+  resolution: "@next/swc-linux-arm64-musl@npm:14.2.3"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
-"@next/swc-linux-x64-gnu@npm:13.4.19":
-  version: 13.4.19
-  resolution: "@next/swc-linux-x64-gnu@npm:13.4.19"
+"@next/swc-linux-x64-gnu@npm:14.2.3":
+  version: 14.2.3
+  resolution: "@next/swc-linux-x64-gnu@npm:14.2.3"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@next/swc-linux-x64-musl@npm:13.4.19":
-  version: 13.4.19
-  resolution: "@next/swc-linux-x64-musl@npm:13.4.19"
+"@next/swc-linux-x64-musl@npm:14.2.3":
+  version: 14.2.3
+  resolution: "@next/swc-linux-x64-musl@npm:14.2.3"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
 
-"@next/swc-win32-arm64-msvc@npm:13.4.19":
-  version: 13.4.19
-  resolution: "@next/swc-win32-arm64-msvc@npm:13.4.19"
+"@next/swc-win32-arm64-msvc@npm:14.2.3":
+  version: 14.2.3
+  resolution: "@next/swc-win32-arm64-msvc@npm:14.2.3"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"@next/swc-win32-ia32-msvc@npm:13.4.19":
-  version: 13.4.19
-  resolution: "@next/swc-win32-ia32-msvc@npm:13.4.19"
+"@next/swc-win32-ia32-msvc@npm:14.2.3":
+  version: 14.2.3
+  resolution: "@next/swc-win32-ia32-msvc@npm:14.2.3"
   conditions: os=win32 & cpu=ia32
   languageName: node
   linkType: hard
 
-"@next/swc-win32-x64-msvc@npm:13.4.19":
-  version: 13.4.19
-  resolution: "@next/swc-win32-x64-msvc@npm:13.4.19"
+"@next/swc-win32-x64-msvc@npm:14.2.3":
+  version: 14.2.3
+  resolution: "@next/swc-win32-x64-msvc@npm:14.2.3"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -5095,6 +4651,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@npmcli/agent@npm:^2.0.0":
+  version: 2.2.2
+  resolution: "@npmcli/agent@npm:2.2.2"
+  dependencies:
+    agent-base: "npm:^7.1.0"
+    http-proxy-agent: "npm:^7.0.0"
+    https-proxy-agent: "npm:^7.0.1"
+    lru-cache: "npm:^10.0.1"
+    socks-proxy-agent: "npm:^8.0.3"
+  checksum: 10/96fc0036b101bae5032dc2a4cd832efb815ce9b33f9ee2f29909ee49d96a0026b3565f73c507a69eb8603f5cb32e0ae45a70cab1e2655990a4e06ae99f7f572a
+  languageName: node
+  linkType: hard
+
 "@npmcli/fs@npm:^1.0.0":
   version: 1.0.0
   resolution: "@npmcli/fs@npm:1.0.0"
@@ -5114,19 +4683,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@npmcli/git@npm:^4.0.0":
-  version: 4.1.0
-  resolution: "@npmcli/git@npm:4.1.0"
+"@npmcli/git@npm:^5.0.0":
+  version: 5.0.7
+  resolution: "@npmcli/git@npm:5.0.7"
   dependencies:
-    "@npmcli/promise-spawn": "npm:^6.0.0"
-    lru-cache: "npm:^7.4.4"
-    npm-pick-manifest: "npm:^8.0.0"
-    proc-log: "npm:^3.0.0"
+    "@npmcli/promise-spawn": "npm:^7.0.0"
+    lru-cache: "npm:^10.0.1"
+    npm-pick-manifest: "npm:^9.0.0"
+    proc-log: "npm:^4.0.0"
     promise-inflight: "npm:^1.0.1"
     promise-retry: "npm:^2.0.1"
     semver: "npm:^7.3.5"
-    which: "npm:^3.0.0"
-  checksum: 10/33512ce12758d67c0322eca25019c4d5ef03e83f5829e09a05389af485bab216cc4df408b8eba98f2d12c119c6dff84f0d8ff25a1ac5d8a46184e55ae8f53754
+    which: "npm:^4.0.0"
+  checksum: 10/73b48213109cc3943e977054d3747ec84ba5f2b809df8899242d27d4f574752f9151330996f632e76a546b0e6d13e25a4a70465b8a34c38a38ca4148024a5ceb
   languageName: node
   linkType: hard
 
@@ -5159,132 +4728,169 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@npmcli/promise-spawn@npm:^6.0.0, @npmcli/promise-spawn@npm:^6.0.1":
-  version: 6.0.2
-  resolution: "@npmcli/promise-spawn@npm:6.0.2"
+"@npmcli/package-json@npm:^5.0.0":
+  version: 5.1.0
+  resolution: "@npmcli/package-json@npm:5.1.0"
   dependencies:
-    which: "npm:^3.0.0"
-  checksum: 10/cc94a83ff1626ad93d42c2ea583dba1fb2d24cdab49caf0af77a3a0ff9bdbba34e09048b6821d4060ea7a58d4a41d49bece4ae3716929e2077c2fff0f5e94d94
+    "@npmcli/git": "npm:^5.0.0"
+    glob: "npm:^10.2.2"
+    hosted-git-info: "npm:^7.0.0"
+    json-parse-even-better-errors: "npm:^3.0.0"
+    normalize-package-data: "npm:^6.0.0"
+    proc-log: "npm:^4.0.0"
+    semver: "npm:^7.5.3"
+  checksum: 10/0e5cb5eff32cf80234525160a702c91a38e4b98ab74e34e2632b43c4350dbad170bd835989cc7d6e18d24798e3242e45b60f3d5e26bd128fe1c4529931105f8e
   languageName: node
   linkType: hard
 
-"@npmcli/run-script@npm:6.0.2, @npmcli/run-script@npm:^6.0.0":
-  version: 6.0.2
-  resolution: "@npmcli/run-script@npm:6.0.2"
+"@npmcli/promise-spawn@npm:^7.0.0":
+  version: 7.0.2
+  resolution: "@npmcli/promise-spawn@npm:7.0.2"
+  dependencies:
+    which: "npm:^4.0.0"
+  checksum: 10/94cbbbeeb20342026c3b68fc8eb09e1600b7645d4e509f2588ef5ea7cff977eb01e628cc8e014595d04a6af4b4bc5c467c950a8135920f39f7c7b57fba43f4e9
+  languageName: node
+  linkType: hard
+
+"@npmcli/redact@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@npmcli/redact@npm:1.1.0"
+  checksum: 10/c6c81c2d1463bc9f30d40f983a3dbb3144503030ff455e5a8904ff82ca39b95e46e9830fa4413f17f9a77604cdbb1f2370c53dd0ba4841cf24b79843e1fcf825
+  languageName: node
+  linkType: hard
+
+"@npmcli/run-script@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@npmcli/run-script@npm:7.0.2"
   dependencies:
     "@npmcli/node-gyp": "npm:^3.0.0"
-    "@npmcli/promise-spawn": "npm:^6.0.0"
-    node-gyp: "npm:^9.0.0"
+    "@npmcli/promise-spawn": "npm:^7.0.0"
+    node-gyp: "npm:^10.0.0"
     read-package-json-fast: "npm:^3.0.0"
-    which: "npm:^3.0.0"
-  checksum: 10/9b22c4c53d4b2e014e7f990cf2e1d32d1830c5629d37a4ee56011bcdfb51424ca8dc3fb3fa550b4abe7e8f0efdd68468d733b754db371b06a5dd300663cf13a2
+    which: "npm:^4.0.0"
+  checksum: 10/4549311f3b937ca81d147b72fbfd41aa6ed7daf70ecc4e9ee3838f9cce1749e9c62c301943a8a67364a96c31bbc67c49ee31526fb12ec2f4b15148f0ef472f98
   languageName: node
   linkType: hard
 
-"@nrwl/devkit@npm:16.8.1":
-  version: 16.8.1
-  resolution: "@nrwl/devkit@npm:16.8.1"
+"@npmcli/run-script@npm:^7.0.0":
+  version: 7.0.4
+  resolution: "@npmcli/run-script@npm:7.0.4"
   dependencies:
-    "@nx/devkit": "npm:16.8.1"
-  checksum: 10/17dcc80e7acf2ed10150c07f39ec5c7f607cf930a88266666d11648d55b52a5efc8e5580471beffe2ad365a524838bcec36cbea9feab3212ab21342d1a15af60
+    "@npmcli/node-gyp": "npm:^3.0.0"
+    "@npmcli/package-json": "npm:^5.0.0"
+    "@npmcli/promise-spawn": "npm:^7.0.0"
+    node-gyp: "npm:^10.0.0"
+    which: "npm:^4.0.0"
+  checksum: 10/f09268051f74af7d7be46e9911a23126d531160c338d3c05d53e6cd7994b88271fb4ec524139fe7f2d826525f15a281eafef3be02831adc1f68556a8a668621a
   languageName: node
   linkType: hard
 
-"@nrwl/tao@npm:16.8.1":
-  version: 16.8.1
-  resolution: "@nrwl/tao@npm:16.8.1"
+"@nrwl/devkit@npm:19.0.3":
+  version: 19.0.3
+  resolution: "@nrwl/devkit@npm:19.0.3"
   dependencies:
-    nx: "npm:16.8.1"
+    "@nx/devkit": "npm:19.0.3"
+  checksum: 10/3ad69accaed7f35951ffad62e71c56869bbd66bc7c42828cfd4adfe46297c318857176045d3dd8ad0b61eaa1ea7acd62d5762485f6898c7d960a0a0b893b829b
+  languageName: node
+  linkType: hard
+
+"@nrwl/tao@npm:19.0.3":
+  version: 19.0.3
+  resolution: "@nrwl/tao@npm:19.0.3"
+  dependencies:
+    nx: "npm:19.0.3"
     tslib: "npm:^2.3.0"
   bin:
     tao: index.js
-  checksum: 10/f1ee57f0adc769faa3a5380080cb6e82893ae5ff2b0d891e1b4da80415db168fe9050810adb47d2a0aa3e732d0e4c0c15482ffad1f4fffe146cae204df3a2af2
+  checksum: 10/419f2a990119e3e12804557da0dbe701fcbe219d1ad6b0477e980ead251cd42e0fa5dd75b4ed4a0a74bc7a7c99a1ca4e56e07c2b565a7d561cf6d6b004d69998
   languageName: node
   linkType: hard
 
-"@nx/devkit@npm:16.8.1, @nx/devkit@npm:>=16.5.1 < 17":
-  version: 16.8.1
-  resolution: "@nx/devkit@npm:16.8.1"
+"@nx/devkit@npm:19.0.3, @nx/devkit@npm:>=17.1.2 < 20":
+  version: 19.0.3
+  resolution: "@nx/devkit@npm:19.0.3"
   dependencies:
-    "@nrwl/devkit": "npm:16.8.1"
+    "@nrwl/devkit": "npm:19.0.3"
     ejs: "npm:^3.1.7"
     enquirer: "npm:~2.3.6"
     ignore: "npm:^5.0.4"
-    semver: "npm:7.5.3"
+    minimatch: "npm:9.0.3"
+    semver: "npm:^7.5.3"
     tmp: "npm:~0.2.1"
     tslib: "npm:^2.3.0"
+    yargs-parser: "npm:21.1.1"
   peerDependencies:
-    nx: ">= 15 <= 17"
-  checksum: 10/537c489602a6b0d4bf88a0ab68184c66f1d800f44c4ea747818a2f1d73ff4257287dc6c202cf279290ced80978f850a76fd425737383d74553e81500600fead1
+    nx: ">= 17 <= 20"
+  checksum: 10/7a725d18c3fd951d7a509d338abd505cd27a6abb9b4b589f0c3c3fb70f6ef208238601f116c41b04930cf1566b0b06996f72141fe85ea215ccd0aedf4568c2b2
   languageName: node
   linkType: hard
 
-"@nx/nx-darwin-arm64@npm:16.8.1":
-  version: 16.8.1
-  resolution: "@nx/nx-darwin-arm64@npm:16.8.1"
+"@nx/nx-darwin-arm64@npm:19.0.3":
+  version: 19.0.3
+  resolution: "@nx/nx-darwin-arm64@npm:19.0.3"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@nx/nx-darwin-x64@npm:16.8.1":
-  version: 16.8.1
-  resolution: "@nx/nx-darwin-x64@npm:16.8.1"
+"@nx/nx-darwin-x64@npm:19.0.3":
+  version: 19.0.3
+  resolution: "@nx/nx-darwin-x64@npm:19.0.3"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@nx/nx-freebsd-x64@npm:16.8.1":
-  version: 16.8.1
-  resolution: "@nx/nx-freebsd-x64@npm:16.8.1"
+"@nx/nx-freebsd-x64@npm:19.0.3":
+  version: 19.0.3
+  resolution: "@nx/nx-freebsd-x64@npm:19.0.3"
   conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
 
-"@nx/nx-linux-arm-gnueabihf@npm:16.8.1":
-  version: 16.8.1
-  resolution: "@nx/nx-linux-arm-gnueabihf@npm:16.8.1"
+"@nx/nx-linux-arm-gnueabihf@npm:19.0.3":
+  version: 19.0.3
+  resolution: "@nx/nx-linux-arm-gnueabihf@npm:19.0.3"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
 
-"@nx/nx-linux-arm64-gnu@npm:16.8.1":
-  version: 16.8.1
-  resolution: "@nx/nx-linux-arm64-gnu@npm:16.8.1"
+"@nx/nx-linux-arm64-gnu@npm:19.0.3":
+  version: 19.0.3
+  resolution: "@nx/nx-linux-arm64-gnu@npm:19.0.3"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@nx/nx-linux-arm64-musl@npm:16.8.1":
-  version: 16.8.1
-  resolution: "@nx/nx-linux-arm64-musl@npm:16.8.1"
+"@nx/nx-linux-arm64-musl@npm:19.0.3":
+  version: 19.0.3
+  resolution: "@nx/nx-linux-arm64-musl@npm:19.0.3"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
-"@nx/nx-linux-x64-gnu@npm:16.8.1":
-  version: 16.8.1
-  resolution: "@nx/nx-linux-x64-gnu@npm:16.8.1"
+"@nx/nx-linux-x64-gnu@npm:19.0.3":
+  version: 19.0.3
+  resolution: "@nx/nx-linux-x64-gnu@npm:19.0.3"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@nx/nx-linux-x64-musl@npm:16.8.1":
-  version: 16.8.1
-  resolution: "@nx/nx-linux-x64-musl@npm:16.8.1"
+"@nx/nx-linux-x64-musl@npm:19.0.3":
+  version: 19.0.3
+  resolution: "@nx/nx-linux-x64-musl@npm:19.0.3"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
 
-"@nx/nx-win32-arm64-msvc@npm:16.8.1":
-  version: 16.8.1
-  resolution: "@nx/nx-win32-arm64-msvc@npm:16.8.1"
+"@nx/nx-win32-arm64-msvc@npm:19.0.3":
+  version: 19.0.3
+  resolution: "@nx/nx-win32-arm64-msvc@npm:19.0.3"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"@nx/nx-win32-x64-msvc@npm:16.8.1":
-  version: 16.8.1
-  resolution: "@nx/nx-win32-x64-msvc@npm:16.8.1"
+"@nx/nx-win32-x64-msvc@npm:19.0.3":
+  version: 19.0.3
+  resolution: "@nx/nx-win32-x64-msvc@npm:19.0.3"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -5594,7 +5200,7 @@ __metadata:
     "@types/react-dom": "npm:^18.2.19"
     "@types/react-router-dom": "npm:5.3.3"
     "@types/testing-library__jest-dom": "npm:5.14.5"
-    bids-validator: "npm:1.13.0"
+    bids-validator: "npm:1.14.6"
     bytes: "npm:^3.0.0"
     comlink: "npm:^4.0.5"
     core-js: "npm:3.25.1"
@@ -5641,7 +5247,7 @@ __metadata:
     "@openneuro/client": "npm:^4.23.0"
     "@types/mkdirp": "npm:1.0.2"
     "@types/node": "npm:20.12.7"
-    bids-validator: "npm:1.10.0"
+    bids-validator: "npm:1.14.6"
     cli-progress: "npm:^3.8.2"
     commander: "npm:7.2.0"
     core-js: "npm:^3.10.1"
@@ -5872,17 +5478,6 @@ __metadata:
   version: 1.15.2
   resolution: "@opentelemetry/semantic-conventions@npm:1.15.2"
   checksum: 10/1f35515109ee8512d136256e78f81ad1334f9c5f5a5d9ceab9f472938e8e177745ac14a2790c819551243f81034d9b0f527b93da72a6929fef5358abd39216e0
-  languageName: node
-  linkType: hard
-
-"@parcel/watcher@npm:2.0.4":
-  version: 2.0.4
-  resolution: "@parcel/watcher@npm:2.0.4"
-  dependencies:
-    node-addon-api: "npm:^3.2.1"
-    node-gyp: "npm:latest"
-    node-gyp-build: "npm:^4.3.0"
-  checksum: 10/ec3ba32c16856c34460d79bc95887f68869201e0cae68c5d1d4cd1f0358673d76dea56e194ede1e83af78656bde4eef2b17716a7396b54f63a40e4655c7a63c4
   languageName: node
   linkType: hard
 
@@ -6233,10 +5828,33 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@sigstore/bundle@npm:^2.3.0, @sigstore/bundle@npm:^2.3.1":
+  version: 2.3.1
+  resolution: "@sigstore/bundle@npm:2.3.1"
+  dependencies:
+    "@sigstore/protobuf-specs": "npm:^0.3.1"
+  checksum: 10/5e1024dfc57bd61068be213e2be68607a8fdd7747f56aa64bb8cdfd28fb48af1a54248a26e22c6953ab4e14d64aad9866cabea355e440ecace6147cb2da5bcbc
+  languageName: node
+  linkType: hard
+
+"@sigstore/core@npm:^1.0.0, @sigstore/core@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@sigstore/core@npm:1.1.0"
+  checksum: 10/4149572091d61c246dd2ff636ff9a31441877db78cc3afe25fd0b28ece87f0094576f8b9077d1dc7c1c959ac4b000d407595becb6cd784c3664e9dd7cb6da36a
+  languageName: node
+  linkType: hard
+
 "@sigstore/protobuf-specs@npm:^0.2.0":
   version: 0.2.1
   resolution: "@sigstore/protobuf-specs@npm:0.2.1"
   checksum: 10/cb0b9d9b3ef44a9f1729d85616c5d7c2ebccde303836a5a345ec33a500c7bd5205ffcc31332e0a90831cccc581dafbdf5b868f050c84270c8df6a4a6f2ce0bcb
+  languageName: node
+  linkType: hard
+
+"@sigstore/protobuf-specs@npm:^0.3.0, @sigstore/protobuf-specs@npm:^0.3.1":
+  version: 0.3.2
+  resolution: "@sigstore/protobuf-specs@npm:0.3.2"
+  checksum: 10/350a6eb834e0f5c50987935c329350ba9df5baedba7c3db6ab6bc55d8730d9e6ff2deb31e770e721b9fef53f1cf6b32f376e28ed72c6e090493bceb820acfb4a
   languageName: node
   linkType: hard
 
@@ -6251,6 +5869,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@sigstore/sign@npm:^2.3.0":
+  version: 2.3.1
+  resolution: "@sigstore/sign@npm:2.3.1"
+  dependencies:
+    "@sigstore/bundle": "npm:^2.3.0"
+    "@sigstore/core": "npm:^1.0.0"
+    "@sigstore/protobuf-specs": "npm:^0.3.1"
+    make-fetch-happen: "npm:^13.0.1"
+    proc-log: "npm:^4.2.0"
+    promise-retry: "npm:^2.0.1"
+  checksum: 10/99d64bfcd06e2922c2f8baa81882ae3b014dccb7124afa9875dcad4f22a00664e66f724a2c39bb14c4a372d39fce31639d09294936032f8c9dc3e0ec03d21869
+  languageName: node
+  linkType: hard
+
 "@sigstore/tuf@npm:^1.0.3":
   version: 1.0.3
   resolution: "@sigstore/tuf@npm:1.0.3"
@@ -6258,6 +5890,27 @@ __metadata:
     "@sigstore/protobuf-specs": "npm:^0.2.0"
     tuf-js: "npm:^1.1.7"
   checksum: 10/5aa1cdea05fabb78232f802821f7e8ee9db3352719b325f2f703f940aac75fc2e71d89cfbd3623ef6b0429e125a5c6145c1fc8ede8d3d5af3affcb71c6453c7b
+  languageName: node
+  linkType: hard
+
+"@sigstore/tuf@npm:^2.3.1":
+  version: 2.3.3
+  resolution: "@sigstore/tuf@npm:2.3.3"
+  dependencies:
+    "@sigstore/protobuf-specs": "npm:^0.3.0"
+    tuf-js: "npm:^2.2.1"
+  checksum: 10/4d3c5aa897b9643b8832506894e65d593af72bec70819182a895cf2ba538d9873d611f07ec01de42da0c517361811b662d3f43075c26c1c10e0fed9cfac13b26
+  languageName: node
+  linkType: hard
+
+"@sigstore/verify@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "@sigstore/verify@npm:1.2.0"
+  dependencies:
+    "@sigstore/bundle": "npm:^2.3.1"
+    "@sigstore/core": "npm:^1.1.0"
+    "@sigstore/protobuf-specs": "npm:^0.3.1"
+  checksum: 10/f93728c425528120b1863f04ed2fdd55915ad0c773153e623bd4d32137067d85f2e139bd14e8779883394ae502f1fd0e2094d559eac4225d31ee617127218720
   languageName: node
   linkType: hard
 
@@ -6300,682 +5953,388 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/abort-controller@npm:^2.0.7":
-  version: 2.0.7
-  resolution: "@smithy/abort-controller@npm:2.0.7"
+"@smithy/abort-controller@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/abort-controller@npm:3.0.0"
   dependencies:
-    "@smithy/types": "npm:^2.3.1"
-    tslib: "npm:^2.5.0"
-  checksum: 10/d1f898bb23ec203fb1444685ee54dc3dcdada0ef9440250a7022fd5aa07c4fbf473649f018e8422dc8cd451aa960ee5b67e7b502e8049776e17aba6b0d555f33
+    "@smithy/types": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/08bf21e79226c60f3654767683a767b34dd7b30d7fd73dfecd4cb13d172a7225f83f45553fd4af2692c95d38bdf2adbe5b132fac0affb4ecece6a41f066d49ba
   languageName: node
   linkType: hard
 
-"@smithy/abort-controller@npm:^2.0.9":
-  version: 2.0.9
-  resolution: "@smithy/abort-controller@npm:2.0.9"
+"@smithy/chunked-blob-reader-native@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/chunked-blob-reader-native@npm:3.0.0"
   dependencies:
-    "@smithy/types": "npm:^2.3.3"
-    tslib: "npm:^2.5.0"
-  checksum: 10/cfdda8b16b9a354115e878e514dbceec46f8549df47bc08c8fad13d8fb4acb2c334ea3cdb6a947a27a40bd278ffee17c3bb38f527d67674bdc30241a385273fb
+    "@smithy/util-base64": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/424aa83f4fc081625a03ec6c64e74ae38c740c0b202d0b998f2bf341b935613491b39c7bf701790a0625219424340d5cfb042b701bfdff4c1cbedc57ee3f2500
   languageName: node
   linkType: hard
 
-"@smithy/chunked-blob-reader-native@npm:^2.0.0":
+"@smithy/chunked-blob-reader@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/chunked-blob-reader@npm:3.0.0"
+  dependencies:
+    tslib: "npm:^2.6.2"
+  checksum: 10/1c7955ae693aa098dd0839d7e8f9e742ab963de4ededa92f201f1982552c35ba625c1b90cf761de81deddd5002ed10f081ad46f6e0a5150066cee8b00f3f6058
+  languageName: node
+  linkType: hard
+
+"@smithy/config-resolver@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/config-resolver@npm:3.0.0"
+  dependencies:
+    "@smithy/node-config-provider": "npm:^3.0.0"
+    "@smithy/types": "npm:^3.0.0"
+    "@smithy/util-config-provider": "npm:^3.0.0"
+    "@smithy/util-middleware": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/78d6a13cb7d8c64ffe4aff675f5fb7114355b406be307576b7f77f880769417ba8e02830dcbb0991dd933c00e9e1e6248706a60e97c98bcf302577bd79ec52e0
+  languageName: node
+  linkType: hard
+
+"@smithy/core@npm:^2.0.0":
   version: 2.0.0
-  resolution: "@smithy/chunked-blob-reader-native@npm:2.0.0"
+  resolution: "@smithy/core@npm:2.0.0"
   dependencies:
-    "@smithy/util-base64": "npm:^2.0.0"
-    tslib: "npm:^2.5.0"
-  checksum: 10/7f8c3946d59299092e8724f242d5896ce5fb7fca6ea7e3b21cf819c33318038214cd6b774317c3b2a9c1c8d54185f3020879a2f3a832f9951112b726525d0228
+    "@smithy/middleware-endpoint": "npm:^3.0.0"
+    "@smithy/middleware-retry": "npm:^3.0.0"
+    "@smithy/middleware-serde": "npm:^3.0.0"
+    "@smithy/protocol-http": "npm:^4.0.0"
+    "@smithy/smithy-client": "npm:^3.0.0"
+    "@smithy/types": "npm:^3.0.0"
+    "@smithy/util-middleware": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/793c84506982e41bbf9b529d578fd0a6ec21badccabfbc1898a785e92c12446ad1ef768c6b2b6970b00b6dd273cff2b2063e259143899ef17b80d8e73bc5f0df
   languageName: node
   linkType: hard
 
-"@smithy/chunked-blob-reader@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "@smithy/chunked-blob-reader@npm:2.0.0"
+"@smithy/credential-provider-imds@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/credential-provider-imds@npm:3.0.0"
   dependencies:
-    tslib: "npm:^2.5.0"
-  checksum: 10/3e35ce2bb2d8338f44b408958fd4b77054cb286b27730674a213d10b6ed84734889441d13dbdffb5f1971c61fe47c5f05703e5a93596ca0a6285937cd8b061cf
+    "@smithy/node-config-provider": "npm:^3.0.0"
+    "@smithy/property-provider": "npm:^3.0.0"
+    "@smithy/types": "npm:^3.0.0"
+    "@smithy/url-parser": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/793e826a6d2ea1d407a4a0329662b41bc30d2e052520af27845bbd4345f454e1974e389fce622c26b06501c7d5a3c4b3844ec99baedb27e8f89d947d2c28fee6
   languageName: node
   linkType: hard
 
-"@smithy/config-resolver@npm:^2.0.10":
-  version: 2.0.10
-  resolution: "@smithy/config-resolver@npm:2.0.10"
-  dependencies:
-    "@smithy/node-config-provider": "npm:^2.0.12"
-    "@smithy/types": "npm:^2.3.3"
-    "@smithy/util-config-provider": "npm:^2.0.0"
-    "@smithy/util-middleware": "npm:^2.0.2"
-    tslib: "npm:^2.5.0"
-  checksum: 10/ca0f8cbacc80bd509f85c700a9f5d474e67ac5fa8ea69bf7eb3c37c3d9911cf70b1df420256e098119120ac7330e8e309058bf5cef531b322e6161b92c955377
-  languageName: node
-  linkType: hard
-
-"@smithy/config-resolver@npm:^2.0.7, @smithy/config-resolver@npm:^2.0.8":
-  version: 2.0.8
-  resolution: "@smithy/config-resolver@npm:2.0.8"
-  dependencies:
-    "@smithy/node-config-provider": "npm:^2.0.10"
-    "@smithy/types": "npm:^2.3.1"
-    "@smithy/util-config-provider": "npm:^2.0.0"
-    "@smithy/util-middleware": "npm:^2.0.0"
-    tslib: "npm:^2.5.0"
-  checksum: 10/9c560f19a5435c7525a1989ca2df8532fa6e5e38555263912f98e01bc3402964b67bed00f2de6efc9e2e4fa12918da95ab53b69f55c9b4173a534288a9be5751
-  languageName: node
-  linkType: hard
-
-"@smithy/credential-provider-imds@npm:^2.0.0, @smithy/credential-provider-imds@npm:^2.0.10":
-  version: 2.0.10
-  resolution: "@smithy/credential-provider-imds@npm:2.0.10"
-  dependencies:
-    "@smithy/node-config-provider": "npm:^2.0.10"
-    "@smithy/property-provider": "npm:^2.0.8"
-    "@smithy/types": "npm:^2.3.1"
-    "@smithy/url-parser": "npm:^2.0.7"
-    tslib: "npm:^2.5.0"
-  checksum: 10/5a5b56c7e95c784c93f37d75c3424447fc6400ee24b7aa769ebfd6293dbcfea87dd1099b5d6a3265a38a8f5117413230103440823a031133982b5713669e1c0a
-  languageName: node
-  linkType: hard
-
-"@smithy/credential-provider-imds@npm:^2.0.12":
-  version: 2.0.12
-  resolution: "@smithy/credential-provider-imds@npm:2.0.12"
-  dependencies:
-    "@smithy/node-config-provider": "npm:^2.0.12"
-    "@smithy/property-provider": "npm:^2.0.10"
-    "@smithy/types": "npm:^2.3.3"
-    "@smithy/url-parser": "npm:^2.0.9"
-    tslib: "npm:^2.5.0"
-  checksum: 10/edc90dff66b92d4ca3986b9ee93e33f96c8a7a0f172d98fc367aec343f01aa3d3dbf8bc378b0e49063ce1a3796c5bd940ca7dc8fd7a2bfacde43cbc1af3fa239
-  languageName: node
-  linkType: hard
-
-"@smithy/eventstream-codec@npm:^2.0.7":
-  version: 2.0.7
-  resolution: "@smithy/eventstream-codec@npm:2.0.7"
+"@smithy/eventstream-codec@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/eventstream-codec@npm:3.0.0"
   dependencies:
     "@aws-crypto/crc32": "npm:3.0.0"
-    "@smithy/types": "npm:^2.3.1"
-    "@smithy/util-hex-encoding": "npm:^2.0.0"
-    tslib: "npm:^2.5.0"
-  checksum: 10/9c63f2a9b7dce85a7b555a8799d261c854d94a469d91d9ccef80d265a96d463fda694ed7590846431977d493705c08862a4097df1220050dd21be3e868d2d6f5
+    "@smithy/types": "npm:^3.0.0"
+    "@smithy/util-hex-encoding": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/66ec273253d59c78ff7967d1fcd56c2479dc5807af360773dcad3d669b75a75682f3cd3c6647bda0ecc3c42cce6ea7d6261fd109e9531b209a51b9b6e93d7c2c
   languageName: node
   linkType: hard
 
-"@smithy/eventstream-codec@npm:^2.0.9":
-  version: 2.0.9
-  resolution: "@smithy/eventstream-codec@npm:2.0.9"
+"@smithy/eventstream-serde-browser@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/eventstream-serde-browser@npm:3.0.0"
   dependencies:
-    "@aws-crypto/crc32": "npm:3.0.0"
-    "@smithy/types": "npm:^2.3.3"
-    "@smithy/util-hex-encoding": "npm:^2.0.0"
-    tslib: "npm:^2.5.0"
-  checksum: 10/969547a9e81785a9ad7f1047641e001b1d062145424d81696ed3b8bf869e88eab04e72c99597f1521b8d021db838359c79ba7b8b7a65f9bd58dbeb7a55be66bd
+    "@smithy/eventstream-serde-universal": "npm:^3.0.0"
+    "@smithy/types": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/a04c6a5207e670ce0c5508d92a70f5372a5fca076e3a7d76e5383753622525042225fdfe8c3cc0b3ee723ce0e7b568b7d2603ed83337538d471a8817c8d4306d
   languageName: node
   linkType: hard
 
-"@smithy/eventstream-serde-browser@npm:^2.0.6":
-  version: 2.0.7
-  resolution: "@smithy/eventstream-serde-browser@npm:2.0.7"
+"@smithy/eventstream-serde-config-resolver@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/eventstream-serde-config-resolver@npm:3.0.0"
   dependencies:
-    "@smithy/eventstream-serde-universal": "npm:^2.0.7"
-    "@smithy/types": "npm:^2.3.1"
-    tslib: "npm:^2.5.0"
-  checksum: 10/226647236fb093479d69e8b400a1c77505fa1216a25575b917c890856e9cdb11a2e82c4fb045a38bb0d811aaf1cfac400982bb4303dbbc42619778c476c51784
+    "@smithy/types": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/c07f698072bc1ddec3fc54cecbe03fece2b86445e9c18183f2621c528258d120a63d3b02b7d6d92fe3e0a73d29275ce18d85a253ebbdb06973666f885586ce72
   languageName: node
   linkType: hard
 
-"@smithy/eventstream-serde-browser@npm:^2.0.9":
-  version: 2.0.9
-  resolution: "@smithy/eventstream-serde-browser@npm:2.0.9"
+"@smithy/eventstream-serde-node@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/eventstream-serde-node@npm:3.0.0"
   dependencies:
-    "@smithy/eventstream-serde-universal": "npm:^2.0.9"
-    "@smithy/types": "npm:^2.3.3"
-    tslib: "npm:^2.5.0"
-  checksum: 10/2d4ea68b40ea6889ea978beeb42ebb04bf6edb218cfbaaa69972dcb377132941880a1165a78b987611da9adf4fb2797cd03cfa2cdf88e78bceeef42c98692ce6
+    "@smithy/eventstream-serde-universal": "npm:^3.0.0"
+    "@smithy/types": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/46921fae3e47926ef31879dffc3e9743bf2b696a7d4b083c3ddfd06568a30d4fe021a70847d8c8561b9637ba01c4cdfdbd7ba3c418977096945a6cb604b041ea
   languageName: node
   linkType: hard
 
-"@smithy/eventstream-serde-config-resolver@npm:^2.0.6":
-  version: 2.0.7
-  resolution: "@smithy/eventstream-serde-config-resolver@npm:2.0.7"
+"@smithy/eventstream-serde-universal@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/eventstream-serde-universal@npm:3.0.0"
   dependencies:
-    "@smithy/types": "npm:^2.3.1"
-    tslib: "npm:^2.5.0"
-  checksum: 10/8a79029a73a418a830253c1014ff85d21b4c88571e7ac4ba42faa6b2e26214e86137952cbf255b7223d2f5ac5c059d8b0d4ed2ea49b20d7fd890df75ed530282
+    "@smithy/eventstream-codec": "npm:^3.0.0"
+    "@smithy/types": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/6bca5785416e8674a032cffab6fd7f93e8a71ba048d300f46e9da82973750e8709c5981c6aa7de2ebe82e01d22eb1df2383b5c5093beedda5f3e600482e84559
   languageName: node
   linkType: hard
 
-"@smithy/eventstream-serde-config-resolver@npm:^2.0.9":
-  version: 2.0.9
-  resolution: "@smithy/eventstream-serde-config-resolver@npm:2.0.9"
+"@smithy/fetch-http-handler@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/fetch-http-handler@npm:3.0.0"
   dependencies:
-    "@smithy/types": "npm:^2.3.3"
-    tslib: "npm:^2.5.0"
-  checksum: 10/92fc631766f7757164d4d5de4bd02c0de0de61222be893c4d659e8cb04653895c84625c098642d4bcd36450c32e3ead340c972ef046a47739e8ec0b53889d054
+    "@smithy/protocol-http": "npm:^4.0.0"
+    "@smithy/querystring-builder": "npm:^3.0.0"
+    "@smithy/types": "npm:^3.0.0"
+    "@smithy/util-base64": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/357b6c5438a654477e3cbd6be72efca6c6d9414cffba7450ff5aed9d420428ba08713a5ace62053d73baecfac2c2e2b568c91ca8bab3069be68abc3139f122be
   languageName: node
   linkType: hard
 
-"@smithy/eventstream-serde-node@npm:^2.0.6":
-  version: 2.0.7
-  resolution: "@smithy/eventstream-serde-node@npm:2.0.7"
+"@smithy/hash-blob-browser@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/hash-blob-browser@npm:3.0.0"
   dependencies:
-    "@smithy/eventstream-serde-universal": "npm:^2.0.7"
-    "@smithy/types": "npm:^2.3.1"
-    tslib: "npm:^2.5.0"
-  checksum: 10/f92d16e1aa1319590dfa4d3ea1d78b5cb85feacd1d3edffb4a12ae5815c2f63414408bc04ca6440f5a29aa2e2eba35a0b86011c43a07d423510850826cb0e918
+    "@smithy/chunked-blob-reader": "npm:^3.0.0"
+    "@smithy/chunked-blob-reader-native": "npm:^3.0.0"
+    "@smithy/types": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/c8f6d76d8dae37bd48334bcd6060195d8d8f6b14d0af7d326cbd7f3dd4db648691bf755f3795e5d6b4ca9b85fbc580a4b010cce6fe9735204e8a667f145f11bb
   languageName: node
   linkType: hard
 
-"@smithy/eventstream-serde-node@npm:^2.0.9":
-  version: 2.0.9
-  resolution: "@smithy/eventstream-serde-node@npm:2.0.9"
+"@smithy/hash-node@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/hash-node@npm:3.0.0"
   dependencies:
-    "@smithy/eventstream-serde-universal": "npm:^2.0.9"
-    "@smithy/types": "npm:^2.3.3"
-    tslib: "npm:^2.5.0"
-  checksum: 10/f1ff4a62d62abb21af1e36d61c9f190bf9c7a4a5d53b19eb8dd282081957485e83119f0af370b5a1d8d459ce40a3f627aaba4e26b3435418fbd997d62e91dd22
+    "@smithy/types": "npm:^3.0.0"
+    "@smithy/util-buffer-from": "npm:^3.0.0"
+    "@smithy/util-utf8": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/99c65bc992bc3adedb68d4304845bf0acd3e55d3cd851874605a937be5dd4da4eeab01e99e971b59d43d6fb4364dab655530c3a89eb32eac0803f6d07179a63b
   languageName: node
   linkType: hard
 
-"@smithy/eventstream-serde-universal@npm:^2.0.7":
-  version: 2.0.7
-  resolution: "@smithy/eventstream-serde-universal@npm:2.0.7"
+"@smithy/hash-stream-node@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/hash-stream-node@npm:3.0.0"
   dependencies:
-    "@smithy/eventstream-codec": "npm:^2.0.7"
-    "@smithy/types": "npm:^2.3.1"
-    tslib: "npm:^2.5.0"
-  checksum: 10/7221b5417036ff9860a06b568f8caf8df42b1c60938a3a2e55b02abc84659111c25a6f54f9928c11ce5e87b21b74b3fe51073d9fc743662819583e6f40109dc8
+    "@smithy/types": "npm:^3.0.0"
+    "@smithy/util-utf8": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/1e67ad794267dcbf2f5008938409b4081e43cbf302d44508f444aaa051ca167e1739418333122b9cce4b98b0815f618326e9c2d55fd5579751ad22ac7e02c9d2
   languageName: node
   linkType: hard
 
-"@smithy/eventstream-serde-universal@npm:^2.0.9":
-  version: 2.0.9
-  resolution: "@smithy/eventstream-serde-universal@npm:2.0.9"
+"@smithy/invalid-dependency@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/invalid-dependency@npm:3.0.0"
   dependencies:
-    "@smithy/eventstream-codec": "npm:^2.0.9"
-    "@smithy/types": "npm:^2.3.3"
-    tslib: "npm:^2.5.0"
-  checksum: 10/6d101a8a8125c890ec93425c8925dd5f04eee608b851837c803a9fad6a68fabc901203cb255a8256ecbe6210e19f30f6b24bf708b74d051cd2d5b4a3bdb02ec8
+    "@smithy/types": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/e78e9cbe1cc8ad04be0dffbc1094eb15294d29b86389ae62c55f0afb96b7354c615fc20f34affed362f857d497e7b34e04b51e732f0b045c2870b749ecc5a2f4
   languageName: node
   linkType: hard
 
-"@smithy/fetch-http-handler@npm:^2.1.2, @smithy/fetch-http-handler@npm:^2.1.3":
-  version: 2.1.3
-  resolution: "@smithy/fetch-http-handler@npm:2.1.3"
+"@smithy/is-array-buffer@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/is-array-buffer@npm:3.0.0"
   dependencies:
-    "@smithy/protocol-http": "npm:^3.0.3"
-    "@smithy/querystring-builder": "npm:^2.0.7"
-    "@smithy/types": "npm:^2.3.1"
-    "@smithy/util-base64": "npm:^2.0.0"
-    tslib: "npm:^2.5.0"
-  checksum: 10/93750fac4bd53e5854cd713da85f1a296900e4d80aed7784078863750cef18470fbf1cc09c8b5e4cbe4cfcedd82a01fe5bfa65c287018b242aa3e3b2a0eae554
+    tslib: "npm:^2.6.2"
+  checksum: 10/cab1fd4033d9863dcd95ff058463eb591574bd47e6b61e36aaaf4c0d0da9ed966a54e1d33ec4db7d67aa85df7d274203e934e04dbb40323d01ef4815f63997fc
   languageName: node
   linkType: hard
 
-"@smithy/fetch-http-handler@npm:^2.1.5":
-  version: 2.1.5
-  resolution: "@smithy/fetch-http-handler@npm:2.1.5"
+"@smithy/md5-js@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/md5-js@npm:3.0.0"
   dependencies:
-    "@smithy/protocol-http": "npm:^3.0.5"
-    "@smithy/querystring-builder": "npm:^2.0.9"
-    "@smithy/types": "npm:^2.3.3"
-    "@smithy/util-base64": "npm:^2.0.0"
-    tslib: "npm:^2.5.0"
-  checksum: 10/c0da440982d085bd3d0ba52a5af18fec532abf11646f38239066fece3bd20109b77e11d9cc1709661855c239b724d2e5366d1b3c3928dfc4738bd95919067d3d
+    "@smithy/types": "npm:^3.0.0"
+    "@smithy/util-utf8": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/098b849ee76c83fb33624dac8d3980a50873564de6fae4e159bac90a6aa9abe0b9fe0fce9a150e5ff438e0a8af2010c50cdc08dd2a8d02b7db2ebb89802743b9
   languageName: node
   linkType: hard
 
-"@smithy/hash-blob-browser@npm:^2.0.6":
-  version: 2.0.7
-  resolution: "@smithy/hash-blob-browser@npm:2.0.7"
+"@smithy/middleware-content-length@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/middleware-content-length@npm:3.0.0"
   dependencies:
-    "@smithy/chunked-blob-reader": "npm:^2.0.0"
-    "@smithy/chunked-blob-reader-native": "npm:^2.0.0"
-    "@smithy/types": "npm:^2.3.1"
-    tslib: "npm:^2.5.0"
-  checksum: 10/4f3273dd29f698920f1d89c9b0740d20839c4c47cbaf4e5d28d679d4e0bcf23ff28a67991e93425ab597ee1aeb310ea7a54d1dec0c5536b2fa31aeb210875c1d
+    "@smithy/protocol-http": "npm:^4.0.0"
+    "@smithy/types": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/2d1dc5766ac83604d43b75b788d4b1f61d8095c9081fe060d5bb21d69b59c4da52869d38eb4f9e13ca8001974b3bce63619f1d8bddfc553041e5b264162fdac9
   languageName: node
   linkType: hard
 
-"@smithy/hash-blob-browser@npm:^2.0.9":
-  version: 2.0.9
-  resolution: "@smithy/hash-blob-browser@npm:2.0.9"
+"@smithy/middleware-endpoint@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/middleware-endpoint@npm:3.0.0"
   dependencies:
-    "@smithy/chunked-blob-reader": "npm:^2.0.0"
-    "@smithy/chunked-blob-reader-native": "npm:^2.0.0"
-    "@smithy/types": "npm:^2.3.3"
-    tslib: "npm:^2.5.0"
-  checksum: 10/cc0fcc85f2d55ea59df2b4905ed95a18c3ad5c30c11fa0e3fa6e7a0a58bbe15fb02af13892eb76f1fe8526f88a437aedb603115de01c0c37268b89ce7c43e3c6
+    "@smithy/middleware-serde": "npm:^3.0.0"
+    "@smithy/node-config-provider": "npm:^3.0.0"
+    "@smithy/shared-ini-file-loader": "npm:^3.0.0"
+    "@smithy/types": "npm:^3.0.0"
+    "@smithy/url-parser": "npm:^3.0.0"
+    "@smithy/util-middleware": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/b39b8a3c8ddc4295ab265ce861360a7a842c94af7fb75d81aba4a89000715e50598138f1a7da4979675738d391472189e9854d35cae10a9e994245ad69c2682f
   languageName: node
   linkType: hard
 
-"@smithy/hash-node@npm:^2.0.6":
-  version: 2.0.7
-  resolution: "@smithy/hash-node@npm:2.0.7"
+"@smithy/middleware-retry@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/middleware-retry@npm:3.0.0"
   dependencies:
-    "@smithy/types": "npm:^2.3.1"
-    "@smithy/util-buffer-from": "npm:^2.0.0"
-    "@smithy/util-utf8": "npm:^2.0.0"
-    tslib: "npm:^2.5.0"
-  checksum: 10/eca84eb7694a59db64114826575f33d64b1cc904805c8863f83b139ba825dbd6588d419949907852667c99dda5577b092939b527ca63e60699b0b35c8c225f99
+    "@smithy/node-config-provider": "npm:^3.0.0"
+    "@smithy/protocol-http": "npm:^4.0.0"
+    "@smithy/service-error-classification": "npm:^3.0.0"
+    "@smithy/smithy-client": "npm:^3.0.0"
+    "@smithy/types": "npm:^3.0.0"
+    "@smithy/util-middleware": "npm:^3.0.0"
+    "@smithy/util-retry": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+    uuid: "npm:^9.0.1"
+  checksum: 10/9158545d2940d77e7ddc1098c1f692041431733e9168183de35a9522af1891a8a1edf55bf549a9c43e4cb43ab544913132b81ec14ee9a7892aea3e7a260fdf1c
   languageName: node
   linkType: hard
 
-"@smithy/hash-node@npm:^2.0.9":
-  version: 2.0.9
-  resolution: "@smithy/hash-node@npm:2.0.9"
+"@smithy/middleware-serde@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/middleware-serde@npm:3.0.0"
   dependencies:
-    "@smithy/types": "npm:^2.3.3"
-    "@smithy/util-buffer-from": "npm:^2.0.0"
-    "@smithy/util-utf8": "npm:^2.0.0"
-    tslib: "npm:^2.5.0"
-  checksum: 10/c237fe6f135575dbc2d44df5dfd6d3abea2c100a10a68d45d05ab8da9bf61b256d0a99aee48cfab41900898a4bdb6c08803789b1c6fab7d723b2e5ec7918ad92
+    "@smithy/types": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/7ca5256fe9290b6ae097fdb9c0180e5219e6d3cb39084fadee007d9e698073498d200c32c439486902e386ab76739176765f64d23673882a08aa0e8de837dc8a
   languageName: node
   linkType: hard
 
-"@smithy/hash-stream-node@npm:^2.0.6":
-  version: 2.0.7
-  resolution: "@smithy/hash-stream-node@npm:2.0.7"
+"@smithy/middleware-stack@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/middleware-stack@npm:3.0.0"
   dependencies:
-    "@smithy/types": "npm:^2.3.1"
-    "@smithy/util-utf8": "npm:^2.0.0"
-    tslib: "npm:^2.5.0"
-  checksum: 10/e256629eac4b624782617c76c2baac3233eeef3c56fe0c51d9a5f1db3467e343388d21decac7d30d5408e49281691cfc40dc382c6e83f8ed7dde16ac4bba6f8a
+    "@smithy/types": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/e85695b2d2d96230f03500b7111f9917abaab516e1850ec90021db7e984718965e05f7afccda084a7ba96a6bbb9d195a7d6e7882b48d7ccec97239101a2978bc
   languageName: node
   linkType: hard
 
-"@smithy/hash-stream-node@npm:^2.0.9":
-  version: 2.0.9
-  resolution: "@smithy/hash-stream-node@npm:2.0.9"
+"@smithy/node-config-provider@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/node-config-provider@npm:3.0.0"
   dependencies:
-    "@smithy/types": "npm:^2.3.3"
-    "@smithy/util-utf8": "npm:^2.0.0"
-    tslib: "npm:^2.5.0"
-  checksum: 10/5a424f4c773e027c75008a1dbd0c0def9e117291a127f1574ff187d0ae7712182e4912b38af67ba10fcc1c74b3b915e1dc0ac5f076c1b538592dec941d7646d4
+    "@smithy/property-provider": "npm:^3.0.0"
+    "@smithy/shared-ini-file-loader": "npm:^3.0.0"
+    "@smithy/types": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/6f5326162484f27c6709796e6f11aaa1cd624cb0632a09340f2f2126c20c64dd10f9ed96400f1e65afdfa11e877f69910951ea2b36264141cc513c51461ac656
   languageName: node
   linkType: hard
 
-"@smithy/invalid-dependency@npm:^2.0.6":
-  version: 2.0.7
-  resolution: "@smithy/invalid-dependency@npm:2.0.7"
+"@smithy/node-http-handler@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/node-http-handler@npm:3.0.0"
   dependencies:
-    "@smithy/types": "npm:^2.3.1"
-    tslib: "npm:^2.5.0"
-  checksum: 10/eaf0fa963f5017b034aab23f2b94ef7a4741163c28341aef6a9c337d144916dcf36d9c683263c88c8f522fecd5a7d2b184b09d337f40b68a06f4082b51631043
+    "@smithy/abort-controller": "npm:^3.0.0"
+    "@smithy/protocol-http": "npm:^4.0.0"
+    "@smithy/querystring-builder": "npm:^3.0.0"
+    "@smithy/types": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/3d2d0fff55ebeabeca4bb9a8b1cc7dd3a9c810281817232eb546b75cfae53da3c9571d25f203232f42cef608f28b795a1cadec3dbfd44aad2029a6141d146ecf
   languageName: node
   linkType: hard
 
-"@smithy/invalid-dependency@npm:^2.0.9":
-  version: 2.0.9
-  resolution: "@smithy/invalid-dependency@npm:2.0.9"
+"@smithy/property-provider@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/property-provider@npm:3.0.0"
   dependencies:
-    "@smithy/types": "npm:^2.3.3"
-    tslib: "npm:^2.5.0"
-  checksum: 10/24e0d2da9cec22d2c821310f836becb66aa39c890e893f47f20e509b10a33c080164cc29076031b9a8f45d37f18a71aee27caa826f0dbf564db34241789da3f8
+    "@smithy/types": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/37c9b949f0df60240b51a4a6e60a772e4ffc5f50de7fb51c74aec4336f46ba7c424f81181487ba6c7a15b5a43f13d82f7609836e96cfc61728e1c26425a5a2b4
   languageName: node
   linkType: hard
 
-"@smithy/is-array-buffer@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "@smithy/is-array-buffer@npm:2.0.0"
+"@smithy/protocol-http@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "@smithy/protocol-http@npm:4.0.0"
   dependencies:
-    tslib: "npm:^2.5.0"
-  checksum: 10/30f8e51403c52f27b5a6777e565128f2c8523d6e9a99f2005cdcaa31b7401376de77fa4a245de4a397d605af1cead8bea3189f3e7450386888e1656fe728030d
+    "@smithy/types": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/0e663013be49ca6867e4d03d2759bae5a72653918617a0184c0f7ecf84043ebaf0f3e6a174f7f6f81934720f90bfce89cecc56510d572cd8d93f423483b74d93
   languageName: node
   linkType: hard
 
-"@smithy/md5-js@npm:^2.0.6":
-  version: 2.0.7
-  resolution: "@smithy/md5-js@npm:2.0.7"
+"@smithy/querystring-builder@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/querystring-builder@npm:3.0.0"
   dependencies:
-    "@smithy/types": "npm:^2.3.1"
-    "@smithy/util-utf8": "npm:^2.0.0"
-    tslib: "npm:^2.5.0"
-  checksum: 10/e25cf7e842d55e2f5f1297dd371f107d143646b0eb41f93413c80baf5db9fe35ea747696fe565cc9f0293eb019f3e0ee4e18c303a16b1c3c68f01db713e24423
+    "@smithy/types": "npm:^3.0.0"
+    "@smithy/util-uri-escape": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/bca3e4c32127f444d7d7812c6afc6cc0dadbbd52a6359f09bf4ba04d2a7f6a09395f61c981b4cf64d714e6010a93ba4a729989f869e4cc32c065aca86bd8f2fc
   languageName: node
   linkType: hard
 
-"@smithy/md5-js@npm:^2.0.9":
-  version: 2.0.9
-  resolution: "@smithy/md5-js@npm:2.0.9"
+"@smithy/querystring-parser@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/querystring-parser@npm:3.0.0"
   dependencies:
-    "@smithy/types": "npm:^2.3.3"
-    "@smithy/util-utf8": "npm:^2.0.0"
-    tslib: "npm:^2.5.0"
-  checksum: 10/9a18576ee7bb14925f9d8ed87335717607c9d1f9d7f25604fed1ed742d9e42d1c1f7925938cce978ddc67103b01f6038af002d34d3d44827eb7963c1cd2b3a7f
+    "@smithy/types": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/c0258dd552819ffd584abc858d702428da4d6d850eeaa47b29bd15972d428e5b6d62cc9a6609c83ad58e1fedcc38a9189093568163eac6ecf24ea38a96e31779
   languageName: node
   linkType: hard
 
-"@smithy/middleware-content-length@npm:^2.0.11":
-  version: 2.0.11
-  resolution: "@smithy/middleware-content-length@npm:2.0.11"
+"@smithy/service-error-classification@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/service-error-classification@npm:3.0.0"
   dependencies:
-    "@smithy/protocol-http": "npm:^3.0.5"
-    "@smithy/types": "npm:^2.3.3"
-    tslib: "npm:^2.5.0"
-  checksum: 10/39351662a4def9dd941c70f561ec415c94372f7f0a9bd34b95265e4c6051bb1384176c80e887cf04b767a7910a4d9c81b10fa51c36ccc311adbe1cb30a37b806
+    "@smithy/types": "npm:^3.0.0"
+  checksum: 10/b7922ac401773fe4ff500378d8731e9fe8b7dceb6707a48ea93051c0158f2cec7195c718dd80b940af57ef584e36982792f1fe7d31d52c4173c1c495775075a0
   languageName: node
   linkType: hard
 
-"@smithy/middleware-content-length@npm:^2.0.8":
-  version: 2.0.9
-  resolution: "@smithy/middleware-content-length@npm:2.0.9"
+"@smithy/shared-ini-file-loader@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/shared-ini-file-loader@npm:3.0.0"
   dependencies:
-    "@smithy/protocol-http": "npm:^3.0.3"
-    "@smithy/types": "npm:^2.3.1"
-    tslib: "npm:^2.5.0"
-  checksum: 10/707f6fcb587b99e8d5811791ed87eb3f3cbff1e43562c60f68650ba4ff43fcff5c6d7c2978d0320acf1096785aade3ec68ef360f05bded5134526cdab77f2b4d
+    "@smithy/types": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/29b2fda4aa6a5688453dd025a1acf867461c9b59db52998e2bac41b7acca8aea45aa41b275cfac27443446a90e9e22da794fb7fd64c2a244cdce80e0c373237f
   languageName: node
   linkType: hard
 
-"@smithy/middleware-endpoint@npm:^2.0.6":
-  version: 2.0.7
-  resolution: "@smithy/middleware-endpoint@npm:2.0.7"
+"@smithy/signature-v4@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/signature-v4@npm:3.0.0"
   dependencies:
-    "@smithy/middleware-serde": "npm:^2.0.7"
-    "@smithy/types": "npm:^2.3.1"
-    "@smithy/url-parser": "npm:^2.0.7"
-    "@smithy/util-middleware": "npm:^2.0.0"
-    tslib: "npm:^2.5.0"
-  checksum: 10/19f4ae3696db7278c764eaa8dd1382fbf5d210724d063ecde3c60772021c3663ce214e7041519bfa62271cc99ecb96a7c94da89128c1309fdb540f6998dcbb39
+    "@smithy/is-array-buffer": "npm:^3.0.0"
+    "@smithy/types": "npm:^3.0.0"
+    "@smithy/util-hex-encoding": "npm:^3.0.0"
+    "@smithy/util-middleware": "npm:^3.0.0"
+    "@smithy/util-uri-escape": "npm:^3.0.0"
+    "@smithy/util-utf8": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/528461766bc6a941216a17331ef61ecc72a2e0171b10c6b40bfafb33e3c83a77f1003541a9986a3c5b61320cc28c95c2aff7c3fa650c6e70a62cb765327e9a9e
   languageName: node
   linkType: hard
 
-"@smithy/middleware-endpoint@npm:^2.0.9":
-  version: 2.0.9
-  resolution: "@smithy/middleware-endpoint@npm:2.0.9"
+"@smithy/smithy-client@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/smithy-client@npm:3.0.0"
   dependencies:
-    "@smithy/middleware-serde": "npm:^2.0.9"
-    "@smithy/types": "npm:^2.3.3"
-    "@smithy/url-parser": "npm:^2.0.9"
-    "@smithy/util-middleware": "npm:^2.0.2"
-    tslib: "npm:^2.5.0"
-  checksum: 10/40394629c3d7273134450511e0449bac92cb90f8e7e55f552d5f6905a168d5def01bdc4a872d2edb1ffe2d62aaa19b2403c488234601000f6e5c42c613e37fa5
+    "@smithy/middleware-endpoint": "npm:^3.0.0"
+    "@smithy/middleware-stack": "npm:^3.0.0"
+    "@smithy/protocol-http": "npm:^4.0.0"
+    "@smithy/types": "npm:^3.0.0"
+    "@smithy/util-stream": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/22c940ac2b884bb91c0bb2746bc782322348fdf9c2e9beff372993dc1705a9d28f12d3bb09a9d7abbe35d76dee937beebd3e53b998691b04035e6462dca75eed
   languageName: node
   linkType: hard
 
-"@smithy/middleware-retry@npm:^2.0.12":
-  version: 2.0.12
-  resolution: "@smithy/middleware-retry@npm:2.0.12"
-  dependencies:
-    "@smithy/node-config-provider": "npm:^2.0.12"
-    "@smithy/protocol-http": "npm:^3.0.5"
-    "@smithy/service-error-classification": "npm:^2.0.2"
-    "@smithy/types": "npm:^2.3.3"
-    "@smithy/util-middleware": "npm:^2.0.2"
-    "@smithy/util-retry": "npm:^2.0.2"
-    tslib: "npm:^2.5.0"
-    uuid: "npm:^8.3.2"
-  checksum: 10/2265c95d1c09644bbb1e3d4ac03cea1b100602aadbbef63f0b8333443fe563988f7dfe3dbe2548dc9c25472f1659689008e06b74c5cd1e1d789d696e7cbcc8ae
-  languageName: node
-  linkType: hard
-
-"@smithy/middleware-retry@npm:^2.0.9":
-  version: 2.0.10
-  resolution: "@smithy/middleware-retry@npm:2.0.10"
-  dependencies:
-    "@smithy/node-config-provider": "npm:^2.0.10"
-    "@smithy/protocol-http": "npm:^3.0.3"
-    "@smithy/service-error-classification": "npm:^2.0.0"
-    "@smithy/types": "npm:^2.3.1"
-    "@smithy/util-middleware": "npm:^2.0.0"
-    "@smithy/util-retry": "npm:^2.0.0"
-    tslib: "npm:^2.5.0"
-    uuid: "npm:^8.3.2"
-  checksum: 10/c44d1c8e608640f159df7cdda1c191a8b866bb1d37fd1d2827f5e16fc773e955f5a948fab67ba70ae6b2a84e2f8e888fd8f3c67bf62e5ff10fbbb13c74533d66
-  languageName: node
-  linkType: hard
-
-"@smithy/middleware-serde@npm:^2.0.6, @smithy/middleware-serde@npm:^2.0.7":
-  version: 2.0.7
-  resolution: "@smithy/middleware-serde@npm:2.0.7"
-  dependencies:
-    "@smithy/types": "npm:^2.3.1"
-    tslib: "npm:^2.5.0"
-  checksum: 10/91e46d17585044993d87648fc4ca1b49d005d94f92deeb599cb4e80b1726c6a091405ceb9aae7324f7c606e5105a3cc239a4023ca1830d4c5084e951750a3326
-  languageName: node
-  linkType: hard
-
-"@smithy/middleware-serde@npm:^2.0.9":
-  version: 2.0.9
-  resolution: "@smithy/middleware-serde@npm:2.0.9"
-  dependencies:
-    "@smithy/types": "npm:^2.3.3"
-    tslib: "npm:^2.5.0"
-  checksum: 10/fa10b0c67176cae3bd441961fbb049994dab2be954376c1ec999eb5abe38faeafc0c96e4f59d3bcde8ed03143c9260c593058db5857eb6ba4c9fd2282c5df307
-  languageName: node
-  linkType: hard
-
-"@smithy/middleware-stack@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "@smithy/middleware-stack@npm:2.0.0"
-  dependencies:
-    tslib: "npm:^2.5.0"
-  checksum: 10/6bbc3ff23fb2903615bf78b66eb16dd0377030f0e293e86d075335caf3906ab39eca45727569b507e123ea64df0f4a9e8c31fef427408352655611b521323860
-  languageName: node
-  linkType: hard
-
-"@smithy/middleware-stack@npm:^2.0.2, @smithy/middleware-stack@npm:^2.0.3":
-  version: 2.0.3
-  resolution: "@smithy/middleware-stack@npm:2.0.3"
-  dependencies:
-    "@smithy/types": "npm:^2.3.3"
-    tslib: "npm:^2.5.0"
-  checksum: 10/ab4ea66a2435eb3831ae33a876723b6ff3fee6a770b0ff3fa7da9d9090889e6517752ea200ebadb6d2da29b8ee2e2a4f354c5d908eaa093c90efa7072e25b892
-  languageName: node
-  linkType: hard
-
-"@smithy/node-config-provider@npm:^2.0.10, @smithy/node-config-provider@npm:^2.0.9":
-  version: 2.0.10
-  resolution: "@smithy/node-config-provider@npm:2.0.10"
-  dependencies:
-    "@smithy/property-provider": "npm:^2.0.8"
-    "@smithy/shared-ini-file-loader": "npm:^2.0.9"
-    "@smithy/types": "npm:^2.3.1"
-    tslib: "npm:^2.5.0"
-  checksum: 10/6b770152af137c82f611cb5b638b68c60aa0b6ef49249254005b9c417f9d1f9f2e7fafe1d3523b78892202605801f1e44e1944dfcc11dfe21ed0c663df9b8f0f
-  languageName: node
-  linkType: hard
-
-"@smithy/node-config-provider@npm:^2.0.12":
-  version: 2.0.12
-  resolution: "@smithy/node-config-provider@npm:2.0.12"
-  dependencies:
-    "@smithy/property-provider": "npm:^2.0.10"
-    "@smithy/shared-ini-file-loader": "npm:^2.0.11"
-    "@smithy/types": "npm:^2.3.3"
-    tslib: "npm:^2.5.0"
-  checksum: 10/b98bdd255501c67fa4a28a0cf26b937fa2fecbf85f62d1e8e94a11af23dde36e10f73add5b6a1f36c2562a605c6eb90b48e360c5c5b8d12fcee08b12124d20b4
-  languageName: node
-  linkType: hard
-
-"@smithy/node-http-handler@npm:^2.1.2, @smithy/node-http-handler@npm:^2.1.3":
-  version: 2.1.3
-  resolution: "@smithy/node-http-handler@npm:2.1.3"
-  dependencies:
-    "@smithy/abort-controller": "npm:^2.0.7"
-    "@smithy/protocol-http": "npm:^3.0.3"
-    "@smithy/querystring-builder": "npm:^2.0.7"
-    "@smithy/types": "npm:^2.3.1"
-    tslib: "npm:^2.5.0"
-  checksum: 10/df7349e993690d493bfffe6a0bfa80159b21cc9bdda4743ee44e27feb9c3de82912d22c908aecab3336be1cf18c23ce1e3bd167088b92a35d13bd10326d21d47
-  languageName: node
-  linkType: hard
-
-"@smithy/node-http-handler@npm:^2.1.5":
-  version: 2.1.5
-  resolution: "@smithy/node-http-handler@npm:2.1.5"
-  dependencies:
-    "@smithy/abort-controller": "npm:^2.0.9"
-    "@smithy/protocol-http": "npm:^3.0.5"
-    "@smithy/querystring-builder": "npm:^2.0.9"
-    "@smithy/types": "npm:^2.3.3"
-    tslib: "npm:^2.5.0"
-  checksum: 10/4dfd0009b2a8bebe1739ad2bb8e56c95af05109f7c288ebf25ccb16e55a78f05c918e2ba64a99908a8e6246c3f912b9ec67ab49ac88642281b0faf492b770155
-  languageName: node
-  linkType: hard
-
-"@smithy/property-provider@npm:^2.0.0, @smithy/property-provider@npm:^2.0.8":
-  version: 2.0.8
-  resolution: "@smithy/property-provider@npm:2.0.8"
-  dependencies:
-    "@smithy/types": "npm:^2.3.1"
-    tslib: "npm:^2.5.0"
-  checksum: 10/e34142edc41c97b2d67f32b16f5ab1c744e356db946dfb4819fdf59815b7d35c8ad2f6c649df2603573017b70dfa355dd5b291922a685c8d03197b6ee7a3b07c
-  languageName: node
-  linkType: hard
-
-"@smithy/property-provider@npm:^2.0.10":
-  version: 2.0.10
-  resolution: "@smithy/property-provider@npm:2.0.10"
-  dependencies:
-    "@smithy/types": "npm:^2.3.3"
-    tslib: "npm:^2.5.0"
-  checksum: 10/94b06d7e409e755a27319c70b604e1f1480082642fb9e9a99304db85d4f2937d0acee86695c56e56746b960643488e602ec40958fc6690bf551a80c15e16b2ef
-  languageName: node
-  linkType: hard
-
-"@smithy/protocol-http@npm:^3.0.2, @smithy/protocol-http@npm:^3.0.3":
-  version: 3.0.3
-  resolution: "@smithy/protocol-http@npm:3.0.3"
-  dependencies:
-    "@smithy/types": "npm:^2.3.1"
-    tslib: "npm:^2.5.0"
-  checksum: 10/cf6fdd63da0062eff04829a1eef837a07f3d58ae7065da19f22be3477b63013e6badb25065c6bb155148e5cfbaa97d693e15ee44ebceff2e36ab756120a177ca
-  languageName: node
-  linkType: hard
-
-"@smithy/protocol-http@npm:^3.0.5":
-  version: 3.0.5
-  resolution: "@smithy/protocol-http@npm:3.0.5"
-  dependencies:
-    "@smithy/types": "npm:^2.3.3"
-    tslib: "npm:^2.5.0"
-  checksum: 10/1fddbff8b1974200f12675747aed8efbc443d3be77c2950f4f08dfe5b41f6487610272e445153a7ee66b5bbfca0e611506f78800dbfb175d1f4c02840ca2c30c
-  languageName: node
-  linkType: hard
-
-"@smithy/querystring-builder@npm:^2.0.7":
-  version: 2.0.7
-  resolution: "@smithy/querystring-builder@npm:2.0.7"
-  dependencies:
-    "@smithy/types": "npm:^2.3.1"
-    "@smithy/util-uri-escape": "npm:^2.0.0"
-    tslib: "npm:^2.5.0"
-  checksum: 10/16651e918555b04a93205a8af2627bf74ce431304881ffdee328e1b1290a01f8b0304111e7fd548ba1fdb807e06607369e0a3a8074831adb992c685833185924
-  languageName: node
-  linkType: hard
-
-"@smithy/querystring-builder@npm:^2.0.9":
-  version: 2.0.9
-  resolution: "@smithy/querystring-builder@npm:2.0.9"
-  dependencies:
-    "@smithy/types": "npm:^2.3.3"
-    "@smithy/util-uri-escape": "npm:^2.0.0"
-    tslib: "npm:^2.5.0"
-  checksum: 10/b06bca2c9f94036e5e2d0ad90452ebbb3cc20be9da060fd4abb6abe09c294ee142aa938983763350136cc3a0bc330c36aaf942a0831765f54b8a54fc377dd236
-  languageName: node
-  linkType: hard
-
-"@smithy/querystring-parser@npm:^2.0.7":
-  version: 2.0.7
-  resolution: "@smithy/querystring-parser@npm:2.0.7"
-  dependencies:
-    "@smithy/types": "npm:^2.3.1"
-    tslib: "npm:^2.5.0"
-  checksum: 10/7bdcc6de616d6d61b18c80c2719ded760d3127d0cccaa18a4300c0fe865a69b2db009b61c3678671c446327aca06ff854ad9a8939d27babce95034557a4952d1
-  languageName: node
-  linkType: hard
-
-"@smithy/querystring-parser@npm:^2.0.9":
-  version: 2.0.9
-  resolution: "@smithy/querystring-parser@npm:2.0.9"
-  dependencies:
-    "@smithy/types": "npm:^2.3.3"
-    tslib: "npm:^2.5.0"
-  checksum: 10/5977ca91941b29f0ba8d7e10bdf3d969f34323bded46fe387275d3b98e654e0fd214e996bb84acfeac17006152e3689a24bbecba433db8cf8f0d6408c6f34ec7
-  languageName: node
-  linkType: hard
-
-"@smithy/service-error-classification@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "@smithy/service-error-classification@npm:2.0.0"
-  checksum: 10/2dfb6baccf09a44ecde33b1276f84631af4d3674e0a8487e82bb397255a94575d669dbe78d7e6ccb3ed0b9640a10715934e74c89235c2c92d950ce87187208f1
-  languageName: node
-  linkType: hard
-
-"@smithy/service-error-classification@npm:^2.0.2":
-  version: 2.0.2
-  resolution: "@smithy/service-error-classification@npm:2.0.2"
-  dependencies:
-    "@smithy/types": "npm:^2.3.3"
-  checksum: 10/41e901ebd29dca3651d10d48f108f9d5064c63d46d788885a5d14f477be54393fe1663fd999d105e1ca41facde5d5ce26d00950e67729a488dfb229a692e8860
-  languageName: node
-  linkType: hard
-
-"@smithy/shared-ini-file-loader@npm:^2.0.11":
-  version: 2.0.11
-  resolution: "@smithy/shared-ini-file-loader@npm:2.0.11"
-  dependencies:
-    "@smithy/types": "npm:^2.3.3"
-    tslib: "npm:^2.5.0"
-  checksum: 10/434fb81f1ed56f8658d0bb6797d442cecb350872615c8642e8437ff42eda847fc4c70fcb8216e6f10328366f20b1cc7d97a15dffcfa4efa2dadf79740c74996c
-  languageName: node
-  linkType: hard
-
-"@smithy/shared-ini-file-loader@npm:^2.0.6, @smithy/shared-ini-file-loader@npm:^2.0.9":
-  version: 2.0.9
-  resolution: "@smithy/shared-ini-file-loader@npm:2.0.9"
-  dependencies:
-    "@smithy/types": "npm:^2.3.1"
-    tslib: "npm:^2.5.0"
-  checksum: 10/8bd9c2e9cfd20cb5fee652e8632a99a6077aecfe44a94e4d94184779fee2f7437226989bdcb703e225ede9a73a76a42ec02423490476b45b3ae51f4866f79e45
-  languageName: node
-  linkType: hard
-
-"@smithy/signature-v4@npm:^2.0.0":
-  version: 2.0.7
-  resolution: "@smithy/signature-v4@npm:2.0.7"
-  dependencies:
-    "@smithy/eventstream-codec": "npm:^2.0.7"
-    "@smithy/is-array-buffer": "npm:^2.0.0"
-    "@smithy/types": "npm:^2.3.1"
-    "@smithy/util-hex-encoding": "npm:^2.0.0"
-    "@smithy/util-middleware": "npm:^2.0.0"
-    "@smithy/util-uri-escape": "npm:^2.0.0"
-    "@smithy/util-utf8": "npm:^2.0.0"
-    tslib: "npm:^2.5.0"
-  checksum: 10/9147ee8d0d3918817ac7d10f467b1ee015b683dbd5ac3d1db3d43188eadb0439ee528ad4f9b8aca4430f33519e2949925a42a7022681769c52afd43c248f5dd4
-  languageName: node
-  linkType: hard
-
-"@smithy/smithy-client@npm:^2.1.3":
-  version: 2.1.4
-  resolution: "@smithy/smithy-client@npm:2.1.4"
-  dependencies:
-    "@smithy/middleware-stack": "npm:^2.0.0"
-    "@smithy/types": "npm:^2.3.1"
-    "@smithy/util-stream": "npm:^2.0.10"
-    tslib: "npm:^2.5.0"
-  checksum: 10/ce1e768fa89e9b59a2ad36f436aedd2b71c49db16d0e8096de13013c722b26d115c0adae35720a9989c7a15de9bab8e7bcadba7c0d644296bd4aeb9e55bd4de9
-  languageName: node
-  linkType: hard
-
-"@smithy/smithy-client@npm:^2.1.6, @smithy/smithy-client@npm:^2.1.7":
-  version: 2.1.7
-  resolution: "@smithy/smithy-client@npm:2.1.7"
-  dependencies:
-    "@smithy/middleware-stack": "npm:^2.0.3"
-    "@smithy/types": "npm:^2.3.3"
-    "@smithy/util-stream": "npm:^2.0.12"
-    tslib: "npm:^2.5.0"
-  checksum: 10/061658efed9b643ac1147e80604f520f53b2909d925f567cb84fe2a06b1d2fa0da479f85a1753cbeceb957469eae502ba833d3cc47368d8db52bd2797ca7ac8d
-  languageName: node
-  linkType: hard
-
-"@smithy/types@npm:^2.3.0, @smithy/types@npm:^2.3.1":
+"@smithy/types@npm:^2.3.0":
   version: 2.3.1
   resolution: "@smithy/types@npm:2.3.1"
   dependencies:
@@ -6984,266 +6343,203 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/types@npm:^2.3.3":
-  version: 2.3.3
-  resolution: "@smithy/types@npm:2.3.3"
+"@smithy/types@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/types@npm:3.0.0"
   dependencies:
-    tslib: "npm:^2.5.0"
-  checksum: 10/d79acfa7412df07aacd3aa4cc8b67be515ee8a09b6dd9cd6ee1d6f44696fdc7f3a7acb99dbc8de46031e8d6a7fe3c2a09ba8998092a717d545e9f12d54c979b3
+    tslib: "npm:^2.6.2"
+  checksum: 10/8b9a45fc24e2e9702bc9614facbb7ad7c5b3b7a7b438afeeae770e25e62182827e3ea24367e466705f25e4f83e89ff89d0acbcd4c42195fba847821b649205db
   languageName: node
   linkType: hard
 
-"@smithy/url-parser@npm:^2.0.6, @smithy/url-parser@npm:^2.0.7":
-  version: 2.0.7
-  resolution: "@smithy/url-parser@npm:2.0.7"
+"@smithy/url-parser@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/url-parser@npm:3.0.0"
   dependencies:
-    "@smithy/querystring-parser": "npm:^2.0.7"
-    "@smithy/types": "npm:^2.3.1"
-    tslib: "npm:^2.5.0"
-  checksum: 10/fbb6d7ee582553132c650b246fc4ebd61c8e2959eb3a2b80d49c0721cd2ce329c1861fa7a3d6119f8f6f7111dc22dc0a36133f5193024f99f0bd43a0d274a735
+    "@smithy/querystring-parser": "npm:^3.0.0"
+    "@smithy/types": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/f88c1a2537593dd8c9643d42fbfde313c630bbb3f2dc9d202d58df298504534c4cedc4595173b1a290ada9220c97096d2653eed9024a00053a08452621db3a9a
   languageName: node
   linkType: hard
 
-"@smithy/url-parser@npm:^2.0.9":
-  version: 2.0.9
-  resolution: "@smithy/url-parser@npm:2.0.9"
+"@smithy/util-base64@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/util-base64@npm:3.0.0"
   dependencies:
-    "@smithy/querystring-parser": "npm:^2.0.9"
-    "@smithy/types": "npm:^2.3.3"
-    tslib: "npm:^2.5.0"
-  checksum: 10/43a8b8d87920483bcd5fdb5b13622b6e8fb8b8dfea823ed9b2b0fab3cfe7bf5fe5a0182d3061bf7936454e1c77d3a78e134ced6c37c7edd0224a15197e5fd1f4
+    "@smithy/util-buffer-from": "npm:^3.0.0"
+    "@smithy/util-utf8": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/3c883d63a33e1cfeebf7f846f167dfc54c832d1f5514d014fbfff06de3aecd5919f01637fc93668dca8a1029752f3a6fab0a94f455dcb7c88f1d472bde294eef
   languageName: node
   linkType: hard
 
-"@smithy/util-base64@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "@smithy/util-base64@npm:2.0.0"
+"@smithy/util-body-length-browser@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/util-body-length-browser@npm:3.0.0"
   dependencies:
-    "@smithy/util-buffer-from": "npm:^2.0.0"
-    tslib: "npm:^2.5.0"
-  checksum: 10/1e99afde11eea39c5400e89ae51e940bc4295d8823b4d362223f26c825bdb78b7f96df1834518f6484a272c6c44ac82ec49cb3fd5cf40108940133a208e6eedf
+    tslib: "npm:^2.6.2"
+  checksum: 10/a0ab6a6d414a62d18e57f3581769379a54bb1fd93606c69bc8d96a3566fdecb8db7b57da9446568d03eef9f004f2a89d7e94bdda79ef280f28b19a71803c0309
   languageName: node
   linkType: hard
 
-"@smithy/util-body-length-browser@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "@smithy/util-body-length-browser@npm:2.0.0"
+"@smithy/util-body-length-node@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/util-body-length-node@npm:3.0.0"
   dependencies:
-    tslib: "npm:^2.5.0"
-  checksum: 10/59ccbe316fe31ca08cbcad3154e6dfec960dc54ca13b1c0b73f7135054ccc7f35bf938ba306ed34dc6931bc8c444222145c8eed0d57198784dc03344e40f4100
+    tslib: "npm:^2.6.2"
+  checksum: 10/aabac66d7111612fd375d67150f8787c5cdc828f7e6acb40ef0b18b4c354e64e0ef2e4b8da2d7f01e8abe931ff2ef8109a408164ce7e5662fd41b470c462f1e4
   languageName: node
   linkType: hard
 
-"@smithy/util-body-length-node@npm:^2.1.0":
-  version: 2.1.0
-  resolution: "@smithy/util-body-length-node@npm:2.1.0"
+"@smithy/util-buffer-from@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/util-buffer-from@npm:3.0.0"
   dependencies:
-    tslib: "npm:^2.5.0"
-  checksum: 10/1b2e3a99811b623d68e800a4c400a0a55eb9ce12f5cfa5b8509a0fdd805a279a931759ff55472983b37dcbcc58221a3bbfef86e5e4304af973a1e2c5f8651078
+    "@smithy/is-array-buffer": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/7e6596b38855c07869f7e8f7b0ad9b70c5e658f4a06c7db71c6134a9a785ac1fdaa84f8b3358c4a572767838498df118daad1fa937237d1fb4b9fce735cf8bb0
   languageName: node
   linkType: hard
 
-"@smithy/util-buffer-from@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "@smithy/util-buffer-from@npm:2.0.0"
+"@smithy/util-config-provider@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/util-config-provider@npm:3.0.0"
   dependencies:
-    "@smithy/is-array-buffer": "npm:^2.0.0"
-    tslib: "npm:^2.5.0"
-  checksum: 10/15326acdb8666ff8c342bfa23ace07ea6a1b7e849b118f5b28f0b93cd775e83c77fa53ab5b04b8f795798d316991042296c3c5522fb68c91df9e921d4c83e398
+    tslib: "npm:^2.6.2"
+  checksum: 10/614c321c5a5a220d7d72d36359c41b4e390566719f7e01cefebffbe7034aae78b4533b27ab2030f93186c5f22893ddf056a3a2376a077d70ce89275f31e1ac46
   languageName: node
   linkType: hard
 
-"@smithy/util-config-provider@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "@smithy/util-config-provider@npm:2.0.0"
+"@smithy/util-defaults-mode-browser@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/util-defaults-mode-browser@npm:3.0.0"
   dependencies:
-    tslib: "npm:^2.5.0"
-  checksum: 10/13910f0643c6bf71184049e58ec6fa5544c1ed94f6b90080fc53d32fffaacb8e4bb5bd80e55d3536af2e9684cae95842ff3e2a07c50c18f00c7f1fe35c34fd8a
-  languageName: node
-  linkType: hard
-
-"@smithy/util-defaults-mode-browser@npm:^2.0.10":
-  version: 2.0.11
-  resolution: "@smithy/util-defaults-mode-browser@npm:2.0.11"
-  dependencies:
-    "@smithy/property-provider": "npm:^2.0.10"
-    "@smithy/smithy-client": "npm:^2.1.7"
-    "@smithy/types": "npm:^2.3.3"
+    "@smithy/property-provider": "npm:^3.0.0"
+    "@smithy/smithy-client": "npm:^3.0.0"
+    "@smithy/types": "npm:^3.0.0"
     bowser: "npm:^2.11.0"
-    tslib: "npm:^2.5.0"
-  checksum: 10/5022ef584787556bb6941243cdcd2677e08494e92da99820761647e149cfcf9c776bc4522dff86364100ddac0eb395c94ec8cb3d456deb92efba50e2de01a3ee
+    tslib: "npm:^2.6.2"
+  checksum: 10/b55f2f1c83d326c5eb1b8c57785987a48b361e0b7bc25da67948f226100082ae2d4cd5a4b5e467ae67345d08995e8a506b275b298694cf8b07db3121b2f8578c
   languageName: node
   linkType: hard
 
-"@smithy/util-defaults-mode-browser@npm:^2.0.7":
-  version: 2.0.8
-  resolution: "@smithy/util-defaults-mode-browser@npm:2.0.8"
+"@smithy/util-defaults-mode-node@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/util-defaults-mode-node@npm:3.0.0"
   dependencies:
-    "@smithy/property-provider": "npm:^2.0.8"
-    "@smithy/types": "npm:^2.3.1"
-    bowser: "npm:^2.11.0"
-    tslib: "npm:^2.5.0"
-  checksum: 10/5845b29927a044581180e984989e2258e253474c712daa681bebe541eab11303cb34c80710e6bb3d9bd8e8788171822b25d24cbf7762f320141e5f154d9b2b21
+    "@smithy/config-resolver": "npm:^3.0.0"
+    "@smithy/credential-provider-imds": "npm:^3.0.0"
+    "@smithy/node-config-provider": "npm:^3.0.0"
+    "@smithy/property-provider": "npm:^3.0.0"
+    "@smithy/smithy-client": "npm:^3.0.0"
+    "@smithy/types": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/0a26701c017a84652bffcc1fd0525e4d90e6014328a87c650c258526059027a91a75db5ac4dba5bad35fb2e1bb900eafb617d13d2d2e2d189e04f0e03af61146
   languageName: node
   linkType: hard
 
-"@smithy/util-defaults-mode-node@npm:^2.0.12":
-  version: 2.0.13
-  resolution: "@smithy/util-defaults-mode-node@npm:2.0.13"
-  dependencies:
-    "@smithy/config-resolver": "npm:^2.0.10"
-    "@smithy/credential-provider-imds": "npm:^2.0.12"
-    "@smithy/node-config-provider": "npm:^2.0.12"
-    "@smithy/property-provider": "npm:^2.0.10"
-    "@smithy/smithy-client": "npm:^2.1.7"
-    "@smithy/types": "npm:^2.3.3"
-    tslib: "npm:^2.5.0"
-  checksum: 10/58757f73757c24eea941dfa0d15fcffd14033454a2024d9c796abd4baad053fb078e2f3f86204aa016cde82dc75a94fc965c42887c8ee48c565296d755f064ea
-  languageName: node
-  linkType: hard
-
-"@smithy/util-defaults-mode-node@npm:^2.0.9":
-  version: 2.0.10
-  resolution: "@smithy/util-defaults-mode-node@npm:2.0.10"
-  dependencies:
-    "@smithy/config-resolver": "npm:^2.0.8"
-    "@smithy/credential-provider-imds": "npm:^2.0.10"
-    "@smithy/node-config-provider": "npm:^2.0.10"
-    "@smithy/property-provider": "npm:^2.0.8"
-    "@smithy/types": "npm:^2.3.1"
-    tslib: "npm:^2.5.0"
-  checksum: 10/c8ff3c2ffd9283ca81a971aecbba9ba380298e95fae5ce1f45c3ab1514f8c02c091fa1f31eb8923728b8c3622e512908b2d37d9e65bc45054032d8255094dbe9
-  languageName: node
-  linkType: hard
-
-"@smithy/util-hex-encoding@npm:^2.0.0":
+"@smithy/util-endpoints@npm:^2.0.0":
   version: 2.0.0
-  resolution: "@smithy/util-hex-encoding@npm:2.0.0"
+  resolution: "@smithy/util-endpoints@npm:2.0.0"
   dependencies:
-    tslib: "npm:^2.5.0"
-  checksum: 10/196b594d5e4a31fbc6a6ada8e1af307e0af55721685df70e20415733f46d6d2d6f7c52f9d2bf4512f0033cc1adb74f115c68025d9b7d7023342ef6f0514cee2a
+    "@smithy/node-config-provider": "npm:^3.0.0"
+    "@smithy/types": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/49e897e8b1c19a79f71edfa1b5fa58f90b3244e5026e38c32c3bd2ff2672f4a2de9dbb0c0cf7dfaf8ae6de25db3c8ea76cfbbfc0db8415935721863bcda527bd
   languageName: node
   linkType: hard
 
-"@smithy/util-middleware@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "@smithy/util-middleware@npm:2.0.0"
+"@smithy/util-hex-encoding@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/util-hex-encoding@npm:3.0.0"
   dependencies:
-    tslib: "npm:^2.5.0"
-  checksum: 10/4dad0f427abed7f6870e1dfcd9a1deb83a0d5bd8bfaf8aa9ca877b71b504d1511d1263d8bc0427b8bfb91ea7663c9430ed9c0b0495c821de5b31f710fba0e1a0
+    tslib: "npm:^2.6.2"
+  checksum: 10/d9f8c4c676410ca51bdbcec5d986883bad0028e26b098fc50e2b57bc81e8a5ce20e160786d08c8552ca0ba662c88ca16f33857ff24a0d183174325b2b40e3c8f
   languageName: node
   linkType: hard
 
-"@smithy/util-middleware@npm:^2.0.2":
-  version: 2.0.2
-  resolution: "@smithy/util-middleware@npm:2.0.2"
+"@smithy/util-middleware@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/util-middleware@npm:3.0.0"
   dependencies:
-    "@smithy/types": "npm:^2.3.3"
-    tslib: "npm:^2.5.0"
-  checksum: 10/2931d99f69dc805b33b545f5a100e54cf1a32ef20fd428f4ca9798bbf8a4bb6ebcf39232c282eb2d48a89c15344b63938a83a7cc03ba7f0afbc00eb73461e7eb
+    "@smithy/types": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/e9878f85326859b8025df7e2cf7aba5b9fb8ec59be2189c61b0082947c967d888d6894ce6e2152a28eda3e03c207453a94fba7dbf084d755e2ada2df5a58cbb5
   languageName: node
   linkType: hard
 
-"@smithy/util-retry@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "@smithy/util-retry@npm:2.0.0"
+"@smithy/util-retry@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/util-retry@npm:3.0.0"
   dependencies:
-    "@smithy/service-error-classification": "npm:^2.0.0"
-    tslib: "npm:^2.5.0"
-  checksum: 10/b98bb03454b41ec3482a734eb54600bc9998330877d655af33c0eca21711d7222b11d6dd6b61dfdc16087b566673d0cfbb0efa8b0c4326be2a33cbbf9b04b29b
+    "@smithy/service-error-classification": "npm:^3.0.0"
+    "@smithy/types": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/9e38115e47f99bd86360864ed4dd84a266a4e8bc528c6cc834760339cfef857263eb557b85e060776775c1a70b0f03ded0133b9b23c31095d41e51d247a2b1a3
   languageName: node
   linkType: hard
 
-"@smithy/util-retry@npm:^2.0.2":
-  version: 2.0.2
-  resolution: "@smithy/util-retry@npm:2.0.2"
+"@smithy/util-stream@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/util-stream@npm:3.0.0"
   dependencies:
-    "@smithy/service-error-classification": "npm:^2.0.2"
-    "@smithy/types": "npm:^2.3.3"
-    tslib: "npm:^2.5.0"
-  checksum: 10/2a5c51766115cad5b66bbdc48c889ebe7f2703fd86209d7ad203f55c141ebe8ad5da8285ee0dba8268c04402085657d2840060843ca706762f7f2b8a8403866b
+    "@smithy/fetch-http-handler": "npm:^3.0.0"
+    "@smithy/node-http-handler": "npm:^3.0.0"
+    "@smithy/types": "npm:^3.0.0"
+    "@smithy/util-base64": "npm:^3.0.0"
+    "@smithy/util-buffer-from": "npm:^3.0.0"
+    "@smithy/util-hex-encoding": "npm:^3.0.0"
+    "@smithy/util-utf8": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/ad263551e2af5b255f05a957d2932444453d7bc69dbacbfd5be961ff3b368b68500fb2f3ac878cabe6369901bb0b7b5eed2a474cc730bafb13f526f63bd5f44c
   languageName: node
   linkType: hard
 
-"@smithy/util-stream@npm:^2.0.10, @smithy/util-stream@npm:^2.0.9":
-  version: 2.0.10
-  resolution: "@smithy/util-stream@npm:2.0.10"
+"@smithy/util-uri-escape@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/util-uri-escape@npm:3.0.0"
   dependencies:
-    "@smithy/fetch-http-handler": "npm:^2.1.3"
-    "@smithy/node-http-handler": "npm:^2.1.3"
-    "@smithy/types": "npm:^2.3.1"
-    "@smithy/util-base64": "npm:^2.0.0"
-    "@smithy/util-buffer-from": "npm:^2.0.0"
-    "@smithy/util-hex-encoding": "npm:^2.0.0"
-    "@smithy/util-utf8": "npm:^2.0.0"
-    tslib: "npm:^2.5.0"
-  checksum: 10/57fe09ebb28f5cbda5cf4a3ed2b1761c5c1606e5bf8b35655af7ee5c90cddce3a7ed410f5336b86328edbd0040249934418d111f82cec96a8b7abec43e5474ef
+    tslib: "npm:^2.6.2"
+  checksum: 10/d44522339325b0f1fe2c5bf1a3f01d5a699eb8718d800dee24378a1a1b301683756dcfd4be4c32db4d6a00cad85893494778ae39fb246a03aef27d06c9852a67
   languageName: node
   linkType: hard
 
-"@smithy/util-stream@npm:^2.0.12":
-  version: 2.0.12
-  resolution: "@smithy/util-stream@npm:2.0.12"
+"@smithy/util-utf8@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/util-utf8@npm:3.0.0"
   dependencies:
-    "@smithy/fetch-http-handler": "npm:^2.1.5"
-    "@smithy/node-http-handler": "npm:^2.1.5"
-    "@smithy/types": "npm:^2.3.3"
-    "@smithy/util-base64": "npm:^2.0.0"
-    "@smithy/util-buffer-from": "npm:^2.0.0"
-    "@smithy/util-hex-encoding": "npm:^2.0.0"
-    "@smithy/util-utf8": "npm:^2.0.0"
-    tslib: "npm:^2.5.0"
-  checksum: 10/c4a6af8653134ddd8e5bc1a3346aed4c9386c74f5553be5174079a90bdedcab6ceb39e9bdff21e09a0fa8847f9a8ff1d84a199bdc44a77a525ea0c4eb17f04dd
+    "@smithy/util-buffer-from": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/1aead297d835af419f75e0c3113c021aa0da671110d1b498035530d5f35d8030092cad5147edaa7ca458aafe27c9383399ccd8176d342942465a2d8357e5cbf4
   languageName: node
   linkType: hard
 
-"@smithy/util-uri-escape@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "@smithy/util-uri-escape@npm:2.0.0"
+"@smithy/util-waiter@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/util-waiter@npm:3.0.0"
   dependencies:
-    tslib: "npm:^2.5.0"
-  checksum: 10/2f121d1fce9878e22fc5eaa0f8f4e47e967fce6d727b4283902d842842c7835b47de08e16b2c6fef389457a6edf2523274019fe511ede98ce0f38a11aea63bc2
+    "@smithy/abort-controller": "npm:^3.0.0"
+    "@smithy/types": "npm:^3.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/d206c9f6613e1c43675a48214dd762cb7f85ba57182d2dbcff80392a1983a7f6b06bd537c89949017100bf641d71a32d0c62299d172c52480240c5a431b797ac
   languageName: node
   linkType: hard
 
-"@smithy/util-utf8@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "@smithy/util-utf8@npm:2.0.0"
-  dependencies:
-    "@smithy/util-buffer-from": "npm:^2.0.0"
-    tslib: "npm:^2.5.0"
-  checksum: 10/43c924be7883287937d91a1f042196b1e7f9400e9114759c2ac5b4fedb6756063faf2e684b153a96573b0039b745c196968ce53ae9f38a2aeb690ad0c3c27ea8
+"@swc/counter@npm:^0.1.3":
+  version: 0.1.3
+  resolution: "@swc/counter@npm:0.1.3"
+  checksum: 10/df8f9cfba9904d3d60f511664c70d23bb323b3a0803ec9890f60133954173047ba9bdeabce28cd70ba89ccd3fd6c71c7b0bd58be85f611e1ffbe5d5c18616598
   languageName: node
   linkType: hard
 
-"@smithy/util-waiter@npm:^2.0.6":
-  version: 2.0.7
-  resolution: "@smithy/util-waiter@npm:2.0.7"
+"@swc/helpers@npm:0.5.5":
+  version: 0.5.5
+  resolution: "@swc/helpers@npm:0.5.5"
   dependencies:
-    "@smithy/abort-controller": "npm:^2.0.7"
-    "@smithy/types": "npm:^2.3.1"
-    tslib: "npm:^2.5.0"
-  checksum: 10/b78f7d5a2a67a79d4db3dfbf9c01fc0b1f454b286f6af3908df77099f9443db6cd22d7fca5190e9b8885574533904abaa1f0186635d1af223cf0cb9eef321047
-  languageName: node
-  linkType: hard
-
-"@smithy/util-waiter@npm:^2.0.9":
-  version: 2.0.9
-  resolution: "@smithy/util-waiter@npm:2.0.9"
-  dependencies:
-    "@smithy/abort-controller": "npm:^2.0.9"
-    "@smithy/types": "npm:^2.3.3"
-    tslib: "npm:^2.5.0"
-  checksum: 10/8327505b38106926c0216d13933e17f38467033681095f01a137cd09dd05dd5fa49be082d85cab264d4febe54cb3b47b95ab9676b5e4fee9211426f51ff3f6d2
-  languageName: node
-  linkType: hard
-
-"@swc/helpers@npm:0.5.1":
-  version: 0.5.1
-  resolution: "@swc/helpers@npm:0.5.1"
-  dependencies:
+    "@swc/counter": "npm:^0.1.3"
     tslib: "npm:^2.4.0"
-  checksum: 10/4954c4d2dd97bf965e863a10ffa44c3fdaf7653f2fa9ef1a6cf7ffffd67f3f832216588f9751afd75fdeaea60c4688c75c01e2405119c448f1a109c9a7958c54
+  checksum: 10/1c5ef04f642542212df28c669438f3e0f459dcde7b448a5b1fcafb2e9e4f13e76d8428535a270e91ed123dd2a21189dbed34086b88a8cf68baf84984d6d0e39b
   languageName: node
   linkType: hard
 
@@ -7389,6 +6685,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@tufjs/canonical-json@npm:2.0.0":
+  version: 2.0.0
+  resolution: "@tufjs/canonical-json@npm:2.0.0"
+  checksum: 10/cc719a1d0d0ae1aa1ba551a82c87dcbefac088e433c03a3d8a1d547ea721350e47dab4ab5b0fca40d5c7ab1f4882e72edc39c9eae15bf47c45c43bcb6ee39f4f
+  languageName: node
+  linkType: hard
+
 "@tufjs/models@npm:1.0.4":
   version: 1.0.4
   resolution: "@tufjs/models@npm:1.0.4"
@@ -7396,6 +6699,16 @@ __metadata:
     "@tufjs/canonical-json": "npm:1.0.0"
     minimatch: "npm:^9.0.0"
   checksum: 10/2c63e9cfc04a4ce8888e9cc9668a7207e3047d64c50dccc3d2c30057d8bd6c4e89256b6094d2109549278da72c75e20cd8717bb5f4b544dc2323288a2a96607f
+  languageName: node
+  linkType: hard
+
+"@tufjs/models@npm:2.0.1":
+  version: 2.0.1
+  resolution: "@tufjs/models@npm:2.0.1"
+  dependencies:
+    "@tufjs/canonical-json": "npm:2.0.0"
+    minimatch: "npm:^9.0.4"
+  checksum: 10/7c5d2b8194195cecddc92ae37523c1375e7aaf2e554941c0f9b71db93bbef4f0af8190438dd321e8f9dfd4ce2a9b582e35a4c4c04bec87e25a289c9c8bedcd4e
   languageName: node
   linkType: hard
 
@@ -7473,15 +6786,6 @@ __metadata:
     "@types/node": "npm:*"
     "@types/responselike": "npm:*"
   checksum: 10/7fe937f9e71a28dc16bc2c3421f00b3e7785342d6e78ebfe840dc66a69c332df45d1ee95d98b2199705923e755c20e09ceac44ceafe792b3b9edead31112a198
-  languageName: node
-  linkType: hard
-
-"@types/concat-stream@npm:^1.6.0":
-  version: 1.6.1
-  resolution: "@types/concat-stream@npm:1.6.1"
-  dependencies:
-    "@types/node": "npm:*"
-  checksum: 10/7d211e74331affd3578b5469244f5cef84a93775f38332adb3ef12413559a23862bc682c6873d0a404b01c9d5d5f7d3ae091fe835b435b633eb420e3055b3e56
   languageName: node
   linkType: hard
 
@@ -7589,15 +6893,6 @@ __metadata:
     "@types/qs": "npm:*"
     "@types/serve-static": "npm:*"
   checksum: 10/e2959a5fecdc53f8a524891a16e66dfc330ee0519e89c2579893179db686e10cfa6079a68e0fb8fd00eedbcaf3eabfd10916461939f3bc02ef671d848532c37e
-  languageName: node
-  linkType: hard
-
-"@types/form-data@npm:0.0.33":
-  version: 0.0.33
-  resolution: "@types/form-data@npm:0.0.33"
-  dependencies:
-    "@types/node": "npm:*"
-  checksum: 10/f0c7437e9dd7b348cf7de772bf9c5ad810ecaec767b9199cfc600f4929d600212b52d1acd5a1c674e1ceec5e063cb4d9ce96c8e479aea8dacd56371e04aab836
   languageName: node
   linkType: hard
 
@@ -7867,24 +7162,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:^10.0.3":
-  version: 10.17.60
-  resolution: "@types/node@npm:10.17.60"
-  checksum: 10/f9161493b3284b1d41d5d594c2768625acdd9e33f992f71ccde47861916e662e2ae438d2cc5f1b285053391a31b52a7564ecedc22d485610d236bfad9c7e6a1c
-  languageName: node
-  linkType: hard
-
 "@types/node@npm:^13.7.0":
   version: 13.13.52
   resolution: "@types/node@npm:13.13.52"
   checksum: 10/a1fbd080dd2462f6f0d0c10cb8328ee6b22e59941fb6beb8bca907f96e00798ce85e94320ccab3bf04f87d6c5443535a62e6896ac59c34c79a286821223e56cd
-  languageName: node
-  linkType: hard
-
-"@types/node@npm:^8.0.0":
-  version: 8.10.66
-  resolution: "@types/node@npm:8.10.66"
-  checksum: 10/49a93cbeeca74e247970b5c2130abe8204587b6d3c5ec259543e7511234e5fa340341668155807ade7a86c22dab1ec8ee18c0ac745e4d54679de1b2dabd99363
   languageName: node
   linkType: hard
 
@@ -7916,7 +7197,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/qs@npm:*, @types/qs@npm:^6.2.31":
+"@types/qs@npm:*":
   version: 6.9.7
   resolution: "@types/qs@npm:6.9.7"
   checksum: 10/7fd6f9c25053e9b5bb6bc9f9f76c1d89e6c04f7707a7ba0e44cc01f17ef5284adb82f230f542c2d5557d69407c9a40f0f3515e8319afd14e1e16b5543ac6cdba
@@ -8435,7 +7716,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xmldom/xmldom@npm:^0.8.8":
+"@xmldom/xmldom@npm:^0.8.10":
   version: 0.8.10
   resolution: "@xmldom/xmldom@npm:0.8.10"
   checksum: 10/62400bc5e0e75b90650e33a5ceeb8d94829dd11f9b260962b71a784cd014ddccec3e603fe788af9c1e839fa4648d8c521ebd80d8b752878d3a40edabc9ce7ccf
@@ -8651,10 +7932,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"abbrev@npm:1, abbrev@npm:^1.0.0":
+"abbrev@npm:1":
   version: 1.1.1
   resolution: "abbrev@npm:1.1.1"
   checksum: 10/2d882941183c66aa665118bafdab82b7a177e9add5eb2776c33e960a4f3c89cff88a1b38aba13a456de01d0dd9d66a8bea7c903268b21ea91dd1097e1e2e8243
+  languageName: node
+  linkType: hard
+
+"abbrev@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "abbrev@npm:2.0.0"
+  checksum: 10/ca0a54e35bea4ece0ecb68a47b312e1a9a6f772408d5bcb9051230aaa94b0460671c5b5c9cb3240eb5b7bc94c52476550eb221f65a0bbd0145bdc9f3113a6707
   languageName: node
   linkType: hard
 
@@ -8786,7 +8074,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"agent-base@npm:^7.1.0":
+"agent-base@npm:^7.1.0, agent-base@npm:^7.1.1":
   version: 7.1.1
   resolution: "agent-base@npm:7.1.1"
   dependencies:
@@ -8845,7 +8133,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ajv@npm:^6.10.0, ajv@npm:^6.10.2, ajv@npm:^6.11.0, ajv@npm:^6.12.3, ajv@npm:^6.12.4, ajv@npm:^6.5.2":
+"ajv@npm:^6.10.0, ajv@npm:^6.11.0, ajv@npm:^6.12.3, ajv@npm:^6.12.4, ajv@npm:^6.5.2":
   version: 6.12.6
   resolution: "ajv@npm:6.12.6"
   dependencies:
@@ -9202,7 +8490,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"asap@npm:^2.0.0, asap@npm:~2.0.3, asap@npm:~2.0.6":
+"asap@npm:^2.0.0, asap@npm:~2.0.3":
   version: 2.0.6
   resolution: "asap@npm:2.0.6"
   checksum: 10/b244c0458c571945e4b3be0b14eb001bea5596f9868cc50cc711dc03d58a7e953517d3f0dad81ccde3ff37d1f074701fa76a6f07d41aaa992d7204a37b915dda
@@ -9245,13 +8533,6 @@ __metadata:
   dependencies:
     tslib: "npm:^2.0.1"
   checksum: 10/c55b375b9aaf44713d8c0f77a08215ab6d44f368b13e44f2141c421022af3c62b615a30c8ea629457f0cbaec409c713401c0188a124552c8fe4a5ad6b17ff3c3
-  languageName: node
-  linkType: hard
-
-"astral-regex@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "astral-regex@npm:1.0.0"
-  checksum: 10/93417fc0879531cd95ace2560a54df865c9461a3ac0714c60cbbaa5f1f85d2bee85489e78d82f70b911b71ac25c5f05fc5a36017f44c9bb33c701bee229ff848
   languageName: node
   linkType: hard
 
@@ -9363,14 +8644,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:^1.0.0":
-  version: 1.6.1
-  resolution: "axios@npm:1.6.1"
+"axios@npm:^1.6.0":
+  version: 1.6.8
+  resolution: "axios@npm:1.6.8"
   dependencies:
-    follow-redirects: "npm:^1.15.0"
+    follow-redirects: "npm:^1.15.6"
     form-data: "npm:^4.0.0"
     proxy-from-env: "npm:^1.1.0"
-  checksum: 10/fb091af3ad47d70fdcba5e71654b9e3c56947d93d8b2375dd0b4db63de9982adab6235aebc514488aa289c7faf103b09e8911280e6f6b1112d1604fe5f111f71
+  checksum: 10/3f9a79eaf1d159544fca9576261ff867cbbff64ed30017848e4210e49f3b01e97cf416390150e6fdf6633f336cd43dc1151f890bbd09c3c01ad60bb0891eee63
   languageName: node
   linkType: hard
 
@@ -9550,77 +8831,42 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bids-validator@npm:1.10.0":
-  version: 1.10.0
-  resolution: "bids-validator@npm:1.10.0"
+"bids-validator@npm:1.14.6":
+  version: 1.14.6
+  resolution: "bids-validator@npm:1.14.6"
   dependencies:
-    "@aws-sdk/client-s3": "npm:^3.9.0"
-    ajv: "npm:^6.5.2"
-    bytes: "npm:^3.0.0"
-    colors: "npm:^1.4.0"
-    cross-fetch: "npm:^3.0.6"
-    date-fns: "npm:^2.7.0"
-    events: "npm:^3.3.0"
-    exifreader: "npm:^4.1.0"
-    hed-validator: "npm:^3.8.0"
-    ignore: "npm:^4.0.2"
-    is-utf8: "npm:^0.2.1"
-    jshint: "npm:^2.9.6"
-    lodash: "npm:^4.17.21"
-    minimatch: "npm:3.0.5"
-    nifti-js: "npm:^1.0.1"
-    p-limit: "npm:^2.1.0"
-    pako: "npm:^1.0.6"
-    path: "npm:^0.12.7"
-    pluralize: "npm:^8.0.0"
-    semver: "npm:^7.3.2"
-    stream-browserify: "npm:^3.0.0"
-    table: "npm:^5.2.3"
-    xml2js: "npm:^0.4.23"
-    yaml: "npm:^1.10.2"
-    yargs: "npm:^16.2.0"
-  bin:
-    bids-validator: bin/bids-validator
-  checksum: 10/10d9fc6dd8fddc28087c704fdb70f0832b4ccc87e7ad07720c059b8cb82f9718715b777f7f2c0beaa643a2308840fa6fd117684dbe5eee69dbfccb173bb437e1
-  languageName: node
-  linkType: hard
-
-"bids-validator@npm:1.13.0":
-  version: 1.13.0
-  resolution: "bids-validator@npm:1.13.0"
-  dependencies:
-    "@aws-sdk/client-s3": "npm:^3.391.0"
+    "@aws-sdk/client-s3": "npm:^3.556.0"
     ajv: "npm:^6.5.2"
     bytes: "npm:^3.1.2"
     colors: "npm:^1.4.0"
     cross-fetch: "npm:^4.0.0"
-    date-fns: "npm:^2.30.0"
+    date-fns: "npm:^3.6.0"
     events: "npm:^3.3.0"
-    exifreader: "npm:^4.12.1"
-    hed-validator: "npm:^3.12.0"
-    ignore: "npm:^5.2.4"
+    exifreader: "npm:^4.22.1"
+    hed-validator: "npm:^3.13.5"
+    ignore: "npm:^5.3.1"
     is-utf8: "npm:^0.2.1"
-    jest: "npm:^29.6.4"
+    jest: "npm:^29.7.0"
     jshint: "npm:^2.13.6"
-    lerna: "npm:^7.2.0"
+    lerna: "npm:^8.1.2"
     lodash: "npm:^4.17.21"
     minimatch: "npm:3.0.5"
-    next: "npm:13.4.19"
+    next: "npm:14.2.3"
     nifti-js: "npm:^1.0.1"
     p-limit: "npm:^2.1.0"
     pako: "npm:^1.0.6"
     path: "npm:^0.12.7"
     pluralize: "npm:^8.0.0"
-    semver: "npm:^7.5.2"
+    semver: "npm:^7.6.0"
     stream-browserify: "npm:^3.0.0"
-    table: "npm:^6.8.1"
+    table: "npm:^6.8.2"
     util: "npm:^0.12.5"
     xml2js: "npm:^0.6.2"
     yaml: "npm:^2.3.1"
     yargs: "npm:^17.7.2"
   bin:
     bids-validator: bin/bids-validator
-  checksum: 10/6fe691895653463c3de80be88c3db5ac85a2b89ee0625f2aed89c299f800550ed8bb0c5d29c2ddfec1ec9739daba9bae0bbfe1664ea9972426c7b6d7c18fcb6e
+  checksum: 10/385ce2c482b052bcc09a35edb24d92d1442878c0320c74b83dec96e3b72ca745cd725c6b019312b09cdf5b1fb30d973b4ba8fef2a0f0d7853128831cdba5035c
   languageName: node
   linkType: hard
 
@@ -9995,6 +9241,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cacache@npm:^18.0.0":
+  version: 18.0.3
+  resolution: "cacache@npm:18.0.3"
+  dependencies:
+    "@npmcli/fs": "npm:^3.1.0"
+    fs-minipass: "npm:^3.0.0"
+    glob: "npm:^10.2.2"
+    lru-cache: "npm:^10.0.1"
+    minipass: "npm:^7.0.3"
+    minipass-collect: "npm:^2.0.1"
+    minipass-flush: "npm:^1.0.5"
+    minipass-pipeline: "npm:^1.2.4"
+    p-map: "npm:^4.0.0"
+    ssri: "npm:^10.0.0"
+    tar: "npm:^6.1.11"
+    unique-filename: "npm:^3.0.0"
+  checksum: 10/d4c161f071524bb636334b8cf94780c014e29c180a886b8184da8f2f44d2aca88d5664797c661e9f74bdbd34697c2f231ed7c24c256cecbb0a0563ad1ada2219
+  languageName: node
+  linkType: hard
+
 "cache-base@npm:^1.0.1":
   version: 1.0.1
   resolution: "cache-base@npm:1.0.1"
@@ -10157,14 +9423,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"caniuse-lite@npm:^1.0.30001406, caniuse-lite@npm:^1.0.30001517":
+"caniuse-lite@npm:^1.0.30001517":
   version: 1.0.30001534
   resolution: "caniuse-lite@npm:1.0.30001534"
   checksum: 10/848c94f57fd9563360b081f1a0b5c4c0558b4939befa367e58eb5b3085a1d5bc29281bc3c3b9946b48ee71292b531191caba0d1eabf4b2a1ad67021b787f6255
   languageName: node
   linkType: hard
 
-"caseless@npm:^0.12.0, caseless@npm:~0.12.0":
+"caniuse-lite@npm:^1.0.30001579":
+  version: 1.0.30001618
+  resolution: "caniuse-lite@npm:1.0.30001618"
+  checksum: 10/b5a65a60af4dd089e80487754a8ea82e41ce104222b3c2b849cc34ffb412282817d6bf2791f2a24caaf8c7bbf36b22e5b17a55c1edeabfbe68912de106ab0f59
+  languageName: node
+  linkType: hard
+
+"caseless@npm:~0.12.0":
   version: 0.12.0
   resolution: "caseless@npm:0.12.0"
   checksum: 10/ea1efdf430975fdbac3505cdd21007f7ac5aa29b6d4d1c091f965853cd1bf87e4b08ea07b31a6d688b038872b7cdf0589d9262d59c699d199585daad052aeb20
@@ -10777,7 +10050,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"concat-stream@npm:^1.5.0, concat-stream@npm:^1.6.0, concat-stream@npm:^1.6.2":
+"concat-stream@npm:^1.5.0":
   version: 1.6.2
   resolution: "concat-stream@npm:1.6.2"
   dependencies:
@@ -10857,12 +10130,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"conventional-changelog-angular@npm:6.0.0":
-  version: 6.0.0
-  resolution: "conventional-changelog-angular@npm:6.0.0"
+"conventional-changelog-angular@npm:7.0.0":
+  version: 7.0.0
+  resolution: "conventional-changelog-angular@npm:7.0.0"
   dependencies:
     compare-func: "npm:^2.0.0"
-  checksum: 10/ddc59ead53a45b817d83208200967f5340866782b8362d5e2e34105fdfa3d3a31585ebbdec7750bdb9de53da869f847e8ca96634a9801f51e27ecf4e7ffe2bad
+  checksum: 10/e7966d2fee5475e76263f30f8b714b2b592b5bf556df225b7091e5090831fc9a20b99598a7d2997e19c2ef8118c0a3150b1eba290786367b0f55a5ccfa804ec9
   languageName: node
   linkType: hard
 
@@ -11408,26 +10681,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"date-and-time@npm:^0.14.2":
-  version: 0.14.2
-  resolution: "date-and-time@npm:0.14.2"
-  checksum: 10/4708a43c01c3d2a10564826ba58cec3129a47abbf835f030b98ceeb6c29039199ec7c8111a9fc85f8b63950c58df1856b3abefb12f6ae5f4ed3586469a3b81fc
+"date-and-time@npm:^3.1.1":
+  version: 3.2.0
+  resolution: "date-and-time@npm:3.2.0"
+  checksum: 10/6a897b27308d7bc82641b5f9761b9d43423fad050e99964856a08a88e8db63825c3db5ae2c8efac8c3f0e5de0044dd3b5136ef86b9a59f0595b1456b9ce3f9a9
   languageName: node
   linkType: hard
 
-"date-fns@npm:^2.16.1, date-fns@npm:^2.17.0, date-fns@npm:^2.21.1":
+"date-fns@npm:^2.16.1, date-fns@npm:^2.21.1":
   version: 2.24.0
   resolution: "date-fns@npm:2.24.0"
   checksum: 10/b33bfdd005c2ddcd1a12db62f6ee891d71bb8a32506b728114b6c9cbd3b8be286efd359216fc21a385c03b73b626f1a27063c54f0809edcbad6b17920622a18c
   languageName: node
   linkType: hard
 
-"date-fns@npm:^2.30.0, date-fns@npm:^2.7.0":
-  version: 2.30.0
-  resolution: "date-fns@npm:2.30.0"
-  dependencies:
-    "@babel/runtime": "npm:^7.21.0"
-  checksum: 10/70b3e8ea7aaaaeaa2cd80bd889622a4bcb5d8028b4de9162cbcda359db06e16ff6e9309e54eead5341e71031818497f19aaf9839c87d1aba1e27bb4796e758a9
+"date-fns@npm:^3.6.0":
+  version: 3.6.0
+  resolution: "date-fns@npm:3.6.0"
+  checksum: 10/cac35c58926a3b5d577082ff2b253612ec1c79eb6754fddef46b6a8e826501ea2cb346ecbd211205f1ba382ddd1f9d8c3f00bf433ad63cc3063454d294e3a6b8
   languageName: node
   linkType: hard
 
@@ -13091,15 +12362,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"exifreader@npm:^4.1.0, exifreader@npm:^4.12.1":
-  version: 4.13.0
-  resolution: "exifreader@npm:4.13.0"
+"exifreader@npm:^4.22.1":
+  version: 4.23.1
+  resolution: "exifreader@npm:4.23.1"
   dependencies:
-    "@xmldom/xmldom": "npm:^0.8.8"
+    "@xmldom/xmldom": "npm:^0.8.10"
   dependenciesMeta:
     "@xmldom/xmldom":
       optional: true
-  checksum: 10/85a555776f02c5b4046cfdaf10a106f35a8be12ce3cffbf934ebf6b7dff154ba91e27699fd0d4b5cc13dbb311dc0348352893814c671478ada39badb5c200e3e
+  checksum: 10/cc0a6ead39f9263ae46268ecb54bf1a332b1a6c935a7f58290e9df789d1555ecd0f3dd1e6d1cbd18fa3d0d28994e56575a05d529d42e194be6e38ae926415470
   languageName: node
   linkType: hard
 
@@ -13335,19 +12606,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-glob@npm:3.2.7, fast-glob@npm:^3.1.1, fast-glob@npm:^3.2.2":
-  version: 3.2.7
-  resolution: "fast-glob@npm:3.2.7"
-  dependencies:
-    "@nodelib/fs.stat": "npm:^2.0.2"
-    "@nodelib/fs.walk": "npm:^1.2.3"
-    glob-parent: "npm:^5.1.2"
-    merge2: "npm:^1.3.0"
-    micromatch: "npm:^4.0.4"
-  checksum: 10/86ef62a138ede74916a10215cfea01cc4fbc18da77f56b802d08db2eff81f47ce1e7f77eda246977b6d600d9b1865eeff599db9899d99b655cb4fea3da146efa
-  languageName: node
-  linkType: hard
-
 "fast-glob@npm:^2.2.6":
   version: 2.2.7
   resolution: "fast-glob@npm:2.2.7"
@@ -13359,6 +12617,19 @@ __metadata:
     merge2: "npm:^1.2.3"
     micromatch: "npm:^3.1.10"
   checksum: 10/9e7d4e4d99ee8cd5a409b862ce9837b0c1d00e179810b820ee3274e22179ecc92a6a2f93f6119781e9bc44945e87c9a8920fa02280ebbb532381730ebe26e138
+  languageName: node
+  linkType: hard
+
+"fast-glob@npm:^3.1.1, fast-glob@npm:^3.2.2":
+  version: 3.2.7
+  resolution: "fast-glob@npm:3.2.7"
+  dependencies:
+    "@nodelib/fs.stat": "npm:^2.0.2"
+    "@nodelib/fs.walk": "npm:^1.2.3"
+    glob-parent: "npm:^5.1.2"
+    merge2: "npm:^1.3.0"
+    micromatch: "npm:^4.0.4"
+  checksum: 10/86ef62a138ede74916a10215cfea01cc4fbc18da77f56b802d08db2eff81f47ce1e7f77eda246977b6d600d9b1865eeff599db9899d99b655cb4fea3da146efa
   languageName: node
   linkType: hard
 
@@ -13737,7 +13008,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"follow-redirects@npm:^1.15.0, follow-redirects@npm:^1.15.6":
+"follow-redirects@npm:^1.15.6":
   version: 1.15.6
   resolution: "follow-redirects@npm:1.15.6"
   peerDependenciesMeta:
@@ -13780,7 +13051,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"form-data@npm:^2.2.0, form-data@npm:^2.3.1":
+"form-data@npm:^2.3.1":
   version: 2.5.1
   resolution: "form-data@npm:2.5.1"
   dependencies:
@@ -14426,27 +13697,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob-to-regexp@npm:^0.4.1":
-  version: 0.4.1
-  resolution: "glob-to-regexp@npm:0.4.1"
-  checksum: 10/9009529195a955c40d7b9690794aeff5ba665cc38f1519e111c58bb54366fd0c106bde80acf97ba4e533208eb53422c83b136611a54c5fefb1edd8dc267cb62e
-  languageName: node
-  linkType: hard
-
-"glob@npm:7.1.4":
-  version: 7.1.4
-  resolution: "glob@npm:7.1.4"
-  dependencies:
-    fs.realpath: "npm:^1.0.0"
-    inflight: "npm:^1.0.4"
-    inherits: "npm:2"
-    minimatch: "npm:^3.0.4"
-    once: "npm:^1.3.0"
-    path-is-absolute: "npm:^1.0.0"
-  checksum: 10/776bcc31371797eb5cf6b58c4618378f8df83d23f00aef8e98af5e7f0e59f5ee8b470c4e95e71cfa7a8682634849e21ea1f1ad38639c1828a2dbc2757bf7a63b
-  languageName: node
-  linkType: hard
-
 "glob@npm:^10.2.2":
   version: 10.3.4
   resolution: "glob@npm:10.3.4"
@@ -14459,6 +13709,21 @@ __metadata:
   bin:
     glob: dist/cjs/src/bin.js
   checksum: 10/6375721bcd0c615fe4c1d61faaf9eb93e15d428f26bac6e85739221a84659b42601b2a085b20915142c0eb3d8a7155914884ff80f145d8c9f2397c8b771b8b60
+  languageName: node
+  linkType: hard
+
+"glob@npm:^10.3.10":
+  version: 10.3.15
+  resolution: "glob@npm:10.3.15"
+  dependencies:
+    foreground-child: "npm:^3.1.0"
+    jackspeak: "npm:^2.3.6"
+    minimatch: "npm:^9.0.1"
+    minipass: "npm:^7.0.4"
+    path-scurry: "npm:^1.11.0"
+  bin:
+    glob: dist/esm/bin.mjs
+  checksum: 10/b2b1c74309979b34fd6010afb50418a12525def32f1d3758d5827fc75d6143fc3ee5d1f3180a43111f6386c9e297c314f208d9d09955a6c6b69f22e92ee97635
   languageName: node
   linkType: hard
 
@@ -14589,7 +13854,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"graceful-fs@npm:4.2.11":
+"graceful-fs@npm:4.2.11, graceful-fs@npm:^4.2.11":
   version: 4.2.11
   resolution: "graceful-fs@npm:4.2.11"
   checksum: 10/bf152d0ed1dc159239db1ba1f74fdbc40cb02f626770dcd5815c427ce0688c2635a06ed69af364396da4636d0408fcf7d4afdf7881724c3307e46aff30ca49e2
@@ -14961,21 +14226,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hed-validator@npm:^3.12.0, hed-validator@npm:^3.8.0":
-  version: 3.12.0
-  resolution: "hed-validator@npm:3.12.0"
+"hed-validator@npm:^3.13.5":
+  version: 3.13.5
+  resolution: "hed-validator@npm:3.13.5"
   dependencies:
     buffer: "npm:^6.0.3"
-    date-and-time: "npm:^0.14.2"
-    date-fns: "npm:^2.17.0"
+    cross-fetch: "npm:^4.0.0"
+    date-and-time: "npm:^3.1.1"
+    date-fns: "npm:^3.6.0"
     events: "npm:^3.3.0"
     lodash: "npm:^4.17.21"
     path: "npm:^0.12.7"
     pluralize: "npm:^8.0.0"
-    semver: "npm:^7.3.4"
-    then-request: "npm:^6.0.2"
-    xml2js: "npm:^0.5.0"
-  checksum: 10/597f55385ac3246eccf3c5bf4d44db39550a6ebb35a2d439ee54093cc3ba8ed50e30a1b04ab3b56e2810f71ce809eb65b724d36c391a831b19f36741df569cdc
+    semver: "npm:^7.6.0"
+    string_decoder: "npm:^1.3.0"
+    xml2js: "npm:^0.6.2"
+  checksum: 10/e99c35356abe97a985764ab7b8ae3d55513fa5e55f187509409477ab878d912c626f1b5b78bd8d3128f756f4d81fec21a0fedca4975fee7f86c34a4579afa7da
   languageName: node
   linkType: hard
 
@@ -15049,6 +14315,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"hosted-git-info@npm:^7.0.0":
+  version: 7.0.2
+  resolution: "hosted-git-info@npm:7.0.2"
+  dependencies:
+    lru-cache: "npm:^10.0.1"
+  checksum: 10/8f085df8a4a637d995f357f48b1e3f6fc1f9f92e82b33fb406415b5741834ed431a510a09141071001e8deea2eee43ce72786463e2aa5e5a70db8648c0eedeab
+  languageName: node
+  linkType: hard
+
 "hpagent@npm:^0.1.1":
   version: 0.1.2
   resolution: "hpagent@npm:0.1.2"
@@ -15096,18 +14371,6 @@ __metadata:
     entities: "npm:1.0"
     readable-stream: "npm:1.1"
   checksum: 10/47db75468728ca587dae3fa5c03dc66caae21f157be5ab6699e411ceca25e7acc7d293ddfea0787b9e6f5c47afd16f7f1a82fc40771f6d7ee84a48c812b9bac5
-  languageName: node
-  linkType: hard
-
-"http-basic@npm:^8.1.1":
-  version: 8.1.3
-  resolution: "http-basic@npm:8.1.3"
-  dependencies:
-    caseless: "npm:^0.12.0"
-    concat-stream: "npm:^1.6.2"
-    http-response-object: "npm:^3.0.1"
-    parse-cache-control: "npm:^1.0.1"
-  checksum: 10/f515c46159da289bc1573251a90f29b36ec7d781587481acc93656bc21d07f664c862662bd0e79144870c0254758e8b328e16ddc0a5c004827fb1503760e561e
   languageName: node
   linkType: hard
 
@@ -15209,15 +14472,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"http-response-object@npm:^3.0.1":
-  version: 3.0.2
-  resolution: "http-response-object@npm:3.0.2"
-  dependencies:
-    "@types/node": "npm:^10.0.3"
-  checksum: 10/f530c1b28d35200ec125e3a1d3c2d6da1f9d78cc52537e9379219e8172bda24f831856eb050a635d9746f9545586532ade60ffe75253d5a1db14dfaf4759d691
-  languageName: node
-  linkType: hard
-
 "http-signature@npm:~1.2.0":
   version: 1.2.0
   resolution: "http-signature@npm:1.2.0"
@@ -15269,7 +14523,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"https-proxy-agent@npm:^7.0.2, https-proxy-agent@npm:^7.0.4":
+"https-proxy-agent@npm:^7.0.1, https-proxy-agent@npm:^7.0.2, https-proxy-agent@npm:^7.0.4":
   version: 7.0.4
   resolution: "https-proxy-agent@npm:7.0.4"
   dependencies:
@@ -15375,23 +14629,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ignore-walk@npm:^6.0.0":
-  version: 6.0.3
-  resolution: "ignore-walk@npm:6.0.3"
+"ignore-walk@npm:^6.0.4":
+  version: 6.0.5
+  resolution: "ignore-walk@npm:6.0.5"
   dependencies:
     minimatch: "npm:^9.0.0"
-  checksum: 10/3cbc0b52c7dc405a3525898d705029f084ef6218df2a82b95520d72e3a6fb3ff893a4c22b73f36d2b7cefbe786a9687c4396de3c628be2844bc0728dc4e455cf
+  checksum: 10/08757abff4dabca4f9f005f9a6cb6684e0c460a1e08c50319460ac13002de0ba8bbde6ad1f4477fefb264135d6253d1268339c18292f82485fcce576af0539d9
   languageName: node
   linkType: hard
 
-"ignore@npm:^4.0.2, ignore@npm:^4.0.3, ignore@npm:^4.0.6":
+"ignore@npm:^4.0.3, ignore@npm:^4.0.6":
   version: 4.0.6
   resolution: "ignore@npm:4.0.6"
   checksum: 10/e04d6bd60d9da12cfe8896acf470824172843dddc25a9be0726199d5e031254634a69ce8479a82f194154b9b28cb3b08bb7a53e56f7f7eba2663e04791e74742
   languageName: node
   linkType: hard
 
-"ignore@npm:^5.0.4, ignore@npm:^5.2.0, ignore@npm:^5.2.4":
+"ignore@npm:^5.0.4, ignore@npm:^5.2.0":
   version: 5.2.4
   resolution: "ignore@npm:5.2.4"
   checksum: 10/4f7caf5d2005da21a382d4bd1d2aa741a3bed51de185c8562dd7f899a81a620ac4fd0619b06f7029a38ae79e4e4c134399db3bd0192c703c3ef54bb82df3086c
@@ -15402,6 +14656,13 @@ __metadata:
   version: 5.1.8
   resolution: "ignore@npm:5.1.8"
   checksum: 10/b3e8dceccb02811ae20a64ee8253b75f9d9a71523fe3ea14cf323e37c7601ddaa9109ccb1e7f09db92203886ed18c7ab9e6255cf9d023fd17200c54bc691d115
+  languageName: node
+  linkType: hard
+
+"ignore@npm:^5.3.1":
+  version: 5.3.1
+  resolution: "ignore@npm:5.3.1"
+  checksum: 10/0a884c2fbc8c316f0b9f92beaf84464253b73230a4d4d286697be45fca081199191ca33e1c2e82d9e5f851f5e9a48a78e25a35c951e7eb41e59f150db3530065
   languageName: node
   linkType: hard
 
@@ -16427,6 +15688,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"isexe@npm:^3.1.1":
+  version: 3.1.1
+  resolution: "isexe@npm:3.1.1"
+  checksum: 10/7fe1931ee4e88eb5aa524cd3ceb8c882537bc3a81b02e438b240e47012eef49c86904d0f0e593ea7c3a9996d18d0f1f3be8d3eaa92333977b0c3a9d353d5563e
+  languageName: node
+  linkType: hard
+
 "isobject@npm:^2.0.0":
   version: 2.1.0
   resolution: "isobject@npm:2.1.0"
@@ -16574,6 +15842,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jackspeak@npm:^2.3.6":
+  version: 2.3.6
+  resolution: "jackspeak@npm:2.3.6"
+  dependencies:
+    "@isaacs/cliui": "npm:^8.0.2"
+    "@pkgjs/parseargs": "npm:^0.11.0"
+  dependenciesMeta:
+    "@pkgjs/parseargs":
+      optional: true
+  checksum: 10/6e6490d676af8c94a7b5b29b8fd5629f21346911ebe2e32931c2a54210134408171c24cee1a109df2ec19894ad04a429402a8438cbf5cc2794585d35428ace76
+  languageName: node
+  linkType: hard
+
 "jake@npm:^10.8.5":
   version: 10.8.7
   resolution: "jake@npm:10.8.7"
@@ -16691,7 +15972,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-diff@npm:>=29.4.3 < 30, jest-diff@npm:^29.7.0":
+"jest-diff@npm:>=29.4.3 < 30, jest-diff@npm:^29.4.1, jest-diff@npm:^29.7.0":
   version: 29.7.0
   resolution: "jest-diff@npm:29.7.0"
   dependencies:
@@ -17070,7 +16351,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest@npm:^29.6.4":
+"jest@npm:^29.7.0":
   version: 29.7.0
   resolution: "jest@npm:29.7.0"
   dependencies:
@@ -17183,7 +16464,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jshint@npm:^2.13.6, jshint@npm:^2.9.6":
+"jshint@npm:^2.13.6":
   version: 2.13.6
   resolution: "jshint@npm:2.13.6"
   dependencies:
@@ -17532,14 +16813,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lerna@npm:^7.2.0":
-  version: 7.3.0
-  resolution: "lerna@npm:7.3.0"
+"lerna@npm:^8.1.2":
+  version: 8.1.3
+  resolution: "lerna@npm:8.1.3"
   dependencies:
-    "@lerna/child-process": "npm:7.3.0"
-    "@lerna/create": "npm:7.3.0"
-    "@npmcli/run-script": "npm:6.0.2"
-    "@nx/devkit": "npm:>=16.5.1 < 17"
+    "@lerna/create": "npm:8.1.3"
+    "@npmcli/run-script": "npm:7.0.2"
+    "@nx/devkit": "npm:>=17.1.2 < 20"
     "@octokit/plugin-enterprise-rest": "npm:6.0.1"
     "@octokit/rest": "npm:19.0.11"
     byte-size: "npm:8.1.1"
@@ -17547,7 +16827,7 @@ __metadata:
     clone-deep: "npm:4.0.1"
     cmd-shim: "npm:6.0.1"
     columnify: "npm:1.6.0"
-    conventional-changelog-angular: "npm:6.0.0"
+    conventional-changelog-angular: "npm:7.0.0"
     conventional-changelog-core: "npm:5.0.1"
     conventional-recommended-bump: "npm:7.0.1"
     cosmiconfig: "npm:^8.2.0"
@@ -17582,14 +16862,14 @@ __metadata:
     npm-packlist: "npm:5.1.1"
     npm-registry-fetch: "npm:^14.0.5"
     npmlog: "npm:^6.0.2"
-    nx: "npm:>=16.5.1 < 17"
+    nx: "npm:>=17.1.2 < 20"
     p-map: "npm:4.0.0"
     p-map-series: "npm:2.1.0"
     p-pipe: "npm:3.1.0"
     p-queue: "npm:6.6.2"
     p-reduce: "npm:2.1.0"
     p-waterfall: "npm:2.1.1"
-    pacote: "npm:^15.2.0"
+    pacote: "npm:^17.0.5"
     pify: "npm:5.0.0"
     read-cmd-shim: "npm:4.0.0"
     read-package-json: "npm:6.0.4"
@@ -17600,7 +16880,7 @@ __metadata:
     slash: "npm:3.0.0"
     ssri: "npm:^9.0.1"
     strong-log-transformer: "npm:2.1.0"
-    tar: "npm:6.1.11"
+    tar: "npm:6.2.1"
     temp-dir: "npm:1.0.0"
     typescript: "npm:>=3 < 6"
     upath: "npm:2.0.1"
@@ -17609,11 +16889,11 @@ __metadata:
     validate-npm-package-name: "npm:5.0.0"
     write-file-atomic: "npm:5.0.1"
     write-pkg: "npm:4.0.0"
-    yargs: "npm:16.2.0"
-    yargs-parser: "npm:20.2.4"
+    yargs: "npm:17.7.2"
+    yargs-parser: "npm:21.1.1"
   bin:
     lerna: dist/cli.js
-  checksum: 10/f3d3cc4eced6d3bdec74739746186472456350384d10c477ecc061a4291c3f5eff9d80a89a33b9294a083c40794167fd857d59d53e4acba336b8e94dd5be269e
+  checksum: 10/822268c86fedba07e7ecf27d219237c8e381c47d33c83ea8c19da7ccb03c0aa051dc86297d5af3244485e18d0de8933b3266b7241349f9fce66d2fc1884a1a9a
   languageName: node
   linkType: hard
 
@@ -17967,7 +17247,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash@npm:^4.17.10, lodash@npm:^4.17.11, lodash@npm:^4.17.12, lodash@npm:^4.17.14, lodash@npm:^4.17.15, lodash@npm:^4.17.21, lodash@npm:^4.2.1, lodash@npm:^4.3.0, lodash@npm:~4.17.21":
+"lodash@npm:^4.17.10, lodash@npm:^4.17.11, lodash@npm:^4.17.12, lodash@npm:^4.17.15, lodash@npm:^4.17.21, lodash@npm:^4.2.1, lodash@npm:^4.3.0, lodash@npm:~4.17.21":
   version: 4.17.21
   resolution: "lodash@npm:4.17.21"
   checksum: 10/c08619c038846ea6ac754abd6dd29d2568aa705feb69339e836dfa8d8b09abbb2f859371e86863eda41848221f9af43714491467b5b0299122431e202bb0c532
@@ -18070,6 +17350,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lru-cache@npm:^10.2.0":
+  version: 10.2.2
+  resolution: "lru-cache@npm:10.2.2"
+  checksum: 10/ff1a496d30b5eaec2c9079080965bb0cede203cf878371f7033a007f1e54cd4aa13cc8abf7ccec4c994a83a22ed5476e83a55bb57cc07e6c1547a42937e42c37
+  languageName: node
+  linkType: hard
+
 "lru-cache@npm:^4.0.0":
   version: 4.1.5
   resolution: "lru-cache@npm:4.1.5"
@@ -18098,7 +17385,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lru-cache@npm:^7.10.1, lru-cache@npm:^7.14.1, lru-cache@npm:^7.4.4, lru-cache@npm:^7.5.1, lru-cache@npm:^7.7.1":
+"lru-cache@npm:^7.10.1, lru-cache@npm:^7.14.1, lru-cache@npm:^7.5.1, lru-cache@npm:^7.7.1":
   version: 7.18.3
   resolution: "lru-cache@npm:7.18.3"
   checksum: 10/6029ca5aba3aacb554e919d7ef804fffd4adfc4c83db00fac8248c7c78811fb6d4b6f70f7fd9d55032b3823446546a007edaa66ad1f2377ae833bd983fac5d98
@@ -18229,7 +17516,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"make-fetch-happen@npm:^11.0.0, make-fetch-happen@npm:^11.0.1, make-fetch-happen@npm:^11.0.3, make-fetch-happen@npm:^11.1.1":
+"make-fetch-happen@npm:^11.0.0, make-fetch-happen@npm:^11.0.1, make-fetch-happen@npm:^11.1.1":
   version: 11.1.1
   resolution: "make-fetch-happen@npm:11.1.1"
   dependencies:
@@ -18249,6 +17536,26 @@ __metadata:
     socks-proxy-agent: "npm:^7.0.0"
     ssri: "npm:^10.0.0"
   checksum: 10/b4b442cfaaec81db159f752a5f2e3ee3d7aa682782868fa399200824ec6298502e01bdc456e443dc219bcd5546c8e4471644d54109c8599841dc961d17a805fa
+  languageName: node
+  linkType: hard
+
+"make-fetch-happen@npm:^13.0.0, make-fetch-happen@npm:^13.0.1":
+  version: 13.0.1
+  resolution: "make-fetch-happen@npm:13.0.1"
+  dependencies:
+    "@npmcli/agent": "npm:^2.0.0"
+    cacache: "npm:^18.0.0"
+    http-cache-semantics: "npm:^4.1.1"
+    is-lambda: "npm:^1.0.1"
+    minipass: "npm:^7.0.2"
+    minipass-fetch: "npm:^3.0.0"
+    minipass-flush: "npm:^1.0.5"
+    minipass-pipeline: "npm:^1.2.4"
+    negotiator: "npm:^0.6.3"
+    proc-log: "npm:^4.2.0"
+    promise-retry: "npm:^2.0.1"
+    ssri: "npm:^10.0.0"
+  checksum: 10/11bae5ad6ac59b654dbd854f30782f9de052186c429dfce308eda42374528185a100ee40ac9ffdc36a2b6c821ecaba43913e4730a12f06f15e895ea9cb23fa59
   languageName: node
   linkType: hard
 
@@ -19171,6 +18478,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"minimatch@npm:9.0.3, minimatch@npm:^9.0.0, minimatch@npm:^9.0.1":
+  version: 9.0.3
+  resolution: "minimatch@npm:9.0.3"
+  dependencies:
+    brace-expansion: "npm:^2.0.1"
+  checksum: 10/c81b47d28153e77521877649f4bab48348d10938df9e8147a58111fe00ef89559a2938de9f6632910c4f7bf7bb5cd81191a546167e58d357f0cfb1e18cecc1c5
+  languageName: node
+  linkType: hard
+
 "minimatch@npm:^3.0.4, minimatch@npm:~3.0.2":
   version: 3.0.4
   resolution: "minimatch@npm:3.0.4"
@@ -19207,12 +18523,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:^9.0.0, minimatch@npm:^9.0.1":
-  version: 9.0.3
-  resolution: "minimatch@npm:9.0.3"
+"minimatch@npm:^9.0.4":
+  version: 9.0.4
+  resolution: "minimatch@npm:9.0.4"
   dependencies:
     brace-expansion: "npm:^2.0.1"
-  checksum: 10/c81b47d28153e77521877649f4bab48348d10938df9e8147a58111fe00ef89559a2938de9f6632910c4f7bf7bb5cd81191a546167e58d357f0cfb1e18cecc1c5
+  checksum: 10/4cdc18d112b164084513e890d6323370db14c22249d536ad1854539577a895e690a27513dc346392f61a4a50afbbd8abc88f3f25558bfbbbb862cd56508b20f5
   languageName: node
   linkType: hard
 
@@ -19250,6 +18566,15 @@ __metadata:
   dependencies:
     minipass: "npm:^3.0.0"
   checksum: 10/14df761028f3e47293aee72888f2657695ec66bd7d09cae7ad558da30415fdc4752bbfee66287dcc6fd5e6a2fa3466d6c484dc1cbd986525d9393b9523d97f10
+  languageName: node
+  linkType: hard
+
+"minipass-collect@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "minipass-collect@npm:2.0.1"
+  dependencies:
+    minipass: "npm:^7.0.3"
+  checksum: 10/b251bceea62090f67a6cced7a446a36f4cd61ee2d5cea9aee7fff79ba8030e416327a1c5aa2908dc22629d06214b46d88fdab8c51ac76bacbf5703851b5ad342
   languageName: node
   linkType: hard
 
@@ -19357,6 +18682,13 @@ __metadata:
   version: 7.0.3
   resolution: "minipass@npm:7.0.3"
   checksum: 10/04d72c8a437de54a024f3758ff17c0226efb532ef37dbdaca1ea6039c7b9b1704e612abbd2e3a0d2c825c64eb0a9ab266c843baa71d18ad1a279baecee28ed97
+  languageName: node
+  linkType: hard
+
+"minipass@npm:^7.0.2, minipass@npm:^7.0.4":
+  version: 7.1.1
+  resolution: "minipass@npm:7.1.1"
+  checksum: 10/6f4f920f1b5ea585d08fa3739b9bd81726cd85a0c972fb371c0fa6c1544d468813fb1694c7bc64ad81f138fd8abf665e2af0f406de9ba5741d8e4a377ed346b1
   languageName: node
   linkType: hard
 
@@ -19707,7 +19039,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.3.4, nanoid@npm:^3.3.6":
+"nanoid@npm:^3.3.6":
   version: 3.3.6
   resolution: "nanoid@npm:3.3.6"
   bin:
@@ -19788,29 +19120,29 @@ __metadata:
   languageName: node
   linkType: hard
 
-"next@npm:13.4.19":
-  version: 13.4.19
-  resolution: "next@npm:13.4.19"
+"next@npm:14.2.3":
+  version: 14.2.3
+  resolution: "next@npm:14.2.3"
   dependencies:
-    "@next/env": "npm:13.4.19"
-    "@next/swc-darwin-arm64": "npm:13.4.19"
-    "@next/swc-darwin-x64": "npm:13.4.19"
-    "@next/swc-linux-arm64-gnu": "npm:13.4.19"
-    "@next/swc-linux-arm64-musl": "npm:13.4.19"
-    "@next/swc-linux-x64-gnu": "npm:13.4.19"
-    "@next/swc-linux-x64-musl": "npm:13.4.19"
-    "@next/swc-win32-arm64-msvc": "npm:13.4.19"
-    "@next/swc-win32-ia32-msvc": "npm:13.4.19"
-    "@next/swc-win32-x64-msvc": "npm:13.4.19"
-    "@swc/helpers": "npm:0.5.1"
+    "@next/env": "npm:14.2.3"
+    "@next/swc-darwin-arm64": "npm:14.2.3"
+    "@next/swc-darwin-x64": "npm:14.2.3"
+    "@next/swc-linux-arm64-gnu": "npm:14.2.3"
+    "@next/swc-linux-arm64-musl": "npm:14.2.3"
+    "@next/swc-linux-x64-gnu": "npm:14.2.3"
+    "@next/swc-linux-x64-musl": "npm:14.2.3"
+    "@next/swc-win32-arm64-msvc": "npm:14.2.3"
+    "@next/swc-win32-ia32-msvc": "npm:14.2.3"
+    "@next/swc-win32-x64-msvc": "npm:14.2.3"
+    "@swc/helpers": "npm:0.5.5"
     busboy: "npm:1.6.0"
-    caniuse-lite: "npm:^1.0.30001406"
-    postcss: "npm:8.4.14"
+    caniuse-lite: "npm:^1.0.30001579"
+    graceful-fs: "npm:^4.2.11"
+    postcss: "npm:8.4.31"
     styled-jsx: "npm:5.1.1"
-    watchpack: "npm:2.4.0"
-    zod: "npm:3.21.4"
   peerDependencies:
     "@opentelemetry/api": ^1.1.0
+    "@playwright/test": ^1.41.2
     react: ^18.2.0
     react-dom: ^18.2.0
     sass: ^1.3.0
@@ -19836,11 +19168,13 @@ __metadata:
   peerDependenciesMeta:
     "@opentelemetry/api":
       optional: true
+    "@playwright/test":
+      optional: true
     sass:
       optional: true
   bin:
     next: dist/bin/next
-  checksum: 10/e5180f07d5d0fd8603ae6f57966c8051a67c69cc07f1d472f1947c82dd1961ec2d57480012f234101f9a0ac90c85839798972efe9b91512417f34db0d2dcbf29
+  checksum: 10/666c9770206ce693732a6d772297f1ddb3ce72f59862fa4cd104c5536da596026f758c4c9256ea790cf22d1bb8a15e27e5ea9455c948f72a9e3ca61fb745b0f5
   languageName: node
   linkType: hard
 
@@ -19876,15 +19210,6 @@ __metadata:
   version: 3.1.1
   resolution: "node-abort-controller@npm:3.1.1"
   checksum: 10/0a2cdb7ec0aeaf3cb31e1ca0e192f5add48f1c5c9c9ed822129f9dddbd9432f69b7425982f94ce803c56a2104884530aa67cd57696e5774b2e5b8ec2f58de042
-  languageName: node
-  linkType: hard
-
-"node-addon-api@npm:^3.2.1":
-  version: 3.2.1
-  resolution: "node-addon-api@npm:3.2.1"
-  dependencies:
-    node-gyp: "npm:latest"
-  checksum: 10/681b52dfa3e15b0a8e5cf283cc0d8cd5fd2a57c559ae670fcfd20544cbb32f75de7648674110defcd17ab2c76ebef630aa7d2d2f930bc7a8cc439b20fe233518
   languageName: node
   linkType: hard
 
@@ -19978,14 +19303,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-gyp-build@npm:^4.3.0":
-  version: 4.6.1
-  resolution: "node-gyp-build@npm:4.6.1"
+"node-gyp@npm:^10.0.0":
+  version: 10.1.0
+  resolution: "node-gyp@npm:10.1.0"
+  dependencies:
+    env-paths: "npm:^2.2.0"
+    exponential-backoff: "npm:^3.1.1"
+    glob: "npm:^10.3.10"
+    graceful-fs: "npm:^4.2.6"
+    make-fetch-happen: "npm:^13.0.0"
+    nopt: "npm:^7.0.0"
+    proc-log: "npm:^3.0.0"
+    semver: "npm:^7.3.5"
+    tar: "npm:^6.1.2"
+    which: "npm:^4.0.0"
   bin:
-    node-gyp-build: bin.js
-    node-gyp-build-optional: optional.js
-    node-gyp-build-test: build-test.js
-  checksum: 10/79b948377492ae8e1aa1c18071661e6020c11f8847d5ce822abd67ec02bee5b21715b1b4861041d2b40d16633824476735bc9a60e81c82c49e715d55ee29b206
+    node-gyp: bin/node-gyp.js
+  checksum: 10/89e105e495e66cd4568af3cf79cdeb67d670eb069e33163c7781d3366470a30367c9bd8dea59e46db16370020139e5bf78b1fbc03284cb571754dfaa59744db5
   languageName: node
   linkType: hard
 
@@ -20007,27 +19341,6 @@ __metadata:
   bin:
     node-gyp: bin/node-gyp.js
   checksum: 10/be9b4eb6df3ed2d14528b8c61d87d8d77b5d0865a4a2a88cc8610871309c610fc5ecc08f5d16a0c2b7eb97053e76e920faaffdedbe3eeca888b71cd4dd60e389
-  languageName: node
-  linkType: hard
-
-"node-gyp@npm:^9.0.0":
-  version: 9.4.0
-  resolution: "node-gyp@npm:9.4.0"
-  dependencies:
-    env-paths: "npm:^2.2.0"
-    exponential-backoff: "npm:^3.1.1"
-    glob: "npm:^7.1.4"
-    graceful-fs: "npm:^4.2.6"
-    make-fetch-happen: "npm:^11.0.3"
-    nopt: "npm:^6.0.0"
-    npmlog: "npm:^6.0.0"
-    rimraf: "npm:^3.0.2"
-    semver: "npm:^7.3.5"
-    tar: "npm:^6.1.2"
-    which: "npm:^2.0.2"
-  bin:
-    node-gyp: bin/node-gyp.js
-  checksum: 10/458317127c63877365f227b18ef2362b013b7f8440b35ae722935e61b31e6b84ec0e3625ab07f90679e2f41a1d5a7df6c4049fdf8e7b3c81fcf22775147b47ac
   languageName: node
   linkType: hard
 
@@ -20138,14 +19451,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nopt@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "nopt@npm:6.0.0"
+"nopt@npm:^7.0.0":
+  version: 7.2.1
+  resolution: "nopt@npm:7.2.1"
   dependencies:
-    abbrev: "npm:^1.0.0"
+    abbrev: "npm:^2.0.0"
   bin:
     nopt: bin/nopt.js
-  checksum: 10/3c1128e07cd0241ae66d6e6a472170baa9f3e84dd4203950ba8df5bafac4efa2166ce917a57ef02b01ba7c40d18b2cc64b29b225fd3640791fe07b24f0b33a32
+  checksum: 10/95a1f6dec8a81cd18cdc2fed93e6f0b4e02cf6bdb4501c848752c6e34f9883d9942f036a5e3b21a699047d8a448562d891e67492df68ec9c373e6198133337ae
   languageName: node
   linkType: hard
 
@@ -20193,6 +19506,18 @@ __metadata:
     semver: "npm:^7.3.5"
     validate-npm-package-license: "npm:^3.0.4"
   checksum: 10/477344ee99c6c81afbc4359f9dc7a3a219cc29a37fe0220a4595bbdb7e1e5fa9e3c195e99900228b72d8676edf99eb99fd3b66aa94b4b8ab74d516f2ff60e510
+  languageName: node
+  linkType: hard
+
+"normalize-package-data@npm:^6.0.0":
+  version: 6.0.1
+  resolution: "normalize-package-data@npm:6.0.1"
+  dependencies:
+    hosted-git-info: "npm:^7.0.0"
+    is-core-module: "npm:^2.8.1"
+    semver: "npm:^7.3.5"
+    validate-npm-package-license: "npm:^3.0.4"
+  checksum: 10/eb0b1815a105adcba09df26befc35da1dc1c3149784b8ddbcaa90c581925b7a9f1d94aefd344b6020eb0261a5f0575a8a9ef8e92c57eb86182de9a510282c2b2
   languageName: node
   linkType: hard
 
@@ -20290,6 +19615,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"npm-package-arg@npm:^11.0.0":
+  version: 11.0.2
+  resolution: "npm-package-arg@npm:11.0.2"
+  dependencies:
+    hosted-git-info: "npm:^7.0.0"
+    proc-log: "npm:^4.0.0"
+    semver: "npm:^7.3.5"
+    validate-npm-package-name: "npm:^5.0.0"
+  checksum: 10/ce4c51900a73aadb408c9830c38a61b1930e1ab08509ec5ebbcf625ad14326ee33b014df289c942039bd28071ab17e813368f68d26a4ccad0eb6e9928f8ad03c
+  languageName: node
+  linkType: hard
+
 "npm-package-arg@npm:^4.0.0 || ^5.0.0 || ^6.0.0, npm-package-arg@npm:^6.0.0, npm-package-arg@npm:^6.1.0":
   version: 6.1.1
   resolution: "npm-package-arg@npm:6.1.1"
@@ -20327,12 +19664,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"npm-packlist@npm:^7.0.0":
-  version: 7.0.4
-  resolution: "npm-packlist@npm:7.0.4"
+"npm-packlist@npm:^8.0.0":
+  version: 8.0.2
+  resolution: "npm-packlist@npm:8.0.2"
   dependencies:
-    ignore-walk: "npm:^6.0.0"
-  checksum: 10/b24644eefa21d33c55a8f49c64eda4b06edfb7d25853be8ded7346e73c6c447be8a0482314b74f04f94e3f5712e467505dc030826ba55a71d1b948459fad6486
+    ignore-walk: "npm:^6.0.4"
+  checksum: 10/707206e5c09a1b8aa04e590592715ba5ab8732add1bbb5eeaff54b9c6b2740764c9e94c99e390c13245970b51c2cc92b8d44594c2784fcd96f255c7109622322
   languageName: node
   linkType: hard
 
@@ -20347,19 +19684,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"npm-pick-manifest@npm:^8.0.0":
-  version: 8.0.2
-  resolution: "npm-pick-manifest@npm:8.0.2"
+"npm-pick-manifest@npm:^9.0.0":
+  version: 9.0.1
+  resolution: "npm-pick-manifest@npm:9.0.1"
   dependencies:
     npm-install-checks: "npm:^6.0.0"
     npm-normalize-package-bin: "npm:^3.0.0"
-    npm-package-arg: "npm:^10.0.0"
+    npm-package-arg: "npm:^11.0.0"
     semver: "npm:^7.3.5"
-  checksum: 10/3f10a34e12cbb576edb694562a32730c6c0244b2929b91202d1be62ece76bc8b282dc7e9535d313d598963f8e3d06d19973611418a191fe3102be149a8fa0910
+  checksum: 10/870053b63c8765a5d22df3aabcf09505342dd30398c68e15a57cc32e9da629c361b12285d72bd0bac100786623d2f2dc5ced16270f39dda7c14660fae677590e
   languageName: node
   linkType: hard
 
-"npm-registry-fetch@npm:^14.0.0, npm-registry-fetch@npm:^14.0.3, npm-registry-fetch@npm:^14.0.5":
+"npm-registry-fetch@npm:^14.0.3, npm-registry-fetch@npm:^14.0.5":
   version: 14.0.5
   resolution: "npm-registry-fetch@npm:14.0.5"
   dependencies:
@@ -20371,6 +19708,22 @@ __metadata:
     npm-package-arg: "npm:^10.0.0"
     proc-log: "npm:^3.0.0"
   checksum: 10/63026b22d6a6afe5cb3a02dca96db783b88d3acc68be94f3485f25a5e4932800fdeff08145a77b35b8f61987033346462d4b3e710c0729a9735357ff97596062
+  languageName: node
+  linkType: hard
+
+"npm-registry-fetch@npm:^16.0.0":
+  version: 16.2.1
+  resolution: "npm-registry-fetch@npm:16.2.1"
+  dependencies:
+    "@npmcli/redact": "npm:^1.1.0"
+    make-fetch-happen: "npm:^13.0.0"
+    minipass: "npm:^7.0.2"
+    minipass-fetch: "npm:^3.0.0"
+    minipass-json-stream: "npm:^1.0.1"
+    minizlib: "npm:^2.1.2"
+    npm-package-arg: "npm:^11.0.0"
+    proc-log: "npm:^4.0.0"
+  checksum: 10/eb5a939f8f1c187b8d739e41bbc37f5d376480e2479f61a4f55af5aa00262a9a55e0053a0cd673d2945716863aaef6afbf97ebbb33fb194259573151c4dff37b
   languageName: node
   linkType: hard
 
@@ -20413,7 +19766,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"npmlog@npm:^6.0.0, npmlog@npm:^6.0.2":
+"npmlog@npm:^6.0.2":
   version: 6.0.2
   resolution: "npmlog@npm:6.0.2"
   dependencies:
@@ -20439,59 +19792,57 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nx@npm:16.8.1, nx@npm:>=16.5.1 < 17":
-  version: 16.8.1
-  resolution: "nx@npm:16.8.1"
+"nx@npm:19.0.3, nx@npm:>=17.1.2 < 20":
+  version: 19.0.3
+  resolution: "nx@npm:19.0.3"
   dependencies:
-    "@nrwl/tao": "npm:16.8.1"
-    "@nx/nx-darwin-arm64": "npm:16.8.1"
-    "@nx/nx-darwin-x64": "npm:16.8.1"
-    "@nx/nx-freebsd-x64": "npm:16.8.1"
-    "@nx/nx-linux-arm-gnueabihf": "npm:16.8.1"
-    "@nx/nx-linux-arm64-gnu": "npm:16.8.1"
-    "@nx/nx-linux-arm64-musl": "npm:16.8.1"
-    "@nx/nx-linux-x64-gnu": "npm:16.8.1"
-    "@nx/nx-linux-x64-musl": "npm:16.8.1"
-    "@nx/nx-win32-arm64-msvc": "npm:16.8.1"
-    "@nx/nx-win32-x64-msvc": "npm:16.8.1"
-    "@parcel/watcher": "npm:2.0.4"
+    "@nrwl/tao": "npm:19.0.3"
+    "@nx/nx-darwin-arm64": "npm:19.0.3"
+    "@nx/nx-darwin-x64": "npm:19.0.3"
+    "@nx/nx-freebsd-x64": "npm:19.0.3"
+    "@nx/nx-linux-arm-gnueabihf": "npm:19.0.3"
+    "@nx/nx-linux-arm64-gnu": "npm:19.0.3"
+    "@nx/nx-linux-arm64-musl": "npm:19.0.3"
+    "@nx/nx-linux-x64-gnu": "npm:19.0.3"
+    "@nx/nx-linux-x64-musl": "npm:19.0.3"
+    "@nx/nx-win32-arm64-msvc": "npm:19.0.3"
+    "@nx/nx-win32-x64-msvc": "npm:19.0.3"
     "@yarnpkg/lockfile": "npm:^1.1.0"
     "@yarnpkg/parsers": "npm:3.0.0-rc.46"
     "@zkochan/js-yaml": "npm:0.0.6"
-    axios: "npm:^1.0.0"
+    axios: "npm:^1.6.0"
     chalk: "npm:^4.1.0"
     cli-cursor: "npm:3.1.0"
     cli-spinners: "npm:2.6.1"
-    cliui: "npm:^7.0.2"
+    cliui: "npm:^8.0.1"
     dotenv: "npm:~16.3.1"
     dotenv-expand: "npm:~10.0.0"
     enquirer: "npm:~2.3.6"
-    fast-glob: "npm:3.2.7"
     figures: "npm:3.2.0"
     flat: "npm:^5.0.2"
     fs-extra: "npm:^11.1.0"
-    glob: "npm:7.1.4"
     ignore: "npm:^5.0.4"
+    jest-diff: "npm:^29.4.1"
     js-yaml: "npm:4.1.0"
     jsonc-parser: "npm:3.2.0"
     lines-and-columns: "npm:~2.0.3"
-    minimatch: "npm:3.0.5"
+    minimatch: "npm:9.0.3"
     node-machine-id: "npm:1.1.12"
     npm-run-path: "npm:^4.0.1"
     open: "npm:^8.4.0"
-    semver: "npm:7.5.3"
+    ora: "npm:5.3.0"
+    semver: "npm:^7.5.3"
     string-width: "npm:^4.2.3"
     strong-log-transformer: "npm:^2.1.0"
     tar-stream: "npm:~2.2.0"
     tmp: "npm:~0.2.1"
     tsconfig-paths: "npm:^4.1.2"
     tslib: "npm:^2.3.0"
-    v8-compile-cache: "npm:2.3.0"
     yargs: "npm:^17.6.2"
     yargs-parser: "npm:21.1.1"
   peerDependencies:
-    "@swc-node/register": ^1.4.2
-    "@swc/core": ^1.2.173
+    "@swc-node/register": ^1.8.0
+    "@swc/core": ^1.3.85
   dependenciesMeta:
     "@nx/nx-darwin-arm64":
       optional: true
@@ -20520,7 +19871,8 @@ __metadata:
       optional: true
   bin:
     nx: bin/nx.js
-  checksum: 10/8632937e4b0afdee86855f1a92afd610f96aeba0bb282891065ca4d65909319aebfbae3ae5a629ece45608e01b7fa760c231a5db5d84407669428099e22fafc2
+    nx-cloud: bin/nx-cloud.js
+  checksum: 10/06198a6f1b0c4a14796a800abd056c8a5a1893a1240aeba26fb45d5fdf2c097e801434212809c5906a8a42e92ea44c1564355fa7fa42692b90d891d3228beacd
   languageName: node
   linkType: hard
 
@@ -20857,6 +20209,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ora@npm:5.3.0":
+  version: 5.3.0
+  resolution: "ora@npm:5.3.0"
+  dependencies:
+    bl: "npm:^4.0.3"
+    chalk: "npm:^4.1.0"
+    cli-cursor: "npm:^3.1.0"
+    cli-spinners: "npm:^2.5.0"
+    is-interactive: "npm:^1.0.0"
+    log-symbols: "npm:^4.0.0"
+    strip-ansi: "npm:^6.0.0"
+    wcwidth: "npm:^1.0.1"
+  checksum: 10/989a075b596c297acfee647010e555709bd657dedd9eee9ff99d923cbc65c68b6189c2c9ea58167675b101433509f87d1674a84047c7b766babab15d9220f1d5
+  languageName: node
+  linkType: hard
+
 "ora@npm:^5.4.1":
   version: 5.4.1
   resolution: "ora@npm:5.4.1"
@@ -21151,31 +20519,31 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pacote@npm:^15.2.0":
-  version: 15.2.0
-  resolution: "pacote@npm:15.2.0"
+"pacote@npm:^17.0.5":
+  version: 17.0.7
+  resolution: "pacote@npm:17.0.7"
   dependencies:
-    "@npmcli/git": "npm:^4.0.0"
+    "@npmcli/git": "npm:^5.0.0"
     "@npmcli/installed-package-contents": "npm:^2.0.1"
-    "@npmcli/promise-spawn": "npm:^6.0.1"
-    "@npmcli/run-script": "npm:^6.0.0"
-    cacache: "npm:^17.0.0"
+    "@npmcli/promise-spawn": "npm:^7.0.0"
+    "@npmcli/run-script": "npm:^7.0.0"
+    cacache: "npm:^18.0.0"
     fs-minipass: "npm:^3.0.0"
-    minipass: "npm:^5.0.0"
-    npm-package-arg: "npm:^10.0.0"
-    npm-packlist: "npm:^7.0.0"
-    npm-pick-manifest: "npm:^8.0.0"
-    npm-registry-fetch: "npm:^14.0.0"
-    proc-log: "npm:^3.0.0"
+    minipass: "npm:^7.0.2"
+    npm-package-arg: "npm:^11.0.0"
+    npm-packlist: "npm:^8.0.0"
+    npm-pick-manifest: "npm:^9.0.0"
+    npm-registry-fetch: "npm:^16.0.0"
+    proc-log: "npm:^4.0.0"
     promise-retry: "npm:^2.0.1"
-    read-package-json: "npm:^6.0.0"
+    read-package-json: "npm:^7.0.0"
     read-package-json-fast: "npm:^3.0.0"
-    sigstore: "npm:^1.3.0"
+    sigstore: "npm:^2.2.0"
     ssri: "npm:^10.0.0"
     tar: "npm:^6.1.11"
   bin:
     pacote: lib/bin.js
-  checksum: 10/57e18f4f963abb5f67f794158a55c01ad23f76e56dcdc74e6b843dfdda017515b0e8c0f56e60e842cd5af5ab9b351afdc49fc70633994f0e5fc0c6c9f4bcaebc
+  checksum: 10/6aa223428e0c8273d48d2e49d7bf3fbe03ea3f6b418a56f7c6d52f3f628d71608a4b4a4cb04f3de0b67fface556df34e47ca1f840c771e24b5e4f57cdbc3f4d4
   languageName: node
   linkType: hard
 
@@ -21203,13 +20571,6 @@ __metadata:
   dependencies:
     callsites: "npm:^3.0.0"
   checksum: 10/6ba8b255145cae9470cf5551eb74be2d22281587af787a2626683a6c20fbb464978784661478dd2a3f1dad74d1e802d403e1b03c1a31fab310259eec8ac560ff
-  languageName: node
-  linkType: hard
-
-"parse-cache-control@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "parse-cache-control@npm:1.0.1"
-  checksum: 10/13171cd97395bdcb9ad29e0b82a789f2313663f2392ab4f699c97ecd2059e18c00834b9c12c9b42f6b0f22bc3c9395d16db9d2e3db7e21538ad5cf2e5ec9fdbe
   languageName: node
   linkType: hard
 
@@ -21470,6 +20831,16 @@ __metadata:
     lru-cache: "npm:^9.1.1 || ^10.0.0"
     minipass: "npm:^5.0.0 || ^6.0.2 || ^7.0.0"
   checksum: 10/eebfb8304fef1d4f7e1486df987e4fd77413de4fce16508dea69fcf8eb318c09a6b15a7a2f4c22877cec1cb7ecbd3071d18ca9de79eeece0df874a00f1f0bdc8
+  languageName: node
+  linkType: hard
+
+"path-scurry@npm:^1.11.0":
+  version: 1.11.1
+  resolution: "path-scurry@npm:1.11.1"
+  dependencies:
+    lru-cache: "npm:^10.2.0"
+    minipass: "npm:^5.0.0 || ^6.0.2 || ^7.0.0"
+  checksum: 10/5e8845c159261adda6f09814d7725683257fcc85a18f329880ab4d7cc1d12830967eae5d5894e453f341710d5484b8fdbbd4d75181b4d6e1eb2f4dc7aeadc434
   languageName: node
   linkType: hard
 
@@ -21790,14 +21161,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:8.4.14":
-  version: 8.4.14
-  resolution: "postcss@npm:8.4.14"
+"postcss@npm:8.4.31":
+  version: 8.4.31
+  resolution: "postcss@npm:8.4.31"
   dependencies:
-    nanoid: "npm:^3.3.4"
+    nanoid: "npm:^3.3.6"
     picocolors: "npm:^1.0.0"
     source-map-js: "npm:^1.0.2"
-  checksum: 10/1940e8d1da04a2ac3e518735ab3e9563e2255bfab14cecc8c11fee97b2a36ac5fee496bccfc7057aaae7ff3accae463cd800d746238cf691bd65a32dba5cb7be
+  checksum: 10/1a6653e72105907377f9d4f2cd341d8d90e3fde823a5ddea1e2237aaa56933ea07853f0f2758c28892a1d70c53bbaca200eb8b80f8ed55f13093003dbec5afa0
   languageName: node
   linkType: hard
 
@@ -21902,6 +21273,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"proc-log@npm:^4.0.0, proc-log@npm:^4.2.0":
+  version: 4.2.0
+  resolution: "proc-log@npm:4.2.0"
+  checksum: 10/4e1394491b717f6c1ade15c570ecd4c2b681698474d3ae2d303c1e4b6ab9455bd5a81566211e82890d5a5ae9859718cc6954d5150bb18b09b72ecb297beae90a
+  languageName: node
+  linkType: hard
+
 "process-nextick-args@npm:~2.0.0":
   version: 2.0.1
   resolution: "process-nextick-args@npm:2.0.1"
@@ -21993,15 +21371,6 @@ __metadata:
   dependencies:
     asap: "npm:~2.0.3"
   checksum: 10/37dbe58ca7b0716cc881f0618128f1fd6ff9c46cdc529a269fd70004e567126a449a94e9428e2d19b53d06182d11b45d0c399828f103e06b2bb87643319bd2e7
-  languageName: node
-  linkType: hard
-
-"promise@npm:^8.0.0":
-  version: 8.1.0
-  resolution: "promise@npm:8.1.0"
-  dependencies:
-    asap: "npm:~2.0.6"
-  checksum: 10/337b5ec09abef9be27c1f35df5fa3207c6996c5d893f60884ad2b102f9eabf42d7204dea9cd815ffc83da914dd84c60f769404dffa4caff6c8095be7f9bfa11a
   languageName: node
   linkType: hard
 
@@ -22231,7 +21600,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"qs@npm:^6.4.0, qs@npm:^6.5.0, qs@npm:^6.5.1, qs@npm:^6.9.4":
+"qs@npm:^6.5.0, qs@npm:^6.5.1, qs@npm:^6.9.4":
   version: 6.10.3
   resolution: "qs@npm:6.10.3"
   dependencies:
@@ -22668,6 +22037,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"read-package-json@npm:^7.0.0":
+  version: 7.0.1
+  resolution: "read-package-json@npm:7.0.1"
+  dependencies:
+    glob: "npm:^10.2.2"
+    json-parse-even-better-errors: "npm:^3.0.0"
+    normalize-package-data: "npm:^6.0.0"
+    npm-normalize-package-bin: "npm:^3.0.0"
+  checksum: 10/4b5684f4ee96ff29d0ec62452d2b1ed2b3fb7e452cd1a1f40869d896082816a231a1e157fa3e72137e140ca961cbe7eeabc952658fc38235c85b202c91f2e584
+  languageName: node
+  linkType: hard
+
 "read-package-tree@npm:^5.1.6":
   version: 5.3.1
   resolution: "read-package-tree@npm:5.3.1"
@@ -22932,13 +22313,6 @@ __metadata:
   version: 0.13.9
   resolution: "regenerator-runtime@npm:0.13.9"
   checksum: 10/efbbcee420cf89b90c634ac4c53e4ac8000c80b4650d6d34560f124185d43b21b824d385ec6147657603a1ec1bed6820fc5dfb78e669f9acc7c1b5d7238b1627
-  languageName: node
-  linkType: hard
-
-"regenerator-runtime@npm:^0.14.0":
-  version: 0.14.0
-  resolution: "regenerator-runtime@npm:0.14.0"
-  checksum: 10/6c19495baefcf5fbb18a281b56a97f0197b5f219f42e571e80877f095320afac0bdb31dab8f8186858e6126950068c3f17a1226437881e3e70446ea66751897c
   languageName: node
   linkType: hard
 
@@ -23735,17 +23109,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:7.5.3":
-  version: 7.5.3
-  resolution: "semver@npm:7.5.3"
-  dependencies:
-    lru-cache: "npm:^6.0.0"
-  bin:
-    semver: bin/semver.js
-  checksum: 10/80b4b3784abff33bacf200727e012dc66768ed5835441e0a802ba9f3f5dd6b10ee366294711f5e7e13d73b82a6127ea55f11f9884d35e76a6a618dc11bc16ccf
-  languageName: node
-  linkType: hard
-
 "semver@npm:^6.0.0, semver@npm:^6.2.0, semver@npm:^6.3.0, semver@npm:^6.3.1":
   version: 6.3.1
   resolution: "semver@npm:6.3.1"
@@ -23755,7 +23118,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^7.0.0, semver@npm:^7.1.1, semver@npm:^7.1.2, semver@npm:^7.2.1, semver@npm:^7.3.2, semver@npm:^7.3.4, semver@npm:^7.3.5, semver@npm:^7.3.7, semver@npm:^7.3.8, semver@npm:^7.5.2, semver@npm:^7.5.3, semver@npm:^7.5.4":
+"semver@npm:^7.0.0, semver@npm:^7.1.1, semver@npm:^7.1.2, semver@npm:^7.2.1, semver@npm:^7.3.2, semver@npm:^7.3.4, semver@npm:^7.3.5, semver@npm:^7.3.7, semver@npm:^7.3.8, semver@npm:^7.5.3, semver@npm:^7.5.4":
   version: 7.5.4
   resolution: "semver@npm:7.5.4"
   dependencies:
@@ -23949,7 +23312,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sigstore@npm:^1.3.0, sigstore@npm:^1.4.0":
+"sigstore@npm:^1.4.0":
   version: 1.9.0
   resolution: "sigstore@npm:1.9.0"
   dependencies:
@@ -23961,6 +23324,20 @@ __metadata:
   bin:
     sigstore: bin/sigstore.js
   checksum: 10/7ff59f6bbc6fbf4e11f99df36562cdfd8f27f74650e1794942b0f9b567c6facdd0a6c245375111c464a0c367e617793a1c1787ec1dea9784ad2fb698932b9fb9
+  languageName: node
+  linkType: hard
+
+"sigstore@npm:^2.2.0":
+  version: 2.3.0
+  resolution: "sigstore@npm:2.3.0"
+  dependencies:
+    "@sigstore/bundle": "npm:^2.3.1"
+    "@sigstore/core": "npm:^1.0.0"
+    "@sigstore/protobuf-specs": "npm:^0.3.1"
+    "@sigstore/sign": "npm:^2.3.0"
+    "@sigstore/tuf": "npm:^2.3.1"
+    "@sigstore/verify": "npm:^1.2.0"
+  checksum: 10/881c6ee139231c167ff7a33b743ef884f4813e897afe7b48a2929fb06b6c74a0b032c8875f836b0a70cad5327252f77755ca26ab6cf639d00adf7fa55e7dc424
   languageName: node
   linkType: hard
 
@@ -24002,17 +23379,6 @@ __metadata:
   version: 2.0.0
   resolution: "slash@npm:2.0.0"
   checksum: 10/512d4350735375bd11647233cb0e2f93beca6f53441015eea241fe784d8068281c3987fbaa93e7ef1c38df68d9c60013045c92837423c69115297d6169aa85e6
-  languageName: node
-  linkType: hard
-
-"slice-ansi@npm:^2.1.0":
-  version: 2.1.0
-  resolution: "slice-ansi@npm:2.1.0"
-  dependencies:
-    ansi-styles: "npm:^3.2.0"
-    astral-regex: "npm:^1.0.0"
-    is-fullwidth-code-point: "npm:^2.0.0"
-  checksum: 10/4e82995aa59cef7eb03ef232d73c2239a15efa0ace87a01f3012ebb942e963fbb05d448ce7391efcd52ab9c32724164aba2086f5143e0445c969221dde3b6b1e
   languageName: node
   linkType: hard
 
@@ -24117,6 +23483,17 @@ __metadata:
     debug: "npm:^4.3.3"
     socks: "npm:^2.6.2"
   checksum: 10/26c75d9c62a9ed3fd494df60e65e88da442f78e0d4bc19bfd85ac37bd2c67470d6d4bba5202e804561cda6674db52864c9e2a2266775f879bc8d89c1445a5f4c
+  languageName: node
+  linkType: hard
+
+"socks-proxy-agent@npm:^8.0.3":
+  version: 8.0.3
+  resolution: "socks-proxy-agent@npm:8.0.3"
+  dependencies:
+    agent-base: "npm:^7.1.1"
+    debug: "npm:^4.3.4"
+    socks: "npm:^2.7.1"
+  checksum: 10/c2112c66d6322e497d68e913c3780f3683237fd394bfd480b9283486a86e36095d0020db96145d88f8ccd9cc73261b98165b461f9c1bf5dc17abfe75c18029ce
   languageName: node
   linkType: hard
 
@@ -25129,18 +24506,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"table@npm:^5.2.3":
-  version: 5.4.6
-  resolution: "table@npm:5.4.6"
-  dependencies:
-    ajv: "npm:^6.10.2"
-    lodash: "npm:^4.17.14"
-    slice-ansi: "npm:^2.1.0"
-    string-width: "npm:^3.0.0"
-  checksum: 10/a00b96779fdeae58fc8b2b10ca7a1dcb81d4a14d1511b2f0202e1ef4ea890ca4d2730cc9b78f399254b9a641458e4897c639079d57dfb7d6726997dd8735a6c3
-  languageName: node
-  linkType: hard
-
 "table@npm:^6.0.4":
   version: 6.7.1
   resolution: "table@npm:6.7.1"
@@ -25155,16 +24520,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"table@npm:^6.8.1":
-  version: 6.8.1
-  resolution: "table@npm:6.8.1"
+"table@npm:^6.8.2":
+  version: 6.8.2
+  resolution: "table@npm:6.8.2"
   dependencies:
     ajv: "npm:^8.0.1"
     lodash.truncate: "npm:^4.4.2"
     slice-ansi: "npm:^4.0.0"
     string-width: "npm:^4.2.3"
     strip-ansi: "npm:^6.0.1"
-  checksum: 10/512c4f2bfb6f46f4d5ced19943ae5db1a5163eac1f23ce752625eb49715f84217c1c62bc2d017eb8985b37e0f85731108f654df809c0b34cca1678a672e7ea20
+  checksum: 10/2946162eb87a91b9bf4283214d26830db96f09cf517eff18e7501d47a4770c529b432bb54c9394337c3dfd6c8dbf66581f76edb37e9838beb6ec394080af4ac2
   languageName: node
   linkType: hard
 
@@ -25192,17 +24557,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tar@npm:6.1.11, tar@npm:^6.0.2, tar@npm:^6.0.5, tar@npm:^6.1.2":
-  version: 6.1.11
-  resolution: "tar@npm:6.1.11"
+"tar@npm:6.2.1":
+  version: 6.2.1
+  resolution: "tar@npm:6.2.1"
   dependencies:
     chownr: "npm:^2.0.0"
     fs-minipass: "npm:^2.0.0"
-    minipass: "npm:^3.0.0"
+    minipass: "npm:^5.0.0"
     minizlib: "npm:^2.1.1"
     mkdirp: "npm:^1.0.3"
     yallist: "npm:^4.0.0"
-  checksum: 10/0e6789e66475922b8e0d1ee648cb26e0ede9a0635284269ca71b2d8acd507bc59ad5557032f0192f8ff22680b50cb66792b56f0240f484fe0d7d8cef81c1b959
+  checksum: 10/bfbfbb2861888077fc1130b84029cdc2721efb93d1d1fb80f22a7ac3a98ec6f8972f29e564103bbebf5e97be67ebc356d37fa48dbc4960600a1eb7230fbd1ea0
   languageName: node
   linkType: hard
 
@@ -25218,6 +24583,20 @@ __metadata:
     safe-buffer: "npm:^5.2.1"
     yallist: "npm:^3.1.1"
   checksum: 10/2715b5964578424ba5164632905a85e5a98c8dffeba657860aafa3a771b2602e6fd2a350bca891d78b8bda8cab5c53134c683ed2269b9925533477a24722e73b
+  languageName: node
+  linkType: hard
+
+"tar@npm:^6.0.2, tar@npm:^6.0.5, tar@npm:^6.1.2":
+  version: 6.1.11
+  resolution: "tar@npm:6.1.11"
+  dependencies:
+    chownr: "npm:^2.0.0"
+    fs-minipass: "npm:^2.0.0"
+    minipass: "npm:^3.0.0"
+    minizlib: "npm:^2.1.1"
+    mkdirp: "npm:^1.0.3"
+    yallist: "npm:^4.0.0"
+  checksum: 10/0e6789e66475922b8e0d1ee648cb26e0ede9a0635284269ca71b2d8acd507bc59ad5557032f0192f8ff22680b50cb66792b56f0240f484fe0d7d8cef81c1b959
   languageName: node
   linkType: hard
 
@@ -25291,25 +24670,6 @@ __metadata:
   version: 0.2.0
   resolution: "text-table@npm:0.2.0"
   checksum: 10/4383b5baaeffa9bb4cda2ac33a4aa2e6d1f8aaf811848bf73513a9b88fd76372dc461f6fd6d2e9cb5100f48b473be32c6f95bd983509b7d92bb4d92c10747452
-  languageName: node
-  linkType: hard
-
-"then-request@npm:^6.0.2":
-  version: 6.0.2
-  resolution: "then-request@npm:6.0.2"
-  dependencies:
-    "@types/concat-stream": "npm:^1.6.0"
-    "@types/form-data": "npm:0.0.33"
-    "@types/node": "npm:^8.0.0"
-    "@types/qs": "npm:^6.2.31"
-    caseless: "npm:~0.12.0"
-    concat-stream: "npm:^1.6.0"
-    form-data: "npm:^2.2.0"
-    http-basic: "npm:^8.1.1"
-    http-response-object: "npm:^3.0.1"
-    promise: "npm:^8.0.0"
-    qs: "npm:^6.4.0"
-  checksum: 10/7a33192fa03493fa7d5a40dbe2039271723c1c226aaa6db91576b439bf56393c8fe5a206478f37855c98284adf31d18c5bb7bafc94ebedae7c5bdb26a580dacc
   languageName: node
   linkType: hard
 
@@ -25817,6 +25177,17 @@ __metadata:
     debug: "npm:^4.3.4"
     make-fetch-happen: "npm:^11.1.1"
   checksum: 10/8ce0061b76a9dc89fc6e53bc1870afeb8e70083a751910273f959c5d0d574ba9b037a22d944ff97623e58eefa16b051f0ac678bd2da973d2f6b57359604fee31
+  languageName: node
+  linkType: hard
+
+"tuf-js@npm:^2.2.1":
+  version: 2.2.1
+  resolution: "tuf-js@npm:2.2.1"
+  dependencies:
+    "@tufjs/models": "npm:2.0.1"
+    debug: "npm:^4.3.4"
+    make-fetch-happen: "npm:^13.0.1"
+  checksum: 10/4c057f4f0cfb183d8634c026a592f4fb29fd4e3d88260e32949642deedf87a1ae407645bae4cca58299458679a1cb7721245cde1885d466c2dbc1fbac0bc008a
   languageName: node
   linkType: hard
 
@@ -26423,7 +25794,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"v8-compile-cache@npm:2.3.0, v8-compile-cache@npm:^2.0.3":
+"uuid@npm:^9.0.1":
+  version: 9.0.1
+  resolution: "uuid@npm:9.0.1"
+  bin:
+    uuid: dist/bin/uuid
+  checksum: 10/9d0b6adb72b736e36f2b1b53da0d559125ba3e39d913b6072f6f033e0c87835b414f0836b45bcfaf2bdf698f92297fea1c3cc19b0b258bc182c9c43cc0fab9f2
+  languageName: node
+  linkType: hard
+
+"v8-compile-cache@npm:^2.0.3":
   version: 2.3.0
   resolution: "v8-compile-cache@npm:2.3.0"
   checksum: 10/7de7423db6f48d76cffae93d70d503e160c97fc85e55945036d719111e20b33c4be5c21aa8b123a3da203bbb3bc4c8180f9667d5ccafcff11d749fae204ec7be
@@ -26711,16 +26091,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"watchpack@npm:2.4.0":
-  version: 2.4.0
-  resolution: "watchpack@npm:2.4.0"
-  dependencies:
-    glob-to-regexp: "npm:^0.4.1"
-    graceful-fs: "npm:^4.1.2"
-  checksum: 10/4280b45bc4b5d45d5579113f2a4af93b67ae1b9607cc3d86ae41cdd53ead10db5d9dc3237f24256d05ef88b28c69a02712f78e434cb7ecc8edaca134a56e8cab
-  languageName: node
-  linkType: hard
-
 "wcwidth@npm:^1.0.0, wcwidth@npm:^1.0.1":
   version: 1.0.1
   resolution: "wcwidth@npm:1.0.1"
@@ -26903,14 +26273,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"which@npm:^3.0.0":
-  version: 3.0.1
-  resolution: "which@npm:3.0.1"
+"which@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "which@npm:4.0.0"
   dependencies:
-    isexe: "npm:^2.0.0"
+    isexe: "npm:^3.1.1"
   bin:
     node-which: bin/which.js
-  checksum: 10/adf720fe9d84be2d9190458194f814b5e9015ae4b88711b150f30d0f4d0b646544794b86f02c7ebeec1db2029bc3e83a7ff156f542d7521447e5496543e26890
+  checksum: 10/f17e84c042592c21e23c8195108cff18c64050b9efb8459589116999ea9da6dd1509e6a1bac3aeebefd137be00fabbb61b5c2bc0aa0f8526f32b58ee2f545651
   languageName: node
   linkType: hard
 
@@ -27154,26 +26524,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"xml2js@npm:^0.4.23":
-  version: 0.4.23
-  resolution: "xml2js@npm:0.4.23"
-  dependencies:
-    sax: "npm:>=0.6.0"
-    xmlbuilder: "npm:~11.0.0"
-  checksum: 10/52896ef39429f860f32471dd7bb2b89ef25b7e15528e3a4366de0bd5e55a251601565e7814763e70f9e75310c3afe649a42b8826442b74b41eff8a0ae333fccc
-  languageName: node
-  linkType: hard
-
-"xml2js@npm:^0.5.0":
-  version: 0.5.0
-  resolution: "xml2js@npm:0.5.0"
-  dependencies:
-    sax: "npm:>=0.6.0"
-    xmlbuilder: "npm:~11.0.0"
-  checksum: 10/27c4d759214e99be5ec87ee5cb1290add427fa43df509d3b92d10152b3806fd2f7c9609697a18b158ccf2caa01e96af067cdba93196f69ca10c90e4f79a08896
-  languageName: node
-  linkType: hard
-
 "xml2js@npm:^0.6.2":
   version: 0.6.2
   resolution: "xml2js@npm:0.6.2"
@@ -27270,7 +26620,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yaml@npm:^1.10.0, yaml@npm:^1.10.2":
+"yaml@npm:^1.10.0":
   version: 1.10.2
   resolution: "yaml@npm:1.10.2"
   checksum: 10/e088b37b4d4885b70b50c9fa1b7e54bd2e27f5c87205f9deaffd1fb293ab263d9c964feadb9817a7b129a5bf30a06582cb08750f810568ecc14f3cdbabb79cb3
@@ -27281,13 +26631,6 @@ __metadata:
   version: 2.3.2
   resolution: "yaml@npm:2.3.2"
   checksum: 10/dba78b314c4b713a7dfa4412c88c1168ffe41fe26cdd4363cb3389194765895415b800f5a2d1a5bdfb0b2e31f1ad689f8e8f9cf78153f24142b68172e72afc95
-  languageName: node
-  linkType: hard
-
-"yargs-parser@npm:20.2.4":
-  version: 20.2.4
-  resolution: "yargs-parser@npm:20.2.4"
-  checksum: 10/db8f251ae40e24782d5c089ed86883ba3c0ce7f3c174002a67ec500802f928df9d505fea5d04829769221ce20b0f69f6fb1138fbb2e2fb102e3e9d426d20edab
   languageName: node
   linkType: hard
 
@@ -27315,18 +26658,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yargs@npm:16.2.0, yargs@npm:^16.2.0":
-  version: 16.2.0
-  resolution: "yargs@npm:16.2.0"
+"yargs@npm:17.7.2, yargs@npm:^17.3.1, yargs@npm:^17.6.2, yargs@npm:^17.7.2":
+  version: 17.7.2
+  resolution: "yargs@npm:17.7.2"
   dependencies:
-    cliui: "npm:^7.0.2"
+    cliui: "npm:^8.0.1"
     escalade: "npm:^3.1.1"
     get-caller-file: "npm:^2.0.5"
     require-directory: "npm:^2.1.1"
-    string-width: "npm:^4.2.0"
+    string-width: "npm:^4.2.3"
     y18n: "npm:^5.0.5"
-    yargs-parser: "npm:^20.2.2"
-  checksum: 10/807fa21211d2117135d557f95fcd3c3d390530cda2eca0c840f1d95f0f40209dcfeb5ec18c785a1f3425896e623e3b2681e8bb7b6600060eda1c3f4804e7957e
+    yargs-parser: "npm:^21.1.1"
+  checksum: 10/abb3e37678d6e38ea85485ed86ebe0d1e3464c640d7d9069805ea0da12f69d5a32df8e5625e370f9c96dd1c2dc088ab2d0a4dd32af18222ef3c4224a19471576
   languageName: node
   linkType: hard
 
@@ -27349,18 +26692,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yargs@npm:^17.3.1, yargs@npm:^17.6.2, yargs@npm:^17.7.2":
-  version: 17.7.2
-  resolution: "yargs@npm:17.7.2"
+"yargs@npm:^16.2.0":
+  version: 16.2.0
+  resolution: "yargs@npm:16.2.0"
   dependencies:
-    cliui: "npm:^8.0.1"
+    cliui: "npm:^7.0.2"
     escalade: "npm:^3.1.1"
     get-caller-file: "npm:^2.0.5"
     require-directory: "npm:^2.1.1"
-    string-width: "npm:^4.2.3"
+    string-width: "npm:^4.2.0"
     y18n: "npm:^5.0.5"
-    yargs-parser: "npm:^21.1.1"
-  checksum: 10/abb3e37678d6e38ea85485ed86ebe0d1e3464c640d7d9069805ea0da12f69d5a32df8e5625e370f9c96dd1c2dc088ab2d0a4dd32af18222ef3c4224a19471576
+    yargs-parser: "npm:^20.2.2"
+  checksum: 10/807fa21211d2117135d557f95fcd3c3d390530cda2eca0c840f1d95f0f40209dcfeb5ec18c785a1f3425896e623e3b2681e8bb7b6600060eda1c3f4804e7957e
   languageName: node
   linkType: hard
 
@@ -27423,13 +26766,6 @@ __metadata:
   version: 0.8.15
   resolution: "zen-observable@npm:0.8.15"
   checksum: 10/30eac3f4055d33f446b4cd075d3543da347c2c8e68fbc35c3f5a19fb43be67c6ed27ee136bc8f8933efa547be7ce04957809ad00ee7f1b00a964f199ae6fb514
-  languageName: node
-  linkType: hard
-
-"zod@npm:3.21.4":
-  version: 3.21.4
-  resolution: "zod@npm:3.21.4"
-  checksum: 10/03c79fa4610a35e24119771970be764c6e177a271a225587f86a7fc35d55e94a154d8e1970d23ffe35b567c147262bedbcb53b31aa30eeef2493fbd13e1b4aca
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Update to [bids-validator version 1.14.6](https://github.com/bids-standard/bids-validator/releases/tag/v1.14.6).