### PR TITLE
fix(app): Show 404 pages on more invalid route paths (root and error pages)

### DIFF
--- a/packages/openneuro-app/src/scripts/errors/errorRoute.jsx
+++ b/packages/openneuro-app/src/scripts/errors/errorRoute.jsx
@@ -7,22 +7,22 @@ import OrcidGeneral from "./orcid/general.jsx"
 import OrcidEmail from "./orcid/email.jsx"
 import OrcidGiven from "./orcid/given.jsx"
 import OrcidFamily from "./orcid/family.jsx"
+import FourOFourPage from "./404page"
 
-class ErrorRoute extends React.Component {
-  render() {
-    return (
-      <div className="container errors">
-        <div className="panel">
-          <Routes>
-            <Route path="orcid" element={<OrcidGeneral />} />
-            <Route path="orcid/email" element={<OrcidEmail />} />
-            <Route path="orcid/given" element={<OrcidGiven />} />
-            <Route path="orcid/family" element={<OrcidFamily />} />
-          </Routes>
-        </div>
+function ErrorRoute() {
+  return (
+    <div className="container errors">
+      <div className="panel">
+        <Routes>
+          <Route path="orcid" element={<OrcidGeneral />} />
+          <Route path="orcid/email" element={<OrcidEmail />} />
+          <Route path="orcid/given" element={<OrcidGiven />} />
+          <Route path="orcid/family" element={<OrcidFamily />} />
+          <Route path="*" element={<FourOFourPage />} />
+        </Routes>
       </div>
-    )
-  }
+    </div>
+  )
 }
 
 export default ErrorRoute

--- a/packages/openneuro-app/src/scripts/routes.tsx
+++ b/packages/openneuro-app/src/scripts/routes.tsx
@@ -39,7 +39,7 @@ const AppRoutes: React.VoidFunctionComponent = () => (
       path="/dashboard"
       element={<Navigate to="/search?mydatasets" replace />}
     />
-    <Route element={<FourOFourPage />} />
+    <Route path="/*" element={<FourOFourPage />} />
   </Routes>
 )
 


### PR DESCRIPTION
Fixes a bug where sometimes the 404 page would not be displayed for an invalid path when it matched part of a valid path.