### PR TITLE
fix(worker): Handle malformed JWT with an HTTP 400 response

### DIFF
--- a/services/datalad/datalad_service/middleware/auth.py
+++ b/services/datalad/datalad_service/middleware/auth.py
@@ -39,6 +39,11 @@ class AuthenticateMiddleware:
                 try:
                     req.context['user'] = jwt.decode(
                         token, key=os.environ['JWT_SECRET'], algorithms=["HS256"])
+                except jwt.exceptions.InvalidSignatureError:
+                    resp.status = falcon.HTTP_BAD_REQUEST
+                    resp.text = "Token malformed and could not be decoded"
+                    resp.complete = True
+                    return
                 except jwt.exceptions.ExpiredSignatureError:
                     resp.status = falcon.HTTP_UNAUTHORIZED
                     resp.text = "Token expired"


### PR DESCRIPTION
Provide HTTP clients (special remotes) feedback when a JWT could not be parsed.