### PR TITLE
CLI: Setup autoenabled OpenNeuro special remote during upload if one doesn't exist

### DIFF
--- a/cli/src/worker/annex.ts
+++ b/cli/src/worker/annex.ts
@@ -1,6 +1,5 @@
 import { GitWorkerContext } from "./types/git-context.ts"
 import { basename, dirname, git, join, relative } from "../deps.ts"
-import { logger } from "../logger.ts"
 
 /**
  * Why are we using hash wasm over web crypto?

--- a/cli/src/worker/annex.ts
+++ b/cli/src/worker/annex.ts
@@ -142,3 +142,20 @@ export async function annexAdd(
     return false
   }
 }
+
+export async function readAnnexPath(
+  logPath: string,
+  context: GitWorkerContext,
+): Promise<string> {
+  const options = {
+    ...context.config(),
+    ref: "git-annex",
+  }
+  const annexBranchOid = await git.resolveRef(options)
+  const { blob } = await git.readBlob({
+    ...options,
+    oid: annexBranchOid,
+    filepath: logPath,
+  })
+  return new TextDecoder().decode(blob)
+}

--- a/cli/src/worker/git.test.ts
+++ b/cli/src/worker/git.test.ts
@@ -1,4 +1,11 @@
-import { assertArrayIncludes, assertEquals, git, join, walk, SEPARATOR } from "../deps.ts"
+import {
+  assertArrayIncludes,
+  assertEquals,
+  git,
+  join,
+  SEPARATOR,
+  walk,
+} from "../deps.ts"
 import { addGitFiles } from "../commands/upload.ts"
 import fs from "node:fs"
 
@@ -102,12 +109,13 @@ LICENSE annex.largefiles=nothing`),
 
   const expectedFiles = [
     join(".git", "refs", "heads", "main"),
+    join(".git", "refs", "heads", "git-annex"),
     join(".git", "config"),
     join(".git", "HEAD"),
     join(".git", "index"),
     ".gitattributes",
     "dataset_description.json",
-    join("sub-01", "anat", "sub-01_T1w.nii.gz")
+    join("sub-01", "anat", "sub-01_T1w.nii.gz"),
   ]
   let gitObjects = 0
   for await (
@@ -123,5 +131,5 @@ LICENSE annex.largefiles=nothing`),
       assertArrayIncludes(expectedFiles, [relativePath])
     }
   }
-  assertEquals(gitObjects, 9)
+  assertEquals(gitObjects, 10)
 })

--- a/cli/src/worker/git.ts
+++ b/cli/src/worker/git.ts
@@ -280,12 +280,16 @@ async function commitAnnexBranch(annexKeys: Record<string, string>) {
         ...context.config(),
         ref: "main",
       })
-    } catch (_err) {
-      // Fallback to master and error if neither exists
-      await git.checkout({
-        ...context.config(),
-        ref: "master",
-      })
+    } catch (err) {
+      if (err.name === "NotFoundError") {
+        // Fallback to master and error if neither exists
+        await git.checkout({
+          ...context.config(),
+          ref: "master",
+        })
+      } else {
+        throw err
+      }
     }
   }
 }

--- a/cli/src/worker/git.ts
+++ b/cli/src/worker/git.ts
@@ -183,7 +183,8 @@ async function commitAnnexBranch(annexKeys: Record<string, string>) {
         if (log && log.includes(uuid)) {
           continue
         } else {
-          const timestamp = performance.timeOrigin + performance.now()
+          const timestamp = (performance.timeOrigin + performance.now()) /
+            1000.0
           const newAnnexLog = `${timestamp}s 1 ${uuid}\n${log ? log : ""}`
           await context.fs.promises.mkdir(join(context.repoPath, hashDir), {
             recursive: true,

--- a/cli/src/worker/types/git-context.ts
+++ b/cli/src/worker/types/git-context.ts
@@ -1,6 +1,22 @@
 import http from "npm:isomorphic-git@1.25.3/http/node/index.js"
+import { decode } from "https://deno.land/x/djwt@v3.0.1/mod.ts"
 import fs from "node:fs"
 import { LevelName } from "../../deps.ts"
+
+/**
+ * Git repo specific token
+ */
+interface OpenNeuroGitToken {
+  sub: string
+  email: string
+  provider: string
+  name: string
+  admin: boolean
+  scopes: [string]
+  dataset: string
+  iat: number
+  exp: number
+}
 
 export class GitWorkerContext {
   // Current working dataset ID
@@ -49,6 +65,12 @@ export class GitWorkerContext {
    */
   get http() {
     return http
+  }
+
+  get author(): { email: string; name: string } {
+    const decodedToken = decode(this.authorization)
+    const { email, name } = decodedToken[1] as OpenNeuroGitToken
+    return { email, name }
   }
 }
 


### PR DESCRIPTION
For the Deno CLI, this adds the missing steps required to configure a special remote.

The remote is always named "OpenNeuro" and `git-annex get` is all that's required for annexed objects if you have configured the OpenNeuro special remote already. This also includes annex branch handling for starting from a dataset not created server side by OpenNeuro (meaning you can upload without cloning first theoretically but we always clone to check if one exists).