### PR TITLE
fix(app): Apply boolQuery constraint for datasetType selected value

### DIFF
--- a/packages/openneuro-app/src/scripts/search/search-params-ctx.tsx
+++ b/packages/openneuro-app/src/scripts/search/search-params-ctx.tsx
@@ -66,6 +66,7 @@ export const removeFilterItem = (setSearchParams) => (param, value) => {
     case "diagnosis_selected":
     case "section_selected":
     case "species_selected":
+    case "bidsDatasetType_selected":
       updatedParams[param] = initialSearchParams[param]
       setSearchParams((prevState) => ({
         ...prevState,

--- a/packages/openneuro-app/src/scripts/search/use-search-results.tsx
+++ b/packages/openneuro-app/src/scripts/search/use-search-results.tsx
@@ -149,6 +149,7 @@ export const useSearchResults = () => {
     tracerNames,
     tracerRadionuclides,
     sortBy_selected,
+    bidsDatasetType_selected,
   } = searchParams
 
   const boolQuery = new BoolQuery()
@@ -225,6 +226,15 @@ export const useSearchResults = () => {
     boolQuery.addClause(
       "filter",
       matchQuery("metadata.dxStatus", diagnosis_selected),
+    )
+  }
+  if (bidsDatasetType_selected) {
+    boolQuery.addClause(
+      "filter",
+      matchQuery(
+        "latestSnapshot.description.DatasetType",
+        bidsDatasetType_selected,
+      ),
     )
   }
   if (tasks.length) {


### PR DESCRIPTION
This matchQuery is missing for the app to apply the DatasetType constraint.