### PR TITLE
fix(draft-render): Display editable list elements inline

### DIFF
--- a/packages/openneuro-app/src/scripts/scss/dataset/dataset-page.scss
+++ b/packages/openneuro-app/src/scripts/scss/dataset/dataset-page.scss
@@ -273,7 +273,7 @@
           }
         }
         p {
-          display: inline-block;
+          display: inline;
         }
       }
     }


### PR DESCRIPTION
Change display from `inline-block`, which respects top/bottom margin/padding, to `inline`, which doesn't.

## Before

![Screenshot from 2024-06-14 12-47-27](https://github.com/OpenNeuroOrg/openneuro/assets/83442/9f41e274-e515-42de-901e-39bc1f38e7aa)


## After
![Screenshot from 2024-06-14 12-47-18](https://github.com/OpenNeuroOrg/openneuro/assets/83442/55f41aaf-7db2-4bee-903d-28fcfc788394)