### PR TITLE
fix(worker): Allow commit summaries (snapshot API) with no files

### DIFF
--- a/services/datalad/datalad_service/handlers/snapshots.py
+++ b/services/datalad/datalad_service/handlers/snapshots.py
@@ -24,16 +24,13 @@ class SnapshotResource:
             resp.status = falcon.HTTP_NOT_FOUND
         elif snapshot:
             files = get_tree(self.store, dataset, snapshot)
-            if files:
-                try:
-                    response = get_snapshot(self.store, dataset, snapshot)
-                    response['files'] = files
-                    resp.media = response
-                    resp.status = falcon.HTTP_OK
-                except KeyError:
-                    # Tree returned objects but does not exist?
-                    resp.status = falcon.HTTP_NOT_FOUND
-            else:
+            try:
+                response = get_snapshot(self.store, dataset, snapshot)
+                response['files'] = files
+                resp.media = response
+                resp.status = falcon.HTTP_OK
+            except KeyError:
+                # Tree returned objects but does not exist?
                 resp.status = falcon.HTTP_NOT_FOUND
         else:
             tags = get_snapshots(self.store,


### PR DESCRIPTION
The 404 here didn't really make sense because it would fail if get_tree returned a tree with no files. That's a valid tree, so it should return the 200 case.