### PR TITLE
fix(worker): Handle a truncated JWT with a correct response

### DIFF
--- a/services/datalad/datalad_service/middleware/auth.py
+++ b/services/datalad/datalad_service/middleware/auth.py
@@ -39,7 +39,7 @@ class AuthenticateMiddleware:
                 try:
                     req.context['user'] = jwt.decode(
                         token, key=os.environ['JWT_SECRET'], algorithms=["HS256"])
-                except jwt.exceptions.InvalidSignatureError:
+                except (jwt.exceptions.InvalidSignatureError, jwt.exceptions.DecodeError):
                     resp.status = falcon.HTTP_BAD_REQUEST
                     resp.text = "Token malformed and could not be decoded"
                     resp.complete = True


### PR DESCRIPTION
DecodeError is raised when the token is truncated. This should be handled the same as InvalidSignatureError to inform the HTTP client (git in testing).