### PR TITLE
fix(worker): Support gzip for git clients that require it

### DIFF
--- a/services/datalad/datalad_service/common/stream.py
+++ b/services/datalad/datalad_service/common/stream.py
@@ -1,5 +1,6 @@
 import os
 import tempfile
+import zlib
 
 CHUNK_SIZE_BYTES = 2048
 
@@ -23,9 +24,13 @@ def update_file(path, stream):
             raise
 
 
-def pipe_chunks(reader, writer):
-    while True:
-        chunk = reader.read(CHUNK_SIZE_BYTES)
-        if not chunk:
-            break
-        writer.write(chunk)
+def pipe_chunks(reader, writer, gzipped=False):
+    # If gzipped, we have to read the entire request and write once
+    if gzipped:
+        writer.write(zlib.decompress(reader.read(), zlib.MAX_WBITS|32))
+    else:
+        while True:
+            chunk = reader.read(CHUNK_SIZE_BYTES)
+            if not chunk:
+                break
+            writer.write(chunk)

--- a/services/datalad/datalad_service/handlers/git.py
+++ b/services/datalad/datalad_service/handlers/git.py
@@ -92,7 +92,7 @@ class GitReceiveResource:
                 os.symlink('/hooks/pre-receive', pre_receive_path)
             process = subprocess.Popen(
                 ['git-receive-pack', '--stateless-rpc', dataset_path], stdin=subprocess.PIPE, stdout=subprocess.PIPE)
-            pipe_chunks(reader=req.bounded_stream, writer=process.stdin)
+            pipe_chunks(reader=req.bounded_stream, writer=process.stdin, gzipped=req.get_header('content-encoding') == 'gzip')
             process.stdin.flush()
             resp.status = falcon.HTTP_OK
             resp.stream = process.stdout
@@ -118,7 +118,7 @@ class GitUploadResource:
             dataset_path = self.store.get_dataset_path(dataset)
             process = subprocess.Popen(
                 ['git-upload-pack', '--stateless-rpc', dataset_path], stdin=subprocess.PIPE, stdout=subprocess.PIPE)
-            pipe_chunks(reader=req.bounded_stream, writer=process.stdin)
+            pipe_chunks(reader=req.bounded_stream, writer=process.stdin, gzipped=req.get_header('content-encoding') == 'gzip')
             process.stdin.flush()
             resp.status = falcon.HTTP_OK
             resp.stream = process.stdout


### PR DESCRIPTION
This is a fallback mode for when the client has set "content-encoding: gzip". Without this, we pass the gzipped response to git-upload-pack/git-receive-pack and this will crash with a protocol error, closing the connection.

Ideally HTTP decompression is handled before the Falcon request handler but introducing an HTTP proxy here is a larger change.

See #3087