### PR TITLE
feat: Terms of service page

### DIFF
--- a/packages/openneuro-app/src/scripts/common/content/download-agreement.ts
+++ b/packages/openneuro-app/src/scripts/common/content/download-agreement.ts
@@ -1,0 +1,9 @@
+export const DownloadAgreement = "I affirm that I have the appropriate \
+                institutional permissions to receive de-identified data for \
+                secondary data analysis, and that neither I nor my collaborators \
+                will attempt to reidentify individuals whose data are contained \
+                in downloads from OpenNeuro. Further, if for any reason the \
+                identity of participants contained in downloads from OpenNeuro \
+                become known to me I will make no effort to recontact such \
+                participants and will provide immediate notice to OpenNeuro \
+                staff."

--- a/packages/openneuro-app/src/scripts/common/content/terms.tsx
+++ b/packages/openneuro-app/src/scripts/common/content/terms.tsx
@@ -1,0 +1,39 @@
+import React, { ReactElement } from "react"
+
+/** Terms and conditions content. */
+export function Terms(): ReactElement {
+  return (
+    <>
+      <p>
+        I am the owner of this dataset and have any necessary ethics permissions
+        to share the data publicly. This dataset does not include any
+        identifiable personal health information as defined by the{" "}
+        <a href="https://www.hhs.gov/hipaa/for-professionals/privacy/laws-regulations/">
+          Health Insurance Portability and Accountability Act of 1996
+        </a>{" "}
+        (including names, zip codes, dates of birth, acquisition dates, etc). I
+        agree to destroy any key linking the personal identity of research
+        participants to the subject codes used in the dataset.
+      </p>
+      <p>
+        I agree that this dataset will become publicly available under a{" "}
+        <a href="https://wiki.creativecommons.org/wiki/CC0">
+          Creative Commons CC0
+        </a>{" "}
+        license after a grace period of 36 months counted from the date of the
+        first snapshot creation for this dataset. You will be able to apply for
+        up to two 6 month extensions to increase the grace period in case the
+        publication of a corresponding paper takes longer than expected. See
+        {" "}
+        <a href="/faq">FAQ</a> for details.
+      </p>
+      <p>This dataset is not subject to GDPR protections.</p>
+      <p>
+        Generally, data should only be uploaded to a single data archive. In the
+        rare cases where it is necessary to upload the data to two databases
+        (such as the NIMH Data Archive), I agree to ensure that the datasets are
+        harmonized across archives.
+      </p>
+    </>
+  )
+}

--- a/packages/openneuro-app/src/scripts/components/agreement.tsx
+++ b/packages/openneuro-app/src/scripts/components/agreement.tsx
@@ -1,5 +1,6 @@
 import React from "react"
 import { useLocalStorage } from "../utils/local-storage"
+import { DownloadAgreement } from "../common/content/download-agreement"
 import styled from "@emotion/styled"
 
 export const STORAGE_KEY = "agreement"
@@ -46,15 +47,7 @@ export const Agreement = () => {
           <div className="grid grid-between">
             <div className="col col-lg col-11">
               <p>
-                By clicking "I Agree", I affirm that I have the appropriate
-                institutional permissions to receive de-identified data for
-                secondary data analysis, and that neither I nor my collaborators
-                will attempt to reidentify individuals whose data are contained
-                in downloads from OpenNeuro. Further, if for any reason the
-                identity of participants contained in downloads from OpenNeuro
-                become known to me I will make no effort to recontact such
-                participants and will provide immediate notice to OpenNeuro
-                staff.
+                By clicking "I Agree", {DownloadAgreement}
               </p>
             </div>
             <div className="col col-lg col-1">

--- a/packages/openneuro-app/src/scripts/pages/__tests__/terms.spec.tsx
+++ b/packages/openneuro-app/src/scripts/pages/__tests__/terms.spec.tsx
@@ -5,7 +5,7 @@ import { TermsPage } from "../terms"
 describe("TermsPage", () => {
   it("renders the terms and conditions", () => {
     render(<TermsPage />)
-    expect(screen.getByText("OpenNeuro Upload Terms and Conditions"))
+    expect(screen.getByText("OpenNeuro Terms and Conditions"))
       .toBeInTheDocument()
   })
 })

--- a/packages/openneuro-app/src/scripts/pages/__tests__/terms.spec.tsx
+++ b/packages/openneuro-app/src/scripts/pages/__tests__/terms.spec.tsx
@@ -1,0 +1,11 @@
+import React from "react"
+import { render, screen } from "@testing-library/react"
+import { TermsPage } from "../terms"
+
+describe("TermsPage", () => {
+  it("renders the terms and conditions", () => {
+    render(<TermsPage />)
+    expect(screen.getByText("OpenNeuro Upload Terms and Conditions"))
+      .toBeInTheDocument()
+  })
+})

--- a/packages/openneuro-app/src/scripts/pages/terms.tsx
+++ b/packages/openneuro-app/src/scripts/pages/terms.tsx
@@ -1,0 +1,36 @@
+import React, { ReactElement } from "react"
+import { Terms } from "../common/content/terms"
+import Helmet from "react-helmet"
+import { frontPage } from "./front-page/front-page-content"
+import styled from "@emotion/styled"
+
+const TermsPageStyle = styled.div`
+  background: white;
+
+  .container {
+    max-width: 60em;
+    min-height: calc(100vh - 125px);
+  }
+`
+
+export function TermsPage(): ReactElement {
+  return (
+    <TermsPageStyle>
+      <Helmet>
+        <title>Terms and Conditions - {frontPage.pageTitle}</title>
+        <meta
+          name="description"
+          content={`Terms and conditions of the ${frontPage.pageTitle} data archive`}
+        />
+      </Helmet>
+      <div className="container">
+        <h2>OpenNeuro Upload Terms and Conditions</h2>
+        <p>
+          By uploading to the {frontPage.pageTitle}{" "}
+          data archive I agree to the following conditions:
+        </p>
+        <Terms />
+      </div>
+    </TermsPageStyle>
+  )
+}

--- a/packages/openneuro-app/src/scripts/pages/terms.tsx
+++ b/packages/openneuro-app/src/scripts/pages/terms.tsx
@@ -10,7 +10,6 @@ const TermsPageStyle = styled.div`
 
   .container {
     max-width: 60em;
-    min-height: calc(100vh - 125px);
   }
 `
 

--- a/packages/openneuro-app/src/scripts/pages/terms.tsx
+++ b/packages/openneuro-app/src/scripts/pages/terms.tsx
@@ -2,6 +2,7 @@ import React, { ReactElement } from "react"
 import { Terms } from "../common/content/terms"
 import Helmet from "react-helmet"
 import { frontPage } from "./front-page/front-page-content"
+import { DownloadAgreement } from "../common/content/download-agreement"
 import styled from "@emotion/styled"
 
 const TermsPageStyle = styled.div`
@@ -24,12 +25,14 @@ export function TermsPage(): ReactElement {
         />
       </Helmet>
       <div className="container">
-        <h2>OpenNeuro Upload Terms and Conditions</h2>
-        <p>
+        <h2>OpenNeuro Terms and Conditions</h2>
+        <h3>
           By uploading to the {frontPage.pageTitle}{" "}
           data archive I agree to the following conditions:
-        </p>
+        </h3>
         <Terms />
+        <h3>Downloading Data:</h3>
+        <p>{DownloadAgreement}</p>
       </div>
     </TermsPageStyle>
   )

--- a/packages/openneuro-app/src/scripts/routes.tsx
+++ b/packages/openneuro-app/src/scripts/routes.tsx
@@ -16,6 +16,7 @@ import Citation from "./pages/citation-page"
 import FourOFourPage from "./errors/404page"
 import { ImportDataset } from "./pages/import-dataset"
 import { DatasetMetadata } from "./pages/metadata/dataset-metadata"
+import { TermsPage } from "./pages/terms"
 
 const AppRoutes: React.VoidFunctionComponent = () => (
   <Routes>
@@ -28,6 +29,7 @@ const AppRoutes: React.VoidFunctionComponent = () => (
     <Route path="/error/*" element={<ErrorRoute />} />
     <Route path="/pet" element={<PETRedirect />} />
     <Route path="/cite" element={<Citation />} />
+    <Route path="/terms" element={<TermsPage />} />
     <Route path="/import" element={<ImportDataset />} />
     <Route path="/metadata" element={<DatasetMetadata />} />
     <Route path="/public" element={<Navigate to="/search" replace />} />

--- a/packages/openneuro-app/src/scripts/uploader/upload-disclaimer-input.tsx
+++ b/packages/openneuro-app/src/scripts/uploader/upload-disclaimer-input.tsx
@@ -1,5 +1,6 @@
 import React from "react"
 import styled from "@emotion/styled"
+import { Terms } from "../common/content/terms"
 
 interface UploadDisclaimerInputProps {
   affirmedDefaced: boolean
@@ -30,36 +31,7 @@ export const UploadDisclaimerInput: React.FunctionComponent<
         By uploading this dataset to OpenNeuro I agree to the following
         conditions:
       </h4>
-      <p>
-        I am the owner of this dataset and have any necessary ethics permissions
-        to share the data publicly. This dataset does not include any
-        identifiable personal health information as defined by the{" "}
-        <a href="https://www.hhs.gov/hipaa/for-professionals/privacy/laws-regulations/">
-          Health Insurance Portability and Accountability Act of 1996
-        </a>{" "}
-        (including names, zip codes, dates of birth, acquisition dates, etc). I
-        agree to destroy any key linking the personal identity of research
-        participants to the subject codes used in the dataset.
-      </p>
-      <p>
-        I agree that this dataset will become publicly available under a{" "}
-        <a href="https://wiki.creativecommons.org/wiki/CC0">
-          Creative Commons CC0
-        </a>{" "}
-        license after a grace period of 36 months counted from the date of the
-        first snapshot creation for this dataset. You will be able to apply for
-        up to two 6 month extensions to increase the grace period in case the
-        publication of a corresponding paper takes longer than expected. See
-        {" "}
-        <a href="/faq">FAQ</a> for details.
-      </p>
-      <p>This dataset is not subject to GDPR protections.</p>
-      <p>
-        Generally, data should only be uploaded to a single data archive. In the
-        rare cases where it is necessary to upload the data to two databases
-        (such as the NIMH Data Archive), I agree to ensure that the datasets are
-        harmonized across archives.
-      </p>
+      <Terms />
       <p>Please affirm one of the following:</p>
       <DisclaimerLabel>
         <input

--- a/packages/openneuro-components/src/footer/Footer.tsx
+++ b/packages/openneuro-components/src/footer/Footer.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-
+import { Link } from "react-router-dom"
 import { frontPage } from "../content/front-page-content"
 
 export interface FooterProps {
@@ -16,9 +16,14 @@ export const Footer: React.FC<FooterProps> = ({ version }) => {
         <div className="col col-4 privacy-policy">
           <span>
             <a href={frontPage.titlePanel.privacyLink}>
-              {frontPage.pageTitle}
-              &#39;s Privacy Policy
+              Privacy Policy
             </a>
+          </span>{" "}
+          &{" "}
+          <span>
+            <Link to="/terms">
+              Terms
+            </Link>
           </span>
         </div>
         <div className="col col-4  copy">

--- a/packages/openneuro-server/src/handlers/sitemap.ts
+++ b/packages/openneuro-server/src/handlers/sitemap.ts
@@ -8,6 +8,8 @@ export const sitemapStaticUrls = () => [
   { url: "/public/datasets", priority: 1.0, changefreq: "daily" },
   { url: "/faq", priority: 0.6, changefreq: "monthly" },
   { url: "/pet", priority: 0.5, changefreq: "monthly" },
+  { url: "/terms", priority: 0.5, changefreq: "monthly" },
+  { url: "/cite", priority: 0.4, changefreq: "monthly" },
   { url: "/public/jobs", priority: 0.5, changefreq: "monthly" },
   { url: "/crn/graphql", priority: 0.3 },
 ]


### PR DESCRIPTION
Implements #2609 to make terms for both upload and downloads referenced in one place. Content is shared from the components that display this information.