### PR TITLE
fix(api): participantCount query should match all instead of only most significant modalities

### DIFF
--- a/packages/openneuro-server/src/graphql/resolvers/snapshots.ts
+++ b/packages/openneuro-server/src/graphql/resolvers/snapshots.ts
@@ -152,7 +152,7 @@ export const participantCount = (obj, { modality }) => {
         $and: [
           queryHasSubjects,
           {
-            "summary.modalities.0": modality,
+            "summary.modalities": modality,
           },
         ],
       }


### PR DESCRIPTION
If the validator has matched a modality, include it in the participant count. Search was already adjusted to follow this behavior, this aligns the participant count values with the search query results.