### PR TITLE
Worker fixes for deletion

### DIFF
--- a/packages/openneuro-app/src/scripts/datalad/mutations/delete.jsx
+++ b/packages/openneuro-app/src/scripts/datalad/mutations/delete.jsx
@@ -32,7 +32,7 @@ const DeleteDataset = ({ datasetId, metadata }) => {
                 },
               })
               window.location.replace(
-                `${window.location.origin}/dashboard/datasets`,
+                `${window.location.origin}/search`,
               )
             })}
           >

--- a/packages/openneuro-app/src/scripts/dataset/mutations/delete.jsx
+++ b/packages/openneuro-app/src/scripts/dataset/mutations/delete.jsx
@@ -32,7 +32,7 @@ const DeleteDataset = ({ datasetId, metadata }) => {
                 },
               })
               window.location.replace(
-                `${window.location.origin}/dashboard/datasets`,
+                `${window.location.origin}/search`,
               )
             })}
           >


### PR DESCRIPTION
Fixes #3128. Runs S3 file cleanup in a process but otherwise waits for deletion to be finished before returning success.

Couple minor fixes included:
* Fixes the redirect after deletion to correctly return to search.
* Avoids eating errors in during deletion and logs them now.
* 404 if the request is made on a dataset which as already been deleted but not otherwise.