### PR TITLE
chore(worker): Cleanup unneeded update_head step

### DIFF
--- a/services/datalad/datalad_service/common/draft.py
+++ b/services/datalad/datalad_service/common/draft.py
@@ -11,13 +11,3 @@ def draft_revision_mutation(dataset_id, ref):
         'query': 'mutation ($datasetId: ID!, $ref: String!) { updateRef(datasetId: $datasetId, ref: $ref) }',
         'variables': {'datasetId': dataset_id, 'ref': ref}
     }
-
-
-async def update_head(dataset_id, dataset_path, hexsha, cookies=None):
-    """Pass HEAD commit references back to OpenNeuro"""
-    # We may want to detect if we need to run validation here?
-    asyncio.create_task(validate_dataset(dataset_id, dataset_path, hexsha))
-    r = requests.post(url=GRAPHQL_ENDPOINT,
-                      json=draft_revision_mutation(dataset_id, hexsha), cookies=cookies)
-    if r.status_code != 200:
-        raise Exception(r.text)

--- a/services/datalad/datalad_service/handlers/upload.py
+++ b/services/datalad/datalad_service/handlers/upload.py
@@ -8,7 +8,6 @@ import pygit2
 
 from datalad_service.common.git import git_commit
 from datalad_service.common.user import get_user_info
-from datalad_service.common.draft import update_head
 
 
 async def move_files(upload_path, dataset_path):
@@ -31,7 +30,6 @@ async def move_files_into_repo(dataset_id, dataset_path, upload_path, name, emai
         hexsha = git_commit(repo, unlock_files, author).hex
     else:
         hexsha = git_commit(repo, unlock_files).hex
-    update_head(dataset_id, dataset_path, hexsha, cookies)
 
 
 class UploadResource:

--- a/services/datalad/datalad_service/tasks/files.py
+++ b/services/datalad/datalad_service/tasks/files.py
@@ -4,7 +4,6 @@ import pygit2
 
 from datalad_service.common.annex import get_repo_files
 from datalad_service.common.git import git_commit, git_commit_index, COMMITTER_EMAIL, COMMITTER_NAME
-from datalad_service.common.draft import update_head
 from datalad_service.tasks.validator import validate_dataset
 
 
@@ -42,7 +41,6 @@ def remove_files(store, dataset, paths, name=None, email=None, cookies=None):
     repo.checkout_index()
     hexsha = str(git_commit_index(repo, author,
                               message="[OpenNeuro] Files removed"))
-    asyncio.create_task(update_head(dataset, dataset_path, hexsha, cookies))
 
 
 def remove_annex_object(dataset_path, annex_key):


### PR DESCRIPTION
The API does not use a cached draft head anymore so updating it is not needed.