### PR TITLE
feat(server): Add flag to enable schema validator for individual datasets

### DIFF
--- a/packages/openneuro-server/src/graphql/resolvers/datasetType.ts
+++ b/packages/openneuro-server/src/graphql/resolvers/datasetType.ts
@@ -1,6 +1,15 @@
+import Dataset from "../../models/dataset"
 import { description } from "./description.js"
 
+/**
+ * Return "schema" or "legacy" depending on the validator preferred for a dataset
+ */
 export async function datasetType(dsOrSnapshot): Promise<"schema" | "legacy"> {
-  const dsDescription = await description(dsOrSnapshot)
-  return dsDescription.DatasetType === "derivative" ? "schema" : "legacy"
+  const ds = new Dataset({ id: dsOrSnapshot.datasetId })
+  if (ds.schemaValidator) {
+    return "schema"
+  } else {
+    const dsDescription = await description(dsOrSnapshot)
+    return dsDescription.DatasetType === "derivative" ? "schema" : "legacy"
+  }
 }

--- a/packages/openneuro-server/src/models/dataset.ts
+++ b/packages/openneuro-server/src/models/dataset.ts
@@ -27,6 +27,7 @@ export interface DatasetDocument extends Document {
   downloads: number
   views: number
   related: [DatasetRelationDocument]
+  schemaValidator: boolean
   _conditions: any
 }
 
@@ -42,6 +43,7 @@ const datasetSchema = new Schema<DatasetDocument>(
     downloads: Number,
     views: Number,
     related: [RelationSchema],
+    schemaValidator: { type: Boolean, default: false },
   },
   { toJSON: { virtuals: true }, toObject: { virtuals: true } },
 )


### PR DESCRIPTION
Add a schemaValidator flag to datasets that allows switching raw datasets to use the schema validator over the legacy validator.