### PR TITLE
Allow for .bids-validator-config.json filename

### DIFF
--- a/services/datalad/hooks/pre-receive
+++ b/services/datalad/hooks/pre-receive
@@ -51,7 +51,7 @@ function validateGitAttributes() {
 function filterDotFiles() {
   local newFiles=$(git diff --stat --name-only --diff-filter=ACMRT ${oldref}..${newref})
   for filename in $newFiles; do
-    if [[ "$filename" = ".bidsignore" ]] || [[ "$filename" =~ ".gitattributes" ]] || [[ "$filename" = ".gitmodules" ]] || [[ "$filename" =~ ^.gitignore|\/\.gitignore ]] || [[ "$filename" =~ ^\.datalad ]]; then
+    if [[ "$filename" = ".bidsignore" ]] || [ "$filename" = ".bids-validator-config.json" ] || [[ "$filename" =~ ".gitattributes" ]] || [[ "$filename" = ".gitmodules" ]] || [[ "$filename" =~ ^.gitignore|\/\.gitignore ]] || [[ "$filename" =~ ^\.datalad ]]; then
       continue
     fi
     if [[ "$filename" =~ ^\..*|\/\..* ]]; then


### PR DESCRIPTION
We have a legitimate configuration for (legacy) bids-validation within dataset in .bids-validator-config.json .
git push was denied with no specific file mentioned but I guess it is because of that file.