### PR TITLE
fix(app): Use correct URLs for loading files that only exist outside of OpenNeuro

### DIFF
--- a/packages/openneuro-app/src/scripts/dataset/files/file-display.jsx
+++ b/packages/openneuro-app/src/scripts/dataset/files/file-display.jsx
@@ -1,4 +1,4 @@
-import React from "react"
+import React, { useContext } from "react"
 import PropTypes from "prop-types"
 import { useParams } from "react-router-dom"
 import FileView from "./file-view.jsx"
@@ -6,6 +6,9 @@ import { apiPath } from "./file"
 import styled from "@emotion/styled"
 import { Media } from "../../styles/media"
 import { DatasetPageBorder } from "../routes/styles/dataset-page-border"
+import DatasetQueryContext from "../../datalad/dataset/dataset-query-context"
+import { fetchMoreDirectory } from "./file-tree-unloaded-directory.jsx"
+import { Loading } from "@openneuro/components/loading"
 
 const PathBreadcrumb = styled.div`
   font-size: 14px;
@@ -52,29 +55,55 @@ FileDisplayBreadcrumb.propTypes = {
   filePath: PropTypes.string,
 }
 
-const FileDisplay = ({ datasetId, snapshotTag = null, filePath }) => (
-  <DatasetPageBorder className="dataset-form display-file">
-    <PathBreadcrumb>
-      <FileDisplayBreadcrumb filePath={filePath} />
-    </PathBreadcrumb>
-    <div className="display-file-body">
-      <FileView
-        datasetId={datasetId}
-        snapshotTag={snapshotTag}
-        path={filePath}
-      />
-    </div>
+const FileDisplay = ({ dataset, snapshotTag = null, filePath }) => {
+  const { fetchMore } = useContext(DatasetQueryContext)
+  const files = snapshotTag ? dataset.files : dataset.draft.files
+  const datasetFile = files.find((file) => file.filename === filePath)
+  // If no file matches, we are missing data, load the next missing parent
+  if (!datasetFile) {
+    const components = filePath.split(":")
+    for (let i = components.length; i > 0; i--) {
+      const path = components.slice(0, i).join(":")
+      const file = files.find((file) => file.filename === path)
+      if (file && file.directory) {
+        fetchMoreDirectory(fetchMore, dataset.id, snapshotTag, file)
+      }
+    }
+    return (
+      <DatasetPageBorder className="dataset-form display-file">
+        <PathBreadcrumb>
+          <FileDisplayBreadcrumb filePath={filePath} />
+        </PathBreadcrumb>
+        <Loading />
+      </DatasetPageBorder>
+    )
+  } else {
+    const url = datasetFile?.urls?.[0] ||
+      apiPath(dataset.id, snapshotTag, filePath)
+    return (
+      <DatasetPageBorder className="dataset-form display-file">
+        <PathBreadcrumb>
+          <FileDisplayBreadcrumb filePath={filePath} />
+        </PathBreadcrumb>
+        <div className="display-file-body">
+          <FileView
+            url={url}
+            path={filePath}
+          />
+        </div>
 
-    <Media greaterThanOrEqual="medium">
-      <hr />
-      <div className="modal-download btn-admin-blue">
-        <a href={apiPath(datasetId, snapshotTag, filePath)} download>
-          <i className="fa fa-download" /> Download
-        </a>
-      </div>
-    </Media>
-  </DatasetPageBorder>
-)
+        <Media greaterThanOrEqual="medium">
+          <hr />
+          <div className="modal-download btn-admin-blue">
+            <a href={url} download>
+              <i className="fa fa-download" /> Download
+            </a>
+          </div>
+        </Media>
+      </DatasetPageBorder>
+    )
+  }
+}
 
 FileDisplay.propTypes = {
   datasetId: PropTypes.string,
@@ -82,10 +111,10 @@ FileDisplay.propTypes = {
   snapshotTag: PropTypes.string,
 }
 
-export const FileDisplayRoute = ({ datasetId, snapshotTag }) => {
+export const FileDisplayRoute = ({ dataset, snapshotTag }) => {
   return (
     <FileDisplay
-      datasetId={datasetId}
+      dataset={dataset}
       snapshotTag={snapshotTag}
       {...useParams()}
     />

--- a/packages/openneuro-app/src/scripts/dataset/files/file-display.jsx
+++ b/packages/openneuro-app/src/scripts/dataset/files/file-display.jsx
@@ -67,6 +67,7 @@ const FileDisplay = ({ dataset, snapshotTag = null, filePath }) => {
       const file = files.find((file) => file.filename === path)
       if (file && file.directory) {
         fetchMoreDirectory(fetchMore, dataset.id, snapshotTag, file)
+        break
       }
     }
     return (

--- a/packages/openneuro-app/src/scripts/dataset/files/file-view.jsx
+++ b/packages/openneuro-app/src/scripts/dataset/files/file-view.jsx
@@ -1,10 +1,8 @@
 import React, { useEffect, useState } from "react"
 import { Loading } from "@openneuro/components/loading"
-import { apiPath } from "./file"
 import FileViewerType from "./file-viewer-type.jsx"
 
-const FileView = ({ datasetId, snapshotTag, path }) => {
-  const url = apiPath(datasetId, snapshotTag, path)
+const FileView = ({ url, path }) => {
   const [data, setData] = useState(new ArrayBuffer(0))
   const [loading, setLoading] = useState(true)
 

--- a/packages/openneuro-app/src/scripts/dataset/routes/snapshot.tsx
+++ b/packages/openneuro-app/src/scripts/dataset/routes/snapshot.tsx
@@ -7,6 +7,7 @@ import { DatasetPageBorder } from "./styles/dataset-page-border"
 import { HeaderRow4 } from "./styles/header-row"
 import FileView from "../files/file-view"
 import styled from "@emotion/styled"
+import { apiPath } from "../files/file"
 
 const FormRow = styled.div`
   margin-top: 0;
@@ -108,8 +109,7 @@ const SnapshotRoute = ({
               <FormRow>
                 <HeaderRow4>Current Changelog</HeaderRow4>
                 <FileView
-                  datasetId={datasetId}
-                  snapshotTag={latestSnapshot.tag}
+                  url={apiPath(datasetId, latestSnapshot.tag, "CHANGES")}
                   path="CHANGES"
                 />
               </FormRow>

--- a/packages/openneuro-app/src/scripts/dataset/routes/tab-routes-draft.tsx
+++ b/packages/openneuro-app/src/scripts/dataset/routes/tab-routes-draft.tsx
@@ -61,7 +61,7 @@ export const TabRoutesDraft = ({ dataset, hasEdit }) => {
       />
       <Route
         path="file-display/:filePath"
-        element={<FileDisplayRoute datasetId={dataset.id} />}
+        element={<FileDisplayRoute dataset={dataset} />}
       />
       <Route path="metadata" element={<AddMetadata dataset={dataset} />} />
     </Routes>

--- a/packages/openneuro-app/src/scripts/dataset/routes/tab-routes-snapshot.tsx
+++ b/packages/openneuro-app/src/scripts/dataset/routes/tab-routes-snapshot.tsx
@@ -39,7 +39,7 @@ export const TabRoutesSnapshot = ({ dataset, snapshot }) => {
       <Route
         path="file-display/:filePath"
         element={
-          <FileDisplayRoute datasetId={dataset.id} snapshotTag={snapshot.tag} />
+          <FileDisplayRoute dataset={snapshot} snapshotTag={snapshot.tag} />
         }
       />
       <Route path="metadata" element={<AddMetadata dataset={dataset} />} />


### PR DESCRIPTION
This resolves some cases where the file viewer would only load a file if OpenNeuro had a copy of it. Instead we always use the export URL unless one does not exist, falling back to OpenNeuro's file access API if needed before showing a 404 for a file that cannot be found in either case.