### PR TITLE
fix(app): Catch parsing errors for extractDateString

### DIFF
--- a/packages/openneuro-app/src/scripts/components/__tests__/data-table.spec.tsx
+++ b/packages/openneuro-app/src/scripts/components/__tests__/data-table.spec.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 import { render } from "@testing-library/react"
-import { DataTable } from "../data-table"
+import { DataTable, extractDateString } from "../data-table"
 
 const tableData = [
   { col1: "text", col2: 50, col3: "string value" },
@@ -11,5 +11,11 @@ describe("DataTable component", () => {
   it("renders a basic table", () => {
     const { asFragment } = render(<DataTable data={tableData}></DataTable>)
     expect(asFragment()).toMatchSnapshot()
+  })
+})
+
+describe("extractDateString()", () => {
+  it("handles invalid date format exceptions", () => {
+    expect(() => extractDateString("1893-09-18T08:27:33")).not.toThrowError()
   })
 })

--- a/packages/openneuro-app/src/scripts/components/data-table.tsx
+++ b/packages/openneuro-app/src/scripts/components/data-table.tsx
@@ -33,7 +33,7 @@ const TD = styled.td`
   padding: 3px;
 `
 
-function extractDateString(dateString) {
+export function extractDateString(dateString) {
   const formats = [
     "yyyy-MM-dd", // ISO 8601
     "yyyy-MM-ddTHH:mm:ss", // ISO 8601 with time
@@ -42,9 +42,13 @@ function extractDateString(dateString) {
   ]
 
   for (const format of formats) {
-    const parsedDate = parse(dateString, format, new Date())
-    if (isValid(parsedDate)) {
-      return parsedDate
+    try {
+      const parsedDate = parse(dateString, format, new Date())
+      if (isValid(parsedDate)) {
+        return parsedDate
+      }
+    } catch (_err) {
+      continue
     }
   }
 


### PR DESCRIPTION
Fixes an exception while parsing dates for TSV display. Adds test coverage for this function in the failing case.

See #3150 