### PR TITLE
feat(app): Generate a parent directory for dataset download scripts

### DIFF
--- a/packages/openneuro-app/src/scripts/dataset/download/__tests__/download-script.spec.tsx
+++ b/packages/openneuro-app/src/scripts/dataset/download/__tests__/download-script.spec.tsx
@@ -1,0 +1,62 @@
+import React from "react"
+import { fireEvent, render, screen } from "@testing-library/react"
+import { MockedProvider } from "@apollo/client/testing"
+import {
+  DownloadScript,
+  generateDownloadScript,
+  getSnapshotDownload,
+} from "../download-script"
+
+describe("DownloadScript", () => {
+  const mockData = {
+    snapshot: {
+      id: "ds000001:1.0.0",
+      downloadFiles: [
+        {
+          id: "a2776e2e194d72419638d7611ddef7efa9c9f643",
+          directory: false,
+          filename: "stimuli/meg/f074.bmp",
+          urls: ["https://example.com/stimuli/meg/f074.bmp"],
+          size: 12345,
+        },
+      ],
+    },
+  }
+
+  it("renders a download script link", () => {
+    render(
+      <MockedProvider mocks={[]} addTypename={false}>
+        <DownloadScript datasetId="ds000001" snapshotTag="some-tag" />
+      </MockedProvider>,
+    )
+    expect(screen.getByText("Download shell script")).toBeInTheDocument()
+  })
+
+  it("creates a clickable download button", async () => {
+    const mocks = [
+      {
+        request: {
+          query: getSnapshotDownload,
+          variables: { datasetId: "ds000001", tag: "some-tag" },
+        },
+        result: { data: mockData },
+      },
+    ]
+
+    render(
+      <MockedProvider mocks={mocks} addTypename={false}>
+        <DownloadScript datasetId="ds000001" snapshotTag="some-tag" />
+      </MockedProvider>,
+    )
+
+    const downloadLink = screen.getByText("Download shell script")
+    fireEvent.click(downloadLink)
+  })
+
+  describe("generateDownloadScript()", () => {
+    it("generates output grouped in an accession number directory", async () => {
+      const script = generateDownloadScript(mockData)
+      expect(script).toContain("-o ds000001-1.0.0/stimuli/meg/f074.bmp")
+    })
+  })
+})

--- a/packages/openneuro-app/src/scripts/dataset/download/download-script.tsx
+++ b/packages/openneuro-app/src/scripts/dataset/download/download-script.tsx
@@ -20,10 +20,12 @@ function inlineDownload(filename, data): void {
   document.body.removeChild(element)
 }
 
-function generateDownloadScript(data): string {
+export function generateDownloadScript(data): string {
+  // ds000001:1.0.0 -> ds000001-1.0.0 for directories
+  const directory = data.snapshot.id.split(":").join("-")
   let script = "#!/bin/sh\n"
   for (const f of data.snapshot.downloadFiles) {
-    script += `curl --create-dirs ${f.urls[0]} -o ${f.filename}\n`
+    script += `curl --create-dirs ${f.urls[0]} -o ${directory}/${f.filename}\n`
   }
   return script
 }
@@ -33,7 +35,7 @@ interface DownloadS3DerivativesProps {
   snapshotTag: string
 }
 
-const getSnapshotDownload = gql`
+export const getSnapshotDownload = gql`
   query snapshot($datasetId: ID!, $tag: String!) {
     snapshot(datasetId: $datasetId, tag: $tag) {
       id


### PR DESCRIPTION
Adds test coverage for this component and the changes to the directory structure.

Instead of `stimuli/meg/f074.bmp` we save to `ds0001234-1.0.0/stimuli/meg/f074.bmp`.