### PR TITLE
fix(worker): More robust purge implementation for S3 annex keys

### DIFF
--- a/services/datalad/tests/test_files.py
+++ b/services/datalad/tests/test_files.py
@@ -4,6 +4,7 @@ from falcon import testing
 import json
 from datalad.api import Dataset
 
+from datalad_service.tasks.files import parse_s3_annex_url
 
 class FileWrapper:
 
@@ -286,3 +287,10 @@ def test_delete_non_existing_file(client, new_dataset):
     assert response.status == falcon.HTTP_OK
     assert json.loads(response.content)[
         'error'] == 'the following files not found: fake, test'
+
+
+def test_parse_s3_annex_url():
+    # 'ex' is an impossible bucket name for an example
+    parsed = parse_s3_annex_url('https://s3.amazonaws.com/ex/ds001077/sub-02/anat/sub-02_T1w.nii.gz?versionId=tMYX62XJtDqDw_0nfS0CUtRx4rrXn_OD', 'ex')
+    assert parsed['VersionId'] == 'tMYX62XJtDqDw_0nfS0CUtRx4rrXn_OD'
+    assert parsed['Key'] == 'ds001077/sub-02/anat/sub-02_T1w.nii.gz'


### PR DESCRIPTION
Fixes several issues with the purge annex key implementation. git-annex does not output ok in the success case here and with force allows you to call purge on any annex key regardless of it if exists or not. Just checking the exit code here should be sufficient to make sure git-annex ran as expected.

We also need to check every S3 URL for a key, previously this would delete one versionId at a time. It's very common for a key to be exported under two versions on S3 and this will remove all copies (including those associated with another file path).

In the future we may need to filter to OpenNeuro created remotes. Need to consider this for several situations with sparse datasets where content is only held remotely.