### PR TITLE
fix(worker): Update move_files_intro_repo for pygit2 0.15 or later

### DIFF
--- a/services/datalad/datalad_service/handlers/upload.py
+++ b/services/datalad/datalad_service/handlers/upload.py
@@ -27,9 +27,9 @@ async def move_files_into_repo(dataset_id, dataset_path, upload_path, name, emai
     await move_files(upload_path, dataset_path)
     if name and email:
         author = pygit2.Signature(name, email)
-        hexsha = git_commit(repo, unlock_files, author).hex
+        hexsha = str(git_commit(repo, unlock_files, author))
     else:
-        hexsha = git_commit(repo, unlock_files).hex
+        hexsha = str(git_commit(repo, unlock_files))
 
 
 class UploadResource:


### PR DESCRIPTION
The hex field was dropped from oid objects in [pygit2 1.15.0](https://github.com/libgit2/pygit2/blob/master/CHANGELOG.md#1150-2024-05-18).