### PR TITLE
feat: Pass custom config to validator

### DIFF
--- a/packages/openneuro-app/src/scripts/workers/schema.worker.ts
+++ b/packages/openneuro-app/src/scripts/workers/schema.worker.ts
@@ -2,6 +2,20 @@
 import { fileListToTree, validate } from "../utils/schema-validator.js"
 import type { BIDSValidatorIssues } from "./worker-interface"
 
+const config = {
+    error: [
+        {code: 'NO_AUTHORS'},
+        {code: 'SUBJECT_FOLDERS'},  // bids-standard/bids-specification#1928 downgrades to warning
+        {code: 'EMPTY_DATASET_NAME'},
+    ]
+}
+
+const options = {
+    json: true,
+    /* Enable after https://github.com/bids-standard/bids-validator/pull/2176 is released */
+    // blacklistModalities: ["micr"],
+}
+
 export async function runValidator(
   files,
   options,
@@ -14,7 +28,7 @@ export async function runValidator(
   } as BIDSValidatorIssues
   try {
     const tree = await fileListToTree(files)
-    const result = await validate(tree, { json: true })
+    const result = await validate(tree, options, config)
     /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
     const issues = Array.from(result.issues, ([key, value]) => value)
     output.issues.warnings = issues.filter(


### PR DESCRIPTION
In prep to migrate to the schema validator, we need to promote some warnings to errors.

Reminded that we need to do this by bids-standard/bids-specification#1928, which proposes to downgrade SUBJECT_FOLDERS from an error to a warning. I don't think OpenNeuro wants to downgrade that, so this preemptively pegs it as an error.