### PR TITLE
refactor(app): Decouple React client from @openneuro/client

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -166,7 +166,7 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./.yarn/__virtual__/@apollo-client-virtual-b0a7bc3113/0/cache/@apollo-client-npm-3.7.2-f336c9e765-57ecb1639d.zip/node_modules/@apollo/client/",\
         "packageDependencies": [\
           ["@apollo/client", "virtual:4112afb9dad10978c159910bf10db9840b981b1333117623c8a4a8cf77481344a0a24735a5506e2920c18e3cfa2cc179489824b6a56c988bb070f4f60da40974#npm:3.7.2"],\
-          ["@graphql-typed-document-node/core", "virtual:cfdc2dcb80f08569825aa9da650a9f11a47b99403260649433bef00e4fa87084ca3a233ec5c966b01f5ad14eba9ef3e7ac0288cee1ae3e3bcd59cdfe3e6941c5#npm:3.1.1"],\
+          ["@graphql-typed-document-node/core", "virtual:b0a7bc31134ab5e9cd89b731397eaadcb411e502896f5b977308abdc16a7bc332cbe7a9f1702fb78e6d1f3d707b98150932cdc7bfe6ead7107c725b68d384429#npm:3.1.1"],\
           ["@types/graphql", null],\
           ["@types/graphql-ws", null],\
           ["@types/react", "npm:17.0.24"],\
@@ -176,7 +176,7 @@ const RAW_RUNTIME_STATE =
           ["@wry/equality", "npm:0.5.2"],\
           ["@wry/trie", "npm:0.3.1"],\
           ["graphql", "npm:16.8.1"],\
-          ["graphql-tag", "virtual:cfdc2dcb80f08569825aa9da650a9f11a47b99403260649433bef00e4fa87084ca3a233ec5c966b01f5ad14eba9ef3e7ac0288cee1ae3e3bcd59cdfe3e6941c5#npm:2.12.6"],\
+          ["graphql-tag", "virtual:b0a7bc31134ab5e9cd89b731397eaadcb411e502896f5b977308abdc16a7bc332cbe7a9f1702fb78e6d1f3d707b98150932cdc7bfe6ead7107c725b68d384429#npm:2.12.6"],\
           ["graphql-ws", null],\
           ["hoist-non-react-statics", "npm:3.3.2"],\
           ["optimism", "npm:0.16.1"],\
@@ -184,7 +184,7 @@ const RAW_RUNTIME_STATE =
           ["react", "npm:18.2.0"],\
           ["react-dom", "virtual:bb4ed02b339ed801b02d2ec15b42a5aa7b1afdaf44119aefaab128a59d6e16cc6018880c169f24bf2107550e914562ee9e1780db01a12e1bc3c492ad0a049c36#npm:18.2.0"],\
           ["response-iterator", "npm:0.2.6"],\
-          ["subscriptions-transport-ws", "virtual:86720daff6fa91ef488bb305b0b2c8253fb3fabde470b409f92b17f3b1d6203e3f6631585a5dc2cd5ccefab01339e6676f430f53e0206b9354f687fcc9c70489#npm:0.11.0"],\
+          ["subscriptions-transport-ws", "virtual:4112afb9dad10978c159910bf10db9840b981b1333117623c8a4a8cf77481344a0a24735a5506e2920c18e3cfa2cc179489824b6a56c988bb070f4f60da40974#npm:0.11.0"],\
           ["symbol-observable", "npm:4.0.0"],\
           ["ts-invariant", "npm:0.10.3"],\
           ["tslib", "npm:2.3.1"],\
@@ -208,7 +208,7 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./.yarn/__virtual__/@apollo-client-virtual-883dc75243/0/cache/@apollo-client-npm-3.7.2-f336c9e765-57ecb1639d.zip/node_modules/@apollo/client/",\
         "packageDependencies": [\
           ["@apollo/client", "virtual:6d9c0fee0b376eb0bb6824eb7a3246834ef21d870b31f75eebe59bb4d027e50f2607ba168fd29d446567f4e9c2a5cad2442c4741fa92c92e0b7e9145c3a3e3a7#npm:3.7.2"],\
-          ["@graphql-typed-document-node/core", "virtual:cfdc2dcb80f08569825aa9da650a9f11a47b99403260649433bef00e4fa87084ca3a233ec5c966b01f5ad14eba9ef3e7ac0288cee1ae3e3bcd59cdfe3e6941c5#npm:3.1.1"],\
+          ["@graphql-typed-document-node/core", "virtual:b0a7bc31134ab5e9cd89b731397eaadcb411e502896f5b977308abdc16a7bc332cbe7a9f1702fb78e6d1f3d707b98150932cdc7bfe6ead7107c725b68d384429#npm:3.1.1"],\
           ["@types/graphql", null],\
           ["@types/graphql-ws", null],\
           ["@types/react", null],\
@@ -218,7 +218,7 @@ const RAW_RUNTIME_STATE =
           ["@wry/equality", "npm:0.5.2"],\
           ["@wry/trie", "npm:0.3.1"],\
           ["graphql", "npm:16.8.1"],\
-          ["graphql-tag", "virtual:cfdc2dcb80f08569825aa9da650a9f11a47b99403260649433bef00e4fa87084ca3a233ec5c966b01f5ad14eba9ef3e7ac0288cee1ae3e3bcd59cdfe3e6941c5#npm:2.12.6"],\
+          ["graphql-tag", "virtual:b0a7bc31134ab5e9cd89b731397eaadcb411e502896f5b977308abdc16a7bc332cbe7a9f1702fb78e6d1f3d707b98150932cdc7bfe6ead7107c725b68d384429#npm:2.12.6"],\
           ["graphql-ws", null],\
           ["hoist-non-react-statics", "npm:3.3.2"],\
           ["optimism", "npm:0.16.1"],\
@@ -250,7 +250,7 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./.yarn/__virtual__/@apollo-client-virtual-e1354b869f/0/cache/@apollo-client-npm-3.7.2-f336c9e765-57ecb1639d.zip/node_modules/@apollo/client/",\
         "packageDependencies": [\
           ["@apollo/client", "virtual:86720daff6fa91ef488bb305b0b2c8253fb3fabde470b409f92b17f3b1d6203e3f6631585a5dc2cd5ccefab01339e6676f430f53e0206b9354f687fcc9c70489#npm:3.7.2"],\
-          ["@graphql-typed-document-node/core", "virtual:cfdc2dcb80f08569825aa9da650a9f11a47b99403260649433bef00e4fa87084ca3a233ec5c966b01f5ad14eba9ef3e7ac0288cee1ae3e3bcd59cdfe3e6941c5#npm:3.1.1"],\
+          ["@graphql-typed-document-node/core", "virtual:b0a7bc31134ab5e9cd89b731397eaadcb411e502896f5b977308abdc16a7bc332cbe7a9f1702fb78e6d1f3d707b98150932cdc7bfe6ead7107c725b68d384429#npm:3.1.1"],\
           ["@types/graphql", null],\
           ["@types/graphql-ws", null],\
           ["@types/react", null],\
@@ -260,7 +260,7 @@ const RAW_RUNTIME_STATE =
           ["@wry/equality", "npm:0.5.2"],\
           ["@wry/trie", "npm:0.3.1"],\
           ["graphql", "npm:16.8.1"],\
-          ["graphql-tag", "virtual:cfdc2dcb80f08569825aa9da650a9f11a47b99403260649433bef00e4fa87084ca3a233ec5c966b01f5ad14eba9ef3e7ac0288cee1ae3e3bcd59cdfe3e6941c5#npm:2.12.6"],\
+          ["graphql-tag", "virtual:b0a7bc31134ab5e9cd89b731397eaadcb411e502896f5b977308abdc16a7bc332cbe7a9f1702fb78e6d1f3d707b98150932cdc7bfe6ead7107c725b68d384429#npm:2.12.6"],\
           ["graphql-ws", null],\
           ["hoist-non-react-statics", "npm:3.3.2"],\
           ["optimism", "npm:0.16.1"],\
@@ -268,7 +268,7 @@ const RAW_RUNTIME_STATE =
           ["react", "npm:18.2.0"],\
           ["react-dom", "virtual:e1354b869fd61933a50febfeb4c06f2e455245c473014babfd8e295047b9ae97007baebac78eca2a945991ae934fd8bdaa617260fdc6568d2ce324c651a72820#npm:17.0.2"],\
           ["response-iterator", "npm:0.2.6"],\
-          ["subscriptions-transport-ws", "virtual:86720daff6fa91ef488bb305b0b2c8253fb3fabde470b409f92b17f3b1d6203e3f6631585a5dc2cd5ccefab01339e6676f430f53e0206b9354f687fcc9c70489#npm:0.11.0"],\
+          ["subscriptions-transport-ws", "virtual:4112afb9dad10978c159910bf10db9840b981b1333117623c8a4a8cf77481344a0a24735a5506e2920c18e3cfa2cc179489824b6a56c988bb070f4f60da40974#npm:0.11.0"],\
           ["symbol-observable", "npm:4.0.0"],\
           ["ts-invariant", "npm:0.10.3"],\
           ["tslib", "npm:2.3.1"],\
@@ -291,7 +291,7 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./.yarn/__virtual__/@apollo-client-virtual-53f8c8a33d/0/cache/@apollo-client-npm-3.7.2-f336c9e765-57ecb1639d.zip/node_modules/@apollo/client/",\
         "packageDependencies": [\
           ["@apollo/client", "virtual:90f6a129d8adfee793b93ece48b319375c46f70206be38f532b28e127912d214b54604b30e8cb269ad6cd82b0db01373baefbe471fefa8ff4f96f22e6afba034#npm:3.7.2"],\
-          ["@graphql-typed-document-node/core", "virtual:cfdc2dcb80f08569825aa9da650a9f11a47b99403260649433bef00e4fa87084ca3a233ec5c966b01f5ad14eba9ef3e7ac0288cee1ae3e3bcd59cdfe3e6941c5#npm:3.1.1"],\
+          ["@graphql-typed-document-node/core", "virtual:b0a7bc31134ab5e9cd89b731397eaadcb411e502896f5b977308abdc16a7bc332cbe7a9f1702fb78e6d1f3d707b98150932cdc7bfe6ead7107c725b68d384429#npm:3.1.1"],\
           ["@types/graphql", null],\
           ["@types/graphql-ws", null],\
           ["@types/react", null],\
@@ -301,7 +301,7 @@ const RAW_RUNTIME_STATE =
           ["@wry/equality", "npm:0.5.2"],\
           ["@wry/trie", "npm:0.3.1"],\
           ["graphql", "npm:16.8.1"],\
-          ["graphql-tag", "virtual:cfdc2dcb80f08569825aa9da650a9f11a47b99403260649433bef00e4fa87084ca3a233ec5c966b01f5ad14eba9ef3e7ac0288cee1ae3e3bcd59cdfe3e6941c5#npm:2.12.6"],\
+          ["graphql-tag", "virtual:b0a7bc31134ab5e9cd89b731397eaadcb411e502896f5b977308abdc16a7bc332cbe7a9f1702fb78e6d1f3d707b98150932cdc7bfe6ead7107c725b68d384429#npm:2.12.6"],\
           ["graphql-ws", null],\
           ["hoist-non-react-statics", "npm:3.3.2"],\
           ["optimism", "npm:0.16.1"],\
@@ -332,7 +332,7 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./.yarn/__virtual__/@apollo-client-virtual-945031681e/0/cache/@apollo-client-npm-3.7.17-a910e140c9-3d820c9289.zip/node_modules/@apollo/client/",\
         "packageDependencies": [\
           ["@apollo/client", "virtual:c2fc35037a51b13304ddc4a4f25c3411d55a80c181781e6c56a152593bcaa12f612a1386ba9ffd9b2aac9a28a54af34cae57545073625b704d851c124fed9d3b#npm:3.7.17"],\
-          ["@graphql-typed-document-node/core", "virtual:cfdc2dcb80f08569825aa9da650a9f11a47b99403260649433bef00e4fa87084ca3a233ec5c966b01f5ad14eba9ef3e7ac0288cee1ae3e3bcd59cdfe3e6941c5#npm:3.1.1"],\
+          ["@graphql-typed-document-node/core", "virtual:b0a7bc31134ab5e9cd89b731397eaadcb411e502896f5b977308abdc16a7bc332cbe7a9f1702fb78e6d1f3d707b98150932cdc7bfe6ead7107c725b68d384429#npm:3.1.1"],\
           ["@types/graphql", null],\
           ["@types/graphql-ws", null],\
           ["@types/react", null],\
@@ -342,7 +342,7 @@ const RAW_RUNTIME_STATE =
           ["@wry/equality", "npm:0.5.2"],\
           ["@wry/trie", "npm:0.4.3"],\
           ["graphql", "npm:16.8.1"],\
-          ["graphql-tag", "virtual:cfdc2dcb80f08569825aa9da650a9f11a47b99403260649433bef00e4fa87084ca3a233ec5c966b01f5ad14eba9ef3e7ac0288cee1ae3e3bcd59cdfe3e6941c5#npm:2.12.6"],\
+          ["graphql-tag", "virtual:b0a7bc31134ab5e9cd89b731397eaadcb411e502896f5b977308abdc16a7bc332cbe7a9f1702fb78e6d1f3d707b98150932cdc7bfe6ead7107c725b68d384429#npm:2.12.6"],\
           ["graphql-ws", null],\
           ["hoist-non-react-statics", "npm:3.3.2"],\
           ["optimism", "npm:0.16.2"],\
@@ -373,7 +373,7 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./.yarn/__virtual__/@apollo-client-virtual-cfdc2dcb80/0/cache/@apollo-client-npm-3.7.2-f336c9e765-57ecb1639d.zip/node_modules/@apollo/client/",\
         "packageDependencies": [\
           ["@apollo/client", "virtual:e74940e35978632a0c14fa5497dc52825a9c66f5b1078eb2e64acf3c410407bb81bc4632771c0031555903c2ed0410b5bd9f7005884e1b336a14c40f1d7762b1#npm:3.7.2"],\
-          ["@graphql-typed-document-node/core", "virtual:cfdc2dcb80f08569825aa9da650a9f11a47b99403260649433bef00e4fa87084ca3a233ec5c966b01f5ad14eba9ef3e7ac0288cee1ae3e3bcd59cdfe3e6941c5#npm:3.1.1"],\
+          ["@graphql-typed-document-node/core", "virtual:b0a7bc31134ab5e9cd89b731397eaadcb411e502896f5b977308abdc16a7bc332cbe7a9f1702fb78e6d1f3d707b98150932cdc7bfe6ead7107c725b68d384429#npm:3.1.1"],\
           ["@types/graphql", null],\
           ["@types/graphql-ws", null],\
           ["@types/react", null],\
@@ -383,7 +383,7 @@ const RAW_RUNTIME_STATE =
           ["@wry/equality", "npm:0.5.2"],\
           ["@wry/trie", "npm:0.3.1"],\
           ["graphql", "npm:16.8.1"],\
-          ["graphql-tag", "virtual:cfdc2dcb80f08569825aa9da650a9f11a47b99403260649433bef00e4fa87084ca3a233ec5c966b01f5ad14eba9ef3e7ac0288cee1ae3e3bcd59cdfe3e6941c5#npm:2.12.6"],\
+          ["graphql-tag", "virtual:b0a7bc31134ab5e9cd89b731397eaadcb411e502896f5b977308abdc16a7bc332cbe7a9f1702fb78e6d1f3d707b98150932cdc7bfe6ead7107c725b68d384429#npm:2.12.6"],\
           ["graphql-ws", null],\
           ["hoist-non-react-statics", "npm:3.3.2"],\
           ["optimism", "npm:0.16.1"],\
@@ -4695,7 +4695,7 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./.yarn/__virtual__/@graphql-tools-utils-virtual-67ac2471be/0/cache/@graphql-tools-utils-npm-10.0.4-08baeb0bb2-f716d19e57.zip/node_modules/@graphql-tools/utils/",\
         "packageDependencies": [\
           ["@graphql-tools/utils", "virtual:1728807850d6df0af9808e024ec3115cb3a28ce8c7ad87b1d3ee8124c91d8ff09a08592411c8193e2748c7895f1c61da00300feeec8e95b0ed1136d58819aba8#npm:10.0.4"],\
-          ["@graphql-typed-document-node/core", "virtual:cfdc2dcb80f08569825aa9da650a9f11a47b99403260649433bef00e4fa87084ca3a233ec5c966b01f5ad14eba9ef3e7ac0288cee1ae3e3bcd59cdfe3e6941c5#npm:3.1.1"],\
+          ["@graphql-typed-document-node/core", "virtual:b0a7bc31134ab5e9cd89b731397eaadcb411e502896f5b977308abdc16a7bc332cbe7a9f1702fb78e6d1f3d707b98150932cdc7bfe6ead7107c725b68d384429#npm:3.1.1"],\
           ["@types/graphql", null],\
           ["dset", "npm:3.1.4"],\
           ["graphql", "npm:16.8.1"],\
@@ -4711,7 +4711,7 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./.yarn/__virtual__/@graphql-tools-utils-virtual-52fd9f8aae/0/cache/@graphql-tools-utils-npm-9.2.1-ed63b70392-b1665043c2.zip/node_modules/@graphql-tools/utils/",\
         "packageDependencies": [\
           ["@graphql-tools/utils", "virtual:efbf874d6b8b3dca6aeb2963feec791ba639b0f8e28d730a466fb2c1e83d0e87ac4cde54ccebe55928ddd107fc63e2e70118b3e60ae8323b52d5bd178fe2184d#npm:9.2.1"],\
-          ["@graphql-typed-document-node/core", "virtual:cfdc2dcb80f08569825aa9da650a9f11a47b99403260649433bef00e4fa87084ca3a233ec5c966b01f5ad14eba9ef3e7ac0288cee1ae3e3bcd59cdfe3e6941c5#npm:3.1.1"],\
+          ["@graphql-typed-document-node/core", "virtual:b0a7bc31134ab5e9cd89b731397eaadcb411e502896f5b977308abdc16a7bc332cbe7a9f1702fb78e6d1f3d707b98150932cdc7bfe6ead7107c725b68d384429#npm:3.1.1"],\
           ["@types/graphql", null],\
           ["graphql", "npm:16.8.1"],\
           ["tslib", "npm:2.6.1"]\
@@ -4731,10 +4731,10 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "SOFT"\
       }],\
-      ["virtual:cfdc2dcb80f08569825aa9da650a9f11a47b99403260649433bef00e4fa87084ca3a233ec5c966b01f5ad14eba9ef3e7ac0288cee1ae3e3bcd59cdfe3e6941c5#npm:3.1.1", {\
-        "packageLocation": "./.yarn/__virtual__/@graphql-typed-document-node-core-virtual-4d6c098334/0/cache/@graphql-typed-document-node-core-npm-3.1.1-b1b114073d-87ff4cee30.zip/node_modules/@graphql-typed-document-node/core/",\
+      ["virtual:b0a7bc31134ab5e9cd89b731397eaadcb411e502896f5b977308abdc16a7bc332cbe7a9f1702fb78e6d1f3d707b98150932cdc7bfe6ead7107c725b68d384429#npm:3.1.1", {\
+        "packageLocation": "./.yarn/__virtual__/@graphql-typed-document-node-core-virtual-54cc8de6ac/0/cache/@graphql-typed-document-node-core-npm-3.1.1-b1b114073d-87ff4cee30.zip/node_modules/@graphql-typed-document-node/core/",\
         "packageDependencies": [\
-          ["@graphql-typed-document-node/core", "virtual:cfdc2dcb80f08569825aa9da650a9f11a47b99403260649433bef00e4fa87084ca3a233ec5c966b01f5ad14eba9ef3e7ac0288cee1ae3e3bcd59cdfe3e6941c5#npm:3.1.1"],\
+          ["@graphql-typed-document-node/core", "virtual:b0a7bc31134ab5e9cd89b731397eaadcb411e502896f5b977308abdc16a7bc332cbe7a9f1702fb78e6d1f3d707b98150932cdc7bfe6ead7107c725b68d384429#npm:3.1.1"],\
           ["@types/graphql", null],\
           ["graphql", "npm:16.8.1"]\
         ],\
@@ -7219,7 +7219,6 @@ const RAW_RUNTIME_STATE =
           ["@emotion/react", "virtual:bb4ed02b339ed801b02d2ec15b42a5aa7b1afdaf44119aefaab128a59d6e16cc6018880c169f24bf2107550e914562ee9e1780db01a12e1bc3c492ad0a049c36#npm:11.11.1"],\
           ["@emotion/styled", "virtual:bb4ed02b339ed801b02d2ec15b42a5aa7b1afdaf44119aefaab128a59d6e16cc6018880c169f24bf2107550e914562ee9e1780db01a12e1bc3c492ad0a049c36#npm:11.11.0"],\
           ["@niivue/niivue", "npm:0.45.1"],\
-          ["@openneuro/client", "workspace:packages/openneuro-client"],\
           ["@openneuro/components", "workspace:packages/openneuro-components"],\
           ["@sentry/react", "virtual:4112afb9dad10978c159910bf10db9840b981b1333117623c8a4a8cf77481344a0a24735a5506e2920c18e3cfa2cc179489824b6a56c988bb070f4f60da40974#npm:8.25.0"],\
           ["@tanstack/react-table", "virtual:4112afb9dad10978c159910bf10db9840b981b1333117623c8a4a8cf77481344a0a24735a5506e2920c18e3cfa2cc179489824b6a56c988bb070f4f60da40974#npm:8.9.3"],\
@@ -7264,7 +7263,7 @@ const RAW_RUNTIME_STATE =
           ["sass", "npm:1.42.1"],\
           ["semver", "npm:5.7.2"],\
           ["stream-browserify", "npm:3.0.0"],\
-          ["subscriptions-transport-ws", "virtual:86720daff6fa91ef488bb305b0b2c8253fb3fabde470b409f92b17f3b1d6203e3f6631585a5dc2cd5ccefab01339e6676f430f53e0206b9354f687fcc9c70489#npm:0.11.0"],\
+          ["subscriptions-transport-ws", "virtual:4112afb9dad10978c159910bf10db9840b981b1333117623c8a4a8cf77481344a0a24735a5506e2920c18e3cfa2cc179489824b6a56c988bb070f4f60da40974#npm:0.11.0"],\
           ["typescript", "patch:typescript@npm%3A5.6.3#optional!builtin<compat/typescript>::version=5.6.3&hash=8c6c40"],\
           ["universal-cookie", "npm:4.0.4"],\
           ["vite", "virtual:4112afb9dad10978c159910bf10db9840b981b1333117623c8a4a8cf77481344a0a24735a5506e2920c18e3cfa2cc179489824b6a56c988bb070f4f60da40974#npm:5.4.8"],\
@@ -7314,8 +7313,8 @@ const RAW_RUNTIME_STATE =
           ["ioredis-mock", "virtual:86720daff6fa91ef488bb305b0b2c8253fb3fabde470b409f92b17f3b1d6203e3f6631585a5dc2cd5ccefab01339e6676f430f53e0206b9354f687fcc9c70489#npm:8.8.1"],\
           ["react", "npm:18.2.0"],\
           ["semver", "npm:5.7.2"],\
-          ["subscriptions-transport-ws", "virtual:86720daff6fa91ef488bb305b0b2c8253fb3fabde470b409f92b17f3b1d6203e3f6631585a5dc2cd5ccefab01339e6676f430f53e0206b9354f687fcc9c70489#npm:0.11.0"],\
-          ["vitest", "virtual:86720daff6fa91ef488bb305b0b2c8253fb3fabde470b409f92b17f3b1d6203e3f6631585a5dc2cd5ccefab01339e6676f430f53e0206b9354f687fcc9c70489#npm:2.1.2"]\
+          ["subscriptions-transport-ws", "virtual:4112afb9dad10978c159910bf10db9840b981b1333117623c8a4a8cf77481344a0a24735a5506e2920c18e3cfa2cc179489824b6a56c988bb070f4f60da40974#npm:0.11.0"],\
+          ["vitest", "virtual:bb4ed02b339ed801b02d2ec15b42a5aa7b1afdaf44119aefaab128a59d6e16cc6018880c169f24bf2107550e914562ee9e1780db01a12e1bc3c492ad0a049c36#npm:2.1.2"]\
         ],\
         "linkType": "SOFT"\
       }]\
@@ -7352,7 +7351,7 @@ const RAW_RUNTIME_STATE =
           ["react-usestateref", "virtual:bb4ed02b339ed801b02d2ec15b42a5aa7b1afdaf44119aefaab128a59d6e16cc6018880c169f24bf2107550e914562ee9e1780db01a12e1bc3c492ad0a049c36#npm:1.0.5"],\
           ["sass", "npm:1.42.1"],\
           ["typescript", "patch:typescript@npm%3A5.6.3#optional!builtin<compat/typescript>::version=5.6.3&hash=8c6c40"],\
-          ["vitest", "virtual:86720daff6fa91ef488bb305b0b2c8253fb3fabde470b409f92b17f3b1d6203e3f6631585a5dc2cd5ccefab01339e6676f430f53e0206b9354f687fcc9c70489#npm:2.1.2"]\
+          ["vitest", "virtual:bb4ed02b339ed801b02d2ec15b42a5aa7b1afdaf44119aefaab128a59d6e16cc6018880c169f24bf2107550e914562ee9e1780db01a12e1bc3c492ad0a049c36#npm:2.1.2"]\
         ],\
         "linkType": "SOFT"\
       }]\
@@ -9530,7 +9529,7 @@ const RAW_RUNTIME_STATE =
           ["jest", null],\
           ["lodash", "npm:4.17.21"],\
           ["redent", "npm:3.0.0"],\
-          ["vitest", "virtual:86720daff6fa91ef488bb305b0b2c8253fb3fabde470b409f92b17f3b1d6203e3f6631585a5dc2cd5ccefab01339e6676f430f53e0206b9354f687fcc9c70489#npm:2.1.2"]\
+          ["vitest", "virtual:bb4ed02b339ed801b02d2ec15b42a5aa7b1afdaf44119aefaab128a59d6e16cc6018880c169f24bf2107550e914562ee9e1780db01a12e1bc3c492ad0a049c36#npm:2.1.2"]\
         ],\
         "packagePeers": [\
           "@jest/globals",\
@@ -10886,10 +10885,10 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "SOFT"\
       }],\
-      ["virtual:359076064a9285b8b15d5b1a7f7427374da544207a98c67be5d139598b418f0e9be2df554db59a534a7be37d4acfa9945577b07994d79254a7498f39cf3250b5#npm:2.1.2", {\
-        "packageLocation": "./.yarn/__virtual__/@vitest-mocker-virtual-1731d5b1da/0/cache/@vitest-mocker-npm-2.1.2-1cdf0ad364-f6ec9aa061.zip/node_modules/@vitest/mocker/",\
+      ["virtual:be6c59e6d9ee99e44033677edf92b524d937dba2eb401cd1bd724b58f6c612890520e2ed4326e2df2173c37a3b98fd026e2d4a35f7474dff6f00e30d067e4d13#npm:2.1.2", {\
+        "packageLocation": "./.yarn/__virtual__/@vitest-mocker-virtual-dda33eb058/0/cache/@vitest-mocker-npm-2.1.2-1cdf0ad364-f6ec9aa061.zip/node_modules/@vitest/mocker/",\
         "packageDependencies": [\
-          ["@vitest/mocker", "virtual:359076064a9285b8b15d5b1a7f7427374da544207a98c67be5d139598b418f0e9be2df554db59a534a7be37d4acfa9945577b07994d79254a7498f39cf3250b5#npm:2.1.2"],\
+          ["@vitest/mocker", "virtual:be6c59e6d9ee99e44033677edf92b524d937dba2eb401cd1bd724b58f6c612890520e2ed4326e2df2173c37a3b98fd026e2d4a35f7474dff6f00e30d067e4d13#npm:2.1.2"],\
           ["@types/msw", null],\
           ["@types/vite", null],\
           ["@types/vitest__spy", null],\
@@ -10897,7 +10896,7 @@ const RAW_RUNTIME_STATE =
           ["estree-walker", "npm:3.0.3"],\
           ["magic-string", "npm:0.30.11"],\
           ["msw", null],\
-          ["vite", "virtual:359076064a9285b8b15d5b1a7f7427374da544207a98c67be5d139598b418f0e9be2df554db59a534a7be37d4acfa9945577b07994d79254a7498f39cf3250b5#npm:5.2.10"]\
+          ["vite", "virtual:be6c59e6d9ee99e44033677edf92b524d937dba2eb401cd1bd724b58f6c612890520e2ed4326e2df2173c37a3b98fd026e2d4a35f7474dff6f00e30d067e4d13#npm:5.2.10"]\
         ],\
         "packagePeers": [\
           "@types/msw",\
@@ -10909,10 +10908,10 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "HARD"\
       }],\
-      ["virtual:5c35b794361dd890bf8d88dcc7af03f2ca07113188cab680b4b85df7c78434e37c7a6767b1ed867236a10e5139f8d323582a6f82ae106407a47b0f0fd19d5528#npm:2.1.2", {\
-        "packageLocation": "./.yarn/__virtual__/@vitest-mocker-virtual-2f01985aa4/0/cache/@vitest-mocker-npm-2.1.2-1cdf0ad364-f6ec9aa061.zip/node_modules/@vitest/mocker/",\
+      ["virtual:e327af8e29a76a477fc3ea999bc224ab02a687c4ee35b52bcf99c59ea12f35681d8e01f8276bd5ca0d054cb7dc635b149838efc69f29104743bbf26c584a7f08#npm:2.1.2", {\
+        "packageLocation": "./.yarn/__virtual__/@vitest-mocker-virtual-7ee1ba4d95/0/cache/@vitest-mocker-npm-2.1.2-1cdf0ad364-f6ec9aa061.zip/node_modules/@vitest/mocker/",\
         "packageDependencies": [\
-          ["@vitest/mocker", "virtual:5c35b794361dd890bf8d88dcc7af03f2ca07113188cab680b4b85df7c78434e37c7a6767b1ed867236a10e5139f8d323582a6f82ae106407a47b0f0fd19d5528#npm:2.1.2"],\
+          ["@vitest/mocker", "virtual:e327af8e29a76a477fc3ea999bc224ab02a687c4ee35b52bcf99c59ea12f35681d8e01f8276bd5ca0d054cb7dc635b149838efc69f29104743bbf26c584a7f08#npm:2.1.2"],\
           ["@types/msw", null],\
           ["@types/vite", null],\
           ["@types/vitest__spy", null],\
@@ -18127,10 +18126,10 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "SOFT"\
       }],\
-      ["virtual:cfdc2dcb80f08569825aa9da650a9f11a47b99403260649433bef00e4fa87084ca3a233ec5c966b01f5ad14eba9ef3e7ac0288cee1ae3e3bcd59cdfe3e6941c5#npm:2.12.6", {\
-        "packageLocation": "./.yarn/__virtual__/graphql-tag-virtual-a60c65bfb9/0/cache/graphql-tag-npm-2.12.6-99a5a7f6de-23a2bc1d3f.zip/node_modules/graphql-tag/",\
+      ["virtual:b0a7bc31134ab5e9cd89b731397eaadcb411e502896f5b977308abdc16a7bc332cbe7a9f1702fb78e6d1f3d707b98150932cdc7bfe6ead7107c725b68d384429#npm:2.12.6", {\
+        "packageLocation": "./.yarn/__virtual__/graphql-tag-virtual-49f374b872/0/cache/graphql-tag-npm-2.12.6-99a5a7f6de-23a2bc1d3f.zip/node_modules/graphql-tag/",\
         "packageDependencies": [\
-          ["graphql-tag", "virtual:cfdc2dcb80f08569825aa9da650a9f11a47b99403260649433bef00e4fa87084ca3a233ec5c966b01f5ad14eba9ef3e7ac0288cee1ae3e3bcd59cdfe3e6941c5#npm:2.12.6"],\
+          ["graphql-tag", "virtual:b0a7bc31134ab5e9cd89b731397eaadcb411e502896f5b977308abdc16a7bc332cbe7a9f1702fb78e6d1f3d707b98150932cdc7bfe6ead7107c725b68d384429#npm:2.12.6"],\
           ["@types/graphql", null],\
           ["graphql", "npm:16.8.1"],\
           ["tslib", "npm:2.3.1"]\
@@ -29611,17 +29610,17 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "SOFT"\
       }],\
-      ["virtual:86720daff6fa91ef488bb305b0b2c8253fb3fabde470b409f92b17f3b1d6203e3f6631585a5dc2cd5ccefab01339e6676f430f53e0206b9354f687fcc9c70489#npm:0.11.0", {\
-        "packageLocation": "./.yarn/__virtual__/subscriptions-transport-ws-virtual-0d009645be/0/cache/subscriptions-transport-ws-npm-0.11.0-6fa3639659-3835ce8154.zip/node_modules/subscriptions-transport-ws/",\
+      ["virtual:4112afb9dad10978c159910bf10db9840b981b1333117623c8a4a8cf77481344a0a24735a5506e2920c18e3cfa2cc179489824b6a56c988bb070f4f60da40974#npm:0.11.0", {\
+        "packageLocation": "./.yarn/__virtual__/subscriptions-transport-ws-virtual-222aa3ddde/0/cache/subscriptions-transport-ws-npm-0.11.0-6fa3639659-3835ce8154.zip/node_modules/subscriptions-transport-ws/",\
         "packageDependencies": [\
-          ["subscriptions-transport-ws", "virtual:86720daff6fa91ef488bb305b0b2c8253fb3fabde470b409f92b17f3b1d6203e3f6631585a5dc2cd5ccefab01339e6676f430f53e0206b9354f687fcc9c70489#npm:0.11.0"],\
+          ["subscriptions-transport-ws", "virtual:4112afb9dad10978c159910bf10db9840b981b1333117623c8a4a8cf77481344a0a24735a5506e2920c18e3cfa2cc179489824b6a56c988bb070f4f60da40974#npm:0.11.0"],\
           ["@types/graphql", null],\
           ["backo2", "npm:1.0.2"],\
           ["eventemitter3", "npm:3.1.2"],\
           ["graphql", "npm:16.8.1"],\
           ["iterall", "npm:1.3.0"],\
           ["symbol-observable", "npm:1.2.0"],\
-          ["ws", "virtual:0d009645becfea4d88882843f0423fcd82285d1b4ccc9cfa7930ffc912a0989555b0246969c43500aed09e6b607d4c48ed0781b1a3705352f665edbcf7185907#npm:7.5.10"]\
+          ["ws", "virtual:222aa3dddeaeaa61af52fac7bb1ac2d89193af1f1652e3dded827e17e51136f3cdf2657f101e4918984f890bad2fb83a40ad7853b91df134ac952fbe7d0a7df7#npm:7.5.10"]\
         ],\
         "packagePeers": [\
           "@types/graphql",\
@@ -31561,45 +31560,6 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "HARD"\
       }],\
-      ["virtual:359076064a9285b8b15d5b1a7f7427374da544207a98c67be5d139598b418f0e9be2df554db59a534a7be37d4acfa9945577b07994d79254a7498f39cf3250b5#npm:5.2.10", {\
-        "packageLocation": "./.yarn/__virtual__/vite-virtual-838d9ef5ca/0/cache/vite-npm-5.2.10-08834d3974-a0c4ac7b95.zip/node_modules/vite/",\
-        "packageDependencies": [\
-          ["vite", "virtual:359076064a9285b8b15d5b1a7f7427374da544207a98c67be5d139598b418f0e9be2df554db59a534a7be37d4acfa9945577b07994d79254a7498f39cf3250b5#npm:5.2.10"],\
-          ["@types/less", null],\
-          ["@types/lightningcss", null],\
-          ["@types/node", "npm:20.12.7"],\
-          ["@types/sass", null],\
-          ["@types/stylus", null],\
-          ["@types/sugarss", null],\
-          ["@types/terser", null],\
-          ["esbuild", "npm:0.20.2"],\
-          ["fsevents", "patch:fsevents@npm%3A2.3.3#optional!builtin<compat/fsevents>::version=2.3.3&hash=df0bf1"],\
-          ["less", null],\
-          ["lightningcss", null],\
-          ["postcss", "npm:8.4.38"],\
-          ["rollup", "npm:4.22.0"],\
-          ["sass", null],\
-          ["stylus", null],\
-          ["sugarss", null],\
-          ["terser", null]\
-        ],\
-        "packagePeers": [\
-          "@types/less",\
-          "@types/lightningcss",\
-          "@types/node",\
-          "@types/sass",\
-          "@types/stylus",\
-          "@types/sugarss",\
-          "@types/terser",\
-          "less",\
-          "lightningcss",\
-          "sass",\
-          "stylus",\
-          "sugarss",\
-          "terser"\
-        ],\
-        "linkType": "HARD"\
-      }],\
       ["virtual:4112afb9dad10978c159910bf10db9840b981b1333117623c8a4a8cf77481344a0a24735a5506e2920c18e3cfa2cc179489824b6a56c988bb070f4f60da40974#npm:5.4.8", {\
         "packageLocation": "./.yarn/__virtual__/vite-virtual-e3ab6cb2ff/0/cache/vite-npm-5.4.8-0e6d2e051d-17fdffa558.zip/node_modules/vite/",\
         "packageDependencies": [\
@@ -31636,6 +31596,45 @@ const RAW_RUNTIME_STATE =
           "less",\
           "lightningcss",\
           "sass-embedded",\
+          "sass",\
+          "stylus",\
+          "sugarss",\
+          "terser"\
+        ],\
+        "linkType": "HARD"\
+      }],\
+      ["virtual:be6c59e6d9ee99e44033677edf92b524d937dba2eb401cd1bd724b58f6c612890520e2ed4326e2df2173c37a3b98fd026e2d4a35f7474dff6f00e30d067e4d13#npm:5.2.10", {\
+        "packageLocation": "./.yarn/__virtual__/vite-virtual-0a29727f15/0/cache/vite-npm-5.2.10-08834d3974-a0c4ac7b95.zip/node_modules/vite/",\
+        "packageDependencies": [\
+          ["vite", "virtual:be6c59e6d9ee99e44033677edf92b524d937dba2eb401cd1bd724b58f6c612890520e2ed4326e2df2173c37a3b98fd026e2d4a35f7474dff6f00e30d067e4d13#npm:5.2.10"],\
+          ["@types/less", null],\
+          ["@types/lightningcss", null],\
+          ["@types/node", "npm:20.12.7"],\
+          ["@types/sass", null],\
+          ["@types/stylus", null],\
+          ["@types/sugarss", null],\
+          ["@types/terser", null],\
+          ["esbuild", "npm:0.20.2"],\
+          ["fsevents", "patch:fsevents@npm%3A2.3.3#optional!builtin<compat/fsevents>::version=2.3.3&hash=df0bf1"],\
+          ["less", null],\
+          ["lightningcss", null],\
+          ["postcss", "npm:8.4.38"],\
+          ["rollup", "npm:4.22.0"],\
+          ["sass", null],\
+          ["stylus", null],\
+          ["sugarss", null],\
+          ["terser", null]\
+        ],\
+        "packagePeers": [\
+          "@types/less",\
+          "@types/lightningcss",\
+          "@types/node",\
+          "@types/sass",\
+          "@types/stylus",\
+          "@types/sugarss",\
+          "@types/terser",\
+          "less",\
+          "lightningcss",\
           "sass",\
           "stylus",\
           "sugarss",\
@@ -31740,7 +31739,7 @@ const RAW_RUNTIME_STATE =
           ["@types/vitest__ui", null],\
           ["@vitest/browser", null],\
           ["@vitest/expect", "npm:2.1.2"],\
-          ["@vitest/mocker", "virtual:359076064a9285b8b15d5b1a7f7427374da544207a98c67be5d139598b418f0e9be2df554db59a534a7be37d4acfa9945577b07994d79254a7498f39cf3250b5#npm:2.1.2"],\
+          ["@vitest/mocker", "virtual:be6c59e6d9ee99e44033677edf92b524d937dba2eb401cd1bd724b58f6c612890520e2ed4326e2df2173c37a3b98fd026e2d4a35f7474dff6f00e30d067e4d13#npm:2.1.2"],\
           ["@vitest/pretty-format", "npm:2.1.2"],\
           ["@vitest/runner", "npm:2.1.2"],\
           ["@vitest/snapshot", "npm:2.1.2"],\
@@ -31758,7 +31757,7 @@ const RAW_RUNTIME_STATE =
           ["tinyexec", "npm:0.3.0"],\
           ["tinypool", "npm:1.0.1"],\
           ["tinyrainbow", "npm:1.2.0"],\
-          ["vite", "virtual:359076064a9285b8b15d5b1a7f7427374da544207a98c67be5d139598b418f0e9be2df554db59a534a7be37d4acfa9945577b07994d79254a7498f39cf3250b5#npm:5.2.10"],\
+          ["vite", "virtual:be6c59e6d9ee99e44033677edf92b524d937dba2eb401cd1bd724b58f6c612890520e2ed4326e2df2173c37a3b98fd026e2d4a35f7474dff6f00e30d067e4d13#npm:5.2.10"],\
           ["vite-node", "npm:2.1.2"],\
           ["why-is-node-running", "npm:2.3.0"]\
         ],\
@@ -31790,7 +31789,7 @@ const RAW_RUNTIME_STATE =
           ["@types/vitest__ui", null],\
           ["@vitest/browser", null],\
           ["@vitest/expect", "npm:2.1.2"],\
-          ["@vitest/mocker", "virtual:5c35b794361dd890bf8d88dcc7af03f2ca07113188cab680b4b85df7c78434e37c7a6767b1ed867236a10e5139f8d323582a6f82ae106407a47b0f0fd19d5528#npm:2.1.2"],\
+          ["@vitest/mocker", "virtual:e327af8e29a76a477fc3ea999bc224ab02a687c4ee35b52bcf99c59ea12f35681d8e01f8276bd5ca0d054cb7dc635b149838efc69f29104743bbf26c584a7f08#npm:2.1.2"],\
           ["@vitest/pretty-format", "npm:2.1.2"],\
           ["@vitest/runner", "npm:2.1.2"],\
           ["@vitest/snapshot", "npm:2.1.2"],\
@@ -31827,10 +31826,10 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "HARD"\
       }],\
-      ["virtual:86720daff6fa91ef488bb305b0b2c8253fb3fabde470b409f92b17f3b1d6203e3f6631585a5dc2cd5ccefab01339e6676f430f53e0206b9354f687fcc9c70489#npm:2.1.2", {\
-        "packageLocation": "./.yarn/__virtual__/vitest-virtual-99934a2974/0/cache/vitest-npm-2.1.2-6430425a96-3a331a1049.zip/node_modules/vitest/",\
+      ["virtual:bb4ed02b339ed801b02d2ec15b42a5aa7b1afdaf44119aefaab128a59d6e16cc6018880c169f24bf2107550e914562ee9e1780db01a12e1bc3c492ad0a049c36#npm:2.1.2", {\
+        "packageLocation": "./.yarn/__virtual__/vitest-virtual-e327af8e29/0/cache/vitest-npm-2.1.2-6430425a96-3a331a1049.zip/node_modules/vitest/",\
         "packageDependencies": [\
-          ["vitest", "virtual:86720daff6fa91ef488bb305b0b2c8253fb3fabde470b409f92b17f3b1d6203e3f6631585a5dc2cd5ccefab01339e6676f430f53e0206b9354f687fcc9c70489#npm:2.1.2"],\
+          ["vitest", "virtual:bb4ed02b339ed801b02d2ec15b42a5aa7b1afdaf44119aefaab128a59d6e16cc6018880c169f24bf2107550e914562ee9e1780db01a12e1bc3c492ad0a049c36#npm:2.1.2"],\
           ["@edge-runtime/vm", null],\
           ["@types/edge-runtime__vm", null],\
           ["@types/happy-dom", null],\
@@ -31840,7 +31839,7 @@ const RAW_RUNTIME_STATE =
           ["@types/vitest__ui", null],\
           ["@vitest/browser", null],\
           ["@vitest/expect", "npm:2.1.2"],\
-          ["@vitest/mocker", "virtual:5c35b794361dd890bf8d88dcc7af03f2ca07113188cab680b4b85df7c78434e37c7a6767b1ed867236a10e5139f8d323582a6f82ae106407a47b0f0fd19d5528#npm:2.1.2"],\
+          ["@vitest/mocker", "virtual:e327af8e29a76a477fc3ea999bc224ab02a687c4ee35b52bcf99c59ea12f35681d8e01f8276bd5ca0d054cb7dc635b149838efc69f29104743bbf26c584a7f08#npm:2.1.2"],\
           ["@vitest/pretty-format", "npm:2.1.2"],\
           ["@vitest/runner", "npm:2.1.2"],\
           ["@vitest/snapshot", "npm:2.1.2"],\
@@ -31941,7 +31940,7 @@ const RAW_RUNTIME_STATE =
           ["@types/vitest__ui", null],\
           ["@vitest/browser", null],\
           ["@vitest/expect", "npm:2.1.2"],\
-          ["@vitest/mocker", "virtual:359076064a9285b8b15d5b1a7f7427374da544207a98c67be5d139598b418f0e9be2df554db59a534a7be37d4acfa9945577b07994d79254a7498f39cf3250b5#npm:2.1.2"],\
+          ["@vitest/mocker", "virtual:be6c59e6d9ee99e44033677edf92b524d937dba2eb401cd1bd724b58f6c612890520e2ed4326e2df2173c37a3b98fd026e2d4a35f7474dff6f00e30d067e4d13#npm:2.1.2"],\
           ["@vitest/pretty-format", "npm:2.1.2"],\
           ["@vitest/runner", "npm:2.1.2"],\
           ["@vitest/snapshot", "npm:2.1.2"],\
@@ -31959,7 +31958,7 @@ const RAW_RUNTIME_STATE =
           ["tinyexec", "npm:0.3.0"],\
           ["tinypool", "npm:1.0.1"],\
           ["tinyrainbow", "npm:1.2.0"],\
-          ["vite", "virtual:359076064a9285b8b15d5b1a7f7427374da544207a98c67be5d139598b418f0e9be2df554db59a534a7be37d4acfa9945577b07994d79254a7498f39cf3250b5#npm:5.2.10"],\
+          ["vite", "virtual:be6c59e6d9ee99e44033677edf92b524d937dba2eb401cd1bd724b58f6c612890520e2ed4326e2df2173c37a3b98fd026e2d4a35f7474dff6f00e30d067e4d13#npm:5.2.10"],\
           ["vite-node", "npm:2.1.2"],\
           ["why-is-node-running", "npm:2.3.0"]\
         ],\
@@ -32517,10 +32516,10 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "HARD"\
       }],\
-      ["virtual:0d009645becfea4d88882843f0423fcd82285d1b4ccc9cfa7930ffc912a0989555b0246969c43500aed09e6b607d4c48ed0781b1a3705352f665edbcf7185907#npm:7.5.10", {\
-        "packageLocation": "./.yarn/__virtual__/ws-virtual-70de7f155e/0/cache/ws-npm-7.5.10-878ccb886b-9c796b84ba.zip/node_modules/ws/",\
+      ["virtual:222aa3dddeaeaa61af52fac7bb1ac2d89193af1f1652e3dded827e17e51136f3cdf2657f101e4918984f890bad2fb83a40ad7853b91df134ac952fbe7d0a7df7#npm:7.5.10", {\
+        "packageLocation": "./.yarn/__virtual__/ws-virtual-099f9140ed/0/cache/ws-npm-7.5.10-878ccb886b-9c796b84ba.zip/node_modules/ws/",\
         "packageDependencies": [\
-          ["ws", "virtual:0d009645becfea4d88882843f0423fcd82285d1b4ccc9cfa7930ffc912a0989555b0246969c43500aed09e6b607d4c48ed0781b1a3705352f665edbcf7185907#npm:7.5.10"],\
+          ["ws", "virtual:222aa3dddeaeaa61af52fac7bb1ac2d89193af1f1652e3dded827e17e51136f3cdf2657f101e4918984f890bad2fb83a40ad7853b91df134ac952fbe7d0a7df7#npm:7.5.10"],\
           ["@types/bufferutil", null],\
           ["@types/utf-8-validate", null],\
           ["bufferutil", null],\

--- a/packages/openneuro-app/package.json
+++ b/packages/openneuro-app/package.json
@@ -19,7 +19,6 @@
     "@emotion/react": "11.11.1",
     "@emotion/styled": "11.11.0",
     "@niivue/niivue": "0.45.1",
-    "@openneuro/client": "^4.28.3",
     "@openneuro/components": "^4.28.3",
     "@sentry/react": "^8.25.0",
     "@tanstack/react-table": "^8.9.3",

--- a/packages/openneuro-app/src/client.jsx
+++ b/packages/openneuro-app/src/client.jsx
@@ -3,14 +3,12 @@
  */
 import "./scripts/utils/global-polyfill"
 import "./scripts/sentry"
-import { ApolloProvider, InMemoryCache } from "@apollo/client"
-import { createClient } from "@openneuro/client"
+import { ApolloClient, ApolloProvider, InMemoryCache } from "@apollo/client"
 import React from "react"
 import { createRoot } from "react-dom/client"
 import { BrowserRouter, Route, Routes } from "react-router-dom"
 import App from "./scripts/app"
 import Index from "./scripts/index"
-import { version } from "./lerna.json"
 import { config } from "./scripts/config"
 import * as gtag from "./scripts/utils/gtag"
 import { relayStylePagination } from "@apollo/client/utilities"
@@ -20,22 +18,22 @@ gtag.initialize(config.analytics.trackingIds)
 
 const mainElement = document.getElementById("main")
 const container = createRoot(mainElement)
+const client = new ApolloClient({
+  uri: `${config.url}/crn/graphql`,
+  cache: new InMemoryCache({
+    typePolicies: {
+      Query: {
+        fields: {
+          advancedSearch: relayStylePagination(),
+        },
+      },
+    },
+  }),
+})
+
 container.render(
   <App>
-    <ApolloProvider
-      client={createClient(`${config.url}/crn/graphql`, {
-        clientVersion: version,
-        cache: new InMemoryCache({
-          typePolicies: {
-            Query: {
-              fields: {
-                advancedSearch: relayStylePagination(),
-              },
-            },
-          },
-        }),
-      })}
-    >
+    <ApolloProvider client={client}>
       <BrowserRouter>
         <Routes>
           <Route path="*" element={<Index />} />

--- a/packages/openneuro-app/src/scripts/dataset/download/download-query.js
+++ b/packages/openneuro-app/src/scripts/dataset/download/download-query.js
@@ -1,10 +1,43 @@
-import { datasets } from "@openneuro/client"
+import { gql } from "@apollo/client"
+
+export const DOWNLOAD_DATASET = gql`
+query downloadDraft($datasetId: ID!, $tree: String) {
+  dataset(id: $datasetId) {
+    id
+    draft {
+      id
+      files(tree: $tree) {
+        id
+        directory
+        filename
+        size
+        urls
+      }
+    }
+  }
+}
+`
+
+export const DOWNLOAD_SNAPSHOT = gql`
+  query downloadSnapshot($datasetId: ID!, $tag: String!, $tree: String) {
+    snapshot(datasetId: $datasetId, tag: $tag) {
+      id
+      files(tree: $tree) {
+        id
+        directory
+        filename
+        size
+        urls
+      }
+    }
+  }
+`
 
 export const downloadDataset =
   (client) => async ({ datasetId, snapshotTag, tree = null }) => {
     if (snapshotTag) {
       const { data } = await client.query({
-        query: datasets.downloadSnapshot,
+        query: DOWNLOAD_SNAPSHOT,
         variables: {
           datasetId,
           tag: snapshotTag,
@@ -14,7 +47,7 @@ export const downloadDataset =
       return data.snapshot.files
     } else {
       const { data } = await client.query({
-        query: datasets.downloadDataset,
+        query: DOWNLOAD_DATASET,
         variables: {
           datasetId,
           tree,

--- a/packages/openneuro-app/src/scripts/uploader/file-upload-parallel.ts
+++ b/packages/openneuro-app/src/scripts/uploader/file-upload-parallel.ts
@@ -1,0 +1,122 @@
+/**
+ * Convert from a URL compatible path
+ * @param {String} path
+ */
+export const decodeFilePath = (path) => {
+  return path.replace(new RegExp(":", "g"), "/")
+}
+
+/**
+ * Determine parallelism based on Request list
+ * @param {Array<Request>} requests
+ * @param {number} bytes expected total size of all requests
+ * @returns {number}
+ */
+export function uploadParallelism(requests, bytes) {
+  const averageSize = bytes / requests.length
+  const parallelism = averageSize / 524288 // 512KB
+  if (parallelism > 8) {
+    return 8
+  } else if (parallelism < 2) {
+    return 2
+  } else {
+    return Math.round(parallelism)
+  }
+}
+
+/**
+ * Extract filename from Request URL
+ * @param {string} url .../a:path:to:a:file
+ */
+export function parseFilename(url) {
+  const filePath = url.substring(url.lastIndexOf("/") + 1)
+  return decodeFilePath(filePath)
+}
+
+/**
+ * Control retry delay for upload file requests
+ * @param {number} step Attempt number
+ * @param {Request} request Active request
+ */
+export async function retryDelay(step, request) {
+  if (step <= 4) {
+    await new Promise((r) => setTimeout(r, step ** 2 * 1000))
+  } else {
+    throw new Error(
+      `Failed to upload file after ${step} attempts - "${request.url}"`,
+    )
+  }
+}
+
+/**
+ * Repeatable function for single file upload fetch request
+ * @param {object} uploadProgress Progress controller instance
+ * @param {typeof fetch} fetch Fetch implementation to use - useful for environments without a native fetch
+ * @returns {function (Request, number): Promise<Response|void>}
+ */
+export const uploadFile =
+  (uploadProgress, fetch) => async (request, attempt = 1) => {
+    // Create a retry function with attempts incremented
+    const filename = parseFilename(request.url)
+    const handleFailure = async (failure) => {
+      const retryClone = request.clone()
+      // eslint-disable-next-line no-console
+      console.warn(`\nRetrying upload for ${filename}: ${failure}`)
+      try {
+        await retryDelay(attempt, request)
+        return uploadFile(uploadProgress, fetch)(retryClone, attempt + 1)
+      } catch (err) {
+        if ("failUpload" in uploadProgress) {
+          uploadProgress.failUpload(filename)
+        }
+        throw err
+      }
+    }
+    // This is needed to cancel the request in case of client errors
+    if ("startUpload" in uploadProgress) {
+      uploadProgress.startUpload(filename)
+    }
+    try {
+      // Clone before using the request to allow retries to reuse the body
+      const response = await fetch(request)
+      if (response.status === 200) {
+        // We need to wait for the response body or fetch-h2 may leave the connection open
+        await response.json()
+        if ("finishUpload" in uploadProgress) {
+          uploadProgress.finishUpload(filename)
+        }
+        uploadProgress.increment()
+      } else {
+        await handleFailure(response.statusText)
+      }
+    } catch (err) {
+      await handleFailure(err)
+    }
+  }
+
+/**
+ * @param {Request[]} requests
+ * @param {number} totalSize
+ * @param {object} uploadProgress
+ * @param {typeof fetch} fetch
+ */
+export async function uploadParallel(
+  requests,
+  totalSize,
+  uploadProgress,
+  fetch,
+) {
+  // Array stride of parallel requests
+  const parallelism = uploadParallelism(requests, totalSize)
+  for (
+    let rIndex = 0;
+    rIndex < requests.length;
+    rIndex = rIndex + parallelism
+  ) {
+    await Promise.allSettled(
+      requests
+        .slice(rIndex, rIndex + parallelism)
+        .map(uploadFile(uploadProgress, fetch)),
+    )
+  }
+}

--- a/packages/openneuro-app/src/scripts/uploader/file-upload.js
+++ b/packages/openneuro-app/src/scripts/uploader/file-upload.js
@@ -1,5 +1,5 @@
 import { config } from "../config"
-import { uploads } from "@openneuro/client"
+import { uploadParallel } from "./file-upload-parallel"
 
 /**
  * Trim the webkitRelativePath value to only include the dataset relative path
@@ -38,7 +38,7 @@ export const getRelativePath = (
  */
 export const encodeFilePath = (file, options = { stripRelativePath: false }) =>
   file.webkitRelativePath
-    ? uploads.encodeFilePath(getRelativePath(file, options))
+    ? getRelativePath(file, options).replace(new RegExp("/", "g"), ":")
     : file.name
 
 /**
@@ -85,5 +85,5 @@ export async function uploadFiles({
 
   // No background fetch
   // Parallelism is handled by the client in this case
-  return uploads.uploadParallel(requests, totalSize, uploadProgress, fetch)
+  return uploadParallel(requests, totalSize, uploadProgress, fetch)
 }

--- a/packages/openneuro-app/src/scripts/uploader/hash-file-list.ts
+++ b/packages/openneuro-app/src/scripts/uploader/hash-file-list.ts
@@ -1,0 +1,36 @@
+/**
+ * Java hashcode implementation for browser and Node.js
+ * @param {string} str
+ */
+function hashCode(str) {
+  return str
+    .split("")
+    .reduce(
+      (prevHash, currVal) =>
+        ((prevHash << 5) - prevHash + currVal.charCodeAt(0)) | 0,
+      0,
+    )
+}
+
+/**
+ * Calculate a hash from a list of files to upload
+ * @param {string} datasetId Dataset namespace for this hash
+ * @param {Array<object>} files Files being uploaded
+ * @returns {string} Hex string identity hash
+ */
+export function hashFileList(datasetId, files) {
+  return Math.abs(
+    hashCode(
+      datasetId +
+        files
+          .map(
+            (f) =>
+              `${
+                "webkitRelativePath" in f ? f.webkitRelativePath : f.filename
+              }:${f.size}`,
+          )
+          .sort()
+          .join(":"),
+    ),
+  ).toString(16)
+}

--- a/packages/openneuro-app/src/scripts/uploader/upload-mutation.js
+++ b/packages/openneuro-app/src/scripts/uploader/upload-mutation.js
@@ -1,5 +1,33 @@
-import { datasets, uploads } from "@openneuro/client"
+import { gql } from "@apollo/client"
 import { SUBMIT_METADATA } from "../dataset/mutations/submit-metadata.jsx"
+
+export const CREATE_DATASET = gql`
+  mutation createDataset($affirmedDefaced: Boolean, $affirmedConsent: Boolean) {
+    createDataset(
+      affirmedDefaced: $affirmedDefaced
+      affirmedConsent: $affirmedConsent
+    ) {
+      id
+    }
+  }
+`
+
+export const PREPARE_UPLOAD = gql`
+  mutation prepareUpload($datasetId: ID!, $uploadId: ID!) {
+    prepareUpload(datasetId: $datasetId, uploadId: $uploadId) {
+      id
+      datasetId
+      token
+      endpoint
+    }
+  }
+`
+
+export const FINISH_UPLOAD = gql`
+  mutation finishUpload($uploadId: ID!) {
+    finishUpload(uploadId: $uploadId)
+  }
+`
 
 /**
  * Create a dataset and update the label
@@ -9,7 +37,7 @@ export const createDataset =
   (client) => ({ affirmedDefaced, affirmedConsent }) => {
     return client
       .mutate({
-        mutation: datasets.createDataset,
+        mutation: CREATE_DATASET,
         variables: { affirmedDefaced, affirmedConsent },
         errorPolicy: "all",
       })
@@ -22,7 +50,7 @@ export const createDataset =
  */
 export const prepareUpload = (client) => ({ datasetId, uploadId }) => {
   return client.mutate({
-    mutation: uploads.prepareUpload,
+    mutation: PREPARE_UPLOAD,
     variables: { datasetId, uploadId },
   })
 }
@@ -33,7 +61,7 @@ export const prepareUpload = (client) => ({ datasetId, uploadId }) => {
  */
 export const finishUpload = (client) => (uploadId) => {
   return client.mutate({
-    mutation: uploads.finishUpload,
+    mutation: FINISH_UPLOAD,
     variables: { uploadId },
   })
 }

--- a/packages/openneuro-app/src/scripts/utils/datalad.js
+++ b/packages/openneuro-app/src/scripts/utils/datalad.js
@@ -1,9 +1,15 @@
-import { datasets } from "@openneuro/client"
+import { gql } from "@apollo/client"
+
+export const TRACK_ANALYTICS = gql`
+  mutation ($datasetId: ID!, $tag: String, $type: AnalyticTypes!) {
+    trackAnalytics(datasetId: $datasetId, tag: $tag, type: $type)
+  }
+`
 
 export function trackAnalytics(client, datasetId, options) {
   options = options || {}
   return client.mutate({
-    mutation: datasets.trackAnalytics,
+    mutation: TRACK_ANALYTICS,
     variables: {
       datasetId: datasetId,
       tag: options.tag,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5740,7 +5740,6 @@ __metadata:
     "@emotion/react": "npm:11.11.1"
     "@emotion/styled": "npm:11.11.0"
     "@niivue/niivue": "npm:0.45.1"
-    "@openneuro/client": "npm:^4.28.3"
     "@openneuro/components": "npm:^4.28.3"
     "@sentry/react": "npm:^8.25.0"
     "@tanstack/react-table": "npm:^8.9.3"


### PR DESCRIPTION
The client package will no longer be needed with the move to deno CLI and this allows for frontend specific client configuration.

Fixes error handling not bubbling up properly across the React app. Otherwise no functional changes.