### PR TITLE
fix(app): Display pending validation when schema validator is running

### DIFF
--- a/packages/openneuro-app/src/scripts/dataset/components/ValidationBlock.tsx
+++ b/packages/openneuro-app/src/scripts/dataset/components/ValidationBlock.tsx
@@ -39,10 +39,10 @@ export const ValidationBlock: React.FC<ValidationBlockProps> = ({
       </div>
     )
   } else {
-    // Reconstruct DatasetIssues from JSON
-    const datasetIssues = new DatasetIssues()
     // If data exists, populate this. Otherwise we show pending.
     if (validation?.issues) {
+      // Reconstruct DatasetIssues from JSON
+      const datasetIssues = new DatasetIssues()
       datasetIssues.issues = validation.issues
       datasetIssues.codeMessages = validation.codeMessages.reduce(
         (acc, curr) => {
@@ -51,11 +51,17 @@ export const ValidationBlock: React.FC<ValidationBlockProps> = ({
         },
         new Map<string, string>(),
       )
+      return (
+        <div className="validation-accordion">
+          <Validation issues={datasetIssues} />
+        </div>
+      )
+    } else {
+      return (
+        <div className="validation-accordion">
+          <Validation issues={null} />
+        </div>
+      )
     }
-    return (
-      <div className="validation-accordion">
-        <Validation issues={datasetIssues} />
-      </div>
-    )
   }
 }

--- a/packages/openneuro-app/src/scripts/dataset/components/__tests__/ValidationBlock.spec.tsx
+++ b/packages/openneuro-app/src/scripts/dataset/components/__tests__/ValidationBlock.spec.tsx
@@ -1,0 +1,42 @@
+import React from "react"
+import { render, screen } from "@testing-library/react"
+import { ValidationBlock } from "../ValidationBlock"
+import { vi } from "vitest"
+
+vi.mock("../../../config.ts")
+
+describe("ValidationBlock component", () => {
+  it("renders legacy validation if issues prop is present", () => {
+    const issues = [
+      {},
+    ]
+    render(<ValidationBlock datasetId="ds000031" issues={issues} />)
+    expect(screen.getByText("BIDS Validation")).toBeInTheDocument()
+  })
+  it("renders schema validation if validation prop is present", () => {
+    const validation = {
+      issues: [
+        {
+          code: "JSON_KEY_RECOMMENDED",
+          location: "/dataset_description.json",
+          rule: "rules.dataset_metadata.dataset_description",
+          subCode: "DatasetType",
+        },
+      ],
+      codeMessages: [
+        { code: "JSON_KEY_RECOMMENDED", message: "message" },
+      ],
+    }
+    render(
+      <ValidationBlock
+        datasetId="ds000031"
+        validation={validation}
+      />,
+    )
+    expect(screen.getByText("BIDS Validation")).toBeInTheDocument()
+  })
+  it("renders pending validation if neither issues nor validation props are present", () => {
+    render(<ValidationBlock datasetId="ds000031" />)
+    expect(screen.getByText("Validation Pending")).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
Fixes a regression found in 4.29.0-alpha.0. Validation would display "valid" while the schema validator was running instead of pending.