### PR TITLE
fix(worker): Avoid .bidsignore fatal warning on push

### DIFF
--- a/services/datalad/hooks/pre-receive
+++ b/services/datalad/hooks/pre-receive
@@ -124,10 +124,7 @@ function main() {
     filterDotFiles
 
     # Check if .bidsignore is in the new tree
-    local bidsignore=$(git show "${newref}:.bidsignore")
-    if [[ "$?" != 0 ]]; then
-      bidsignore=""
-    fi
+    local bidsignore=$(git show "${newref}:.bidsignore" 2> /dev/null)
 
     # Run validation with bidsschematools
     python -m bidsschematools pre-receive-hook <<END


### PR DESCRIPTION
Prevents this expected warning from being displayed by the git client during pushes.

```
remote: fatal: path '.bidsignore' does not exist in '3ef30e4a79e1f36b47ae08910feb597703e0d5bc'
```