### PR TITLE
fix(app): Prevent loading files for viewers with built in data transfer

### DIFF
--- a/packages/openneuro-app/src/scripts/dataset/files/__tests__/file-types.spec.ts
+++ b/packages/openneuro-app/src/scripts/dataset/files/__tests__/file-types.spec.ts
@@ -1,0 +1,15 @@
+import { isNifti, isNwb } from "../file-types"
+
+describe("isNifti()", () => {
+  it("detects nifti files", () => {
+    expect(isNifti("sub-01/anat/sub-01_T1w.nii.gz")).toBeTruthy()
+    expect(isNifti("dataset_description.json")).toBeFalsy()
+  })
+})
+describe("isNwb()", () => {
+  it("detects nwb/edf files", () => {
+    expect(isNwb("eeg/sub-5_task-oa_eeg.edf")).toBeTruthy()
+    expect(isNwb("eeg/sub-cbm009_task-protmap_eeg.edf")).toBeTruthy()
+    expect(isNwb("sub-01/anat/sub-01_T1w.nii.gz")).toBeFalsy()
+  })
+})

--- a/packages/openneuro-app/src/scripts/dataset/files/file-types.ts
+++ b/packages/openneuro-app/src/scripts/dataset/files/file-types.ts
@@ -1,0 +1,10 @@
+export function isNifti(path) {
+  return path.endsWith(".nii.gz") ||
+    path.endsWith(".nii") ||
+    path.endsWith(".mgh") ||
+    path.endsWith(".mgz")
+}
+
+export function isNwb(path) {
+  return path.endsWith(".edf") || path.endsWith(".nwb")
+}

--- a/packages/openneuro-app/src/scripts/dataset/files/file-view.jsx
+++ b/packages/openneuro-app/src/scripts/dataset/files/file-view.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react"
 import { Loading } from "@openneuro/components/loading"
 import FileViewerType from "./file-viewer-type.jsx"
+import { isNifti, isNwb } from "./file-types"
 
 const FileView = ({ url, path }) => {
   const [data, setData] = useState(new ArrayBuffer(0))
@@ -15,7 +16,12 @@ const FileView = ({ url, path }) => {
 
   useEffect(() => {
     if (loading) {
-      fetchUrl()
+      // These viewers load their own data
+      if (isNifti(path) || isNwb(path)) {
+        setLoading(false)
+      } else {
+        fetchUrl()
+      }
     }
   })
 

--- a/packages/openneuro-app/src/scripts/dataset/files/file-viewer-type.jsx
+++ b/packages/openneuro-app/src/scripts/dataset/files/file-viewer-type.jsx
@@ -7,6 +7,7 @@ import FileViewerTsv from "./viewers/file-viewer-tsv.jsx"
 import FileViewerCsv from "./viewers/file-viewer-csv.jsx"
 import FileViewerHtml from "./viewers/file-viewer-html.jsx"
 import { FileViewerNeurosift } from "./viewers/file-viewer-neurosift"
+import { isNifti } from "./file-types"
 
 /**
  * Choose the right viewer for each file type
@@ -21,10 +22,7 @@ const FileViewerType = ({ path, url, data }) => {
   ) {
     return <FileViewerText data={data} />
   } else if (
-    path.endsWith(".nii.gz") ||
-    path.endsWith(".nii") ||
-    path.endsWith(".mgh") ||
-    path.endsWith(".mgz")
+    isNifti(path)
   ) {
     return <FileViewerNifti imageUrl={url} />
   } else if (path.endsWith(".json")) {


### PR DESCRIPTION
Skip data requests for some files when the viewer includes data loading.

Fixes #3225 