### PR TITLE
fix(app): prevent unnecessary download of EDF/NWB data to browser

### DIFF
--- a/packages/openneuro-app/src/scripts/dataset/files/file-view.jsx
+++ b/packages/openneuro-app/src/scripts/dataset/files/file-view.jsx
@@ -1,13 +1,18 @@
 import React, { useEffect, useState } from "react"
 import { Loading } from "@openneuro/components/loading"
 import FileViewerType from "./file-viewer-type.jsx"
-import { isNifti, isNwb } from "./file-types"
 
 const FileView = ({ url, path }) => {
   const [data, setData] = useState(new ArrayBuffer(0))
   const [loading, setLoading] = useState(true)
 
   const fetchUrl = async () => {
+    if (path.endsWith(".edf") || path.endsWith(".nwb")) {
+      // don't actually download the data for these file types
+      setData(new ArrayBuffer(0))
+      setLoading(false)
+      return
+    }
     const response = await fetch(url)
     const data = await response.arrayBuffer()
     setData(data)
@@ -16,12 +21,7 @@ const FileView = ({ url, path }) => {
 
   useEffect(() => {
     if (loading) {
-      // These viewers load their own data
-      if (isNifti(path) || isNwb(path)) {
-        setLoading(false)
-      } else {
-        fetchUrl()
-      }
+      fetchUrl()
     }
   })
 


### PR DESCRIPTION
Recently support for viewing EDF and NWB files was added by embedding a Neurosift iframe
https://github.com/OpenNeuroOrg/openneuro/pull/3187

However I recently noticed that when navigating to such a file, the entire content of the file gets downloaded to the browser before the view is rendered. This is unnecessary (and potentially very resource demanding) as neurosift handles efficient lazy-loading of the file without downloading the entire thing.

This PR solves the issue by conditionally skipping the fetch step in the case of these file extension types.

tag: @nellh