### PR TITLE
fix(app): Avoid modifying the array when reading file URLs for browser downloads

### DIFF
--- a/packages/openneuro-app/src/scripts/dataset/download/download-native.js
+++ b/packages/openneuro-app/src/scripts/dataset/download/download-native.js
@@ -82,7 +82,7 @@ const downloadTree = async (
       // Skip files which are already complete
       if (fileHandle.size == file.size) continue
       const writable = await fileHandle.createWritable()
-      const { body, status, statusText } = await fetch(file.urls.pop())
+      const { body, status, statusText } = await fetch(file.urls[0])
       let loaded = 0
       const progress = new TransformStream({
         transform(chunk, controller) {


### PR DESCRIPTION
Fixes issue #3232 caused by this array no longer being possible to modify in place.