### PR TITLE
fix(cli): Ship commonjs instead of typescript for npm

### DIFF
--- a/packages/openneuro-cli/tsconfig.json
+++ b/packages/openneuro-cli/tsconfig.json
@@ -3,6 +3,8 @@
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist",
+    "module": "commonjs",
+    "moduleResolution": "node",
     "tsBuildInfoFile": "../../.build-cache/cli.tsbuildinfo"
   },
   "include": ["./src"],

--- a/packages/openneuro-client/tsconfig.json
+++ b/packages/openneuro-client/tsconfig.json
@@ -3,6 +3,8 @@
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist",
+    "module": "commonjs",
+    "moduleResolution": "node",
     "tsBuildInfoFile": "../../.build-cache/client.tsbuildinfo"
   },
   "include": ["src"],


### PR DESCRIPTION
This fixes a regression with the CLI package being shipped in the wrong dist format.