### PR TITLE
chore(server): Add telemetry for failed ORCID auth

### DIFF
--- a/packages/openneuro-server/src/libs/authentication/orcid.ts
+++ b/packages/openneuro-server/src/libs/authentication/orcid.ts
@@ -1,6 +1,7 @@
 import passport from "passport"
 import User from "../../models/user"
 import { parsedJwtFromRequest } from "./jwt"
+import * as Sentry from "@sentry/node"
 
 export const requestAuth = passport.authenticate("orcid", {
   session: false,
@@ -9,6 +10,7 @@ export const requestAuth = passport.authenticate("orcid", {
 export const authCallback = (req, res, next) =>
   passport.authenticate("orcid", (err, user) => {
     if (err) {
+      Sentry.captureException(err)
       if (err.type) {
         return res.redirect(`/error/orcid/${err.type}`)
       } else {

--- a/packages/openneuro-server/src/libs/orcid.ts
+++ b/packages/openneuro-server/src/libs/orcid.ts
@@ -2,6 +2,7 @@
 import request from "request"
 import xmldoc from "xmldoc"
 import config from "../config"
+import * as Sentry from "@sentry/node"
 
 export default {
   getProfile(token) {
@@ -20,6 +21,7 @@ export default {
         },
         (err, res) => {
           if (err) {
+            Sentry.captureException(err)
             reject({
               message:
                 "An unexpected ORCID login failure occurred, please try again later.",


### PR DESCRIPTION
Seeing this fail occasionally and this way we can record the frequency and what sort of errors are detected.