### PR TITLE
fix(server): Prevent doNotCache error when an exception occurs during a cache miss

### DIFF
--- a/packages/openneuro-server/src/cache/__tests__/item.spec.ts
+++ b/packages/openneuro-server/src/cache/__tests__/item.spec.ts
@@ -1,0 +1,32 @@
+import CacheItem from "../item"
+import { CacheType } from "../types"
+
+const redisMock = vi.fn(() => ({
+  getBuffer: vi.fn(),
+  setex: vi.fn(),
+  set: vi.fn(),
+}))
+
+describe("CacheItem", () => {
+  it("should succeed when the cache miss sets doNotCache but throws an exception", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const item = new CacheItem(redisMock() as any, CacheType.commitFiles, [
+      "ds000001",
+      "12345678",
+    ])
+    let fail = true
+    expect(
+      await item.get(async (doNotCache) => {
+        // On the first try
+        if (fail) {
+          fail = false
+          doNotCache(true)
+          throw new Error("expected failure")
+        } else {
+          doNotCache(false)
+          return true
+        }
+      }),
+    ).toBe(true)
+  })
+})

--- a/packages/openneuro-server/src/cache/item.ts
+++ b/packages/openneuro-server/src/cache/item.ts
@@ -2,6 +2,7 @@ import type { Redis } from "ioredis"
 import * as zlib from "zlib"
 import { promisify } from "util"
 import type { CacheType } from "./types"
+import * as Sentry from "@sentry/node"
 export { CacheType } from "./types"
 
 const compress = promisify(zlib.gzip)
@@ -77,9 +78,10 @@ class CacheItem {
         }
         return data
       }
-    } catch {
+    } catch (err) {
+      Sentry.captureException(err)
       // Keep going as though we had a cache miss if there is a problem but don't cache it
-      return miss()
+      return miss((_doNotCache: boolean) => {})
     }
   }
   /**


### PR DESCRIPTION
It's expected that Redis cache items cache miss function may fail on the first call. The miss should be retried but this would always fail because of the missing doNotCache signal. This fix calls the cache miss and passes in the required signal but ignores it. If the second miss fails, the error is handled by the caller.

Adds a test for this case and now logs the failure.