### PR TITLE
ci: Bump macos-12 to macos-14 for Deno test

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -18,7 +18,7 @@ jobs:
     timeout-minutes: 5
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-12]
+        os: [ubuntu-22.04, macos-14]
       fail-fast: false
     defaults:
       run:


### PR DESCRIPTION
Update to a more current release of the macOS environment for CI.