### PR TITLE
Provide correct error feedback for Deno CLI auth

### DIFF
--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -14,7 +14,7 @@ export function getConfig(): ClientConfig {
   const url = localStorage.getItem("url")
   const token = localStorage.getItem("token")
   const errorReporting = localStorage.getItem("errorReporting") === "true"
-  if (url && token && errorReporting) {
+  if (url && token) {
     const config: ClientConfig = {
       url,
       token,

--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -22,7 +22,7 @@ export function getConfig(): ClientConfig {
     }
     return config
   } else {
-    throw new LoginError("Run `openneuro login` before upload.")
+    throw new LoginError("Run `openneuro login` before running commands.")
   }
 }
 


### PR DESCRIPTION
Fixes a couple error handling issues in CLI auth.

* LoginError would throw a mismatched error message for any commands besides upload.
* errorReporting false would always throw an auth error.