### PR TITLE
fix(server): Limit validation to 50k issues

### DIFF
--- a/packages/openneuro-server/src/graphql/resolvers/__tests__/validation.spec.ts
+++ b/packages/openneuro-server/src/graphql/resolvers/__tests__/validation.spec.ts
@@ -1,0 +1,22 @@
+import { validationSeveritySort } from "../validation"
+
+vi.mock("../../../config.ts")
+
+describe("validation resolvers", () => {
+  describe("validationSeveritySort", () => {
+    it("sorts severity error before warning", () => {
+      const issues = [
+        { severity: "warning" },
+        { severity: "error" },
+        { severity: "error" },
+        { severity: "warning" },
+        { severity: "error" },
+      ]
+      const sortedIssues = issues.sort(validationSeveritySort)
+      expect(sortedIssues[0].severity).toBe("error")
+      expect(sortedIssues[1].severity).toBe("error")
+      expect(sortedIssues[2].severity).toBe("error")
+      expect(sortedIssues[3].severity).toBe("warning")
+    })
+  })
+})

--- a/packages/openneuro-server/src/graphql/resolvers/validation.ts
+++ b/packages/openneuro-server/src/graphql/resolvers/validation.ts
@@ -38,12 +38,21 @@ export const snapshotValidation = async (snapshot) => {
     .exec()
 }
 
+export function validationSeveritySort(a, b) {
+  return a.severity.localeCompare(b.severity)
+}
+
 /**
  * Save issues data returned by the datalad service
  *
  * Returns only a boolean if successful or not
  */
 export const updateValidation = (obj, args) => {
+  // Limit to 50k issues with errors sorted first
+  if (args.validation.issues.length > 50000) {
+    args.validation.issues.sort(validationSeveritySort)
+    args.validation.issues = args.validation.issues.slice(0, 50000)
+  }
   return Validation.updateOne(
     {
       id: args.validation.id,


### PR DESCRIPTION
Prevents failing to report validation for datasets with larger than 16MB BSON issues.

We may remove this limit if the upstream validator provides a less verbose output.