### PR TITLE
feat(git): Whitelist git and datalad dotfiles in pre-receive hook

### DIFF
--- a/services/datalad/hooks/pre-receive
+++ b/services/datalad/hooks/pre-receive
@@ -29,6 +29,16 @@ README* annex.largefiles=nothing
 LICENSE annex.largefiles=nothing
 "
 
+# Acceptable dotfiles
+readonly WHITELIST=".bidsignore
+.gitattributes
+.gitignore
+.gitmodules
+**/.gitattributes
+**/.gitignore
+.datalad/.gitattributes
+.datalad/config"
+
 function validateGitAttributes() {
   # Find .gitattributes file
   local gitAttributes=$(git show "${newref}:.gitattributes")
@@ -51,7 +61,7 @@ function validateGitAttributes() {
 function filterDotFiles() {
   local newFiles=$(git diff --stat --name-only --diff-filter=ACMRT ${oldref}..${newref})
   for filename in $newFiles; do
-    if [[ "$filename" = ".bidsignore" ]] || [[ "$filename" =~ ".gitattributes" ]] || [[ "$filename" = ".gitmodules" ]] || [[ "$filename" =~ ^.gitignore|\/\.gitignore ]] || [[ "$filename" =~ ^\.datalad ]]; then
+    if [[ "$filename" = ".bidsignore" ]] || [[ "$filename" =~ \.git(attributes|ignore)$ ]] || [[ "$filename" = ".gitmodules" ]] || [[ "$filename" =~ ^\.datalad ]]; then
       continue
     fi
     if [[ "$filename" =~ ^\..*|\/\..* ]]; then
@@ -151,9 +161,7 @@ function main() {
     python -m bidsschematools pre-receive-hook <<END
 bids-hook-v2
 $( git show "${newref}:dataset_description.json" | tr -d '\r\n' )
-.datalad/config
-.gitattributes
-.bidsignore
+${WHITELIST}
 ${bidsignore}
 0001
 $( git ls-tree --name-only -r "${newref}" )


### PR DESCRIPTION
This is a minimal response to #3143, ensuring standard git and datalad files are permitted, along with `.bidsignore`.

I was not able to figure out an easy way to deduplicate the whitelist to pass to `bst pre-receive-hook` with our `filterDotFiles()` function.

In general I prefer a whitelist to a blacklist, as it is otherwise too easy to introduce garbage by adding `.*` to `.bidsignore`. If we want to support `.bids-validator-config.json`, then we will need to have a way of making our configuration take precedence. That will probably require an update to the validator.