### PR TITLE
fix(cli): Show download finished message only after it has completely run

### DIFF
--- a/cli/src/commands/download.ts
+++ b/cli/src/commands/download.ts
@@ -51,7 +51,11 @@ export async function downloadAction(
   // Close after all tasks are queued
   worker.postMessage({ command: "done" })
 
-  console.log(
-    "Download complete. To download all data files, use `datalad get` or `git-annex get`.",
-  )
+  worker.addEventListener("message", (event) => {
+    if (event.data.command === "closed") {
+      console.log(
+        "Download complete. To download all data files, use `datalad get` or `git-annex get`.",
+      )
+    }
+  })
 }


### PR DESCRIPTION
For smaller datasets this would be pretty synchronous but the worker can be transferring objects for a while. Wait for the worker to send the closed message before showing the download complete message.