### PR TITLE
fix(cli): Configure and enable a git-annex remote when downloading datasets

### DIFF
--- a/cli/src/commands/download.ts
+++ b/cli/src/commands/download.ts
@@ -44,8 +44,14 @@ export async function downloadAction(
 
   console.log("Downloading...")
 
+  // Clone main/master and git-annex branches
   worker.postMessage({
     "command": "clone",
+  })
+
+  // Setup any git-annex remotes required for downloads
+  worker.postMessage({
+    "command": "remote-setup",
   })
 
   // Close after all tasks are queued


### PR DESCRIPTION
Adds a new git-annex worker command to enable remote configuration. This will setup a working remote during download to skip the enableremote step before using datalad get or git-annex get on objects in a downloaded dataset.