### PR TITLE
tests(cli): Increase tolerance of timing for PromiseQueue test

### DIFF
--- a/cli/src/worker/queue.test.ts
+++ b/cli/src/worker/queue.test.ts
@@ -10,14 +10,14 @@ Deno.test("PromiseQueue should execute promises in order", async () => {
     order.push(1)
   })
   promiseQueue.enqueue(async () => {
-    await new Promise((resolve) => setTimeout(resolve, 5))
+    await new Promise((resolve) => setTimeout(resolve, 10))
     order.push(2)
   })
   promiseQueue.enqueue(async () => {
     order.push(3)
   })
 
-  await new Promise((resolve) => setTimeout(resolve, 20))
+  await new Promise((resolve) => setTimeout(resolve, 50))
 
   assertEquals(order, [1, 2, 3])
 })


### PR DESCRIPTION
This fails on macOS because the event loop takes longer to process the two setTimeout calls. Increasing the tolerance to 50ms seems to work.