### PR TITLE
ci(deno): Use version 2.0 to prevent lockfile mismatch on publish

### DIFF
--- a/.github/workflows/deno-jsr.yml
+++ b/.github/workflows/deno-jsr.yml
@@ -18,5 +18,5 @@ jobs:
       - uses: actions/checkout@v4
       - uses: denoland/setup-deno@v2
         with:
-          deno-version: v1.x
+          deno-version: v2.x
       - run: deno publish


### PR DESCRIPTION
Update to the latest version of Deno for publishing to prevent this failure:

https://github.com/OpenNeuroOrg/openneuro/actions/runs/12817467427/job/35740756628