### PR TITLE
fix(cli): Fix path-browserify throwing syntax error

### DIFF
--- a/cli/deno.json
+++ b/cli/deno.json
@@ -31,6 +31,6 @@
     "@std/testing": "jsr:@std/testing@^1.0.1",
     "@wok/djwt": "jsr:@wok/djwt@^3.0.2",
     "ignore": "npm:ignore@^5.3.0",
-    "isomorphic-git": "npm:isomorphic-git@^1.25.6"
+    "isomorphic-git": "npm:isomorphic-git@1.27.1"
   }
 }

--- a/cli/deno.lock
+++ b/cli/deno.lock
@@ -14,6 +14,7 @@
     "jsr:@cliffy/keycode@1.0.0-rc.7": "1.0.0-rc.7",
     "jsr:@cliffy/prompt@^1.0.0-rc.7": "1.0.0-rc.7",
     "jsr:@cliffy/table@1.0.0-rc.5": "1.0.0-rc.5",
+    "jsr:@cliffy/table@1.0.0-rc.7": "1.0.0-rc.7",
     "jsr:@deno-library/progress@^1.4.9": "1.4.9",
     "jsr:@effigies/cliffy-command@1.0.0-dev.8": "1.0.0-dev.8",
     "jsr:@effigies/cliffy-table@1.0.0-dev.5": "1.0.0-dev.5",
@@ -23,6 +24,7 @@
     "jsr:@std/assert@1.0.0-rc.2": "1.0.0-rc.2",
     "jsr:@std/assert@^1.0.3": "1.0.10",
     "jsr:@std/assert@~1.0.6": "1.0.10",
+    "jsr:@std/async@^1.0.4": "1.0.9",
     "jsr:@std/bytes@^1.0.2": "1.0.2",
     "jsr:@std/bytes@^1.0.3": "1.0.4",
     "jsr:@std/cli@1.0.0-rc.2": "1.0.0-rc.2",
@@ -44,7 +46,7 @@
     "jsr:@std/fs@^1.0.3": "1.0.3",
     "jsr:@std/fs@^1.0.4": "1.0.8",
     "jsr:@std/fs@^1.0.7": "1.0.8",
-    "jsr:@std/internal@^1.0.2": "1.0.2",
+    "jsr:@std/internal@^1.0.2": "1.0.5",
     "jsr:@std/internal@^1.0.5": "1.0.5",
     "jsr:@std/io@0.225": "0.225.0",
     "jsr:@std/io@~0.224.2": "0.224.7",
@@ -81,7 +83,7 @@
     "npm:isomorphic-git@*": "1.27.1",
     "npm:isomorphic-git@1.25.3": "1.25.3",
     "npm:isomorphic-git@1.25.6": "1.25.6",
-    "npm:isomorphic-git@^1.25.6": "1.27.1"
+    "npm:isomorphic-git@1.27.1": "1.27.1"
   },
   "jsr": {
     "@bids/schema@1.0.0": {
@@ -125,7 +127,7 @@
       "dependencies": [
         "jsr:@cliffy/flags@1.0.0-rc.5",
         "jsr:@cliffy/internal@1.0.0-rc.5",
-        "jsr:@cliffy/table",
+        "jsr:@cliffy/table@1.0.0-rc.5",
         "jsr:@std/fmt@~0.225.4",
         "jsr:@std/text@1.0.0-rc.1"
       ]
@@ -187,6 +189,12 @@
         "jsr:@std/fmt@~0.225.4"
       ]
     },
+    "@cliffy/table@1.0.0-rc.7": {
+      "integrity": "9fdd9776eda28a0b397981c400eeb1aa36da2371b43eefe12e6ff555290e3180",
+      "dependencies": [
+        "jsr:@std/fmt@~1.0.2"
+      ]
+    },
     "@deno-library/progress@1.4.9": {
       "integrity": "86db695ae338cb1ae3ffa46d6f2e6a9cdef33a15c2ace6fa25354a91a9dd3909",
       "dependencies": [
@@ -198,6 +206,7 @@
       "dependencies": [
         "jsr:@cliffy/flags@1.0.0-rc.7",
         "jsr:@cliffy/internal@1.0.0-rc.7",
+        "jsr:@cliffy/table@1.0.0-rc.7",
         "jsr:@effigies/cliffy-table@^1.0.0-dev.5",
         "jsr:@std/fmt@~1.0.2",
         "jsr:@std/text@~1.0.7"
@@ -232,6 +241,9 @@
       "dependencies": [
         "jsr:@std/internal@^1.0.5"
       ]
+    },
+    "@std/async@1.0.9": {
+      "integrity": "c6472fd0623b3f3daae023cdf7ca5535e1b721dfbf376562c0c12b3fb4867f91"
     },
     "@std/bytes@1.0.2": {
       "integrity": "fbdee322bbd8c599a6af186a1603b3355e59a5fb1baa139f8f4c3c9a1b3e3d57"
@@ -374,6 +386,7 @@
       "integrity": "9c25841137ee818933e1722091bb9ed5fdc251c35e84c97979a52196bdb6c5c3",
       "dependencies": [
         "jsr:@std/assert@^1.0.3",
+        "jsr:@std/async",
         "jsr:@std/data-structures",
         "jsr:@std/fs@^1.0.2",
         "jsr:@std/internal@^1.0.2",
@@ -1153,7 +1166,7 @@
       "jsr:@wok/djwt@^3.0.2",
       "npm:@sentry/deno@^8.27.0",
       "npm:ignore@^5.3.0",
-      "npm:isomorphic-git@^1.25.6"
+      "npm:isomorphic-git@1.27.1"
     ]
   }
 }


### PR DESCRIPTION
This is a regression introduced by isomorphic-git@1.27.2.

Pinning to the older version until this can be fixed upstream. Previously isomorphic-git would use an internal implementation of path.join but broke deno support by migrating to path-browserify.

Fixes #3289 