### PR TITLE
fix(cli): Be consistent about using deno.json's import map

### DIFF
--- a/cli/deno.json
+++ b/cli/deno.json
@@ -31,6 +31,7 @@
     "@std/testing": "jsr:@std/testing@^1.0.1",
     "@wok/djwt": "jsr:@wok/djwt@^3.0.2",
     "ignore": "npm:ignore@^5.3.0",
-    "isomorphic-git": "npm:isomorphic-git@1.27.1"
+    "isomorphic-git": "npm:isomorphic-git@1.27.1",
+    "hash-wasm": "npm:hash-wasm@^4.12.0"
   }
 }

--- a/cli/deno.lock
+++ b/cli/deno.lock
@@ -74,6 +74,7 @@
     "npm:@types/node@*": "18.16.19",
     "npm:ajv@8.17.1": "8.17.1",
     "npm:hash-wasm@*": "4.11.0",
+    "npm:hash-wasm@^4.12.0": "4.12.0",
     "npm:hed-validator@3.15.5": "3.15.5",
     "npm:ignore@*": "5.3.2",
     "npm:ignore@5.3.0": "5.3.0",
@@ -506,6 +507,9 @@
     },
     "hash-wasm@4.11.0": {
       "integrity": "sha512-HVusNXlVqHe0fzIzdQOGolnFN6mX/fqcrSAOcTBXdvzrXVHwTz11vXeKRmkR5gTuwVpvHZEIyKoePDvuAR+XwQ=="
+    },
+    "hash-wasm@4.12.0": {
+      "integrity": "sha512-+/2B2rYLb48I/evdOIhP+K/DD2ca2fgBjp6O+GBEnCDk2e4rpeXIK8GvIyRPjTezgmWn9gmKwkQjjx6BtqDHVQ=="
     },
     "hed-validator@3.15.5": {
       "integrity": "sha512-os1Q2ecNT2QwVLHISjjHKvodW3cyuSnOKCadjggcMd7f6QmMwuSg1E4pyqOX2MxruMbAt4/K4Qiju+lIUm89iQ==",
@@ -1165,6 +1169,7 @@
       "jsr:@std/testing@^1.0.1",
       "jsr:@wok/djwt@^3.0.2",
       "npm:@sentry/deno@^8.27.0",
+      "npm:hash-wasm@^4.12.0",
       "npm:ignore@^5.3.0",
       "npm:isomorphic-git@1.27.1"
     ]

--- a/cli/src/gitattributes.ts
+++ b/cli/src/gitattributes.ts
@@ -1,4 +1,4 @@
-import ignore from "npm:ignore"
+import ignore from "ignore"
 /**
  * Git annex supports many backends, we support a limited subset used by OpenNeuro (for now)
  * https://git-annex.branchable.com/backends/

--- a/cli/src/worker/annex.ts
+++ b/cli/src/worker/annex.ts
@@ -1,12 +1,12 @@
 import type { GitWorkerContext } from "./types/git-context.ts"
 import { basename, dirname, join, relative } from "@std/path"
-import { default as git } from "npm:isomorphic-git"
+import { default as git } from "isomorphic-git"
 
 /**
  * Why are we using hash wasm over web crypto?
  * Web crypto cannot do streaming hashes of the common git-annex functions yet.
  */
-import { createMD5, createSHA256 } from "npm:hash-wasm"
+import { createMD5, createSHA256 } from "hash-wasm"
 
 /**
  * Reusable hash factories

--- a/cli/src/worker/git.test.ts
+++ b/cli/src/worker/git.test.ts
@@ -1,6 +1,6 @@
 import { join, SEPARATOR } from "@std/path"
 import { walk } from "@std/fs/walk"
-import { default as git } from "npm:isomorphic-git"
+import { default as git } from "isomorphic-git"
 import { assertEquals } from "@std/assert/equals"
 import { assertArrayIncludes } from "@std/assert/array-includes"
 import { addGitFiles } from "../commands/upload.ts"

--- a/cli/src/worker/git.ts
+++ b/cli/src/worker/git.ts
@@ -5,7 +5,7 @@ import {
   parseGitAttributes,
 } from "../gitattributes.ts"
 import { dirname, join } from "@std/path"
-import { default as git, STAGE, TREE } from "npm:isomorphic-git"
+import { default as git, STAGE, TREE } from "isomorphic-git"
 import { logger, setupLogging } from "../logger.ts"
 import { PromiseQueue } from "./queue.ts"
 import { checkKey, storeKey } from "./transferKey.ts"

--- a/cli/src/worker/types/git-context.ts
+++ b/cli/src/worker/types/git-context.ts
@@ -1,4 +1,4 @@
-import http from "npm:isomorphic-git@1.25.3/http/node/index.js"
+import http from "isomorphic-git/http/node/index.js"
 import { decode } from "@wok/djwt"
 import fs from "node:fs"
 import type { LevelName } from "@std/log/levels"


### PR DESCRIPTION
In a few places the CLI was not using the import map correctly.

See #3289.