### PR TITLE
feat(search): Enable indexing for all modality agnostic BIDS fields

### DIFF
--- a/packages/openneuro-search/src/mappings/datasets-mapping.json
+++ b/packages/openneuro-search/src/mappings/datasets-mapping.json
@@ -61,7 +61,14 @@
             "Name": { "type": "text" },
             "Authors": { "type": "text" },
             "SeniorAuthor": { "type": "text" },
-            "DatasetType": { "type": "keyword" }
+            "DatasetType": { "type": "keyword" },
+            "License": { "type": "keyword" },
+            "Acknowledgements": { "type": "text" },
+            "HowToAcknowledge": { "type": "text" },
+            "Funding": { "type": "text" },
+            "EthicsApprovals": { "type": "text" },
+            "ReferencesAndLinks": { "type": "text" },
+            "DatasetDOI": { "type": "text" }
           }
         },
         "readme": {

--- a/packages/openneuro-search/src/query.ts
+++ b/packages/openneuro-search/src/query.ts
@@ -40,6 +40,13 @@ export const INDEX_DATASET_FRAGMENT = gql`
         Authors
         SeniorAuthor
         DatasetType
+        License
+        Acknowledgements
+        HowToAcknowledge
+        Funding
+        EthicsApprovals
+        ReferencesAndLinks
+        DatasetDOI
       }
       summary {
         tasks


### PR DESCRIPTION
Add indexing for missing dataset_description.json [modality agnostic fields](https://bids-specification.readthedocs.io/en/v1.4.0/03-modality-agnostic-files.html).