### PR TITLE
Provide copyright year range

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -7,7 +7,7 @@
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
 project = 'OpenNeuro'
-copyright = '2022, Stanford Center for Reproducible Neuroscience'
+copyright = '2015-2025, Stanford Center for Reproducible Neuroscience'
 author = 'Stanford Center for Reproducible Neuroscience'
 
 # -- General configuration ---------------------------------------------------


### PR DESCRIPTION
To signify that project
- is active (has significant developments this 2025 year)
- has outstanding history -- was there for almost a decade

to altogether indicate to visitor that it is a mature and well-maintaed project.

With current "2022" it provides opposite feeling.