### PR TITLE
Provide mappings for Chrises and Matthew to make "git shortlog -sn" more correct

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,5 @@
+Chris Filo Gorgolewski <krzysztof.gorgolewski@gmail.com>
+Christopher J. Markiewicz <effigies@gmail.com>
+Christopher J. Markiewicz <effigies@gmail.com> <markiewicz@stanford.edu>
+Matthew Zito <matthewtzito@gmail.com>
+Matthew Zito <matthewtzito@gmail.com> <47864657+MatthewZito@users.noreply.github.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1,5 +1,5 @@
-Chris Filo Gorgolewski <krzysztof.gorgolewski@gmail.com>
-Christopher J. Markiewicz <effigies@gmail.com>
-Christopher J. Markiewicz <effigies@gmail.com> <markiewicz@stanford.edu>
+Chris Gorgolewski <krzysztof.gorgolewski@gmail.com>
+Christopher J. Markiewicz <markiewicz@stanford.edu>
+Christopher J. Markiewicz <markiewicz@stanford.edu> <effigies@gmail.com>
 Matthew Zito <matthewtzito@gmail.com>
 Matthew Zito <matthewtzito@gmail.com> <47864657+MatthewZito@users.noreply.github.com>


### PR DESCRIPTION
Without this change, "git shortlog -sn" would make a separate entry for every differently used name and email address. With this it unifies it.

Also by virtue of consolidating others, it raises me in the ranks!

on this branch to proud 20th position

```shell
❯ git shortlog -sn master | nl | grep Halchenko
    20	    15	Yaroslav Halchenko
```

from the old shameful 22nd

```shell
❯ git shortlog -sn master | nl | grep Halchenko
    22	    15	Yaroslav Halchenko
```