### PR TITLE
feat: Require events.tsv for non-rest tasks

### DIFF
--- a/cli/src/validator-config.json
+++ b/cli/src/validator-config.json
@@ -2,7 +2,8 @@
   "error": [
     { "code": "NO_AUTHORS" },
     { "code": "SUBJECT_FOLDERS" },
-    { "code": "EMPTY_DATASET_NAME" }
+    { "code": "EMPTY_DATASET_NAME" },
+    { "code": "EVENTS_TSV_MISSING" }
   ],
   "warning": [
     { "code": "PARTICIPANT_ID_MISMATCH" }

--- a/services/datalad/datalad_service/tasks/assets/validator-config.json
+++ b/services/datalad/datalad_service/tasks/assets/validator-config.json
@@ -2,7 +2,8 @@
   "error": [
     { "code": "NO_AUTHORS" },
     { "code": "SUBJECT_FOLDERS" },
-    { "code": "EMPTY_DATASET_NAME" }
+    { "code": "EMPTY_DATASET_NAME" },
+    { "code": "EVENTS_TSV_MISSING" }
   ],
   "warning": [
     { "code": "PARTICIPANT_ID_MISMATCH" }


### PR DESCRIPTION
Promotes EVENTS_TSV_MISSING to an error.

This may end up with some false positives. We should be able to do some additional filtering based on path, but if the logic gets complicated then this would be a good use case for patching the schema.
