### PR TITLE
feat(app): Allow users to delete datasets if no versions have been created

### DIFF
--- a/packages/openneuro-app/src/scripts/dataset/routes/delete-page.tsx
+++ b/packages/openneuro-app/src/scripts/dataset/routes/delete-page.tsx
@@ -1,22 +1,16 @@
 import React, { useState } from "react"
-import { useCookies } from "react-cookie"
 import DeleteDatasetForm from "../mutations/delete-dataset-form.jsx"
 import DeleteDataset from "../mutations/delete.jsx"
 import LoggedIn from "../../authentication/logged-in.jsx"
-import { getProfile } from "../../authentication/profile"
-import AdminUser from "../../authentication/admin-user.jsx"
-import { RegularUser } from "../../authentication/regular-user"
 import { DatasetPageBorder } from "./styles/dataset-page-border"
 import { HeaderRow3 } from "./styles/header-row"
 
-interface DeletePageProps {
-  dataset: {
-    permissions: Record<string, object>
-    id: string
-  }
+interface DeletePageAction {
+  datasetId: string
+  hasEdit: boolean
 }
 
-const DeletePage = ({ dataset }: DeletePageProps): React.ReactElement => {
+export function DeletePageAction({ datasetId, hasEdit }: DeletePageAction) {
   const [values, setValues] = useState({
     reason: "",
     redirect: "",
@@ -28,40 +22,79 @@ const DeletePage = ({ dataset }: DeletePageProps): React.ReactElement => {
     }
     setValues(newValues)
   }
-  const [cookies] = useCookies()
-  const user = getProfile(cookies)
-  const hasEdit = user && user.admin
+  return (
+    <>
+      <DeleteDatasetForm
+        values={values}
+        onChange={handleInputChange}
+        hideDisabled={false}
+        hasEdit={hasEdit}
+      />
+      <p>
+        <small className="warning-text">
+          * Warning: this action will permanently remove this dataset along with
+          associated snapshots.
+        </small>
+      </p>
+      <div className="dataset-form-controls">
+        <LoggedIn>
+          <DeleteDataset datasetId={datasetId} metadata={values} />
+        </LoggedIn>
+      </div>
+    </>
+  )
+}
+
+interface DeletePageMessageProps {
+  hasEdit: boolean
+}
+
+export function DeletePageMessage({ hasEdit }: DeletePageMessageProps) {
+  if (hasEdit) {
+    return (
+      <>
+        <p>
+          This dataset has versions with DOIs that would be orphaned by
+          deletion.
+        </p>
+        <p>
+          If deletion is required please contact support to permanently remove a
+          dataset and all versions of it. Provide a reason for the removal
+          request and if the dataset is a duplicate or has been supplanted by
+          another provide that information for a redirect to be created.
+        </p>
+      </>
+    )
+  } else {
+    return (
+      <p>
+        Login or request dataset admin permissions from a dataset admin to
+        delete this dataset.
+      </p>
+    )
+  }
+}
+
+interface DeletePageProps {
+  dataset: {
+    permissions: Record<string, object>
+    id: string
+    snapshots: object[]
+  }
+  hasEdit: boolean
+}
+
+const DeletePage = (
+  { dataset, hasEdit }: DeletePageProps,
+): React.ReactElement => {
   const datasetId = dataset.id
+  const canBeDeleted = dataset.snapshots.length === 0 && hasEdit
   return (
     <DatasetPageBorder>
       <HeaderRow3>Delete Dataset</HeaderRow3>
-      <AdminUser>
-        <DeleteDatasetForm
-          values={values}
-          onChange={handleInputChange}
-          hideDisabled={false}
-          hasEdit={hasEdit}
-        />
-        <p>
-          <small className="warning-text">
-            * Warning: this action will permanently remove this dataset along
-            with associated snapshots.
-          </small>
-        </p>
-        <div className="dataset-form-controls">
-          <LoggedIn>
-            <DeleteDataset datasetId={datasetId} metadata={values} />
-          </LoggedIn>
-        </div>
-      </AdminUser>
-      <RegularUser>
-        <p>
-          Please contact support to permanently remove a dataset and all
-          versions of it. Provide a reason for the removal request and if the
-          dataset is a duplicate or has been supplanted by another provide that
-          information for a redirect to be created.
-        </p>
-      </RegularUser>
+      {canBeDeleted
+        ? <DeletePageAction datasetId={datasetId} hasEdit={hasEdit} />
+        : <DeletePageMessage hasEdit={hasEdit} />}
     </DatasetPageBorder>
   )
 }

--- a/packages/openneuro-app/src/scripts/dataset/routes/snapshot.tsx
+++ b/packages/openneuro-app/src/scripts/dataset/routes/snapshot.tsx
@@ -74,8 +74,8 @@ const SnapshotRoute = ({
           )}
           <p>
             Create a new version of this dataset for download and public access.
-            This will begin an export of this dataset to GitHub and S3 if it has
-            been made public.
+            DOIs are assigned to versions created. This will begin an export of
+            this dataset to GitHub and S3 if it has been made public.
           </p>
           <FormRow className="snapshot-input-group">
             {newVersion}
@@ -128,6 +128,14 @@ const SnapshotRoute = ({
               You must add at least one change message to create a new version
             </small>
           )}
+          {snapshots.length === 0
+            ? (
+              <p>
+                Once a version has been created and DOI assigned, the dataset
+                can no longer be deleted.
+              </p>
+            )
+            : null}
           <div className="dataset-form-controls">
             <SnapshotDataset
               datasetId={datasetId}

--- a/packages/openneuro-app/src/scripts/dataset/routes/tab-routes-draft.tsx
+++ b/packages/openneuro-app/src/scripts/dataset/routes/tab-routes-draft.tsx
@@ -31,7 +31,10 @@ export const TabRoutesDraft = ({ dataset, hasEdit }) => {
         path="derivatives"
         element={<Derivatives derivatives={dataset.derivatives} />}
       />
-      <Route path="delete" element={<DeletePage dataset={dataset} />} />
+      <Route
+        path="delete"
+        element={<DeletePage dataset={dataset} hasEdit={hasEdit} />}
+      />
       <Route path="admin" element={<AdminDataset dataset={dataset} />} />
       <Route
         path="publish"


### PR DESCRIPTION
Updates messaging around version creation to indicate that creating the first version will disable deletion.

See #3316