### PR TITLE
update the filters-block on the search page

### DIFF
--- a/packages/openneuro-app/src/scripts/search/filters-block-container.tsx
+++ b/packages/openneuro-app/src/scripts/search/filters-block-container.tsx
@@ -52,7 +52,7 @@ const FiltersBlockContainer: FC<FiltersBlockContainerProps> = ({
     }
 
   const removeAllFilters = (): void => {
-    // Reset params to default values
+    // reset params to default values
     setSearchParams((prevState) => ({
       ...prevState,
       ...getSelectParams(initialSearchParams),


### PR DESCRIPTION
issue:
the query was being removed when you clear the modality, basically giving you what would be equal to "reset filters", 

change:
now when you remove modality you keep the other params that you have set but get redirected back to the general search.  