### PR TITLE
Reset local working trees before CLI uploads

### DIFF
--- a/cli/deno.json
+++ b/cli/deno.json
@@ -13,8 +13,8 @@
     "proseWrap": "preserve"
   },
   "tasks": {
-    "tests": "deno test --allow-read --allow-write --allow-env ./",
-    "coverage": "deno test --allow-read --allow-write --allow-net --allow-env --coverage ./ && deno coverage ./coverage --lcov > ./coverage.lcov"
+    "tests": "deno test --allow-read --allow-write --allow-env --allow-sys ./",
+    "coverage": "deno test --allow-read --allow-write --allow-net --allow-env --allow-sys --coverage ./ && deno coverage ./coverage --lcov > ./coverage.lcov"
   },
   "imports": {
     "@bids/validator": "jsr:@bids/validator@^2.0.2",

--- a/cli/deno.lock
+++ b/cli/deno.lock
@@ -19,9 +19,10 @@
     "jsr:@effigies/cliffy-command@1.0.0-dev.8": "1.0.0-dev.8",
     "jsr:@effigies/cliffy-table@1.0.0-dev.5": "1.0.0-dev.5",
     "jsr:@effigies/cliffy-table@^1.0.0-dev.5": "1.0.0-dev.5",
+    "jsr:@libs/typing@3": "3.1.2",
     "jsr:@libs/xml@6.0.1": "6.0.1",
     "jsr:@std/assert@1.0.0-rc.2": "1.0.0-rc.2",
-    "jsr:@std/assert@^1.0.3": "1.0.10",
+    "jsr:@std/assert@^1.0.3": "1.0.11",
     "jsr:@std/assert@~1.0.6": "1.0.11",
     "jsr:@std/async@^1.0.4": "1.0.9",
     "jsr:@std/bytes@^1.0.2": "1.0.2",
@@ -224,8 +225,14 @@
         "jsr:@std/fmt@~1.0.2"
       ]
     },
+    "@libs/typing@3.1.2": {
+      "integrity": "72342a0eaedcc1f3f3ec18f8f9573759011c68f135e2ec6c7282c59843f7a37e"
+    },
     "@libs/xml@6.0.1": {
-      "integrity": "64af4f93464c77c3e1158fb97c3657779ca554b14f38616b96cde31e22d8a309"
+      "integrity": "64af4f93464c77c3e1158fb97c3657779ca554b14f38616b96cde31e22d8a309",
+      "dependencies": [
+        "jsr:@libs/typing"
+      ]
     },
     "@std/assert@1.0.0-rc.2": {
       "integrity": "0484eab1d76b55fca1c3beaff485a274e67dd3b9f065edcbe70030dfc0b964d3"
@@ -243,7 +250,10 @@
       ]
     },
     "@std/assert@1.0.11": {
-      "integrity": "2461ef3c368fe88bc60e186e7744a93112f16fd110022e113a0849e94d1c83c1"
+      "integrity": "2461ef3c368fe88bc60e186e7744a93112f16fd110022e113a0849e94d1c83c1",
+      "dependencies": [
+        "jsr:@std/internal@^1.0.5"
+      ]
     },
     "@std/async@1.0.9": {
       "integrity": "c6472fd0623b3f3daae023cdf7ca5535e1b721dfbf376562c0c12b3fb4867f91"

--- a/cli/src/worker/getDefault.test.ts
+++ b/cli/src/worker/getDefault.test.ts
@@ -1,0 +1,42 @@
+import { assertEquals, assertRejects } from "@std/assert"
+import { getDefault } from "./getDefault.ts"
+import { GitWorkerContext } from "./types/git-context.ts"
+import { join } from "@std/path"
+import { default as git } from "isomorphic-git"
+
+Deno.test("getDefault()", async (t) => {
+  const testDir = await Deno.makeTempDir()
+  const context = new GitWorkerContext(
+    "ds000000",
+    testDir,
+    testDir,
+    "http://localhost",
+    "test",
+    "test",
+    "test",
+  )
+  await git.init({ ...context.config(), defaultBranch: "main" })
+  await context.fs.promises.writeFile(join(testDir, "test.txt"), "test")
+  await git.add({ ...context.config(), filepath: "test.txt" })
+  await git.commit({
+    ...context.config(),
+    message: "test",
+    author: {
+      name: "Test Name",
+      email: "test@example.com",
+    },
+  })
+  await t.step("returns main if present", async () => {
+    assertEquals(await getDefault(context), "main")
+  })
+  await t.step("returns master if main is not present", async () => {
+    await git.branch({ ...context.config(), ref: "master" })
+    await git.deleteBranch({ ...context.config(), ref: "main" })
+    assertEquals(await getDefault(context), "master")
+  })
+  await t.step("throws if neither main or master are present", async () => {
+    await git.deleteBranch({ ...context.config(), ref: "master" })
+    await assertRejects(async () => await getDefault(context))
+  })
+  await Deno.remove(testDir, { recursive: true })
+})

--- a/cli/src/worker/getDefault.ts
+++ b/cli/src/worker/getDefault.ts
@@ -1,0 +1,19 @@
+import { default as git } from "isomorphic-git"
+import type { GitWorkerContext } from "./types/git-context.ts"
+
+/**
+ * Determine if the default branch is main or master
+ */
+export async function getDefault(context: GitWorkerContext): Promise<string> {
+  try {
+    await git.resolveRef({ ...context.config(), ref: "main" })
+    return "main"
+  } catch (_err) {
+    try {
+      await git.resolveRef({ ...context.config(), ref: "master" })
+      return "master"
+    } catch (_err) {
+      throw new Error("Could not determine default branch")
+    }
+  }
+}

--- a/cli/src/worker/resetWorktree.test.ts
+++ b/cli/src/worker/resetWorktree.test.ts
@@ -1,0 +1,53 @@
+import { assertEquals } from "@std/assert"
+import { resetWorktree } from "./resetWorktree.ts"
+import { GitWorkerContext } from "./types/git-context.ts"
+import { join } from "@std/path"
+import { default as git } from "isomorphic-git"
+
+Deno.test("resetWorktree()", async (t) => {
+  const testDir = await Deno.makeTempDir()
+  const context = new GitWorkerContext(
+    "ds000000",
+    testDir,
+    testDir,
+    "http://localhost",
+    "test",
+    "test",
+    "test",
+  )
+  await git.init({ ...context.config(), defaultBranch: "main" })
+  await context.fs.promises.writeFile(join(testDir, "test.txt"), "test")
+  await git.add({ ...context.config(), filepath: "test.txt" })
+  await git.commit({
+    ...context.config(),
+    message: "test",
+    author: {
+      name: "Test Name",
+      email: "test@example.com",
+    },
+  })
+  await context.fs.promises.writeFile(join(testDir, "test2.txt"), "test")
+  await git.add({ ...context.config(), filepath: "test2.txt" })
+  await context.fs.promises.writeFile(join(testDir, "test3.txt"), "test")
+  await t.step("cleans up dirty working trees", async () => {
+    await resetWorktree(context, "main")
+    const status = await git.status({
+      ...context.config(),
+      filepath: "test.txt",
+    })
+    assertEquals(status, "unmodified")
+    try {
+      await context.fs.promises.access(join(testDir, "test2.txt"))
+      throw new Error("test2.txt should not exist")
+    } catch (_err) {
+      // Expected
+    }
+    try {
+      await context.fs.promises.access(join(testDir, "test3.txt"))
+      throw new Error("test3.txt should not exist")
+    } catch (_err) {
+      // Expected
+    }
+  })
+  await Deno.remove(testDir, { recursive: true })
+})

--- a/cli/src/worker/resetWorktree.ts
+++ b/cli/src/worker/resetWorktree.ts
@@ -1,0 +1,32 @@
+import { join } from "@std/path/join"
+import type { GitWorkerContext } from "./types/git-context.ts"
+import { default as git } from "isomorphic-git"
+
+// Status Matrix Row Indexes
+const FILEPATH = 0
+const HEAD = 1
+const WORKDIR = 2
+const STAGE = 3
+
+/**
+ * Ensure clean worktree state before updates
+ */
+export async function resetWorktree(context: GitWorkerContext, branch: string) {
+  // Status Matrix State
+  const UNCHANGED = 1
+
+  const allFiles = await git.statusMatrix(context.config())
+  // Get all files which have been modified or staged - does not include new untracked files or deleted files
+  const modifiedFiles = allFiles
+    .filter((row) => row[WORKDIR] > UNCHANGED && row[STAGE] > UNCHANGED)
+    .map((row) => row[FILEPATH])
+
+  // Delete modified/staged files
+  await Promise.all(
+    modifiedFiles.map((path) =>
+      context.fs.promises.rm(join(context.repoPath, path))
+    ),
+  )
+
+  await git.checkout({ ...context.config(), ref: branch, force: true })
+}


### PR DESCRIPTION
This fixes at least one cause of the issue in #3325 where the working tree could be contaminated by a previous attempt. Files either added to the index or in the tree but not indexed would cause a branch change to fail and unpredictable behavior after that.

Includes an improvement to consolidate the logic for determining the default branch by checking refs instead of simply attempting to checkout branches and handling the error case. If the dataset repo has main or both, we'll use main, if only master is present master is used.