### PR TITLE
search filters update for Invalid DS on My Datasets - use latestSnapshot.validation.errors over draft.issues.severity

### DIFF
--- a/packages/openneuro-app/src/scripts/search/inputs/show-datasets-radios.tsx
+++ b/packages/openneuro-app/src/scripts/search/inputs/show-datasets-radios.tsx
@@ -19,16 +19,23 @@ const ShowDatasetsRadios: FC = () => {
     datasetStatus_available,
     datasetStatus_selected,
   } = searchParams
-  const setShowSelected = (datasetType_selected) =>
+
+  const setShowSelected = (datasetType_selected) => {
     setSearchParams((prevState) => ({
       ...prevState,
       datasetType_selected,
+      datasetStatus_selected: datasetType_selected === "My Datasets"
+        ? prevState.datasetStatus_selected
+        : undefined,
     }))
-  const setShowMyUploadsSelected = (datasetStatus_selected) =>
+  }
+
+  const setShowMyUploadsSelected = (datasetStatus_selected) => {
     setSearchParams((prevState) => ({
       ...prevState,
       datasetStatus_selected,
     }))
+  }
 
   return loggedOut ? null : (
     <>
@@ -44,23 +51,21 @@ const ShowDatasetsRadios: FC = () => {
           setSelected={setShowSelected}
         />
       </div>
-      {datasetType_selected == "My Datasets"
-        ? (
-          <AccordionWrap className="facet-accordion">
-            <AccordionTab
-              accordionStyle="plain"
-              label="My Datasets Status"
-              startOpen={true}
-            >
-              <FacetSelect
-                selected={datasetStatus_selected}
-                setSelected={setShowMyUploadsSelected}
-                items={datasetStatus_available}
-              />
-            </AccordionTab>
-          </AccordionWrap>
-        )
-        : null}
+      {datasetType_selected === "My Datasets" && (
+        <AccordionWrap className="facet-accordion">
+          <AccordionTab
+            accordionStyle="plain"
+            label="My Datasets Status"
+            startOpen={true}
+          >
+            <FacetSelect
+              selected={datasetStatus_selected}
+              setSelected={setShowMyUploadsSelected}
+              items={datasetStatus_available}
+            />
+          </AccordionTab>
+        </AccordionWrap>
+      )}
     </>
   )
 }

--- a/packages/openneuro-search/src/mappings/datasets-mapping.json
+++ b/packages/openneuro-search/src/mappings/datasets-mapping.json
@@ -57,6 +57,11 @@
             }
           }
         },
+        "validation": {
+          "properties": {
+            "errors": { "type": "integer" }
+          }
+        },
         "description": {
           "properties": {
             "Name": { "type": "text" },

--- a/packages/openneuro-search/src/query.ts
+++ b/packages/openneuro-search/src/query.ts
@@ -49,6 +49,9 @@ export const INDEX_DATASET_FRAGMENT = gql`
         ReferencesAndLinks
         DatasetDOI
       }
+      validation{
+        errors
+      }
       summary {
         tasks
         modalities

--- a/packages/openneuro-search/src/query.ts
+++ b/packages/openneuro-search/src/query.ts
@@ -49,7 +49,7 @@ export const INDEX_DATASET_FRAGMENT = gql`
         ReferencesAndLinks
         DatasetDOI
       }
-      validation{
+      validation {
         errors
       }
       summary {

--- a/packages/openneuro-server/src/graphql/resolvers/dataset-search.ts
+++ b/packages/openneuro-server/src/graphql/resolvers/dataset-search.ts
@@ -181,8 +181,10 @@ const parseQuery = async (query, datasetType, datasetStatus, userId) => {
       })
     } else if (datasetStatus === "Invalid") {
       addClause(query, "filter", {
-        term: {
-          ["draft.issues.severity"]: "error",
+        range: {
+          "latestSnapshot.validation.errors": {
+            gt: 0,
+          },
         },
       })
     }


### PR DESCRIPTION
- update to the dataset mapping/query to include validation, 
- changes to search resolver to check if validation.errors is greater than zero, 
- removes the status filter if you are not viewing my datasets on search