### PR TITLE
fix(app): Fix component crash in validation.errors check

### DIFF
--- a/packages/openneuro-components/src/search-page/SearchResultItem.tsx
+++ b/packages/openneuro-components/src/search-page/SearchResultItem.tsx
@@ -314,7 +314,7 @@ export const SearchResultItem = ({
     )
   } else {
     // Test if there's any schema validator errors
-    invalid = node.latestSnapshot.validation.errors > 0
+    invalid = node.latestSnapshot.validation?.errors > 0
   }
   const shared = !node.public && node.uploader.id !== profile.sub
 


### PR DESCRIPTION
It's possible to run into this crash with a mix of legacy and schema validator datasets in your my datasets page results.