### PR TITLE
fix(app): Show "valid" if schema validation has returned no issues but ran successfully

### DIFF
--- a/packages/openneuro-app/src/scripts/dataset/components/ValidationBlock.tsx
+++ b/packages/openneuro-app/src/scripts/dataset/components/ValidationBlock.tsx
@@ -50,7 +50,7 @@ export const ValidationBlock: React.FC<ValidationBlockProps> = ({
     )
   } else {
     // If data exists, populate this. Otherwise we show pending.
-    if (validation?.warnings + validation?.errors > 0) {
+    if (validation) {
       return (
         <div className="validation-accordion">
           <Validation

--- a/packages/openneuro-app/src/scripts/dataset/components/__tests__/ValidationBlock.spec.tsx
+++ b/packages/openneuro-app/src/scripts/dataset/components/__tests__/ValidationBlock.spec.tsx
@@ -44,4 +44,14 @@ describe("ValidationBlock component", () => {
     render(<ValidationBlock datasetId="ds000031" />)
     expect(screen.getByText("Validation Pending")).toBeInTheDocument()
   })
+  it("renders validation if `validation` is present but errors and warnings are zero", () => {
+    render(
+      <ValidationBlock
+        datasetId="ds000031"
+        validation={{ errors: 0, warnings: 0, issues: [], codeMessages: [] }}
+      />,
+    )
+    expect(screen.getByText("Valid")).toBeInTheDocument()
+    expect(screen.queryByText("Validation Pending")).not.toBeInTheDocument()
+  })
 })


### PR DESCRIPTION
This would fail to show validation as complete but valid if only the schema validator had run and returned no issues or warnings.