### PR TITLE
fix(app): Fix footer link to GitHub version

### DIFF
--- a/packages/openneuro-components/src/footer/Footer.tsx
+++ b/packages/openneuro-components/src/footer/Footer.tsx
@@ -7,14 +7,16 @@ export interface FooterProps {
 }
 
 export const Footer: React.FC<FooterProps> = ({ version }) => {
+  const versionLink =
+    `https://github.com/OpenNeuroOrg/openneuro/releases/tag/v${version}`
   return (
     <footer className="on-foot">
       <div className="grid grid-between align-center">
         <div className="col col-4  version">
           <span>
             OpenNeuro
-            <a href="https://github.com/OpenNeuroOrg/openneuro/releases/tag/v{version}">
-              v{version}
+            <a href={versionLink}>
+              {" "}v{version}
             </a>
           </span>
         </div>


### PR DESCRIPTION
The link here didn't actually work since it was a static string.