### PR TITLE
fix(app): Match modality selections on value instead of labels

### DIFF
--- a/packages/openneuro-app/src/scripts/search/inputs/modality-select.tsx
+++ b/packages/openneuro-app/src/scripts/search/inputs/modality-select.tsx
@@ -37,7 +37,7 @@ const ModalitySelect: FC<ModalitySelectProps> = ({
       }),
     )
     const modality_selected_path = flattenedModalities.find((modality) => {
-      return modality.label === modality_selected
+      return modality.value === modality_selected
     })?.portalPath
     navigate(modality_selected_path)
   }


### PR DESCRIPTION
Fix a bug where the modality search selection wasn't being set correctly when choosing filters on the front page.