### PR TITLE
CI: Explicitly set tests event loop scope to function

### DIFF
--- a/services/datalad/pytest.ini
+++ b/services/datalad/pytest.ini
@@ -2,3 +2,4 @@
 pythonpath = .
 addopts = "--import-mode=importlib"
 asyncio_mode=auto
+asyncio_default_fixture_loop_scope = "function"


### PR DESCRIPTION
The following deprecation warning is popping up in the python tests
```
/home/runner/.local/share/virtualenvs/datalad-JQpnqbsc/lib/python3.11/site-packages/pytest_asyncio/plugin.py:207: PytestDeprecationWarning: The configuration option "asyncio_default_fixture_loop_scope" is unset.
The event loop scope for asynchronous fixtures will default to the fixture caching scope. Future versions of pytest-asyncio will default the loop scope for asynchronous fixtures to function scope. Set the default fixture loop scope explicitly in order to avoid unexpected behavior in the future. Valid fixture loop scopes are: "function", "class", "module", "package", "session"

  warnings.warn(PytestDeprecationWarning(_DEFAULT_FIXTURE_LOOP_SCOPE_UNSET))
```