### PR TITLE
fix(app): Correct sign out behavior to work regardless of path

### DIFF
--- a/packages/openneuro-app/src/scripts/authentication/signOut.ts
+++ b/packages/openneuro-app/src/scripts/authentication/signOut.ts
@@ -2,7 +2,7 @@ import cookies from "../utils/cookies.js"
 
 const signOut = () => {
   // Delete the token will reset client login state
-  cookies.remove("accessToken")
+  cookies.remove("accessToken", { path: "/" })
 }
 
 export default signOut


### PR DESCRIPTION
This fixes an issue where the user logout action would fail to remove the cookie depending on how the page was loaded.