### PR TITLE
fix(server): Extend repo access token lifetime to 7 days

### DIFF
--- a/packages/openneuro-server/src/libs/authentication/jwt.ts
+++ b/packages/openneuro-server/src/libs/authentication/jwt.ts
@@ -95,7 +95,11 @@ export function generateReviewerToken(
  *
  * Similarly to the upload token, this shorter lived token is specific to git access
  */
-export function generateRepoToken(user, datasetId, expiresIn = 60 * 60 * 24) {
+export function generateRepoToken(
+  user,
+  datasetId,
+  expiresIn = 7 * 60 * 60 * 24,
+) {
   const options = {
     scopes: ["dataset:git"],
     dataset: datasetId,


### PR DESCRIPTION
Support longer running uploads without refreshing the token.

This is a quick fix for #3393 - planning to add token refresh support and reduce this again later.