### PR TITLE
fix(app): Prevent extra scrolling on content boxes

### DIFF
--- a/packages/openneuro-app/src/scripts/components/scss/global.scss
+++ b/packages/openneuro-app/src/scripts/components/scss/global.scss
@@ -86,7 +86,6 @@ blockquote {
 }
 
 .sticky-content {
-  min-height: calc(100vh - 30px);
   padding: 0;
 }
 .sticky-footer {

--- a/packages/openneuro-app/src/scripts/pages/citation-page.tsx
+++ b/packages/openneuro-app/src/scripts/pages/citation-page.tsx
@@ -8,7 +8,7 @@ const CitationPageStyle = styled.div`
 
   .container {
     max-width: 60em;
-    min-height: calc(100vh - 125px);
+    min-height: calc(100vh - 152px);
   }
 `
 

--- a/packages/openneuro-app/src/scripts/pages/import-dataset.tsx
+++ b/packages/openneuro-app/src/scripts/pages/import-dataset.tsx
@@ -17,7 +17,7 @@ const ImportDatasetPageStyle = styled.div`
 
   .container {
     max-width: 60em;
-    min-height: calc(100vh - 125px);
+    min-height: calc(100vh - 152px);
   }
 `
 

--- a/packages/openneuro-app/src/scripts/pages/metadata/dataset-metadata.tsx
+++ b/packages/openneuro-app/src/scripts/pages/metadata/dataset-metadata.tsx
@@ -9,7 +9,7 @@ const MetadataPageStyle = styled.div`
   background: white;
   overflow-x: scroll;
   padding: 1em;
-  height: calc(100vh - 125px);
+  height: calc(100vh - 152px);
   white-space: nowrap;
 `
 


### PR DESCRIPTION
I noticed these pages scrolled despite having less than one page of content.