### PR TITLE
Prevent git index from being updated twice during commits

### DIFF
--- a/services/datalad/datalad_service/common/git.py
+++ b/services/datalad/datalad_service/common/git.py
@@ -82,7 +82,7 @@ def git_commit(repo, file_paths, author=None, message="[OpenNeuro] Recorded chan
     # Refresh index with git-annex specific handling
     annex_command = ["git-annex", "add"] + file_paths
     try:
-        subprocess.run(annex_command, check=True, cwd=repo.workdir)
+        subprocess.run(annex_command, check=True, capture_output=True, cwd=repo.workdir)
     except subprocess.CalledProcessError as e:
         sentry_sdk.capture_exception(e)
         logger.error(f"Error running git-annex add for paths {file_paths}: {e}")


### PR DESCRIPTION
`git-annex add` called here updates the git index on disk. We would throw away this work and immediately create a pygit2 index in memory. This was usually fine but slightly inefficient, however it can lead to a race condition where two attempts at creating a commit would end up with a different on disk and in memory index. By limiting this to only git-annex add and reading the on disk index, the index is always consistent and avoids the risk of adding large files as regular git objects accidentally.

Adding some additional error handling here that should help with debugging this kind of failure in the future.

Fixes #2848