### PR TITLE
Update download instructions for Deno CLI

### DIFF
--- a/packages/openneuro-app/src/scripts/dataset/download/__tests__/__snapshots__/download-command-line.spec.jsx.snap
+++ b/packages/openneuro-app/src/scripts/dataset/download/__tests__/__snapshots__/download-command-line.spec.jsx.snap
@@ -6,7 +6,7 @@ exports[`dataset/download > DownloadSampleCommand component > renders successful
     class="css-xak41w"
     role="figure"
   >
-    openneuro download --draft ds000001 ds000001-download/
+    deno run -A jsr:@openneuro/cli download --draft ds000001 ds000001-download/
   </pre>
 </DocumentFragment>
 `;

--- a/packages/openneuro-app/src/scripts/dataset/download/__tests__/__snapshots__/download-command-line.spec.jsx.snap
+++ b/packages/openneuro-app/src/scripts/dataset/download/__tests__/__snapshots__/download-command-line.spec.jsx.snap
@@ -6,6 +6,12 @@ exports[`dataset/download > DownloadSampleCommand component > renders successful
     class="css-xak41w"
     role="figure"
   >
+    # Login by following the prompts
+    <br />
+    deno run -A jsr:@openneuro/cli login
+    <br />
+    # Download the repository
+    <br />
     deno run -A jsr:@openneuro/cli download --draft ds000001 ds000001-download/
   </pre>
 </DocumentFragment>

--- a/packages/openneuro-app/src/scripts/dataset/download/__tests__/download-command-line.spec.jsx
+++ b/packages/openneuro-app/src/scripts/dataset/download/__tests__/download-command-line.spec.jsx
@@ -13,11 +13,11 @@ describe("dataset/download", () => {
     it("drafts show draft flag", () => {
       render(<DownloadSampleCommand {...defProps} />)
       expect(screen.getByRole("figure")).toHaveTextContent("--draft")
-      expect(screen.queryByText("--snapshot")).not.toBeInTheDocument()
+      expect(screen.queryByText("--version")).not.toBeInTheDocument()
     })
     it("snapshots show snapshot flag", () => {
       render(<DownloadSampleCommand {...defProps} snapshotTag="1.0.0" />)
-      expect(screen.getByRole("figure")).toHaveTextContent("--snapshot")
+      expect(screen.getByRole("figure")).toHaveTextContent("--version")
       expect(screen.queryByText("--draft")).not.toBeInTheDocument()
     })
   })

--- a/packages/openneuro-app/src/scripts/dataset/download/download-command-line.jsx
+++ b/packages/openneuro-app/src/scripts/dataset/download/download-command-line.jsx
@@ -31,9 +31,9 @@ const DownloadCommandLine = ({ datasetId, snapshotTag }) => (
     </p>
     <DownloadSampleCommand datasetId={datasetId} snapshotTag={snapshotTag} />
     <p>
-      This will download to {datasetId}
-      -download/ in the current directory. To download data files, use datalad
-      or git-annex.
+      This will download a DataLad dataset to {datasetId}
+      -download/ in the current directory. To download annexed files, use
+      datalad or git-annex.
     </p>
     <ShellExample>
       cd {datasetId}-download && datalad get [PATH]

--- a/packages/openneuro-app/src/scripts/dataset/download/download-command-line.jsx
+++ b/packages/openneuro-app/src/scripts/dataset/download/download-command-line.jsx
@@ -4,9 +4,9 @@ import ShellExample from "./shell-example.jsx"
 
 export const DownloadSampleCommand = ({ datasetId, snapshotTag }) => (
   <ShellExample role="figure">
-    openneuro download {snapshotTag ? `--snapshot ${snapshotTag}` : "--draft"}
-    {" "}
-    {datasetId} {datasetId}
+    deno run -A jsr:@openneuro/cli download{" "}
+    {snapshotTag ? `--version ${snapshotTag}` : "--draft"} {datasetId}{" "}
+    {datasetId}
     -download/
   </ShellExample>
 )
@@ -18,15 +18,14 @@ DownloadSampleCommand.propTypes = {
 
 const DownloadCommandLine = ({ datasetId, snapshotTag }) => (
   <div>
-    <h4>Download with Node.js</h4>
+    <h4>Download with Deno</h4>
     <p>
-      Using{" "}
-      <a href="https://www.npmjs.com/package/@openneuro/cli">@openneuro/cli</a>
-      {" "}
+      Using <a href="https://jsr.io/@openneuro/cli">@openneuro/cli</a>{" "}
       you can download this dataset from the command line using{" "}
-      <a href="https://nodejs.org/en/download/">Node.js</a>. This method is good
-      for larger datasets or unstable connections, but has known issues on
-      Windows.
+      <a href="https://docs.deno.com/runtime/getting_started/installation/">
+        Deno
+      </a>. This method is good for larger datasets or unstable connections, but
+      has known issues on Windows.
     </p>
     <DownloadSampleCommand datasetId={datasetId} snapshotTag={snapshotTag} />
     <p>

--- a/packages/openneuro-app/src/scripts/dataset/download/download-command-line.jsx
+++ b/packages/openneuro-app/src/scripts/dataset/download/download-command-line.jsx
@@ -4,6 +4,9 @@ import ShellExample from "./shell-example.jsx"
 
 export const DownloadSampleCommand = ({ datasetId, snapshotTag }) => (
   <ShellExample role="figure">
+    # Login by following the prompts<br />
+    deno run -A jsr:@openneuro/cli login<br />
+    # Download the repository<br />
     deno run -A jsr:@openneuro/cli download{" "}
     {snapshotTag ? `--version ${snapshotTag}` : "--draft"} {datasetId}{" "}
     {datasetId}
@@ -24,15 +27,17 @@ const DownloadCommandLine = ({ datasetId, snapshotTag }) => (
       you can download this dataset from the command line using{" "}
       <a href="https://docs.deno.com/runtime/getting_started/installation/">
         Deno
-      </a>. This method is good for larger datasets or unstable connections, but
-      has known issues on Windows.
+      </a>.
     </p>
     <DownloadSampleCommand datasetId={datasetId} snapshotTag={snapshotTag} />
     <p>
       This will download to {datasetId}
-      -download/ in the current directory. If your download is interrupted and
-      you need to retry, rerun the command to resume the download.
+      -download/ in the current directory. To download data files, use datalad
+      or git-annex.
     </p>
+    <ShellExample>
+      cd {datasetId}-download && datalad get [PATH]
+    </ShellExample>
   </div>
 )
 

--- a/packages/openneuro-app/src/scripts/dataset/download/download-datalad.jsx
+++ b/packages/openneuro-app/src/scripts/dataset/download/download-datalad.jsx
@@ -27,9 +27,12 @@ const DownloadDataladExample = ({
         .git
       </ShellExample>
       {hasEdit && (
-        <ShellExample>
-          datalad install {config.url}/git/{workerId}/{datasetId}
-        </ShellExample>
+        <>
+          <p>Directly from OpenNeuro:</p>
+          <ShellExample>
+            datalad install {config.url}/git/{workerId}/{datasetId}
+          </ShellExample>
+        </>
       )}
     </>
   )

--- a/packages/openneuro-app/src/scripts/dataset/download/download-s3.jsx
+++ b/packages/openneuro-app/src/scripts/dataset/download/download-s3.jsx
@@ -25,10 +25,6 @@ const DownloadS3Instructions = ({ datasetId, s3Bucket }) => (
       uses <a href="https://aws.amazon.com/cli/">AWS CLI.</a>
     </p>
     <DownloadSampleS3 datasetId={datasetId} s3Bucket={s3Bucket} />
-    <p>
-      To download unpublished datasets or older snapshots, see advanced methods
-      below.
-    </p>
   </div>
 )
 


### PR DESCRIPTION
This recommends using the new CLI and includes instructions for how to download annexed files.