### PR TITLE
deps: Update to git-annex 10.20250320

### DIFF
--- a/services/datalad/Dockerfile
+++ b/services/datalad/Dockerfile
@@ -17,7 +17,7 @@ COPY --from=deno /deno /usr/local/bin/deno
 RUN apt-get update \
   && apt-get install -y curl openssh-client \
   && ssh-keyscan github.com >> /root/.ssh/known_hosts \
-  && curl -L http://archive.org/download/git-annex-builds/SHA256E-s53592796--6e0a3c16d50379f89d2064081376a3f7f6efa1a89eb1afc2a2335597e7cf9fac.tar.gz | tar -C /usr/local/bin --strip-components 1 -xvz \
+  && curl -L https://storage.googleapis.com/openneuro-git-annex/10.20250320/SHA256E-s62052170--58aadf91f6b05a8ed9fb6a351d5e786da9fe1890e202b9b935d18e876caf25a1.tar.gz | tar -C /usr/local/bin --strip-components 1 -xvz \
   && pip3 install 'pipenv==2020.6.2' \
   && pipenv install --deploy --system \
   && chmod 600 /root/.ssh/config \


### PR DESCRIPTION
Updating to the most recent git-annex available and switch to our own mirror of releases.

https://git-annex.branchable.com/news/version_10.20250320/