### PR TITLE
fix: Correct modality variable when loading aggregates for front page

### DIFF
--- a/packages/openneuro-app/src/scripts/components/header/LandingExpandedHeader.tsx
+++ b/packages/openneuro-app/src/scripts/components/header/LandingExpandedHeader.tsx
@@ -39,7 +39,7 @@ export const LandingExpandedHeader: React.FC<LandingExpandedHeaderProps> = ({
           cubeImage={item.cubeImage}
           altText={item.altText}
           cubeFaceImage={item.cubeFaceImage}
-          stats={aggregateCounts(item.label)}
+          stats={aggregateCounts(item.label.toLowerCase())}
           onClick={(redirectPath) => (_err) => {
             navigate(redirectPath)
           }}

--- a/packages/openneuro-app/src/scripts/pages/front-page/aggregate-queries/use-publicDatasets-count.ts
+++ b/packages/openneuro-app/src/scripts/pages/front-page/aggregate-queries/use-publicDatasets-count.ts
@@ -21,7 +21,7 @@ const BRAIN_INITIATIVE_COUNT = gql`
 `
 
 const usePublicDatasetsCount = (modality?: string) => {
-  const isNIH = modality === "NIH"
+  const isNIH = modality === "nih"
 
   const query = isNIH ? BRAIN_INITIATIVE_COUNT : PUBLIC_DATASETS_COUNT
   const variables = isNIH

--- a/packages/openneuro-server/src/graphql/resolvers/snapshots.ts
+++ b/packages/openneuro-server/src/graphql/resolvers/snapshots.ts
@@ -136,7 +136,7 @@ export const undoDeprecateSnapshot = async (
 }
 
 export const participantCount = (obj, { modality }) => {
-  const cacheKey = modality === "NIH" ? "NIH" : modality || "all"
+  const cacheKey = modality === "nih" ? "nih" : modality || "all"
   const cache = new CacheItem(
     redis,
     CacheType.participantCount,
@@ -151,7 +151,7 @@ export const participantCount = (obj, { modality }) => {
 
     let matchQuery: Record<string, unknown> = queryHasSubjects
 
-    if (modality && modality !== "NIH") {
+    if (modality && modality !== "nih") {
       matchQuery = {
         $and: [
           queryHasSubjects,
@@ -160,7 +160,7 @@ export const participantCount = (obj, { modality }) => {
           },
         ],
       }
-    } else if (modality === "NIH") {
+    } else if (modality === "nih") {
       // When modality is 'NIH', we don't filter by a specific modality.
       // Instead, we query for datasets that have any modality within the NIH portal
       matchQuery = {


### PR DESCRIPTION
Fixes a regression in 4.34.0 where the modality counts would not always be displayed correctly. This is because some queries would run with uppercase names when 4.34.0 normalizes all modality names to lowercase strings.