### PR TITLE
fix(app): Fix a broken link to localhost on front page

### DIFF
--- a/packages/openneuro-app/src/scripts/common/content/affiliate-content.jsx
+++ b/packages/openneuro-app/src/scripts/common/content/affiliate-content.jsx
@@ -63,7 +63,7 @@ export const affiliateContent = [
     contentTwo: (
       <>
         View the collection of{" "}
-        <a href="http://localhost:9876/search/nih?query=%7B%22brain_initiative%22%3A%22true%22%7D">
+        <a href="/search/nih?query=%7B%22brain_initiative%22%3A%22true%22%7D">
           BRAIN Initiative datasets
         </a>
       </>


### PR DESCRIPTION
This should have been a relative URL.