### PR TITLE
Migrate Google accounts to ORCID

### DIFF
--- a/config.env.example
+++ b/config.env.example
@@ -62,7 +62,7 @@ FRESH_DESK_URL=
 ENGINE_API_KEY=
 
 # MongoDB URL
-MONGO_URL=mongodb://mongo:27017/crn
+MONGO_URL=mongodb://mongo:27017/crn?replicaSet=rs0
 
 # DataLad service container host and port
 DATALAD_SERVICE_URI=datalad

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,7 +75,17 @@ services:
 
   # mongodb
   mongo:
-    image: docker.io/library/mongo:5.0
+    image: docker.io/library/mongo:6.0
+    command: ["--replSet", "rs0", "--bind_ip_all", "--port", "27017"]
+    ports:
+      - 27017:27017
+    healthcheck:
+      test: echo "try { rs.status() } catch (err) { rs.initiate({_id:'rs0',members:[{_id:0,host:'host.docker.internal:27017'}]}) }" | mongosh --port 27017 --quiet
+      interval: 5s
+      timeout: 30s
+      start_period: 0s
+      start_interval: 1s
+      retries: 30
     volumes:
       - ${PERSISTENT_DIR}/mongo:/data/db:z
 

--- a/packages/openneuro-app/src/scripts/components/header/LandingExpandedHeader.tsx
+++ b/packages/openneuro-app/src/scripts/components/header/LandingExpandedHeader.tsx
@@ -81,21 +81,21 @@ export const LandingExpandedHeader: React.FC<LandingExpandedHeaderProps> = ({
                     <h3>SIGN IN</h3>
                   </div>
                   <div>
-                    <a href={loginUrls.google}>
-                      <Button
-                        label="Google"
-                        color="#fff"
-                        icon="fab fa-google"
-                        iconSize="23px"
-                      />
-                    </a>
-                  </div>
-                  <div>
                     <a href={loginUrls.orcid}>
                       <Button
                         label="ORCID"
                         color="#fff"
                         imgSrc={orcidIcon}
+                        iconSize="23px"
+                      />
+                    </a>
+                  </div>
+                  <div>
+                    <a href={loginUrls.google}>
+                      <Button
+                        label="Google"
+                        color="#fff"
+                        icon="fab fa-google"
                         iconSize="23px"
                       />
                     </a>

--- a/packages/openneuro-app/src/scripts/components/header/header.scss
+++ b/packages/openneuro-app/src/scripts/components/header/header.scss
@@ -203,8 +203,7 @@ header {
     align-items: center;
   }
   > div {
-    flex-basis: 50%;
-    max-width: 50%;
+    flex-basis: 100%;
     margin: 0 10px 0 0;
     &:last-child {
       margin: 0 0 0 10px;

--- a/packages/openneuro-app/src/scripts/components/modal/UserLoginModal.tsx
+++ b/packages/openneuro-app/src/scripts/components/modal/UserLoginModal.tsx
@@ -30,17 +30,6 @@ export const UserLoginModal = ({
         </div>
         <div className="sign-in-modal-content">
           <div>
-            <a href={loginUrls.google + `?redirectPath=${btoa(redirectPath)}`}>
-              <Button
-                className="login-button"
-                primary
-                label="Google"
-                icon="fab fa-google"
-                iconSize="23px"
-              />
-            </a>
-          </div>
-          <div>
             <a href={loginUrls.orcid + `?redirectPath=${btoa(redirectPath)}`}>
               <Button
                 className="login-button"
@@ -66,6 +55,18 @@ export const UserLoginModal = ({
                 }
               />
             </AccordionWrap>
+            <div>
+              <a
+                href={loginUrls.google + `?redirectPath=${btoa(redirectPath)}`}
+              >
+                <Button
+                  className="login-button"
+                  label="Migrate Google to ORCID"
+                  icon="fab fa-google"
+                  iconSize="23px"
+                />
+              </a>
+            </div>
           </div>
         </div>
       </Modal>

--- a/packages/openneuro-app/src/scripts/components/modal/__tests__/UserLoginModal.spec.tsx
+++ b/packages/openneuro-app/src/scripts/components/modal/__tests__/UserLoginModal.spec.tsx
@@ -31,7 +31,7 @@ describe("UserLoginModal component", () => {
       </MemoryRouter>,
     )
     expect(
-      screen.getByRole("link", { name: /orcid/i }).getAttribute("href"),
+      screen.getByRole("link", { name: "ORCID" }).getAttribute("href"),
     ).toBe("https://openneuro.org/crn/auth/orcid?redirectPath=L2ltcG9ydA==")
   })
 })

--- a/packages/openneuro-app/src/scripts/index.tsx
+++ b/packages/openneuro-app/src/scripts/index.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import React, { useEffect } from "react"
 import Uploader from "./uploader/uploader.jsx"
 import AppRoutes from "./routes"
 import HeaderContainer from "./common/containers/header"
@@ -6,11 +6,24 @@ import FooterContainer from "./common/containers/footer"
 import { SearchParamsProvider } from "./search/search-params-ctx"
 import { UserModalOpenProvider } from "./utils/user-login-modal-ctx"
 import { useAnalytics } from "./utils/analytics"
-
+import { useLocation, useNavigate } from "react-router-dom"
 import "../assets/email-header.png"
+import { useUser } from "./queries/user.js"
 
 const Index = (): React.ReactElement => {
   useAnalytics()
+  // Redirect authenticated Google users to the migration step if they are in any other route
+  const navigate = useNavigate()
+  const location = useLocation()
+  const { user, loading, error } = useUser()
+  useEffect(() => {
+    if (
+      !loading && !error && location.pathname !== "/orcid-link" &&
+      user?.provider === "google"
+    ) {
+      navigate("/orcid-link")
+    }
+  }, [location.pathname, user])
   return (
     <Uploader>
       <SearchParamsProvider>

--- a/packages/openneuro-app/src/scripts/pages/__tests__/orcid-link.spec.tsx
+++ b/packages/openneuro-app/src/scripts/pages/__tests__/orcid-link.spec.tsx
@@ -1,0 +1,13 @@
+import React from "react"
+import { render, screen } from "@testing-library/react"
+import { OrcidLinkPage } from "../orcid-link"
+import { vitest } from "vitest"
+
+vitest.mock("../../config")
+
+describe("OrcidLinkPage", () => {
+  it("renders orcid link button", () => {
+    render(<OrcidLinkPage />)
+    expect(screen.getByRole("button")).toHaveTextContent("Link ORCID")
+  })
+})

--- a/packages/openneuro-app/src/scripts/pages/orcid-link.tsx
+++ b/packages/openneuro-app/src/scripts/pages/orcid-link.tsx
@@ -30,8 +30,21 @@ export function OrcidLinkPage() {
       <div className="container">
         <h2>ORCID account migration</h2>
         <p>
-          OpenNeuro is moving to ORCID for all logins. Please link an ORCID to
-          your account to continue and use ORCID for future logins.
+          OpenNeuro is moving to ORCID for all accounts. Please link an ORCID to
+          your account to continue and use ORCID for future logins. If you have
+          used Google login before, any datasets, comments, and permissions you
+          have will be merged into the combined OpenNeuro account.
+        </p>
+        <h3>Why are we making this change?</h3>
+        <p>
+          ORCID allows richer researcher metadata for contributions and
+          optionally sharing contributions to datasets as works on your ORCID
+          profile.
+        </p>
+        <h3>Will Google accounts continue to work?</h3>
+        <p>
+          Yes but to make new contributions you will need link an ORCID. Your
+          Google login will be an optional method for authentication.
         </p>
         <a href={loginUrls.orcid + `?migrate`}>
           <Button

--- a/packages/openneuro-app/src/scripts/pages/orcid-link.tsx
+++ b/packages/openneuro-app/src/scripts/pages/orcid-link.tsx
@@ -1,0 +1,46 @@
+import React from "react"
+import Helmet from "react-helmet"
+import { frontPage } from "./front-page/front-page-content"
+import loginUrls from "../authentication/loginUrls"
+import { Button } from "../components/button/Button"
+import orcidIcon from "../../assets/orcid_24x24.png"
+import styled from "@emotion/styled"
+
+const OrcidLinkPageStyle = styled.div`
+  background: white;
+
+  .container {
+    max-width: 60em;
+    min-height: calc(100vh - 152px);
+  }
+`
+
+export function OrcidLinkPage() {
+  return (
+    <OrcidLinkPageStyle>
+      <Helmet>
+        <title>
+          Link ORCID to your existing account - {frontPage.pageTitle}
+        </title>
+        <meta
+          name="description"
+          content="How to link your ORCID account to your Google based OpenNeuro account"
+        />
+      </Helmet>
+      <div className="container">
+        <h2>ORCID account migration</h2>
+        <p>
+          OpenNeuro is moving to ORCID for all logins. Please link an ORCID to
+          your account to continue and use ORCID for future logins.
+        </p>
+        <a href={loginUrls.orcid + `?migrate`}>
+          <Button
+            className="login-button"
+            label="Link ORCID"
+            imgSrc={orcidIcon}
+          />
+        </a>
+      </div>
+    </OrcidLinkPageStyle>
+  )
+}

--- a/packages/openneuro-app/src/scripts/pages/orcid-link.tsx
+++ b/packages/openneuro-app/src/scripts/pages/orcid-link.tsx
@@ -33,7 +33,8 @@ export function OrcidLinkPage() {
           OpenNeuro is moving to ORCID for all accounts. Please link an ORCID to
           your account to continue and use ORCID for future logins. If you have
           used Google login before, any datasets, comments, and permissions you
-          have will be merged into the combined OpenNeuro account.
+          have will be merged into the combined OpenNeuro account linked to your
+          ORCID iD.
         </p>
         <h3>Why are we making this change?</h3>
         <p>
@@ -43,8 +44,8 @@ export function OrcidLinkPage() {
         </p>
         <h3>Will Google accounts continue to work?</h3>
         <p>
-          Yes but to make new contributions you will need link an ORCID. Your
-          Google login will be an optional method for authentication.
+          To make new contributions you will need link an ORCID but any existing
+          contributions will remain available.
         </p>
         <a href={loginUrls.orcid + `?migrate`}>
           <Button

--- a/packages/openneuro-app/src/scripts/routes.tsx
+++ b/packages/openneuro-app/src/scripts/routes.tsx
@@ -22,6 +22,7 @@ import { UserQuery } from "./users/user-query"
 import LoggedIn from "../scripts/authentication/logged-in"
 import LoggedOut from "../scripts/authentication/logged-out"
 import FourOThreePage from "./errors/403page"
+import { OrcidLinkPage } from "./pages/orcid-link"
 
 const AppRoutes: React.VoidFunctionComponent = () => (
   <Routes>
@@ -39,6 +40,7 @@ const AppRoutes: React.VoidFunctionComponent = () => (
     <Route path="/import" element={<ImportDataset />} />
     <Route path="/metadata" element={<DatasetMetadata />} />
     <Route path="/public" element={<Navigate to="/search" replace />} />
+    <Route path="/orcid-link" element={<OrcidLinkPage />} />
     <Route
       path="/user/:orcid/*"
       element={

--- a/packages/openneuro-server/src/libs/authentication/google.ts
+++ b/packages/openneuro-server/src/libs/authentication/google.ts
@@ -3,8 +3,6 @@ import * as Sentry from "@sentry/node"
 import User from "../../models/user"
 import { PROVIDERS } from "./passport"
 import { userMigration } from "./user-migration"
-import { authCallback as orcidAuthCallback } from "./orcid"
-import { parsedJwtFromRequest } from "./jwt"
 
 const loginErrorHandler = (next) => (loginErr) => {
   if (loginErr) {
@@ -31,7 +29,7 @@ export const authCallback = async (req, res, next) => {
   return passport.authenticate(
     PROVIDERS.GOOGLE,
     { session: false },
-    async (err, user, info) => {
+    async (err, user, _info) => {
       // First we check if an ORCID user exists for this login
       let orcidUser
       if (user?.orcid) {

--- a/packages/openneuro-server/src/libs/authentication/google.ts
+++ b/packages/openneuro-server/src/libs/authentication/google.ts
@@ -1,4 +1,5 @@
 import passport from "passport"
+import * as Sentry from "@sentry/node"
 
 export const requestAuth = (req, res, next) =>
   passport.authenticate("google", {
@@ -12,7 +13,31 @@ export const requestAuth = (req, res, next) =>
     state: req.query.redirectPath || null,
   })(req, res, next)
 
-export const authCallback = passport.authenticate("google", {
-  failureRedirect: "/",
-  session: false,
-})
+export const authCallback = (req, res, next) =>
+  passport.authenticate("google", { session: false }, (err, user, info) => {
+    if (err) {
+      Sentry.captureException(err)
+      // Redirect to a generic error page or handle specific errors if possible
+      return res.redirect("/error/google/unknown")
+    }
+    if (!user) {
+      // Authentication failed (e.g., user denied access)
+      return res.redirect("/")
+    }
+
+    if (user.orcid) {
+      // User has ORCID linked already, redirect them through ORCID oauth
+      // TODO - Migrate Google data to their ORCID account here if required
+    } else {
+      // User does not have ORCID linked, redirect to the ORCID linking page after login
+      req.query.state = Buffer.from("/orcid-link").toString("base64")
+    }
+
+    req.logIn(user, { session: false }, (loginErr) => {
+      if (loginErr) {
+        Sentry.captureException(loginErr)
+        return next(loginErr) // Pass error to Express error handler
+      }
+      return next()
+    })
+  })(req, res, next)

--- a/packages/openneuro-server/src/libs/authentication/google.ts
+++ b/packages/openneuro-server/src/libs/authentication/google.ts
@@ -1,8 +1,21 @@
 import passport from "passport"
 import * as Sentry from "@sentry/node"
+import User from "../../models/user"
+import { PROVIDERS } from "./passport"
+import { userMigration } from "./user-migration"
+import { authCallback as orcidAuthCallback } from "./orcid"
+import { parsedJwtFromRequest } from "./jwt"
+
+const loginErrorHandler = (next) => (loginErr) => {
+  if (loginErr) {
+    Sentry.captureException(loginErr)
+    return next(loginErr) // Pass error to Express error handler
+  }
+  return next()
+}
 
 export const requestAuth = (req, res, next) =>
-  passport.authenticate("google", {
+  passport.authenticate(PROVIDERS.GOOGLE, {
     scope: [
       "https://www.googleapis.com/auth/userinfo.email",
       "https://www.googleapis.com/auth/userinfo.profile",
@@ -13,31 +26,45 @@ export const requestAuth = (req, res, next) =>
     state: req.query.redirectPath || null,
   })(req, res, next)
 
-export const authCallback = (req, res, next) =>
-  passport.authenticate("google", { session: false }, (err, user, info) => {
-    if (err) {
-      Sentry.captureException(err)
-      // Redirect to a generic error page or handle specific errors if possible
-      return res.redirect("/error/google/unknown")
-    }
-    if (!user) {
-      // Authentication failed (e.g., user denied access)
-      return res.redirect("/")
-    }
-
-    if (user.orcid) {
-      // User has ORCID linked already, redirect them through ORCID oauth
-      // TODO - Migrate Google data to their ORCID account here if required
-    } else {
-      // User does not have ORCID linked, redirect to the ORCID linking page after login
-      req.query.state = Buffer.from("/orcid-link").toString("base64")
-    }
-
-    req.logIn(user, { session: false }, (loginErr) => {
-      if (loginErr) {
-        Sentry.captureException(loginErr)
-        return next(loginErr) // Pass error to Express error handler
+export const authCallback = async (req, res, next) => {
+  // Google auth and redirect to linking page
+  return passport.authenticate(
+    PROVIDERS.GOOGLE,
+    { session: false },
+    async (err, user, info) => {
+      // First we check if an ORCID user exists for this login
+      let orcidUser
+      if (user?.orcid) {
+        orcidUser = await User.findOne({
+          providerId: user.orcid,
+          provider: PROVIDERS.ORCID,
+        })
       }
-      return next()
-    })
-  })(req, res, next)
+      if (orcidUser && user?.migrated) {
+        // User has ORCID linked already, redirect to login as linked account
+        return res.redirect("/crn/auth/orcid")
+      } else if (orcidUser && !(user?.migrated)) {
+        // Linked but not migrated, migrate here and then login
+        try {
+          await userMigration(orcidUser.providerId, user.id)
+        } catch (_err) {
+          // Already logged, just redirect to error page
+          return next(_err)
+        }
+        return res.redirect("/crn/auth/orcid")
+      } else {
+        if (err) {
+          Sentry.captureException(err)
+          // Redirect to a generic error page or handle specific errors if possible
+          return res.redirect("/error/google/unknown")
+        }
+        if (!user) {
+          // Authentication failed (e.g., user denied access)
+          return res.redirect("/")
+        }
+        req.query.state = Buffer.from("/orcid-link").toString("base64")
+        return req.logIn(user, { session: false }, loginErrorHandler(next))
+      }
+    },
+  )(req, res, next)
+}

--- a/packages/openneuro-server/src/libs/authentication/orcid.ts
+++ b/packages/openneuro-server/src/libs/authentication/orcid.ts
@@ -21,6 +21,7 @@ export const authCallback = (req, res, next) =>
     if (!user) {
       return res.redirect("/")
     }
+    // Google user
     const existingAuth = parsedJwtFromRequest(req)
     if (existingAuth) {
       // Migrate Google to ORCID

--- a/packages/openneuro-server/src/libs/authentication/orcid.ts
+++ b/packages/openneuro-server/src/libs/authentication/orcid.ts
@@ -1,5 +1,4 @@
 import passport from "passport"
-import User from "../../models/user"
 import { parsedJwtFromRequest } from "./jwt"
 import * as Sentry from "@sentry/node"
 import { userMigration } from "./user-migration"

--- a/packages/openneuro-server/src/libs/authentication/orcid.ts
+++ b/packages/openneuro-server/src/libs/authentication/orcid.ts
@@ -2,6 +2,7 @@ import passport from "passport"
 import User from "../../models/user"
 import { parsedJwtFromRequest } from "./jwt"
 import * as Sentry from "@sentry/node"
+import { userMigration } from "./user-migration"
 
 export const requestAuth = passport.authenticate("orcid", {
   session: false,
@@ -22,17 +23,15 @@ export const authCallback = (req, res, next) =>
     }
     const existingAuth = parsedJwtFromRequest(req)
     if (existingAuth) {
-      // Save ORCID to primary account
-      User.findOne({ id: existingAuth.sub })
-        .then((userModel) => {
-          userModel.orcid = user.providerId
-          return userModel.save().then(() => {
-            res.redirect("/")
+      // Migrate Google to ORCID
+      if (existingAuth.provider === "google") {
+        return userMigration(user.providerId, existingAuth.sub).then(() => {
+          // Complete login with ORCID as primary account
+          req.logIn(user, { session: false }, (err) => {
+            return next(err)
           })
         })
-        .catch((err) => {
-          return next(err)
-        })
+      }
     } else {
       // Complete login with ORCID as primary account
       req.logIn(user, { session: false }, (err) => {

--- a/packages/openneuro-server/src/libs/authentication/passport.ts
+++ b/packages/openneuro-server/src/libs/authentication/passport.ts
@@ -9,7 +9,7 @@ import { encrypt } from "./crypto"
 import { addJWT, jwtFromRequest } from "./jwt"
 import orcid from "../orcid"
 
-const PROVIDERS = {
+export const PROVIDERS = {
   GOOGLE: "google",
   ORCID: "orcid",
 }

--- a/packages/openneuro-server/src/libs/authentication/user-migration.ts
+++ b/packages/openneuro-server/src/libs/authentication/user-migration.ts
@@ -91,6 +91,8 @@ export async function userMigration(orcid: string, userId: string) {
           orcidUser.blocked = true
         }
         await orcidUser.save({ session })
+        // Save the orcid value that was actually used for future logins
+        googleUser.orcid = orcidUser.providerId
         googleUser.migrated = true
         await googleUser.save({ session })
         // Save success

--- a/packages/openneuro-server/src/libs/authentication/user-migration.ts
+++ b/packages/openneuro-server/src/libs/authentication/user-migration.ts
@@ -1,0 +1,107 @@
+import mongoose from "mongoose"
+import User from "../../models/user"
+import UserMigration from "../../models/userMigration"
+import Dataset from "../../models/dataset"
+import Permission from "../../models/permission"
+import Comment from "../../models/comment"
+import Deletion from "../../models/deletion"
+import * as Sentry from "@sentry/node"
+
+/**
+ * Move content from a Google account to an ORCID one
+ *
+ * Automatic rollback and error reporting if anything here fails
+ *
+ * Records the migration steps taken in the UserMigration model
+ *
+ * @param orcid ORCID iD of the user's primary account
+ * @param userId Account being merged with the ORCID account
+ */
+export async function userMigration(orcid: string, userId: string) {
+  const session = await mongoose.startSession()
+  try {
+    await session.withTransaction(async () => {
+      try {
+        // Load both original records
+        const orcidUser = await User.findOne({
+          providerId: orcid,
+          provider: "orcid",
+        })
+        const googleUser = await User.findOne({
+          id: userId,
+          provider: "google",
+        })
+
+        // Save the original user records
+        const migration = new UserMigration({ session })
+        migration.users.push(orcidUser.toObject())
+        migration.users.push(googleUser.toObject())
+        await migration.save({ session })
+
+        // Migrate dataset ownership
+        const datasets = await Dataset.find({ uploader: googleUser.id }, {
+          session,
+        })
+        for (const dataset of datasets) {
+          dataset.uploader = orcidUser.id
+          // Record this dataset uploader as migrated
+          migration.datasets.push(dataset.id)
+          await dataset.save({ session })
+        }
+
+        // Migrate dataset permissions
+        const permissions = await Permission.find({ userId: googleUser.id }, {
+          session,
+        })
+        for (const permission of permissions) {
+          permission.userId = orcidUser.id
+          // Record this permission as migrated
+          migration.permissions.push(permission.toObject())
+          await permission.save({ session })
+        }
+
+        // Migrate dataset deletions
+        const deletions = await Deletion.find({ userId: googleUser.id }, {
+          session,
+        })
+        for (const deletion of deletions) {
+          deletion.user._id = orcidUser.id
+          // Record this deletion as migrated
+          migration.deletions.push(deletion.toObject())
+          await deletion.save({ session })
+        }
+
+        // Migrate comments
+        const comments = await Comment.find({ userId: googleUser.id }, {
+          session,
+        })
+        for (const comment of comments) {
+          comment.user._id = orcidUser.id
+          // Record this comment as migrated
+          migration.comments.push(comment.toObject())
+          await comment.save({ session })
+        }
+
+        // Migrate admin permissions if different
+        if (googleUser.admin) {
+          orcidUser.admin = true
+        }
+        // If either account is blocked should we even migrate?
+        if (googleUser.blocked) {
+          orcidUser.blocked = true
+        }
+        await orcidUser.save({ session })
+        googleUser.migrated = true
+        await googleUser.save({ session })
+        // Save success
+        migration.success = true
+        await migration.save({ session })
+      } catch (err) {
+        Sentry.captureException(err)
+        throw err
+      }
+    })
+  } finally {
+    await session.endSession()
+  }
+}

--- a/packages/openneuro-server/src/models/user.ts
+++ b/packages/openneuro-server/src/models/user.ts
@@ -5,20 +5,37 @@ const { Schema, model } = mongoose
 
 export interface UserDocument extends Document {
   _id: string
+  // OpenNeuro specific user uuid
   id: string
+  // Best contact email for the user (notifications)
   email: string
+  // User's preferred name (visible)
   name: string
+  // Login provider
   provider: StaticRangeInit
+  // The id from the login provider
   providerId: string
+  // ORCID iD associated with this OpenNeuro user
   orcid: string
+  // Google account id associated with this OpenNeuro user
+  google: string
+  // Is this a migrated account? Migrated accounts were Google accounts moved to ORCID and disabled
+  migrated: boolean
   refresh: string
+  // Is this user a site admin with permissions for all datasets?
   admin: boolean
+  // Has this user been banned from the site?
   blocked: boolean
+  // Original account creation time
   created: Date
+  // Last time the user authenticated
   lastSeen: Date
   location: string
+  // Institution populated from ORCID
   institution: string
+  // GitHub account linked
   github: string
+  // User profile links
   links: string[]
 }
 
@@ -29,6 +46,8 @@ const userSchema = new Schema({
   provider: String, // Login provider
   providerId: String, // Login provider unique id
   orcid: String, // ORCID iD regardless of provider id
+  google: String, // Google ID if this is an ORCID account with a Google account linked
+  migrated: { type: Boolean, default: false },
   refresh: String,
   admin: { type: Boolean, default: false },
   blocked: { type: Boolean, default: false },

--- a/packages/openneuro-server/src/models/userMigration.ts
+++ b/packages/openneuro-server/src/models/userMigration.ts
@@ -1,0 +1,32 @@
+import { v4 as uuidv4 } from "uuid"
+import mongoose from "mongoose"
+import type { Document } from "mongoose"
+const { Schema, model } = mongoose
+
+export interface UserMigrationDocument extends Document {
+  _id: string
+  orcid: string
+  google: string
+  users: object[]
+  datasets: string[]
+  permissions: object[]
+  comments: object[]
+  deletions: object[]
+  success: boolean
+}
+
+const userMigrationSchema = new Schema({
+  id: { type: String, default: uuidv4 }, // OpenNeuro id
+  orcid: String,
+  google: String,
+  datasets: { type: [String], default: [] },
+  permissions: { type: [Object], default: [] },
+  comments: { type: [String], default: [] },
+  deletions: { type: [String], default: [] },
+  users: { type: [Object], default: [] },
+  success: Boolean,
+})
+
+const User = model<UserMigrationDocument>("UserMigration", userMigrationSchema)
+
+export default User

--- a/packages/openneuro-server/src/routes.ts
+++ b/packages/openneuro-server/src/routes.ts
@@ -178,7 +178,7 @@ const router = express.Router()
 
 for (const route of routes) {
   const arr = Object.hasOwn(route, "middleware") ? route.middleware : []
-  // @ts-expect-error
+  // @ts-expect-error This is actually working.
   arr.unshift(route.url)
   arr.push(route.handler)
   router[route.method](...arr)

--- a/packages/openneuro-server/src/routes.ts
+++ b/packages/openneuro-server/src/routes.ts
@@ -178,6 +178,7 @@ const router = express.Router()
 
 for (const route of routes) {
   const arr = Object.hasOwn(route, "middleware") ? route.middleware : []
+  // @ts-expect-error
   arr.unshift(route.url)
   arr.push(route.handler)
   router[route.method](...arr)


### PR DESCRIPTION
This will require ORCID for all logins on OpenNeuro. If a user has a Google account without a linked ORCID, they will be asked to link one.

Google only accounts will continue to function but a new website login will require linking ORCID to continue using the website. For deployment, the plan is to invalidate OpenNeuro's existing API keys.

The migration here is non-destructive, creating a log of the updated records and rolling back the transaction if the migration fails. A successful migration changes ownership of the content from the Google account to the new or existing ORCID account and marks the Google account as a "migrated" account.

After an account is migrated, it can still be used for login but in some cases will require the client to complete both the Google and ORCID oauth flows, so users should be encouraged to use their ORCID for logins.

Fixes #180.