### PR TITLE
fix(app): Display subcodes for schema validation

### DIFF
--- a/packages/openneuro-app/src/scripts/validation/__tests__/__snapshots__/validation-issues.spec.tsx.snap
+++ b/packages/openneuro-app/src/scripts/validation/__tests__/__snapshots__/validation-issues.spec.tsx.snap
@@ -9,8 +9,17 @@ exports[`Issue component > renders one issue 1`] = `
       class="e-meta"
     >
       <label>
-        /dataset_description.json
+        Location:
       </label>
+       /dataset_description.json
+    </div>
+    <div
+      class="e-meta"
+    >
+      <label>
+        Subcode:
+      </label>
+       DatasetType
     </div>
     <div
       class="e-meta"

--- a/packages/openneuro-app/src/scripts/validation/validation-issues.tsx
+++ b/packages/openneuro-app/src/scripts/validation/validation-issues.tsx
@@ -18,15 +18,19 @@ export function Issue({ datasetIssues, issue, groupBy }: IssueProps) {
       {groupBy === "location"
         ? (
           <div className="e-meta">
-            <label>{issue.code}</label>
-            <span>{issue.subCode ? ` - ${issue.subCode}` : ""}</span>
+            <label>Code:</label> {issue.code}
           </div>
         )
         : (
           <div className="e-meta">
-            <label>{issue.location}</label>
+            <label>Location:</label> {issue.location}
           </div>
         )}
+      {issue.subCode && (
+        <div className="e-meta">
+          <label>Subcode:</label> {issue.subCode}
+        </div>
+      )}
       <div className="e-meta">
         <label>Rule:</label> {issue.rule}
       </div>


### PR DESCRIPTION
Subcode wasn't being displayed unless you sorted by location. This shows it in both cases and consistently labels the code/location/subcode fields.