### PR TITLE
fix: adding setSearchParams to datasetType_selected if unset

### DIFF
--- a/packages/openneuro-app/src/scripts/search/search-params-ctx.tsx
+++ b/packages/openneuro-app/src/scripts/search/search-params-ctx.tsx
@@ -79,12 +79,10 @@ export const removeFilterItem = (setSearchParams) => (param, value) => {
     /* Handle simple filter resets. */
     case "datasetType_selected":
       // when datasetType is unset, unset datasetStatus as well
-      updatedParams["datasetStatus_selected"] =
-        initialSearchParams["datasetStatus_selected"]
-      updatedParams[param] = initialSearchParams[param]
       setSearchParams((prevState) => ({
         ...prevState,
-        ...updatedParams,
+        [param]: initialSearchParams[param],
+        "datasetStatus_selected": initialSearchParams["datasetStatus_selected"],
       }))
       break
     case "modality_selected":

--- a/packages/openneuro-app/src/scripts/search/search-params-ctx.tsx
+++ b/packages/openneuro-app/src/scripts/search/search-params-ctx.tsx
@@ -24,7 +24,7 @@ export const SearchParamsProvider: React.FC<SearchParamsProviderProps> = ({
       Sentry.addBreadcrumb({
         category: "routing",
         message: "No query found in URL. Using initialSearchParams.",
-        level: "info"
+        level: "info",
       })
     }
   } catch (err) {
@@ -81,6 +81,11 @@ export const removeFilterItem = (setSearchParams) => (param, value) => {
       // when datasetType is unset, unset datasetStatus as well
       updatedParams["datasetStatus_selected"] =
         initialSearchParams["datasetStatus_selected"]
+      updatedParams[param] = initialSearchParams[param]
+      setSearchParams((prevState) => ({
+        ...prevState,
+        ...updatedParams,
+      }))
       break
     case "modality_selected":
     case "brain_initiative":


### PR DESCRIPTION
I noticed the dataset type filters were not being removed if X'd out. 

This calls the setSearchParams if they are removed. 