### PR TITLE
fix: update fuzziness  distance for Elasticsearch search

### DIFF
--- a/packages/openneuro-app/src/scripts/search/use-search-results.tsx
+++ b/packages/openneuro-app/src/scripts/search/use-search-results.tsx
@@ -266,7 +266,7 @@ export const useSearchResults = () => {
       matchQuery(
         "latestSnapshot.description.Authors",
         joinWithOR(authors),
-        "3",
+        "2",
       ),
     )
   }


### PR DESCRIPTION
Addresses #3383

This PR addresses the `illegal_argument_exception: Valid edit distances are [0, 1, 2] but was [3]` error that was occurring in the GraphQL response for dataset searches.

The error was tracked down to the Elasticsearch `matchQuery` used for `latestSnapshot.description.Authors`. 

The fix updates the fuzziness setting for author searches from '3' to '2', 
