### PR TITLE
fix(app): Prevent page crash loading history

### DIFF
--- a/packages/openneuro-app/src/scripts/dataset/fragments/__tests__/dataset-history.spec.tsx
+++ b/packages/openneuro-app/src/scripts/dataset/fragments/__tests__/dataset-history.spec.tsx
@@ -1,0 +1,155 @@
+import React from "react"
+import { render, screen } from "@testing-library/react"
+import { MockedProvider } from "@apollo/client/testing"
+import { DatasetHistory, GET_HISTORY } from "../dataset-history"
+
+describe("DatasetHistory", () => {
+  it("renders an example history correctly", async () => {
+    const dataset = {
+      id: "ds000001",
+      name: "Test Dataset",
+      created: "2023-01-01T00:00:00.000Z",
+      downloads: 0,
+      views: 0,
+      stars: 0,
+      size: 0,
+      history: [
+        {
+          id: "adbafb8cc26558e1fe2be02fa782bf9f1a6c2556",
+          date: "2023-01-01T00:00:00.000Z",
+          authorName: "Test Author",
+          authorEmail: "test@example.com",
+          references: "",
+          message: "Initial commit",
+        },
+        {
+          id: "adbafb8cc26558e1fe2be02fa782bf9f1a6c0313",
+          date: "2023-01-02T00:00:00.000Z",
+          authorName: "Test Author",
+          authorEmail: "test@example.com",
+          references: "1.0.0",
+          message: "Test snapshot",
+        },
+      ],
+      authors: [],
+      editors: [],
+      public: true,
+      uploader: null,
+      latestSnapshot: null,
+      relatedDatasets: [],
+      mriqcResults: null,
+      tasks: [],
+      modalities: [],
+      datasetSummary: null,
+      datasetDescription: null,
+      readme: null,
+      license: null,
+      funding: null,
+      acknowledgements: null,
+      howToAcknowledge: null,
+      ethicsApprovals: [],
+      publications: [],
+      datasetMetadata: [],
+      changelog: null,
+      issues: [],
+      starred: false,
+      followers: [],
+      hasOpenIssues: false,
+      createdAt: "2023-01-01T00:00:00.000Z",
+      updatedAt: "2023-01-01T00:00:00.000Z",
+      uploaderId: null,
+      orcid: null,
+      userId: null,
+      user: null,
+      isPrivate: false,
+      onboarded: false,
+      worker: 0,
+      __typename: "Dataset",
+    }
+    const mocks = [
+      {
+        request: {
+          query: GET_HISTORY,
+          variables: { datasetId: dataset.id },
+        },
+        result: {
+          data: {
+            dataset,
+          },
+        },
+      },
+    ]
+    await render(
+      <MockedProvider mocks={mocks}>
+        <DatasetHistory datasetId={dataset.id} />
+      </MockedProvider>,
+    )
+    expect(await screen.findByText("Initial commit")).toBeInTheDocument()
+    expect(await screen.findByText("Test snapshot")).toBeInTheDocument()
+  })
+  it("renders correctly when dataset.history is null", async () => {
+    const dataset = {
+      id: "ds000001",
+      name: "Test Dataset",
+      created: "2023-01-01T00:00:00.000Z",
+      downloads: 0,
+      views: 0,
+      stars: 0,
+      size: 0,
+      history: null,
+      authors: [],
+      editors: [],
+      public: true,
+      uploader: null,
+      latestSnapshot: null,
+      relatedDatasets: [],
+      mriqcResults: null,
+      tasks: [],
+      modalities: [],
+      datasetSummary: null,
+      datasetDescription: null,
+      readme: null,
+      license: null,
+      funding: null,
+      acknowledgements: null,
+      howToAcknowledge: null,
+      ethicsApprovals: [],
+      publications: [],
+      datasetMetadata: [],
+      changelog: null,
+      issues: [],
+      starred: false,
+      followers: [],
+      hasOpenIssues: false,
+      createdAt: "2023-01-01T00:00:00.000Z",
+      updatedAt: "2023-01-01T00:00:00.000Z",
+      uploaderId: null,
+      orcid: null,
+      userId: null,
+      user: null,
+      isPrivate: false,
+      onboarded: false,
+      worker: 0,
+      __typename: "Dataset",
+    }
+    const mocks = [
+      {
+        request: {
+          query: GET_HISTORY,
+          variables: { datasetId: dataset.id },
+        },
+        result: {
+          data: {
+            dataset,
+          },
+        },
+      },
+    ]
+    await render(
+      <MockedProvider mocks={mocks}>
+        <DatasetHistory datasetId={dataset.id} />
+      </MockedProvider>,
+    )
+    expect(await screen.findByText("No history available")).toBeInTheDocument()
+  })
+})

--- a/packages/openneuro-app/src/scripts/dataset/fragments/dataset-history.jsx
+++ b/packages/openneuro-app/src/scripts/dataset/fragments/dataset-history.jsx
@@ -2,10 +2,9 @@ import React from "react"
 import PropTypes from "prop-types"
 import styled from "@emotion/styled"
 import { gql, useQuery } from "@apollo/client"
-
 import Revalidate from "../mutations/revalidate.jsx"
 
-const GET_HISTORY = gql`
+export const GET_HISTORY = gql`
   query getHistory($datasetId: ID!) {
     dataset(id: $datasetId) {
       id
@@ -29,16 +28,16 @@ const DatasetHistoryTable = styled.div`
   .row:nth-of-type(2n) {
     padding-top: 1em;
   }
-  .row:nth-of-type(2n + 1) {
+  .row:nth-of-type(2n+1) {
     padding-bottom: 1em;
   }
   .row:nth-of-type(4n),
-  .row:nth-of-type(4n + 1) {
+  .row:nth-of-type(4n+1) {
     background: #f4f4f4;
   }
 `
 
-const DatasetHistory = ({ datasetId }) => {
+export const DatasetHistory = ({ datasetId }) => {
   const { loading, data } = useQuery(GET_HISTORY, {
     variables: { datasetId },
     errorPolicy: "all",
@@ -58,7 +57,7 @@ const DatasetHistory = ({ datasetId }) => {
             <h4 className="col-lg col col-2">References</h4>
             <h4 className="col-lg col col-2 text--right">Action</h4>
           </div>
-          {data.dataset.history.map((commit) => (
+          {data.dataset?.history?.map((commit) => (
             <React.Fragment key={commit.id}>
               <div className="grid faux-table">
                 <div className="commit col-lg col col-2">
@@ -83,7 +82,7 @@ const DatasetHistory = ({ datasetId }) => {
                 <div className="col-lg col col-12">{commit.message}</div>
               </div>
             </React.Fragment>
-          ))}
+          )) || "No history available"}
         </DatasetHistoryTable>
       </div>
     )


### PR DESCRIPTION
Fixes a page crash that would occur if a dataset's history value was null. Add test coverage for history present or null cases.