### PR TITLE
fix(app): Prevent component crash on UploadSelect when user query is loading

### DIFF
--- a/packages/openneuro-app/src/scripts/uploader/upload-select.jsx
+++ b/packages/openneuro-app/src/scripts/uploader/upload-select.jsx
@@ -6,7 +6,7 @@ import { useUser } from "../queries/user"
 const UploadSelect = () => {
   const { user, loading, error } = useUser()
   const disabled = loading || Boolean(error) || !user || !user.email
-  const noEmail = !user.email
+  const noEmail = !(user?.email)
   return (
     <div>
       <UploaderContext.Consumer>


### PR DESCRIPTION
Fixes an issue in 4.35.0 where the UploadSelect component would fail to render depending on the state of the user info client side cache.