### PR TITLE
dev(app): Enable Apollo client devtools connection outside of production

### DIFF
--- a/packages/openneuro-app/src/client.jsx
+++ b/packages/openneuro-app/src/client.jsx
@@ -30,6 +30,7 @@ const client = new ApolloClient({
       },
     },
   }),
+  connectToDevTools: config.sentry.environment !== "production",
 })
 
 container.render(


### PR DESCRIPTION
Enables the Apollo Client devtools connection for dev and staging environments.