### PR TITLE
if name is empty/missing print accession number as name, 

### DIFF
--- a/packages/openneuro-app/src/scripts/components/search-page/SearchResultItem.tsx
+++ b/packages/openneuro-app/src/scripts/components/search-page/SearchResultItem.tsx
@@ -127,6 +127,8 @@ export const SearchResultItem = ({
   const hasEdit = hasEditPermissions(node.permissions, profileSub) || isAdmin
 
   const heading = node.latestSnapshot.description?.Name
+    ? node.latestSnapshot.description?.Name
+    : node.id
   const summary = node.latestSnapshot?.summary
   const datasetId = node.id
   const numSessions = summary?.sessions.length > 0 ? summary.sessions.length : 1
@@ -134,7 +136,7 @@ export const SearchResultItem = ({
   const accessionNumber = (
     <span className="result-summary-meta">
       <strong>Openneuro Accession Number:</strong>
-      <span>{node.id}</span>
+      <Link to={"/datasets/" + datasetId}>{node.id}</Link>
     </span>
   )
   const sessions = (


### PR DESCRIPTION
**Addresses #3452**

- If the dataset name is empty or missing, the accession number is now displayed as the result heading.
- Adds a link to the dataset using the accession number in the footer of the result.
- per suggestion - The full result card is not wrapped in a link to ensure proper accessibility and interaction with embedded elements like tooltips for ownership icons and dataset stats. We can adjust further if needed