### PR TITLE
fix: Enforce eol=lf for .json, .tsv, CHANGES, README and LICENSE

### DIFF
--- a/services/datalad/datalad_service/tasks/dataset.py
+++ b/services/datalad/datalad_service/tasks/dataset.py
@@ -18,14 +18,14 @@ GIT_ATTRIBUTES = """* annex.backend=SHA256E
 **/.git* annex.largefiles=nothing
 *.bval annex.largefiles=nothing
 *.bvec annex.largefiles=nothing
-*.json annex.largefiles=largerthan=1mb
+*.json text eol=lf annex.largefiles=largerthan=1mb
+*.tsv text eol=lf annex.largefiles=largerthan=1mb
 phenotype/*.tsv annex.largefiles=anything
-*.tsv annex.largefiles=largerthan=1mb
 dataset_description.json annex.largefiles=nothing
 .bidsignore annex.largefiles=nothing
-CHANGES annex.largefiles=nothing
-README* annex.largefiles=nothing
-LICENSE annex.largefiles=nothing
+CHANGES text eol=lf annex.largefiles=nothing
+README* text eol=lf annex.largefiles=nothing
+LICENSE* text eol=lf annex.largefiles=nothing
 """
 
 DATALAD_CONFIG = """[datalad "dataset"]

--- a/services/datalad/datalad_service/tasks/dataset.py
+++ b/services/datalad/datalad_service/tasks/dataset.py
@@ -26,6 +26,7 @@ dataset_description.json annex.largefiles=nothing
 CHANGES text eol=lf annex.largefiles=nothing
 README* text eol=lf annex.largefiles=nothing
 LICENSE* text eol=lf annex.largefiles=nothing
+CITATION.cff text eol=lf annex.largefiles=nothing
 """
 
 DATALAD_CONFIG = """[datalad "dataset"]


### PR DESCRIPTION
This PR marks `.json`, `.tsv`, `CHANGES`, `README[.*]`, `LICENSE[.*]` and `CITATION.cff` as text and instructs git to normalize to LF (as oppposed to CRLF) line endings.

Closes #3465.