### PR TITLE
fix(app): Include a suggested filename in download links

### DIFF
--- a/packages/openneuro-app/src/scripts/dataset/files/__tests__/__snapshots__/file.spec.jsx.snap
+++ b/packages/openneuro-app/src/scripts/dataset/files/__tests__/__snapshots__/file.spec.jsx.snap
@@ -29,7 +29,7 @@ exports[`File component > renders for dataset snapshots 1`] = `
         >
           <a
             aria-label="download file"
-            download=""
+            download="README"
             href="/crn/datasets/ds001/snapshots/1.0.0/files/README"
           >
             <i
@@ -90,7 +90,7 @@ exports[`File component > renders with common props 1`] = `
         >
           <a
             aria-label="download file"
-            download=""
+            download="README"
             href="/crn/datasets/ds001/files/README"
           >
             <i

--- a/packages/openneuro-app/src/scripts/dataset/files/file.tsx
+++ b/packages/openneuro-app/src/scripts/dataset/files/file.tsx
@@ -149,7 +149,7 @@ const File = ({
                 <a
                   href={urls?.[0] ||
                     apiPath(datasetId, snapshotTag, filePath(path, filename))}
-                  download
+                  download={filename}
                   aria-label="download file"
                 >
                   <i className="fa fa-download" />


### PR DESCRIPTION
Looked at addressing this at the API level but it comes with a performance cost, instead set it on the download links.

Fixes #3304
