### PR TITLE
Use annexed content for edits to dataset_description.json and CHANGES

### DIFF
--- a/services/datalad/datalad_service/common/git.py
+++ b/services/datalad/datalad_service/common/git.py
@@ -1,9 +1,13 @@
+import asyncio
+import io
+import os
 import pathlib
 import re
 import subprocess
 import logging
 import sentry_sdk
 
+import aiofiles
 import pygit2
 from charset_normalizer import from_bytes
 
@@ -24,6 +28,59 @@ def git_show(repo, committish, obj):
     data_bytes = (commit.tree / obj).read_raw()
     result = from_bytes(data_bytes).best()
     return str(result)
+
+
+async def read_from_bytes_as_stream(data: bytes, chunk_size: int = 1024):
+    """
+    Reads from a bytes object as an async stream, yielding chunks.
+    """
+    buffer = io.BytesIO(data)
+    while True:
+        chunk = await asyncio.to_thread(buffer.read, chunk_size)
+        if not chunk:
+            break
+        yield chunk
+
+
+async def read_from_aiofile_as_stream(aiofile_obj, chunk_size: int = 1024):
+    """
+    Reads from an aiofiles file object as an async stream, yielding chunks.
+    Ensures the file is closed after streaming.
+    """
+    try:
+        while True:
+            chunk = await aiofile_obj.read(chunk_size)
+            if not chunk:
+                break
+            yield chunk
+    finally:
+        await aiofile_obj.close()
+
+
+async def git_show_content(repo, committish, filename):
+    """
+    Similar to git_show but resolves annexed content if possible.
+    
+    Returns a stream for the consumer.
+    Annex content is typically much larger and worth streaming.
+    """
+    dataset_root = str(pathlib.Path(repo.path).parent)
+    commit, _ = repo.resolve_refish(committish)
+    data_bytes = (commit.tree / filename).read_raw()
+    result = str(from_bytes(data_bytes[0:4096]).best())
+    if result.find('.git/annex') != -1:
+        # Resolve absolute path for annex target
+        target_path = os.path.normpath(os.path.join(
+            dataset_root, os.path.dirname(filename), result))
+        # Verify the annex path is within the dataset dir
+        if dataset_root == os.path.commonpath((dataset_root, target_path)):
+            file_obj = await aiofiles.open(target_path, 'rb')
+            return read_from_aiofile_as_stream(file_obj), os.path.getsize(target_path)
+        else:
+            raise OpenNeuroGitError("Invalid symlinked path in git_show_content")
+    else:
+        # Git object
+        return read_from_bytes_as_stream(data_bytes), len(data_bytes)
 
 
 def git_show_object(repo, obj):

--- a/services/datalad/datalad_service/handlers/description.py
+++ b/services/datalad/datalad_service/handlers/description.py
@@ -1,5 +1,5 @@
 import falcon
-import os
+import sentry_sdk
 
 from datalad_service.tasks.description import update_description
 
@@ -21,13 +21,14 @@ class DescriptionResource:
                 }
                 resp.status = falcon.HTTP_UNPROCESSABLE_ENTITY
             try:
-                updated = update_description(
+                updated = await update_description(
                     self.store, dataset, description_fields)
                 dataset_description = updated
                 resp.media = dataset_description
                 resp.status = falcon.HTTP_OK
-            except:
-                resp.media = {'error': 'dataset update failed'}
+            except Exception as e:
+                sentry_sdk.capture_exception(e)
+                resp.media = {'error': 'dataset_description.json update failed'}
                 resp.status = falcon.HTTP_500
         else:
             resp.media = {

--- a/services/datalad/datalad_service/handlers/snapshots.py
+++ b/services/datalad/datalad_service/handlers/snapshots.py
@@ -4,7 +4,7 @@ import logging
 
 import falcon
 
-from datalad_service.tasks.snapshots import SnapshotDescriptionException, create_snapshot, get_snapshot, get_snapshots, SnapshotExistsException
+from datalad_service.tasks.snapshots import SnapshotDescriptionException, create_snapshot, get_snapshot, get_snapshots, SnapshotExistsException, SnapshotChangesException
 from datalad_service.tasks.files import get_tree
 from datalad_service.tasks.publish import export_dataset, monitor_remote_configs
 from datalad_service.common.git import delete_tag
@@ -66,6 +66,9 @@ class SnapshotResource:
             resp.media = {'error': repr(err)}
             resp.status = falcon.HTTP_CONFLICT
         except SnapshotDescriptionException as err:
+            resp.media = {'error': repr(err)}
+            resp.status = falcon.HTTP_BAD_REQUEST
+        except SnapshotChangesException as err:
             resp.media = {'error': repr(err)}
             resp.status = falcon.HTTP_BAD_REQUEST
 

--- a/services/datalad/datalad_service/handlers/snapshots.py
+++ b/services/datalad/datalad_service/handlers/snapshots.py
@@ -52,7 +52,7 @@ class SnapshotResource:
         ds_path = self.store.get_dataset_path(dataset)
 
         try:
-            created = create_snapshot(
+            created = await create_snapshot(
                 self.store, dataset, snapshot, description_fields, snapshot_changes)
             resp.media = created
             resp.status = falcon.HTTP_OK

--- a/services/datalad/datalad_service/handlers/snapshots.py
+++ b/services/datalad/datalad_service/handlers/snapshots.py
@@ -4,10 +4,11 @@ import logging
 
 import falcon
 
-from datalad_service.tasks.snapshots import SnapshotDescriptionException, create_snapshot, get_snapshot, get_snapshots, SnapshotExistsException, SnapshotChangesException
+from datalad_service.common.annex import EditAnnexedFileException
+from datalad_service.common.git import delete_tag
+from datalad_service.tasks.snapshots import create_snapshot, get_snapshot, get_snapshots, SnapshotExistsException
 from datalad_service.tasks.files import get_tree
 from datalad_service.tasks.publish import export_dataset, monitor_remote_configs
-from datalad_service.common.git import delete_tag
 
 
 class SnapshotResource:
@@ -65,10 +66,7 @@ class SnapshotResource:
         except SnapshotExistsException as err:
             resp.media = {'error': repr(err)}
             resp.status = falcon.HTTP_CONFLICT
-        except SnapshotDescriptionException as err:
-            resp.media = {'error': repr(err)}
-            resp.status = falcon.HTTP_BAD_REQUEST
-        except SnapshotChangesException as err:
+        except EditAnnexedFileException as err:
             resp.media = {'error': repr(err)}
             resp.status = falcon.HTTP_BAD_REQUEST
 

--- a/services/datalad/datalad_service/tasks/description.py
+++ b/services/datalad/datalad_service/tasks/description.py
@@ -1,7 +1,8 @@
+import aiofiles
 import json
 import os
 
-from datalad_service.common.git import git_show
+from datalad_service.common.git import git_show_content
 from datalad_service.tasks.files import commit_files
 
 
@@ -11,26 +12,29 @@ def edit_description(description, new_fields):
     return updated
 
 
-def update_description(store, dataset, description_fields, name=None, email=None):
+async def update_description(store, dataset, description_fields, name=None, email=None):
     repo = store.get_dataset_repo(dataset)
-    description = git_show(
+    description_stream, description_size = await git_show_content(
         repo, 'HEAD', 'dataset_description.json')
+    all_content_bytes_list = []
+    async for chunk in description_stream:
+        all_content_bytes_list.append(chunk)
+    description = b"".join(all_content_bytes_list).decode()
     description_json = json.loads(description)
     if description_json.get('License') != 'CC0':
         description_fields = edit_description(
             description_fields, {'License': 'CC0'})
     if description_fields is not None and any(description_fields):
         updated = edit_description(description_json, description_fields)
-        path = os.path.join(store.get_dataset_path(
-            dataset), 'dataset_description.json')
-        with open(path, 'r+', encoding='utf-8', newline='') as description_file:
-            description_file_contents = description_file.read()
+        path = os.path.realpath(os.path.join(store.get_dataset_path(dataset), 'dataset_description.json'))
+        async with aiofiles.open(path, 'r+', encoding='utf-8', newline='') as description_file:
+            description_file_contents = await description_file.read()
             if description != description_file_contents:
                 raise Exception('unexpected dataset_description.json contents',
                                 description, description_file_contents)
-            description_file.seek(0)
-            description_file.truncate(0)
-            description_file.write(json.dumps(
+            await description_file.seek(0)
+            await description_file.truncate(0)
+            await description_file.write(json.dumps(
                 updated, indent=4, ensure_ascii=False))
         # Commit new content, run validator
         commit_files(store, dataset, [

--- a/services/datalad/datalad_service/tasks/snapshots.py
+++ b/services/datalad/datalad_service/tasks/snapshots.py
@@ -109,11 +109,12 @@ async def write_new_changes(dataset_path, tag, new_changes, date):
     updated = edit_changes(changes, new_changes, tag, date)
     path = os.path.join(dataset_path, 'CHANGES')
     real_path = os.path.realpath(path)
-    # Open the working tree or annexed path to verify contents
-    async with aiofiles.open(real_path, 'r', encoding='utf-8') as changes_file:
-        changes_file_contents = await changes_file.read()
-        if changes.strip() != changes_file_contents.strip():
-            raise SnapshotChangesException('unexpected CHANGES content')
+    if os.path.exists(real_path):
+        # Open the working tree or annexed path to verify contents
+        async with aiofiles.open(real_path, 'r', encoding='utf-8') as changes_file:
+            changes_file_contents = await changes_file.read()
+            if changes.strip() != changes_file_contents.strip():
+                raise SnapshotChangesException('unexpected CHANGES content')
     # Open the working tree path to overwrite
     if path != real_path:
         os.unlink(path)

--- a/services/datalad/datalad_service/tasks/snapshots.py
+++ b/services/datalad/datalad_service/tasks/snapshots.py
@@ -151,7 +151,7 @@ def save_snapshot(store, dataset, snapshot):
     repo.references.create(f'refs/tags/{snapshot}', str(repo.head.target))
 
 
-def create_snapshot(store, dataset, snapshot, description_fields, snapshot_changes):
+async def create_snapshot(store, dataset, snapshot, description_fields, snapshot_changes):
     """
     Create a new snapshot (git tag).
 
@@ -159,7 +159,7 @@ def create_snapshot(store, dataset, snapshot, description_fields, snapshot_chang
     """
     validate_snapshot_name(store, dataset, snapshot)
     validate_datalad_config(store, dataset)
-    update_description(store, dataset, description_fields)
+    await update_description(store, dataset, description_fields)
     update_changes(store, dataset, snapshot, snapshot_changes)
     save_snapshot(store, dataset, snapshot)
     return get_snapshot(store, dataset, snapshot)

--- a/services/datalad/tests/conftest.py
+++ b/services/datalad/tests/conftest.py
@@ -179,3 +179,13 @@ def client(datalad_store, monkeypatch):
     monkeypatch.setenv('DATALAD_DATASET_PATH', str(datalad_store.annex_path))
     monkeypatch.setattr(datalad_service.config, 'DATALAD_DATASET_PATH', str(datalad_store.annex_path))
     return testing.TestClient(create_app())
+
+
+@pytest.fixture(autouse=True)
+def mock_validate_dataset_task(monkeypatch):
+    """
+    Mocks the validate_dataset task to prevent event loop errors in tests.
+    """
+    async def async_noop_validator(*args, **kwargs):
+        return None
+    monkeypatch.setattr('datalad_service.tasks.files.validate_dataset', async_noop_validator)


### PR DESCRIPTION
This will use and maintain the annexed state for CHANGES and dataset_description.json when creating snapshots.

Fixes #3464 