### PR TITLE
feat(cli): Add support for symlinked content during uploads

### DIFF
--- a/cli/src/commands/upload.ts
+++ b/cli/src/commands/upload.ts
@@ -38,7 +38,7 @@ export async function addGitFiles(
   for await (
     const walkEntry of walk(dataset_directory_abs, {
       includeDirs: false,
-      includeSymlinks: false,
+      includeSymlinks: true,
     })
   ) {
     const relativePath = relative(dataset_directory_abs, walkEntry.path)

--- a/cli/src/worker/git.ts
+++ b/cli/src/worker/git.ts
@@ -114,7 +114,16 @@ async function shouldBeAnnexed(
  * git-annex add equivalent
  */
 async function add(event: GitWorkerEventAdd) {
-  const { size } = await context.fs.promises.stat(event.data.path)
+  let size
+  try {
+    const stats = await context.fs.promises.stat(event.data.path)
+    size = stats.size
+  } catch (_err) {
+    console.log(
+      `${event.data.relativePath} could not be added, check if this file is accessible and not a broken symlink.`,
+    )
+    return await done()
+  }
   const annexed = await shouldBeAnnexed(
     event.data.relativePath,
     size,


### PR DESCRIPTION
This will traverse symlinks during CLI uploads. This is for the current mode of creating a managed annex repo during upload.

Fixes #3421