### PR TITLE
fix(cli): Don't exempt .gitattributes from dotfile filtering

### DIFF
--- a/cli/src/commands/upload.ts
+++ b/cli/src/commands/upload.ts
@@ -43,7 +43,7 @@ export async function addGitFiles(
   ) {
     const relativePath = relative(dataset_directory_abs, walkEntry.path)
     if (
-      relativePath === ".bidsignore" || relativePath === ".gitattributes" ||
+      relativePath === ".bidsignore" ||
       !relativePath.startsWith(".")
     ) {
       worker.postMessage({


### PR DESCRIPTION
Users have accidentally added bad .gitattributes when pushing without history. It makes more sense to use the OpenNeuro default gitattributes in this case.

If a user intends to add a .gitattributes, they are likely using DataLad or git-annex directly.