### PR TITLE
fix(app): Prevent a crash displaying snapshot page if authors is undefined

### DIFF
--- a/packages/openneuro-app/src/scripts/dataset/routes/snapshot.tsx
+++ b/packages/openneuro-app/src/scripts/dataset/routes/snapshot.tsx
@@ -18,7 +18,7 @@ const FormRow = styled.div`
 export const NoErrors = ({ validation, authors, children }) => {
   const noErrors = validation?.errors === 0
   // zero authors will cause DOI minting to fail
-  const hasAuthor = authors.length > 0
+  const hasAuthor = authors?.length > 0
   if (noErrors && hasAuthor) {
     return children
   } else {


### PR DESCRIPTION
This can be the case if the dataset was created for the purpose of uploading via DataLad or git-annex.