### PR TITLE
fix(server): Restrict the User.email field to admins or your own user

### DIFF
--- a/packages/openneuro-app/src/scripts/users/user-card.tsx
+++ b/packages/openneuro-app/src/scripts/users/user-card.tsx
@@ -21,12 +21,18 @@ export const UserCard: React.FC<UserCardProps> = ({ orcidUser }) => {
             {location}
           </li>
         )}
-        <li>
-          <i className="fas fa-envelope"></i>
-          <a href={"mailto:" + email} target="_blank" rel="noopener noreferrer">
-            {email}
-          </a>
-        </li>
+        {email && (
+          <li>
+            <i className="fas fa-envelope"></i>
+            <a
+              href={"mailto:" + email}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {email}
+            </a>
+          </li>
+        )}
         {orcid && (
           <li className={styles.orcid}>
             <i className="fab fa-orcid" aria-hidden="true"></i>

--- a/packages/openneuro-server/src/graphql/resolvers/comment.ts
+++ b/packages/openneuro-server/src/graphql/resolvers/comment.ts
@@ -105,7 +105,7 @@ export const deleteComment = async (
 const CommentFields = {
   parent: (obj) => comment(obj, { id: obj.parentId }),
   replies,
-  user: (obj) => user(obj, { id: obj.user._id }),
+  user: (obj) => user(obj, { id: obj.user._id }, null),
 }
 
 export default CommentFields

--- a/packages/openneuro-server/src/graphql/resolvers/dataset.ts
+++ b/packages/openneuro-server/src/graphql/resolvers/dataset.ts
@@ -278,7 +278,7 @@ const worker = (obj) => getDatasetWorker(obj.id)
  * Dataset object
  */
 const Dataset = {
-  uploader: (ds) => user(ds, { id: ds.uploader }),
+  uploader: (ds, _, context) => user(ds, { id: ds.uploader }, context),
   draft: async (obj) => {
     const draftHead = await datalad.getDraftHead(obj.id)
     return {

--- a/packages/openneuro-server/src/graphql/resolvers/metadata.ts
+++ b/packages/openneuro-server/src/graphql/resolvers/metadata.ts
@@ -27,7 +27,7 @@ export const metadata = async (
   // TODO - This could be a user object that is resolved with the full type instead of just email
   // Email matches the existing records however and the user object would require other changes
   const adminUsers = []
-  const { userPermissions } = await permissions(dataset)
+  const { userPermissions } = await permissions(dataset, null, context)
   for (const user of userPermissions) {
     if (user.level === "admin") {
       const userObj = await user.user

--- a/packages/openneuro-server/src/graphql/resolvers/user.ts
+++ b/packages/openneuro-server/src/graphql/resolvers/user.ts
@@ -6,14 +6,22 @@ function isValidOrcid(orcid: string): boolean {
   return /^[0-9]{4}-[0-9]{4}-[0-9]{4}-[0-9]{3}[0-9X]$/.test(orcid || "")
 }
 
-export const user = (obj, { id }) => {
+export async function user(obj, { id }, { userInfo }) {
+  let user
   if (isValidOrcid(id)) {
-    return User.findOne({
+    user = await User.findOne({
       $or: [{ "provider": "orcid", "providerId": id }],
     }).exec()
   } else {
     // If it's not a valid ORCID, fall back to querying by user id
-    return User.findOne({ "id": id }).exec()
+    user = await User.findOne({ "id": id }).exec()
+  }
+  if (userInfo?.admin || user.id === userInfo?.id) {
+    return user.toObject()
+  } else {
+    const obj = user.toObject()
+    delete obj.email
+    return obj
   }
 }
 


### PR DESCRIPTION
Require admin access to retrieve the connected email address except for your own user.

This hides this value on the profile page except when viewing your own profile or for site admins.