### PR TITLE
fix: Do not delete remotes if dataset has not been exported

### DIFF
--- a/services/datalad/datalad_service/handlers/dataset.py
+++ b/services/datalad/datalad_service/handlers/dataset.py
@@ -50,7 +50,10 @@ class DatasetResource:
         dataset_path = self.store.get_dataset_path(dataset)
 
         if await aiofiles.os.path.exists(dataset_path):
-            await delete_siblings(dataset)
+            repo = pygit2.Repository(dataset_path)
+            if 'github' in repo.remotes.names():
+                await delete_siblings(dataset)
+
             await delete_dataset(dataset_path)
 
             resp.media = {}


### PR DESCRIPTION
Addresses the "doesn't have a sibling" portion of https://github.com/OpenNeuroOrg/openneuro/issues/3335. It's not clear that we shouldn't fail in some way if GitHub is temporarily unavailable.