### PR TITLE
fix(server): Prevent a crash when userInfo context is null for user resolver

### DIFF
--- a/packages/openneuro-server/src/graphql/resolvers/comment.ts
+++ b/packages/openneuro-server/src/graphql/resolvers/comment.ts
@@ -105,7 +105,7 @@ export const deleteComment = async (
 const CommentFields = {
   parent: (obj) => comment(obj, { id: obj.parentId }),
   replies,
-  user: (obj) => user(obj, { id: obj.user._id }, null),
+  user: (obj) => user(obj, { id: obj.user._id }),
 }
 
 export default CommentFields

--- a/packages/openneuro-server/src/graphql/resolvers/permissions.ts
+++ b/packages/openneuro-server/src/graphql/resolvers/permissions.ts
@@ -34,7 +34,7 @@ const publishPermissions = async (datasetId) => {
     userPermissions: await Promise.all(
       userPermissions.map(async (userPermission) => ({
         ...userPermission,
-        user: await user(ds, { id: userPermission.userId }, null),
+        user: await user(ds, { id: userPermission.userId }),
       })),
     ),
   }

--- a/packages/openneuro-server/src/graphql/resolvers/user.ts
+++ b/packages/openneuro-server/src/graphql/resolvers/user.ts
@@ -7,7 +7,11 @@ function isValidOrcid(orcid: string): boolean {
   return /^[0-9]{4}-[0-9]{4}-[0-9]{4}-[0-9]{3}[0-9X]$/.test(orcid || "")
 }
 
-export async function user(obj, { id }, { userInfo }) {
+export async function user(
+  obj,
+  { id },
+  { userInfo }: { userInfo?: Record<string, unknown> } = {},
+) {
   let user
   if (isValidOrcid(id)) {
     user = await User.findOne({


### PR DESCRIPTION
Fixes a regression in 4.36.0 that would cause 404 on some dataset pages.

https://openneuro.sentry.io/issues/6660107519/events/17b77898203640ad9e95c2eba888b93b/