### PR TITLE
 moving tools into the header for more space / pre-annotation feature

### DIFF
--- a/packages/openneuro-app/src/scripts/dataset/__tests__/__snapshots__/snapshot-container.spec.tsx.snap
+++ b/packages/openneuro-app/src/scripts/dataset/__tests__/__snapshots__/snapshot-container.spec.tsx.snap
@@ -52,7 +52,7 @@ exports[`SnapshotContainer component > renders successfully 1`] = `
                   class="hexagon-wrapper"
                 >
                   <div
-                    class="hexagon no-modality"
+                    class="hexagon mri"
                   />
                   <div
                     class="label"

--- a/packages/openneuro-app/src/scripts/dataset/__tests__/__snapshots__/snapshot-container.spec.tsx.snap
+++ b/packages/openneuro-app/src/scripts/dataset/__tests__/__snapshots__/snapshot-container.spec.tsx.snap
@@ -94,7 +94,7 @@ exports[`SnapshotContainer component > renders successfully 1`] = `
                   </span>
                 </span>
                 <span
-                  class="css-zov466"
+                  class="css-126f3py"
                 >
                   <span
                     class=" "

--- a/packages/openneuro-app/src/scripts/dataset/__tests__/__snapshots__/snapshot-container.spec.tsx.snap
+++ b/packages/openneuro-app/src/scripts/dataset/__tests__/__snapshots__/snapshot-container.spec.tsx.snap
@@ -39,10 +39,10 @@ exports[`SnapshotContainer component > renders successfully 1`] = `
         class="container"
       >
         <div
-          class="grid grid-between"
+          class="ds-header-inner"
         >
           <div
-            class="col"
+            class="ds-inner-left"
           >
             <h1>
               <a
@@ -62,73 +62,157 @@ exports[`SnapshotContainer component > renders successfully 1`] = `
                 </div>
               </a>
               DS003-downsampled (only T1)
-              <div
-                class="css-1dyyc64"
-              >
-                <div
-                  class="toggle-counter-wrap"
-                >
-                  <span
-                    class=" "
-                    data-flow="up"
-                    data-tooltip="Get notified on new versions/comments"
-                  >
-                    <span
-                      class="toggle-counter"
-                    >
-                      <button
-                        aria-label="Following"
-                        class="on-button on-button--medium on-button--default icon-text toggle-btn active"
-                        role="button"
-                        type="button"
-                      >
-                        <i
-                          aria-hidden="true"
-                          class="fa fa-star css-1qxtz39"
-                        />
-                        Following
-                        <span
-                          class="count-span"
-                        >
-                          1
-                        </span>
-                      </button>
-                    </span>
-                  </span>
-                </div>
-                <div
-                  class="toggle-counter-wrap"
-                >
-                  <span
-                    class=" "
-                    data-flow="up"
-                    data-tooltip="Save to your bookmarked datasets"
-                  >
-                    <span
-                      class="toggle-counter"
-                    >
-                      <button
-                        aria-label="Bookmark"
-                        class="on-button on-button--medium on-button--default icon-text toggle-btn"
-                        role="button"
-                        type="button"
-                      >
-                        <i
-                          aria-hidden="true"
-                          class="fa fa-bookmark css-1qxtz39"
-                        />
-                        Bookmark
-                        <span
-                          class="count-span"
-                        >
-                          0
-                        </span>
-                      </button>
-                    </span>
-                  </span>
-                </div>
-              </div>
             </h1>
+            <div
+              class="dataset-tool-buttons"
+            >
+              <span
+                class="css-1dvuowd"
+              >
+                <span
+                  class="css-1hlo510"
+                >
+                  <span
+                    class=" "
+                    data-flow="up"
+                    data-tooltip="View the dataset file tree"
+                  >
+                    <a
+                      href="/datasets/ds001032/versions/1.0.0"
+                    >
+                      <span
+                        aria-label="Files"
+                        class=" on-icon icon-text "
+                        role="img"
+                      >
+                        <i
+                          class="fa fa-folder"
+                        />
+                        Files
+                      </span>
+                    </a>
+                  </span>
+                </span>
+                <span
+                  class="css-zov466"
+                >
+                  <span
+                    class=" "
+                    data-flow="up"
+                    data-tooltip="How to Download"
+                  >
+                    <a
+                      href="/datasets/ds001032/versions/1.0.0/download"
+                    >
+                      <span
+                        aria-label="Download"
+                        class=" on-icon icon-text "
+                        role="img"
+                      >
+                        <i
+                          class="fa fa-download"
+                        />
+                        Download
+                      </span>
+                    </a>
+                  </span>
+                </span>
+                <span
+                  class="css-1hlo510"
+                >
+                  <span
+                    class=" "
+                    data-flow="up"
+                    data-tooltip="View the dataset metadata"
+                  >
+                    <a
+                      href="/datasets/ds001032/versions/1.0.0/metadata"
+                    >
+                      <span
+                        aria-label="Metadata"
+                        class=" on-icon icon-text "
+                        role="img"
+                      >
+                        <i
+                          class="fa fa-file-code"
+                        />
+                        Metadata
+                      </span>
+                    </a>
+                  </span>
+                </span>
+              </span>
+            </div>
+          </div>
+          <div
+            class="ds-inner-right"
+          >
+            <div
+              class="css-zw18vc"
+            >
+              <div
+                class="toggle-counter-wrap"
+              >
+                <span
+                  class=" "
+                  data-flow="up"
+                  data-tooltip="Get notified on new versions/comments"
+                >
+                  <span
+                    class="toggle-counter"
+                  >
+                    <button
+                      aria-label="Following"
+                      class="on-button on-button--medium on-button--default icon-text toggle-btn active"
+                      role="button"
+                      type="button"
+                    >
+                      <i
+                        aria-hidden="true"
+                        class="fa fa-star css-1qxtz39"
+                      />
+                      Following
+                      <span
+                        class="count-span"
+                      >
+                        1
+                      </span>
+                    </button>
+                  </span>
+                </span>
+              </div>
+              <div
+                class="toggle-counter-wrap"
+              >
+                <span
+                  class=" "
+                  data-flow="up"
+                  data-tooltip="Save to your bookmarked datasets"
+                >
+                  <span
+                    class="toggle-counter"
+                  >
+                    <button
+                      aria-label="Bookmark"
+                      class="on-button on-button--medium on-button--default icon-text toggle-btn"
+                      role="button"
+                      type="button"
+                    >
+                      <i
+                        aria-hidden="true"
+                        class="fa fa-bookmark css-1qxtz39"
+                      />
+                      Bookmark
+                      <span
+                        class="count-span"
+                      >
+                        0
+                      </span>
+                    </button>
+                  </span>
+                </span>
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -370,86 +454,6 @@ exports[`SnapshotContainer component > renders successfully 1`] = `
                 </div>
               </div>
             </div>
-          </div>
-          <div
-            class="dataset-tool-buttons"
-          >
-            <span
-              class="css-1dvuowd"
-            >
-              <span
-                class="css-1mdlu11"
-              >
-                <span
-                  class=" "
-                  data-flow="up"
-                  data-tooltip="View the dataset file tree"
-                >
-                  <a
-                    href="/datasets/ds001032/versions/1.0.0"
-                  >
-                    <span
-                      aria-label="Files"
-                      class=" on-icon icon-text "
-                      role="img"
-                    >
-                      <i
-                        class="fa fa-folder"
-                      />
-                      Files
-                    </span>
-                  </a>
-                </span>
-              </span>
-              <span
-                class="css-aokf2s"
-              >
-                <span
-                  class=" "
-                  data-flow="up"
-                  data-tooltip="How to Download"
-                >
-                  <a
-                    href="/datasets/ds001032/versions/1.0.0/download"
-                  >
-                    <span
-                      aria-label="Download"
-                      class=" on-icon icon-text "
-                      role="img"
-                    >
-                      <i
-                        class="fa fa-download"
-                      />
-                      Download
-                    </span>
-                  </a>
-                </span>
-              </span>
-              <span
-                class="css-1mdlu11"
-              >
-                <span
-                  class=" "
-                  data-flow="up"
-                  data-tooltip="View the dataset metadata"
-                >
-                  <a
-                    href="/datasets/ds001032/versions/1.0.0/metadata"
-                  >
-                    <span
-                      aria-label="Metadata"
-                      class=" on-icon icon-text "
-                      role="img"
-                    >
-                      <i
-                        class="fa fa-file-code"
-                      />
-                      Metadata
-                    </span>
-                  </a>
-                </span>
-              </span>
-            </span>
           </div>
           <div
             class="css-1xk6djt"

--- a/packages/openneuro-app/src/scripts/dataset/common/follow-toggles.tsx
+++ b/packages/openneuro-app/src/scripts/dataset/common/follow-toggles.tsx
@@ -4,7 +4,7 @@ import "@emotion/react"
 export const FollowToggles = styled.div`
   display: flex;
   font-size: 14px;
-  margin-left: auto;
+  margin: 10px 0;
 
   .toggle-counter-wrap {
     display: inline-flex;

--- a/packages/openneuro-app/src/scripts/dataset/components/DatasetHeader.tsx
+++ b/packages/openneuro-app/src/scripts/dataset/components/DatasetHeader.tsx
@@ -2,7 +2,7 @@ import React from "react"
 import { Link } from "react-router-dom"
 
 export interface DatasetHeaderProps {
-  modality: string
+  modality: string | null | undefined
   pageHeading: string
   renderEditor?: () => React.ReactNode
   datasetUserActions?: React.ReactNode
@@ -16,6 +16,8 @@ export const DatasetHeader: React.FC<DatasetHeaderProps> = ({
   datasetHeaderTools,
   datasetUserActions,
 }) => {
+  const hexagonClass = modality ? modality.toLowerCase() : "no-modality"
+
   return (
     <div className="dataset-header">
       <div className="container">
@@ -24,7 +26,7 @@ export const DatasetHeader: React.FC<DatasetHeaderProps> = ({
             <h1>
               <Link to={"/search/modality/" + modality}>
                 <div className="hexagon-wrapper">
-                  <div className="hexagon no-modality"></div>
+                  <div className={`hexagon ${hexagonClass}`}></div>
                   <div className="label">
                     {modality
                       ? (

--- a/packages/openneuro-app/src/scripts/dataset/components/DatasetHeader.tsx
+++ b/packages/openneuro-app/src/scripts/dataset/components/DatasetHeader.tsx
@@ -17,7 +17,6 @@ export const DatasetHeader: React.FC<DatasetHeaderProps> = ({
   datasetHeaderTools,
   datasetUserActions,
 }) => {
-  console.log(children)
   return (
     <div className="dataset-header">
       <div className="container">

--- a/packages/openneuro-app/src/scripts/dataset/components/DatasetHeader.tsx
+++ b/packages/openneuro-app/src/scripts/dataset/components/DatasetHeader.tsx
@@ -5,8 +5,8 @@ export interface DatasetHeaderProps {
   modality: string
   pageHeading: string
   renderEditor?: () => React.ReactNode
-  children?: JSX.Element
-  datasetHeaderTools: React.ReactNode
+  datasetUserActions?: React.ReactNode
+  datasetHeaderTools?: React.ReactNode
 }
 
 export const DatasetHeader: React.FC<DatasetHeaderProps> = ({
@@ -15,6 +15,7 @@ export const DatasetHeader: React.FC<DatasetHeaderProps> = ({
   renderEditor,
   children,
   datasetHeaderTools,
+  datasetUserActions,
 }) => {
   console.log(children)
   return (
@@ -39,7 +40,7 @@ export const DatasetHeader: React.FC<DatasetHeaderProps> = ({
             </h1>
             {datasetHeaderTools}
           </div>
-          <div className="ds-inner-right">{children}</div>
+          <div className="ds-inner-right">{datasetUserActions}</div>
         </div>
       </div>
     </div>

--- a/packages/openneuro-app/src/scripts/dataset/components/DatasetHeader.tsx
+++ b/packages/openneuro-app/src/scripts/dataset/components/DatasetHeader.tsx
@@ -13,7 +13,6 @@ export const DatasetHeader: React.FC<DatasetHeaderProps> = ({
   pageHeading,
   modality,
   renderEditor,
-  children,
   datasetHeaderTools,
   datasetUserActions,
 }) => {

--- a/packages/openneuro-app/src/scripts/dataset/components/DatasetHeader.tsx
+++ b/packages/openneuro-app/src/scripts/dataset/components/DatasetHeader.tsx
@@ -6,6 +6,7 @@ export interface DatasetHeaderProps {
   pageHeading: string
   renderEditor?: () => React.ReactNode
   children?: JSX.Element
+  datasetHeaderTools: React.ReactNode
 }
 
 export const DatasetHeader: React.FC<DatasetHeaderProps> = ({
@@ -13,12 +14,14 @@ export const DatasetHeader: React.FC<DatasetHeaderProps> = ({
   modality,
   renderEditor,
   children,
+  datasetHeaderTools,
 }) => {
+  console.log(children)
   return (
     <div className="dataset-header">
       <div className="container">
-        <div className="grid grid-between">
-          <div className="col">
+        <div className="ds-header-inner">
+          <div className="ds-inner-left">
             <h1>
               <Link to={"/search/modality/" + modality}>
                 <div className="hexagon-wrapper">
@@ -33,9 +36,10 @@ export const DatasetHeader: React.FC<DatasetHeaderProps> = ({
                 </div>
               </Link>
               {renderEditor?.() || pageHeading}
-              {children}
             </h1>
+            {datasetHeaderTools}
           </div>
+          <div className="ds-inner-right">{children}</div>
         </div>
       </div>
     </div>

--- a/packages/openneuro-app/src/scripts/dataset/components/DatasetToolButton.tsx
+++ b/packages/openneuro-app/src/scripts/dataset/components/DatasetToolButton.tsx
@@ -21,7 +21,7 @@ export const DatasetToolStyle: StyledComponent<DatasetToolStyleProps> = styled
   justify-content: center;
   a {
     pointer-events: ${props.disable ? "none" : "auto"};
-    color: ${props.disable ? "rgba(0, 0, 0, 0.5)" : "#fff"};
+    color: ${props.disable ? "rgba(255, 255, 255, 0.7)" : "#fff"};
     font-size: 17px;
     text-decoration: none;
     font-weight: 400;

--- a/packages/openneuro-app/src/scripts/dataset/components/DatasetToolButton.tsx
+++ b/packages/openneuro-app/src/scripts/dataset/components/DatasetToolButton.tsx
@@ -15,29 +15,28 @@ export const DatasetToolStyle: StyledComponent<DatasetToolStyleProps> = styled
   .span<DatasetToolStyleProps>(
     (props) => `
   display: flex;
-  margin: 0 auto 10px;
+  margin: 0;
   flex-basis: auto;
   padding: 0 15px;
   justify-content: center;
   a {
     pointer-events: ${props.disable ? "none" : "auto"};
-    color: ${
-      props.disable ? "rgba(0, 0, 0, 0.5);" : "var(--current-theme-primary);"
-    }
+    color: ${props.disable ? "rgba(0, 0, 0, 0.5)" : "#fff"};
     font-size: 17px;
     text-decoration: none;
     font-weight: 400;
     padding: 4px;
-    border-bottom: 2px solid transparent;
+    border-bottom: 8px solid transparent;
     border-bottom-color: ${
-      props.active ? "var(--current-theme-primary)" : "transparent"
+      props.active ? "var(--current-theme-primary-light);" : "transparent;"
     };
     i {
       margin-right: 6px;
       font-size: 15px;
     }
     &:hover {
-      border-bottom-color: var(--current-theme-primary);
+      color: #fff;
+      border-bottom-color: #fff;
     }
   }
 `,

--- a/packages/openneuro-app/src/scripts/dataset/draft-container.tsx
+++ b/packages/openneuro-app/src/scripts/dataset/draft-container.tsx
@@ -153,17 +153,6 @@ const DraftContainer: React.FC<DraftContainerProps> = ({ dataset }) => {
                   }
                 />
               </div>
-              {
-                /* <DatasetTools
-                hasEdit={hasEdit}
-                isPublic={dataset.public}
-                datasetId={datasetId}
-                isAdmin={isAdmin}
-                hasSnapshot={dataset.snapshots.length !== 0}
-                isDatasetAdmin={isDatasetAdmin}
-                hasDerivatives={hasDerivatives}
-              /> */
-              }
               <DatasetPageTabContainer>
                 <TabRoutesDraft dataset={dataset} hasEdit={hasEdit} />
               </DatasetPageTabContainer>

--- a/packages/openneuro-app/src/scripts/dataset/draft-container.tsx
+++ b/packages/openneuro-app/src/scripts/dataset/draft-container.tsx
@@ -100,7 +100,6 @@ const DraftContainer: React.FC<DraftContainerProps> = ({ dataset }) => {
                 hasEdit={hasEdit}
                 isPublic={dataset.public}
                 datasetId={datasetId}
-                snapshotId={datasetId}
                 isAdmin={isAdmin}
                 isDatasetAdmin={isDatasetAdmin}
                 hasDerivatives={hasDerivatives}

--- a/packages/openneuro-app/src/scripts/dataset/draft-container.tsx
+++ b/packages/openneuro-app/src/scripts/dataset/draft-container.tsx
@@ -93,34 +93,37 @@ const DraftContainer: React.FC<DraftContainerProps> = ({ dataset }) => {
       >
         <DatasetHeader
           pageHeading={description.Name}
-          modality={modality}
-          renderEditor={() => (
-            <>
-              <EditDescriptionField
+          modality={summary?.modalities[0]}
+          datasetHeaderTools={
+            <div className="dataset-tool-buttons">
+              <DatasetTools
+                hasEdit={hasEdit}
+                isPublic={dataset.public}
                 datasetId={datasetId}
-                field="Name"
-                rows={2}
-                description={description.Name}
-                editMode={hasEdit}
-              >
-                {description.Name}
-              </EditDescriptionField>
-              <FollowToggles>
-                <FollowDataset
-                  profile={profile !== null}
-                  datasetId={dataset.id}
-                  following={dataset.following}
-                  followers={dataset.followers.length}
-                />
-                <StarDataset
-                  profile={profile !== null}
-                  datasetId={dataset.id}
-                  starred={dataset.starred}
-                  stars={dataset.stars.length}
-                />
-              </FollowToggles>
-            </>
-          )}
+                snapshotId={datasetId}
+                isAdmin={isAdmin}
+                isDatasetAdmin={isDatasetAdmin}
+                hasDerivatives={hasDerivatives}
+                hasSnapshot={dataset.snapshots.length !== 0}
+              />
+            </div>
+          }
+          datasetUserActions={
+            <FollowToggles>
+              <FollowDataset
+                profile={profile !== null}
+                datasetId={dataset.id}
+                following={dataset.following}
+                followers={dataset.followers.length}
+              />
+              <StarDataset
+                profile={profile !== null}
+                datasetId={dataset.id}
+                starred={dataset.starred}
+                stars={dataset.stars.length}
+              />
+            </FollowToggles>
+          }
         />
         <DatasetAlertDraft
           isPrivate={!dataset.public}
@@ -151,7 +154,8 @@ const DraftContainer: React.FC<DraftContainerProps> = ({ dataset }) => {
                   }
                 />
               </div>
-              <DatasetTools
+              {
+                /* <DatasetTools
                 hasEdit={hasEdit}
                 isPublic={dataset.public}
                 datasetId={datasetId}
@@ -159,7 +163,8 @@ const DraftContainer: React.FC<DraftContainerProps> = ({ dataset }) => {
                 hasSnapshot={dataset.snapshots.length !== 0}
                 isDatasetAdmin={isDatasetAdmin}
                 hasDerivatives={hasDerivatives}
-              />
+              /> */
+              }
               <DatasetPageTabContainer>
                 <TabRoutesDraft dataset={dataset} hasEdit={hasEdit} />
               </DatasetPageTabContainer>

--- a/packages/openneuro-app/src/scripts/dataset/snapshot-container.tsx
+++ b/packages/openneuro-app/src/scripts/dataset/snapshot-container.tsx
@@ -110,8 +110,7 @@ export const SnapshotContainer: React.FC<SnapshotContainerProps> = ({
                   />
                 </div>
               }
-            >
-              <>
+              datasetUserActions={
                 <FollowToggles>
                   <FollowDataset
                     profile={profile !== null}
@@ -126,8 +125,8 @@ export const SnapshotContainer: React.FC<SnapshotContainerProps> = ({
                     stars={dataset.stars.length}
                   />
                 </FollowToggles>
-              </>
-            </DatasetHeader>
+              }
+            />
           </>
         )}
         {!dataset.public && isDatasetAdmin && (

--- a/packages/openneuro-app/src/scripts/dataset/snapshot-container.tsx
+++ b/packages/openneuro-app/src/scripts/dataset/snapshot-container.tsx
@@ -93,41 +93,39 @@ export const SnapshotContainer: React.FC<SnapshotContainerProps> = ({
         className={`dataset dataset-draft dataset-page dataset-page-${modality?.toLowerCase()}`}
       >
         {summary && (
-          <>
-            <DatasetHeader
-              pageHeading={description.Name}
-              modality={summary?.modalities[0]}
-              datasetHeaderTools={
-                <div className="dataset-tool-buttons">
-                  <DatasetTools
-                    hasEdit={hasEdit}
-                    isPublic={dataset.public}
-                    datasetId={datasetId}
-                    snapshotId={snapshot.tag}
-                    isAdmin={isAdmin}
-                    isDatasetAdmin={isDatasetAdmin}
-                    hasDerivatives={hasDerivatives}
-                  />
-                </div>
-              }
-              datasetUserActions={
-                <FollowToggles>
-                  <FollowDataset
-                    profile={profile !== null}
-                    datasetId={dataset.id}
-                    following={dataset.following}
-                    followers={dataset.followers.length}
-                  />
-                  <StarDataset
-                    profile={profile !== null}
-                    datasetId={dataset.id}
-                    starred={dataset.starred}
-                    stars={dataset.stars.length}
-                  />
-                </FollowToggles>
-              }
-            />
-          </>
+          <DatasetHeader
+            pageHeading={description.Name}
+            modality={summary?.modalities[0]}
+            datasetHeaderTools={
+              <div className="dataset-tool-buttons">
+                <DatasetTools
+                  hasEdit={hasEdit}
+                  isPublic={dataset.public}
+                  datasetId={datasetId}
+                  snapshotId={snapshot.tag}
+                  isAdmin={isAdmin}
+                  isDatasetAdmin={isDatasetAdmin}
+                  hasDerivatives={hasDerivatives}
+                />
+              </div>
+            }
+            datasetUserActions={
+              <FollowToggles>
+                <FollowDataset
+                  profile={profile !== null}
+                  datasetId={dataset.id}
+                  following={dataset.following}
+                  followers={dataset.followers.length}
+                />
+                <StarDataset
+                  profile={profile !== null}
+                  datasetId={dataset.id}
+                  starred={dataset.starred}
+                  stars={dataset.stars.length}
+                />
+              </FollowToggles>
+            }
+          />
         )}
         {!dataset.public && isDatasetAdmin && (
           <DatasetAlertPrivate

--- a/packages/openneuro-app/src/scripts/dataset/snapshot-container.tsx
+++ b/packages/openneuro-app/src/scripts/dataset/snapshot-container.tsx
@@ -97,21 +97,36 @@ export const SnapshotContainer: React.FC<SnapshotContainerProps> = ({
             <DatasetHeader
               pageHeading={description.Name}
               modality={summary?.modalities[0]}
+              datasetHeaderTools={
+                <div className="dataset-tool-buttons">
+                  <DatasetTools
+                    hasEdit={hasEdit}
+                    isPublic={dataset.public}
+                    datasetId={datasetId}
+                    snapshotId={snapshot.tag}
+                    isAdmin={isAdmin}
+                    isDatasetAdmin={isDatasetAdmin}
+                    hasDerivatives={hasDerivatives}
+                  />
+                </div>
+              }
             >
-              <FollowToggles>
-                <FollowDataset
-                  profile={profile !== null}
-                  datasetId={dataset.id}
-                  following={dataset.following}
-                  followers={dataset.followers.length}
-                />
-                <StarDataset
-                  profile={profile !== null}
-                  datasetId={dataset.id}
-                  starred={dataset.starred}
-                  stars={dataset.stars.length}
-                />
-              </FollowToggles>
+              <>
+                <FollowToggles>
+                  <FollowDataset
+                    profile={profile !== null}
+                    datasetId={dataset.id}
+                    following={dataset.following}
+                    followers={dataset.followers.length}
+                  />
+                  <StarDataset
+                    profile={profile !== null}
+                    datasetId={dataset.id}
+                    starred={dataset.starred}
+                    stars={dataset.stars.length}
+                  />
+                </FollowToggles>
+              </>
             </DatasetHeader>
           </>
         )}
@@ -154,17 +169,6 @@ export const SnapshotContainer: React.FC<SnapshotContainerProps> = ({
                       gitHash={snapshot.hexsha}
                     />
                   }
-                />
-              </div>
-              <div className="dataset-tool-buttons">
-                <DatasetTools
-                  hasEdit={hasEdit}
-                  isPublic={dataset.public}
-                  datasetId={datasetId}
-                  snapshotId={snapshot.tag}
-                  isAdmin={isAdmin}
-                  isDatasetAdmin={isDatasetAdmin}
-                  hasDerivatives={hasDerivatives}
                 />
               </div>
               <DatasetPageTabContainer>
@@ -263,18 +267,17 @@ export const SnapshotContainer: React.FC<SnapshotContainerProps> = ({
                     />
                   </>
                 ))}
-              {!isAnonymousReviewer &&
-                (
-                  <MetaDataBlock
-                    heading="Uploaded by"
-                    item={
-                      <>
-                        <Username user={dataset.uploader} /> on{" "}
-                        <DateDistance date={dataset.created} />
-                      </>
-                    }
-                  />
-                )}
+              {!isAnonymousReviewer && (
+                <MetaDataBlock
+                  heading="Uploaded by"
+                  item={
+                    <>
+                      <Username user={dataset.uploader} /> on{" "}
+                      <DateDistance date={dataset.created} />
+                    </>
+                  }
+                />
+              )}
 
               {dataset.snapshots.length && (
                 <MetaDataBlock
@@ -362,16 +365,13 @@ export interface SnapshotLoaderProps {
 const SnapshotLoader: React.FC<SnapshotLoaderProps> = ({ dataset }) => {
   const { tag } = useParams()
   const { loading, error, data, fetchMore, stopPolling, startPolling } =
-    useQuery(
-      getSnapshotDetails,
-      {
-        variables: {
-          datasetId: dataset.id,
-          tag,
-        },
-        errorPolicy: "all",
+    useQuery(getSnapshotDetails, {
+      variables: {
+        datasetId: dataset.id,
+        tag,
       },
-    )
+      errorPolicy: "all",
+    })
   if (loading) {
     return (
       <div className="loading-dataset">
@@ -392,10 +392,7 @@ const SnapshotLoader: React.FC<SnapshotLoaderProps> = ({ dataset }) => {
           startPolling,
         }}
       >
-        <SnapshotContainer
-          dataset={dataset}
-          snapshot={data.snapshot}
-        />
+        <SnapshotContainer dataset={dataset} snapshot={data.snapshot} />
       </DatasetQueryContext.Provider>
     )
   }

--- a/packages/openneuro-app/src/scripts/scss/dataset/dataset-page.scss
+++ b/packages/openneuro-app/src/scripts/scss/dataset/dataset-page.scss
@@ -383,11 +383,6 @@
 .dataset-page {
   .dataset-header {
     background-color: var(--current-theme-header);
-    // background: linear-gradient(
-    //   16deg,
-    //   var(--current-theme-header-dark),
-    //   var(--current-theme-header)
-    // );
   }
 }
 

--- a/packages/openneuro-app/src/scripts/scss/dataset/dataset-page.scss
+++ b/packages/openneuro-app/src/scripts/scss/dataset/dataset-page.scss
@@ -1,11 +1,34 @@
 @import '../variables.scss';
 .dataset {
   .dataset-header {
+    .ds-header-inner{
+      display:  flex;
+      align-items: center;
+      flex-wrap: wrap;
+      justify-content: space-between;
+      @media screen and (max-width: 767px) {
+        flex-direction: column;
+        justify-content: flex-start;
+        align-items: center;
+      }
+      .ds-inner-left{
+        max-width: 70%;
+        @media screen and (max-width: 767px) {
+          max-width: 100%;
+        }
+      }
+      .ds-inner-right{
+        max-width: 30%;
+        @media screen and (max-width: 767px) {
+          max-width: 100%;
+        }
+      }
     h1 {
       display: flex;
       align-items: center;
       color: #fff;
       font-size: 24px;
+      margin:10px 0 ;
       @media (max-width: 767px) {
         font-size: 20px;
         flex-wrap: wrap;
@@ -13,7 +36,7 @@
       }
     }
     .hexagon-wrapper {
-      margin-right: 10px;
+      
       @media (max-width: 767px) {
         width: 56px;
         height: 56px;
@@ -22,6 +45,10 @@
         }
       }
     }
+    .dataset-tool-buttons{
+      flex-basis: 100%;
+    }
+  }
   }
 
   .dataset-header-alert {
@@ -147,7 +174,7 @@
 .dataset {
   .hexagon-wrapper {
     text-align: center;
-    margin: 20px auto;
+    margin: 20px 10px;
     position: relative;
     display: inline-block;
     width: 45px;
@@ -356,11 +383,11 @@
 .dataset-page {
   .dataset-header {
     background-color: var(--current-theme-header);
-    background: linear-gradient(
-      16deg,
-      var(--current-theme-header-dark),
-      var(--current-theme-header)
-    );
+    // background: linear-gradient(
+    //   16deg,
+    //   var(--current-theme-header-dark),
+    //   var(--current-theme-header)
+    // );
   }
 }
 


### PR DESCRIPTION
Based on newest designs for Annotation feature. This will move the dataset tools towards that approach before we make any updates RE: annotation

ux/ui update to move dataset tools into the dataset header. 

- removes the gradient in the header
- subtle styling updates for various screen sizes
- allows for more room and additional tool tabs