### PR TITLE
fix(server): Add missing read-limited scope to ORCID oauth

### DIFF
--- a/packages/openneuro-server/src/libs/authentication/passport.ts
+++ b/packages/openneuro-server/src/libs/authentication/passport.ts
@@ -166,7 +166,7 @@ export const setupPassportAuth = () => {
           config.auth.orcid.apiURI.includes("sandbox"),
         clientID: config.auth.orcid.clientID,
         clientSecret: config.auth.orcid.clientSecret,
-        scope: "/activities/update",
+        scope: ["/activities/update", "/read-limited"],
         callbackURL: `${config.url + config.apiPrefix}auth/orcid/callback`,
       },
       verifyORCIDUser,


### PR DESCRIPTION
`/activities/update` also requires `/read-limited` separately to read trusted institutional data. Fixes #3498 