### PR TITLE
fix(server): Use fetch to better instrument ORCID API timeouts

### DIFF
--- a/packages/openneuro-server/src/libs/authentication/passport.ts
+++ b/packages/openneuro-server/src/libs/authentication/passport.ts
@@ -95,9 +95,8 @@ export const verifyORCIDUser = (
   params,
   done,
 ) => {
-  const token = `${profile.orcid}:${profile.access_token}`
   orcid
-    .getProfile(token)
+    .getProfile(profile.orcid, profile.access_token)
     .then((info) => {
       profile.info = info
       profile.provider = PROVIDERS.ORCID

--- a/packages/openneuro-server/src/libs/orcid.ts
+++ b/packages/openneuro-server/src/libs/orcid.ts
@@ -1,110 +1,120 @@
 // Camel case rule is disabled since ORCID API uses snake case variables
-import request from "request"
 import xmldoc from "xmldoc"
 import config from "../config"
 import * as Sentry from "@sentry/node"
 
 export default {
-  getProfile(token) {
-    return new Promise((resolve, reject) => {
-      const data = token.split(":")
-      if (data.length != 2) {
-        reject("Invalid token")
-      }
-      const orcid = data[0]
-      const accessToken = data[1]
-
-      request.get(
+  async getProfile(orcid, accessToken) {
+    try {
+      const response = await fetch(
         `${config.auth.orcid.apiURI}/v2.0/${orcid}/record`,
         {
-          headers: { Authorization: `Bearer ${accessToken}` },
-        },
-        (err, res) => {
-          if (err) {
-            Sentry.captureException(err)
-            reject({
-              message:
-                "An unexpected ORCID login failure occurred, please try again later.",
-            })
-          }
-          const doc = new xmldoc.XmlDocument(res.body)
-          let name = doc.valueWithPath(
-            "person:person.person:name.personal-details:credit-name",
-          )
-          const firstname = doc.valueWithPath(
-            "person:person.person:name.personal-details:given-names",
-          )
-          const lastname = doc.valueWithPath(
-            "person:person.person:name.personal-details:family-name",
-          )
-          const email = doc.valueWithPath(
-            "person:person.email:emails.email:email.email:email",
-          )
-
-          if (!name && firstname && lastname) {
-            if (firstname && lastname) {
-              name = `${firstname} ${lastname}`
-            } else {
-              name = lastname || firstname
-            }
-          }
-
-          resolve({
-            name,
-            email,
-          })
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+          },
         },
       )
-    })
-  },
+      const text = await response.text()
+      const doc = new xmldoc.XmlDocument(text)
+      let name = doc.valueWithPath(
+        "person:person.person:name.personal-details:credit-name",
+      )
+      const firstname = doc.valueWithPath(
+        "person:person.person:name.personal-details:given-names",
+      )
+      const lastname = doc.valueWithPath(
+        "person:person.person:name.personal-details:family-name",
+      )
+      const email = doc.valueWithPath(
+        "person:person.email:emails.email:email.email:email",
+      )
 
-  refreshToken(refreshToken, callback) {
-    request.post(
-      `${config.auth.orcid.URI}/oauth/token`,
-      {
-        form: {
-          client_id: config.auth.orcid.clientID,
-          client_secret: config.auth.orcid.clientSecret,
-          redirect_uri: config.auth.orcid.redirectURI,
-          grant_type: "refresh_token",
-          refresh_token: refreshToken,
-        },
-        json: true,
-      },
-      (err, res) => {
-        if (!err) {
-          const { orcid, access_token } = res.body
-          res.body.access_token = `${orcid}:${access_token}`
-        }
-        callback(err, res.body)
-      },
-    )
-  },
-
-  validateToken(code, callback) {
-    request.post(
-      `${config.auth.orcid.URI}/oauth/token`,
-      {
-        form: {
-          client_id: config.auth.orcid.clientID,
-          client_secret: config.auth.orcid.clientSecret,
-          redirect_uri: config.auth.orcid.redirectURI,
-          grant_type: "authorization_code",
-          code,
-        },
-        json: true,
-      },
-      (err, res) => {
-        if (!err) {
-          const { orcid, access_token } = res.body
-          res.body.access_token = `${orcid}:${access_token}`
-
-          // Check if user has email
-          this.getProfile(res.body.access_token)
+      if (!name && firstname && lastname) {
+        if (firstname && lastname) {
+          name = `${firstname} ${lastname}`
         } else {
-          callback(err, res.body)
+          name = lastname || firstname
         }
-      },
-    )
+      }
+
+      return {
+        name,
+        email,
+      }
+    } catch (err) {
+      Sentry.captureException(err, {
+        extra: {
+          orcid,
+        },
+      })
+    }
+  },
+
+  async refreshToken(refreshToken, callback) {
+    try {
+      const form = new URLSearchParams({
+        client_id: config.auth.orcid.clientID,
+        client_secret: config.auth.orcid.clientSecret,
+        redirect_uri: config.auth.orcid.redirectURI,
+        grant_type: "refresh_token",
+        refresh_token: refreshToken,
+      })
+      const res = await fetch(`${config.auth.orcid.URI}/oauth/token`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/x-www-form-urlencoded",
+          Accept: "application/json",
+        },
+        body: form,
+      })
+      const body = await res.json()
+      if (!res.ok) {
+        callback(
+          new Error(body.error_description || `ORCID API error: ${res.status}`),
+          body,
+        )
+      } else {
+        const { orcid, access_token } = body
+        body.access_token = `${orcid}:${access_token}`
+        callback(null, body)
+      }
+    } catch (err) {
+      Sentry.captureException(err)
+      callback(err, null)
+    }
+  },
+
+  async validateToken(code, callback) {
+    try {
+      const form = new URLSearchParams({
+        client_id: config.auth.orcid.clientID,
+        client_secret: config.auth.orcid.clientSecret,
+        redirect_uri: config.auth.orcid.redirectURI,
+        grant_type: "authorization_code",
+        code,
+      })
+      const res = await fetch(`${config.auth.orcid.URI}/oauth/token`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/x-www-form-urlencoded",
+          Accept: "application/json",
+        },
+        body: form,
+      })
+      const body = await res.json()
+      if (!res.ok) {
+        callback(
+          new Error(body.error_description || `ORCID API error: ${res.status}`),
+          body,
+        )
+      } else {
+        const { orcid, access_token } = body
+        body.access_token = `${orcid}:${access_token}`
+        callback(null, body)
+      }
+    } catch (err) {
+      Sentry.captureException(err)
+      callback(err, null)
+    }
   },
 }


### PR DESCRIPTION
Seeing timeouts with getProfile clustered at specific times but the request library is not logged by Sentry. Switch to using fetch for these requests so we can drop the request dependency and log the request here.