### PR TITLE
fix(app): Add cache for dataset/revision keys of validation data

### DIFF
--- a/packages/openneuro-server/src/cache/types.ts
+++ b/packages/openneuro-server/src/cache/types.ts
@@ -13,5 +13,6 @@ export enum CacheType {
   participantCount = "participantCount",
   snapshotDownload = "download",
   draftRevision = "revision",
-  brainInitiative = "brainInitiative"
+  brainInitiative = "brainInitiative",
+  validation = "validation",
 }


### PR DESCRIPTION
This is the slowest part of resolving the index query, adding this saves about 75% of indexing time at the expense of moving a lot of information into Redis. I think aging out data that is not requested in two weeks should prevent this from exhausting the cache but may need some tuning still.