### PR TITLE
Preserve browser location on ORCID logins

### DIFF
--- a/packages/openneuro-server/src/libs/authentication/orcid.ts
+++ b/packages/openneuro-server/src/libs/authentication/orcid.ts
@@ -4,9 +4,11 @@ import * as Sentry from "@sentry/node"
 import { userMigration } from "./user-migration"
 import User from "../../models/user"
 
-export const requestAuth = passport.authenticate("orcid", {
-  session: false,
-})
+export const requestAuth = (req, res, next) =>
+  passport.authenticate("orcid", {
+    session: false,
+    state: req.query.redirectPath || null,
+  })(req, res, next)
 
 /**
  * Complete a successful login


### PR DESCRIPTION
This was just missing from the ORCID login implementation. We need to set the state value to remember the path before login and the rest of the login process was already setup to handle restoring the state after login.