### PR TITLE
Fix for file viewer failure to load snapshot files

### DIFF
--- a/packages/openneuro-app/src/scripts/dataset/files/file-display.tsx
+++ b/packages/openneuro-app/src/scripts/dataset/files/file-display.tsx
@@ -1,5 +1,4 @@
 import React, { useContext } from "react"
-import PropTypes from "prop-types"
 import { useParams } from "react-router-dom"
 import FileView from "./file-view.jsx"
 import { apiPath } from "./file"
@@ -23,10 +22,16 @@ const PathBreadcrumb = styled.div`
   }
 `
 
+interface FileDisplayBreadcrumbProps {
+  filePath: string
+}
+
 /**
  * Create dataset -> dir -> filename breadcrumbs
  */
-export const FileDisplayBreadcrumb = ({ filePath }) => {
+export const FileDisplayBreadcrumb = (
+  { filePath }: FileDisplayBreadcrumbProps,
+) => {
   const tokens = filePath.split(":")
   return (
     <>
@@ -51,13 +56,23 @@ export const FileDisplayBreadcrumb = ({ filePath }) => {
   )
 }
 
-FileDisplayBreadcrumb.propTypes = {
-  filePath: PropTypes.string,
+interface FileDisplayFileArray {
+  filename: string
+  directory: boolean
+  urls: string[]
 }
 
-const FileDisplay = ({ dataset, snapshotTag = null, filePath }) => {
+interface FileDisplayProps {
+  datasetId: string
+  files: FileDisplayFileArray[]
+  snapshotTag?: string
+  filePath?: string
+}
+
+const FileDisplay = (
+  { datasetId, files, snapshotTag = null, filePath }: FileDisplayProps,
+) => {
   const { fetchMore } = useContext(DatasetQueryContext)
-  const files = snapshotTag ? dataset.files : dataset.draft.files
   const datasetFile = files.find((file) => file.filename === filePath)
   // If no file matches, we are missing data, load the next missing parent
   if (!datasetFile) {
@@ -66,7 +81,7 @@ const FileDisplay = ({ dataset, snapshotTag = null, filePath }) => {
       const path = components.slice(0, i).join(":")
       const file = files.find((file) => file.filename === path)
       if (file && file.directory) {
-        fetchMoreDirectory(fetchMore, dataset.id, snapshotTag, file)
+        fetchMoreDirectory(fetchMore, datasetId, snapshotTag, file)
         break
       }
     }
@@ -80,7 +95,7 @@ const FileDisplay = ({ dataset, snapshotTag = null, filePath }) => {
     )
   } else {
     const url = datasetFile?.urls?.[0] ||
-      apiPath(dataset.id, snapshotTag, filePath)
+      apiPath(datasetId, snapshotTag, filePath)
     return (
       <DatasetPageBorder className="dataset-form display-file">
         <PathBreadcrumb>
@@ -106,25 +121,23 @@ const FileDisplay = ({ dataset, snapshotTag = null, filePath }) => {
   }
 }
 
-FileDisplay.propTypes = {
-  datasetId: PropTypes.string,
-  filePath: PropTypes.string,
-  snapshotTag: PropTypes.string,
+interface FileDisplayRouteProps {
+  datasetId: string
+  files: FileDisplayFileArray[]
+  snapshotTag?: string
 }
 
-export const FileDisplayRoute = ({ dataset, snapshotTag }) => {
+export const FileDisplayRoute = (
+  { datasetId, files, snapshotTag }: FileDisplayRouteProps,
+) => {
   return (
     <FileDisplay
-      dataset={dataset}
+      datasetId={datasetId}
+      files={files}
       snapshotTag={snapshotTag}
       {...useParams()}
     />
   )
-}
-
-FileDisplayRoute.propTypes = {
-  datasetId: PropTypes.string,
-  snapshotTag: PropTypes.string,
 }
 
 export default FileDisplay

--- a/packages/openneuro-app/src/scripts/dataset/files/index.tsx
+++ b/packages/openneuro-app/src/scripts/dataset/files/index.tsx
@@ -1,6 +1,0 @@
-import Files from "./files"
-import FileDisplay from "./file-display"
-
-export { FileDisplay }
-
-export default Files

--- a/packages/openneuro-app/src/scripts/dataset/routes/tab-routes-draft.tsx
+++ b/packages/openneuro-app/src/scripts/dataset/routes/tab-routes-draft.tsx
@@ -64,7 +64,12 @@ export const TabRoutesDraft = ({ dataset, hasEdit }) => {
       />
       <Route
         path="file-display/:filePath"
-        element={<FileDisplayRoute dataset={dataset} />}
+        element={
+          <FileDisplayRoute
+            datasetId={dataset.id}
+            files={dataset.draft.files}
+          />
+        }
       />
       <Route path="metadata" element={<AddMetadata dataset={dataset} />} />
     </Routes>

--- a/packages/openneuro-app/src/scripts/dataset/routes/tab-routes-snapshot.tsx
+++ b/packages/openneuro-app/src/scripts/dataset/routes/tab-routes-snapshot.tsx
@@ -39,7 +39,11 @@ export const TabRoutesSnapshot = ({ dataset, snapshot }) => {
       <Route
         path="file-display/:filePath"
         element={
-          <FileDisplayRoute dataset={snapshot} snapshotTag={snapshot.tag} />
+          <FileDisplayRoute
+            datasetId={dataset.id}
+            files={snapshot.files}
+            snapshotTag={snapshot.tag}
+          />
         }
       />
       <Route path="metadata" element={<AddMetadata dataset={dataset} />} />


### PR DESCRIPTION
The wrong datasetId value could be passed into the FileDisplay component, which would result in an API error trying to load a file for display. The `ds000001:1.0.0` snapshot id instead of correct `ds000001` was being used. Refactors the props for this component to match the requirements instead of using the broader dataset/snapshot type.

Fixes #3415