### PR TITLE
fix(server): Metadata.grantFunderName may not be present for datasets

### DIFF
--- a/packages/openneuro-server/src/graphql/resolvers/brainInitiative.ts
+++ b/packages/openneuro-server/src/graphql/resolvers/brainInitiative.ts
@@ -30,7 +30,7 @@ export const brainInitiative = async (
   return await cache.get(async () => {
     try {
       const metadata = await Metadata.findOne({ datasetId: dataset.id })
-      if (metadata.grantFunderName.match(brainInitiativeMatch)) {
+      if (metadata?.grantFunderName?.match(brainInitiativeMatch)) {
         return true
       } else {
         // Fetch snapshot if metadata didn't match


### PR DESCRIPTION
Fix a minor error for the brainInitiative resolver when datasets do not have this field defined.