### PR TITLE
Fix: Display loading spinner on initial search load

### DIFF
--- a/packages/openneuro-app/src/scripts/search/search-container.tsx
+++ b/packages/openneuro-app/src/scripts/search/search-container.tsx
@@ -120,6 +120,8 @@ const SearchContainer: FC<SearchContainerProps> = ({ portalContent }) => {
   const is_grant_portal = portalContent?.portal || false
   const grant = portalContent?.grant || null
 
+  const [initialLoading, setInitialLoading] = useState(true)
+
   useEffect(() => {
     setDefaultSearch(
       modality,
@@ -139,6 +141,13 @@ const SearchContainer: FC<SearchContainerProps> = ({ portalContent }) => {
   ])
 
   const { loading, data, fetchMore, variables } = useSearchResults()
+
+  useEffect(() => {
+    if (!loading && data) {
+      setInitialLoading(false)
+    }
+  }, [loading, data])
+
   const loadMore = () => {
     fetchMore({
       variables: {
@@ -276,7 +285,7 @@ const SearchContainer: FC<SearchContainerProps> = ({ portalContent }) => {
           </>
         )}
         renderLoading={() =>
-          loading
+          (initialLoading || loading)
             ? (
               <div className="search-loading">
                 <Loading />

--- a/packages/openneuro-app/src/scripts/search/search-container.tsx
+++ b/packages/openneuro-app/src/scripts/search/search-container.tsx
@@ -120,8 +120,6 @@ const SearchContainer: FC<SearchContainerProps> = ({ portalContent }) => {
   const is_grant_portal = portalContent?.portal || false
   const grant = portalContent?.grant || null
 
-  const [initialLoading, setInitialLoading] = useState(true)
-
   useEffect(() => {
     setDefaultSearch(
       modality,
@@ -141,12 +139,6 @@ const SearchContainer: FC<SearchContainerProps> = ({ portalContent }) => {
   ])
 
   const { loading, data, fetchMore, variables } = useSearchResults()
-
-  useEffect(() => {
-    if (!loading && data) {
-      setInitialLoading(false)
-    }
-  }, [loading, data])
 
   const loadMore = () => {
     fetchMore({
@@ -285,7 +277,7 @@ const SearchContainer: FC<SearchContainerProps> = ({ portalContent }) => {
           </>
         )}
         renderLoading={() =>
-          (initialLoading || loading)
+          loading
             ? (
               <div className="search-loading">
                 <Loading />

--- a/packages/openneuro-app/src/scripts/search/use-search-results.tsx
+++ b/packages/openneuro-app/src/scripts/search/use-search-results.tsx
@@ -404,7 +404,7 @@ export const useSearchResults = () => {
     // fetchPolicy is workaround for stuck loading bug (https://github.com/apollographql/react-apollo/issues/3270#issuecomment-579614837)
     // TODO: find better solution
     fetchPolicy: "cache-and-network",
-    nextFetchPolicy: "cache-first",
+    nextFetchPolicy: "cache-and-network",
     notifyOnNetworkStatusChange: true,
   })
 }


### PR DESCRIPTION
adds initialLoading state to show loading animation by default 

closes #3486 