### PR TITLE
fix(worker): Match accession number only for dataset maintenance tasks

### DIFF
--- a/services/datalad/datalad_service/tasks/maintenance.py
+++ b/services/datalad/datalad_service/tasks/maintenance.py
@@ -1,6 +1,7 @@
 import os
 import logging
 import subprocess
+import re
 import random
 
 
@@ -23,7 +24,7 @@ def dataset_factory():
                     os.path.join(DATALAD_DATASET_PATH, d)
                     for d in os.listdir(DATALAD_DATASET_PATH)
                     if os.path.isdir(os.path.join(DATALAD_DATASET_PATH, d))
-                    and d.startswith('ds')
+                    and re.match(r'^ds\d{6}$', d)
                 ]
                 if not datasets:
                     logging.warning(


### PR DESCRIPTION
Avoid running maintenance tasks on temporary backups or other files that may include the dataset name.