### PR TITLE
feat(server): Allow worker scopes for tokens

### DIFF
--- a/packages/openneuro-server/src/graphql/permissions.ts
+++ b/packages/openneuro-server/src/graphql/permissions.ts
@@ -138,13 +138,18 @@ export const checkDatasetWrite = async (
     // Quick path for anonymous writes
     throw new Error(state.errorMessage)
   }
-  if (userId && !(userInfo.email)) {
-    throw new Error("Connect an email to make contributions to OpenNeuro.")
-  }
   if (userId && userInfo.admin) {
     // Always allow site admins
     return true
   }
+  // Allow worker scoped tokens to make admin actions on specific datasets
+  if (userId && userInfo?.worker && datasetId === userInfo?.dataset) {
+    return true
+  }
+  if (userId && !(userInfo.email)) {
+    throw new Error("Connect an email to make contributions to OpenNeuro.")
+  }
+  // Finally check the permissions model if other checks have not returned
   const permission = await Permission.findOne({ datasetId, userId }).exec()
   if (checkPermissionLevel(permission, state)) {
     return true

--- a/packages/openneuro-server/src/libs/authentication/passport.ts
+++ b/packages/openneuro-server/src/libs/authentication/passport.ts
@@ -120,6 +120,14 @@ export const setupPassportAuth = () => {
       (jwt, done) => {
         if (jwt.scopes?.includes("dataset:indexing")) {
           done(null, { admin: false, blocked: false, indexer: true })
+        } else if (jwt.scopes?.includes("dataset:worker")) {
+          done(null, {
+            id: jwt.sub,
+            admin: false,
+            blocked: false,
+            worker: true,
+            dataset: jwt.dataset,
+          })
         } else if (jwt.scopes?.includes("dataset:reviewer")) {
           done(null, {
             admin: false,


### PR DESCRIPTION
This adds a dataset:worker scope to the API. Allows the worker to make automated requests to the API with the scope of updating a single dataset.

This also corrects an issue where special tokens that never contain emails would occasionally throw an error where the request should have succeeded by checking the email state after the special cases.