### PR TITLE
Add git-annex fsck checks for datasets

### DIFF
--- a/services/datalad/datalad_service/common/onchange.py
+++ b/services/datalad/datalad_service/common/onchange.py
@@ -1,0 +1,11 @@
+from datalad_service.tasks.fsck import git_annex_fsck_local, git_annex_fsck_remote
+
+
+async def on_head(dataset_path):
+    """Called after any change to HEAD."""
+    await git_annex_fsck_local.kiq(dataset_path)
+
+
+async def on_tag(dataset_path, tag):
+    """Called after any new tag."""
+    await git_annex_fsck_remote.kiq(dataset_path, tag)

--- a/services/datalad/datalad_service/handlers/dataset.py
+++ b/services/datalad/datalad_service/handlers/dataset.py
@@ -41,7 +41,7 @@ class DatasetResource:
                 author = pygit2.Signature(name, email)
             else:
                 author = None
-            hexsha = create_dataset(self.store, dataset, author)
+            hexsha = await create_dataset(self.store, dataset, author)
             resp.media = {'hexsha': hexsha}
             resp.status = falcon.HTTP_OK
 

--- a/services/datalad/datalad_service/handlers/draft.py
+++ b/services/datalad/datalad_service/handlers/draft.py
@@ -53,9 +53,9 @@ class DraftResource:
                 # Add all changes to the index
                 if name and email:
                     author = pygit2.Signature(name, email)
-                    media_dict['ref'] = str(git_commit(repo, ['.'], author))
+                    media_dict['ref'] = str(await git_commit(repo, ['.'], author))
                 else:
-                    media_dict['ref'] = str(git_commit(repo, ['.']))
+                    media_dict['ref'] = str(await git_commit(repo, ['.']))
                 resp.media = media_dict
                 resp.status = falcon.HTTP_OK
             except:

--- a/services/datalad/datalad_service/handlers/files.py
+++ b/services/datalad/datalad_service/handlers/files.py
@@ -6,7 +6,6 @@ import falcon
 import pygit2
 
 from datalad_service.common.git import (
-    git_show,
     git_show_content,
     git_tree,
     OpenNeuroGitError,
@@ -125,7 +124,7 @@ class FilesResource:
                     media_dict['email'] = email
                 try:
                     if len(dirs_to_delete) > 0:
-                        remove_files(
+                        await remove_files(
                             self.store,
                             dataset,
                             dirs_to_delete,
@@ -135,7 +134,7 @@ class FilesResource:
                         )
                         resp.status = falcon.HTTP_INTERNAL_SERVER_ERROR
                     if len(files_to_delete) > 0:
-                        remove_files(
+                        await remove_files(
                             self.store,
                             dataset,
                             files_to_delete,

--- a/services/datalad/datalad_service/handlers/upload.py
+++ b/services/datalad/datalad_service/handlers/upload.py
@@ -34,9 +34,9 @@ async def move_files_into_repo(
     await move_files(upload_path, dataset_path)
     if name and email:
         author = pygit2.Signature(name, email)
-        hexsha = str(git_commit(repo, unlock_files, author))
+        hexsha = str(await git_commit(repo, unlock_files, author))
     else:
-        hexsha = str(git_commit(repo, unlock_files))
+        hexsha = str(await git_commit(repo, unlock_files))
 
 
 class UploadResource:

--- a/services/datalad/datalad_service/tasks/dataset.py
+++ b/services/datalad/datalad_service/tasks/dataset.py
@@ -42,7 +42,7 @@ def create_datalad_config(dataset_path):
         configfile.write(config)
 
 
-def create_dataset(store, dataset, author=None, initial_head='main'):
+async def create_dataset(store, dataset, author=None, initial_head='main'):
     """Create a DataLad git-annex repo for a new dataset.
 
     initial_head is only meant for tests and is overridden by the implementation of git_commit
@@ -61,7 +61,7 @@ def create_dataset(store, dataset, author=None, initial_head='main'):
     # Set a datalad UUID
     create_datalad_config(dataset_path)
     repo.index.add('.datalad/config')
-    git_commit(
+    await git_commit(
         repo,
         ['.gitattributes', '.datalad/config'],
         author,

--- a/services/datalad/datalad_service/tasks/description.py
+++ b/services/datalad/datalad_service/tasks/description.py
@@ -32,7 +32,7 @@ async def update_description(store, dataset, description_fields, name=None, emai
             path, description, json.dumps(updated, indent=4, ensure_ascii=False)
         )
         # Commit new content, run validator
-        commit_files(store, dataset, ['dataset_description.json'])
+        await commit_files(store, dataset, ['dataset_description.json'])
         return updated
     else:
         return description_json

--- a/services/datalad/datalad_service/tasks/files.py
+++ b/services/datalad/datalad_service/tasks/files.py
@@ -21,7 +21,7 @@ from datalad_service.config import AWS_SECRET_ACCESS_KEY
 from datalad_service.config import AWS_S3_PUBLIC_BUCKET
 
 
-def commit_files(store, dataset, files, name=None, email=None, cookies=None):
+async def commit_files(store, dataset, files, name=None, email=None, cookies=None):
     """
     Commit a list of files with the email and name provided.
 
@@ -35,9 +35,9 @@ def commit_files(store, dataset, files, name=None, email=None, cookies=None):
         and pygit2.Signature(name, email)
         or pygit2.Signature(COMMITTER_NAME, COMMITTER_EMAIL)
     )
-    ref = git_commit(repo, files, author)
+    ref = await git_commit(repo, files, author)
     # Run the validator but don't block on the request
-    asyncio.create_task(validate_dataset.kiq(dataset, dataset_path, str(ref), cookies))
+    await validate_dataset.kiq(dataset, dataset_path, str(ref), cookies)
     return ref
 
 
@@ -47,7 +47,7 @@ def get_tree(store, dataset, tree):
     return get_repo_files(dataset, dataset_path, tree)
 
 
-def remove_files(store, dataset, paths, name=None, email=None, cookies=None):
+async def remove_files(store, dataset, paths, name=None, email=None, cookies=None):
     dataset_path = store.get_dataset_path(dataset)
     repo = pygit2.Repository(dataset_path)
     if name and email:
@@ -57,7 +57,9 @@ def remove_files(store, dataset, paths, name=None, email=None, cookies=None):
     repo.index.remove_all(paths)
     repo.index.write()
     repo.checkout_index()
-    hexsha = str(git_commit_index(repo, author, message='[OpenNeuro] Files removed'))
+    hexsha = str(
+        await git_commit_index(repo, author, message='[OpenNeuro] Files removed')
+    )
 
 
 def parse_s3_annex_url(url, bucket_name=AWS_S3_PUBLIC_BUCKET):

--- a/services/datalad/datalad_service/tasks/fsck.py
+++ b/services/datalad/datalad_service/tasks/fsck.py
@@ -1,0 +1,119 @@
+import json
+import io
+import logging
+import subprocess
+
+import pygit2
+import requests
+
+from datalad_service.broker import broker
+from datalad_service.config import GRAPHQL_ENDPOINT
+
+
+def get_head_commit_and_references(repo):
+    """
+    Returns the current HEAD commit and any references (tags) pointing to it.
+    """
+    head_commit = repo[repo.head.target]
+    references = []
+    for ref in repo.references:
+        if (
+            ref.startswith('refs/tags/')
+            and repo.lookup_reference(ref).target == head_commit.id
+        ):
+            references.append(ref)
+    return head_commit, references
+
+
+@broker.task
+def git_annex_fsck_local(dataset_path):
+    """Run git-annex fsck for local annexed objects in the draft. Runs on commits, verifies checksums."""
+    try:
+        commit, references = get_head_commit_and_references(
+            pygit2.Repository(dataset_path)
+        )
+    except pygit2.GitError:
+        logging.error(f'Could not open git repository for {dataset_path}')
+        return
+    annex_command = (
+        'git-annex',
+        'fsck',
+        '--json',
+        '--json-error-messages',
+        '--incremental-schedule',
+        '7d',
+        '--time-limit=15m',
+    )
+    annex_process = subprocess.Popen(
+        annex_command, cwd=dataset_path, stdout=subprocess.PIPE
+    )
+    bad_files = []
+    for annexed_file_json in io.TextIOWrapper(annex_process.stdout, encoding='utf-8'):
+        annexed_file = json.loads(annexed_file_json)
+        if not annexed_file['success']:
+            bad_files.append(annexed_file)
+    if len(bad_files) > 0:
+        logging.error(f'missing or corrupt annexed objects found in {dataset_path}')
+    # Send any bad files to updateFileCheck
+    requests.post(
+        url=GRAPHQL_ENDPOINT,
+        json={
+            'query': 'mutation ($datasetId: ID!, $hexsha: String!, $refs: [String], $annexFsck: [AnnexFsck]) { updateFileChecks(datasetId: $datasetId, hexsha: $hexsha, refs: $refs, annexFsck: $annexFsck) { datasetId, hexsha } }',
+            'variables': {
+                'datasetId': dataset_path.split('/')[-1],
+                'hexsha': str(commit.id),
+                'refs': references,
+                'annexFsck': bad_files,
+            },
+        },
+    )
+
+
+@broker.task
+def git_annex_fsck_remote(dataset_path, branch=None, remote='s3-PUBLIC'):
+    """Run incremental fsck for one branch (tag) and remote."""
+    try:
+        # Basic sanity check opening the repo before running git-annex
+        repo = pygit2.Repository(dataset_path)
+    except pygit2.GitError:
+        logging.error(f'Could not open git repository for {dataset_path}')
+        return
+    if not branch:
+        # Find the newest tag chronologically
+        all_tags = sorted(
+            [tag for tag in repo.references if tag.startswith('refs/tags/')],
+            key=lambda tag: repo.lookup_reference(tag).target.commit_time,
+            reverse=True,
+        )
+        if all_tags:
+            branch = all_tags[0]
+        else:
+            logging.info(
+                f'No tags found for dataset: {dataset_path}. Skipping remote fsck.'
+            )
+            return
+
+    # Run at most once per month per dataset
+    annex_command = (
+        'git-annex',
+        'fsck',
+        f'--branch={branch}',
+        '--from={remote}',
+        '--fast',
+        '--json',
+        '--json-error-messages',
+        '--incremental-schedule=7d',
+        '--time-limit=15m',
+    )
+    annex_process = subprocess.Popen(
+        annex_command, cwd=dataset_path, stdout=subprocess.PIPE
+    )
+    bad_files = []
+    for annexed_file_json in io.TextIOWrapper(annex_process.stdout, encoding='utf-8'):
+        annexed_file = json.loads(annexed_file_json)
+        if not annexed_file['success']:
+            bad_files.append(annexed_file)
+    if len(bad_files) > 0:
+        logging.error(
+            f'{dataset_path} remote {remote} has missing or corrupt annexed objects'
+        )

--- a/services/datalad/datalad_service/tasks/fsck.py
+++ b/services/datalad/datalad_service/tasks/fsck.py
@@ -42,7 +42,6 @@ def git_annex_fsck_local(dataset_path):
         '--json-error-messages',
         '--incremental-schedule',
         '7d',
-        '--time-limit=15m',
     )
     annex_process = subprocess.Popen(
         annex_command, cwd=dataset_path, stdout=subprocess.PIPE
@@ -103,7 +102,6 @@ def git_annex_fsck_remote(dataset_path, branch=None, remote='s3-PUBLIC'):
         '--json',
         '--json-error-messages',
         '--incremental-schedule=7d',
-        '--time-limit=15m',
     )
     annex_process = subprocess.Popen(
         annex_command, cwd=dataset_path, stdout=subprocess.PIPE

--- a/services/datalad/tests/test_bids.py
+++ b/services/datalad/tests/test_bids.py
@@ -70,10 +70,10 @@ def test_read_dataset_description(new_dataset):
     assert description['Name'] == 'Test fixture new dataset'
 
 
-def test_read_dataset_description_invalid_json(new_dataset):
+async def test_read_dataset_description_invalid_json(new_dataset):
     repo = Repository(new_dataset.path)
     open(os.path.join(new_dataset.path, 'dataset_description.json'), 'w').close()
-    git_commit(repo, ['dataset_description.json'])
+    await git_commit(repo, ['dataset_description.json'])
     description = read_dataset_description(new_dataset.path, 'HEAD')
     assert description is None
 


### PR DESCRIPTION
This adds a task that runs after HEAD is updated or a tag is created to verify local or remote annex fsck state.

There is a 7 day delay before the same objects will be rechecked, any changed objects are always rechecked - the delay just limits how often we recheck an already validated file. This delay may need to be adjusted depending on the resource usage in production.

One included major change required is the move coroutines for commits.