### PR TITLE
Add FileCheck model and updateFileCheck mutation

### DIFF
--- a/packages/openneuro-server/src/graphql/resolvers/fileCheck.ts
+++ b/packages/openneuro-server/src/graphql/resolvers/fileCheck.ts
@@ -1,0 +1,17 @@
+import FileCheck from "../../models/fileCheck"
+import { checkDatasetAdmin } from "../permissions"
+
+export const updateFileCheck = async (
+  obj,
+  { datasetId, hexsha, refs, remote, annexFsck },
+  { user, userInfo },
+) => {
+  await checkDatasetAdmin(datasetId, user, userInfo)
+  return await FileCheck.findOneAndUpdate(
+    { datasetId, hexsha },
+    { datasetId, hexsha, remote, refs, annexFsck },
+    { upsert: true, new: true },
+  )
+    .lean()
+    .exec()
+}

--- a/packages/openneuro-server/src/graphql/resolvers/mutation.ts
+++ b/packages/openneuro-server/src/graphql/resolvers/mutation.ts
@@ -45,6 +45,7 @@ import {
 } from "./importRemoteDataset"
 import { saveAdminNote } from "./datasetEvents"
 import { createGitEvent } from "./gitEvents"
+import { updateFileCheck } from "./fileCheck"
 
 const Mutation = {
   createDataset,
@@ -93,6 +94,7 @@ const Mutation = {
   updateUser,
   saveAdminNote,
   createGitEvent,
+  updateFileCheck,
 }
 
 export default Mutation

--- a/packages/openneuro-server/src/graphql/schema.ts
+++ b/packages/openneuro-server/src/graphql/schema.ts
@@ -207,10 +207,10 @@ export const typeDefs = `
     createGitEvent(datasetId: ID!, commit: String!, reference: String!): DatasetEvent
     # Create or update a fileCheck document
     updateFileCheck(
-      datasetId: String!
+      datasetId: ID!
       hexsha: String!
       refs: [String!]!
-      annexFsck: [AnnexFsckInput!]
+      annexFsck: [AnnexFsckInput!]!
     ): FileCheck
   }
 

--- a/packages/openneuro-server/src/graphql/schema.ts
+++ b/packages/openneuro-server/src/graphql/schema.ts
@@ -205,6 +205,13 @@ export const typeDefs = `
     saveAdminNote(id: ID, datasetId: ID!, note: String!): DatasetEvent
     # Create a git event log for dataset changes
     createGitEvent(datasetId: ID!, commit: String!, reference: String!): DatasetEvent
+    # Create or update a fileCheck document
+    updateFileCheck(
+      datasetId: String!
+      hexsha: String!
+      refs: [String!]!
+      annexFsck: [AnnexFsckInput!]
+    ): FileCheck
   }
 
   # Anonymous dataset reviewer
@@ -900,6 +907,32 @@ export const typeDefs = `
     # Notes associated with the event
     note: String
   }
+
+  type FileCheck {
+    datasetId: String!
+    hexsha: String!
+    refs: [String!]!
+    annexFsck: [AnnexFsck!]
+  }
+
+  type AnnexFsck {
+    command: String
+    errorMessages: [String]
+    file: String
+    key: String
+    note: String
+    success: Boolean
+  }
+
+  input AnnexFsckInput {
+    command: String
+    errorMessages: [String]
+    file: String
+    key: String
+    note: String
+    success: Boolean
+  }
+
 `
 
 schemaComposer.addTypeDefs(typeDefs)

--- a/packages/openneuro-server/src/graphql/schema.ts
+++ b/packages/openneuro-server/src/graphql/schema.ts
@@ -211,6 +211,7 @@ export const typeDefs = `
       hexsha: String!
       refs: [String!]!
       annexFsck: [AnnexFsckInput!]!
+      remote: String
     ): FileCheck
   }
 
@@ -913,6 +914,7 @@ export const typeDefs = `
     hexsha: String!
     refs: [String!]!
     annexFsck: [AnnexFsck!]
+    remote: String
   }
 
   type AnnexFsck {

--- a/packages/openneuro-server/src/models/fileCheck.ts
+++ b/packages/openneuro-server/src/models/fileCheck.ts
@@ -32,6 +32,6 @@ const fileCheckSchema = new Schema({
   }],
 })
 
-const FileCheck = model<FileCheckDocument>("File", fileCheckSchema)
+const FileCheck = model<FileCheckDocument>("FileCheck", fileCheckSchema)
 
 export default FileCheck

--- a/packages/openneuro-server/src/models/fileCheck.ts
+++ b/packages/openneuro-server/src/models/fileCheck.ts
@@ -1,0 +1,37 @@
+import mongoose from "mongoose"
+import type { Document } from "mongoose"
+const { Schema, model } = mongoose
+
+export interface FileCheckDocument extends Document {
+  datasetId: string
+  hexsha: string
+  refs: string[]
+  remote: string
+  annexFsck: {
+    command: string
+    "error-messages": string[]
+    file: string
+    key: string
+    note: string
+    success: boolean
+  }[]
+}
+
+const fileCheckSchema = new Schema({
+  datasetId: { type: String, required: true },
+  hexsha: { type: String, required: true },
+  refs: { type: [String], required: true },
+  remote: { type: String, default: "local", required: true },
+  annexFsck: [{
+    command: String,
+    "error-messages": [String],
+    file: String,
+    key: String,
+    note: String,
+    success: Boolean,
+  }],
+})
+
+const FileCheck = model<FileCheckDocument>("File", fileCheckSchema)
+
+export default FileCheck


### PR DESCRIPTION
This adds a model for storing file checks for datasets. Initially this just records annex fsck output but additional fields can be added for other kinds of file based checks.

One mutation is added updateFileCheck which allows the worker to report annex fsck status on each commit.

For API authentication a token is generated using #3533's worker scope for a specific dataset.