### PR TITLE
feat(worker): Post annex fsck status back to the API

### DIFF
--- a/services/datalad/datalad_service/config.py
+++ b/services/datalad/datalad_service/config.py
@@ -26,6 +26,9 @@ GRAPHQL_ENDPOINT = os.getenv('GRAPHQL_ENDPOINT', 'http://server:8111/crn/graphql
 # Site URL
 CRN_SERVER_URL = os.getenv('CRN_SERVER_URL')
 
+# Request secret for API calls
+JWT_SECRET = os.getenv('JWT_SECRET')
+
 # Redit connection for task queue
 REDIS_HOST = os.getenv('REDIS_HOST')
 REDIS_PORT = os.getenv('REDIS_PORT')


### PR DESCRIPTION
Enable update_file_check for git_annex_fsck_local / git_annex_fsck_remote to report results back to the API.