### PR TITLE
feat(server): Add a fileCheck resolve for drafts

### DIFF
--- a/packages/openneuro-server/src/graphql/schema.ts
+++ b/packages/openneuro-server/src/graphql/schema.ts
@@ -546,6 +546,8 @@ export const typeDefs = `
     head: String
     # Total size in bytes of this draft
     size: BigInt
+    # File issues
+    fileCheck: FileCheck
   }
 
   # Tagged snapshot of a draft


### PR DESCRIPTION
Used to check for a successful git-annex fsck when creating snapshots.