### PR TITLE
Use queue_name instead of a custom worker label for worker specific tasks

### DIFF
--- a/services/datalad/datalad_service/broker/__init__.py
+++ b/services/datalad/datalad_service/broker/__init__.py
@@ -14,11 +14,13 @@ if 'pytest' in sys.modules:
 else:
     redis_url = f'redis://{config.REDIS_HOST}:{config.REDIS_PORT}/8'
     worker_id = get_docker_scale()
+    worker_name = f'worker-{worker_id}'
     result_backend = RedisAsyncResultBackend(
         redis_url=redis_url,
         result_ex_time=5000,
     )
     broker = RedisStreamBroker(
         url=redis_url,
+        queue_name=worker_name,
     ).with_result_backend(result_backend)
     broker.add_middlewares(WorkerMiddleware(worker_id))

--- a/services/datalad/datalad_service/broker/scheduler.py
+++ b/services/datalad/datalad_service/broker/scheduler.py
@@ -5,6 +5,6 @@ from taskiq_redis import RedisScheduleSource
 from datalad_service import config
 from datalad_service.broker import broker
 
-redis_source = RedisScheduleSource(f'redis://{config.REDIS_HOST}:{config.REDIS_PORT}/0')
+redis_source = RedisScheduleSource(f'redis://{config.REDIS_HOST}:{config.REDIS_PORT}/8')
 label_source = LabelScheduleSource(broker)
 scheduler = TaskiqScheduler(broker, sources=[redis_source, label_source])

--- a/services/datalad/datalad_service/broker/worker_middleware.py
+++ b/services/datalad/datalad_service/broker/worker_middleware.py
@@ -1,4 +1,8 @@
+import random
+
 from taskiq import TaskiqMessage, TaskiqMiddleware
+
+from datalad_service import config
 
 
 class WorkerMiddleware(TaskiqMiddleware):
@@ -11,5 +15,10 @@ class WorkerMiddleware(TaskiqMiddleware):
 
     async def pre_send(self, message: TaskiqMessage) -> TaskiqMessage:
         if self.worker_id:
-            message.labels['worker'] = self.worker_id
+            message.labels['queue_name'] = f'worker-{self.worker_id}'
+        else:
+            # Pick a random worker since this task was not assigned to one
+            message.labels['queue_name'] = (
+                f'worker-{random.randint(0, config.DATALAD_WORKERS - 1)}'
+            )
         return message


### PR DESCRIPTION
This makes it easier to reset the queue for a specific worker without affecting others and doing this configuration at broker setup avoids needing to configure it with the k8s container command.

One minor fix for the scheduler to use the same db offset in Redis.