### PR TITLE
deps: Bump @bids/validator to 2.1.1

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -1259,6 +1259,28 @@ const RAW_RUNTIME_STATE =
         "linkType": "HARD"\
       }]\
     ]],\
+    ["@bids/validator", [\
+      ["jsr:2.1.1::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Fbids__validator%2F2.1.1.tgz", {\
+        "packageLocation": "./.yarn/cache/@jsr-bids__validator-npm-2.1.1-8108dda95d-c189ea5dd8.zip/node_modules/@jsr/bids__validator/",\
+        "packageDependencies": [\
+          ["@bids/nifti-reader-js", "npm:0.6.9"],\
+          ["@bids/validator", "jsr:2.1.1::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Fbids__validator%2F2.1.1.tgz"],\
+          ["@jsr/bids__schema", "npm:1.1.0::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Fbids__schema%2F1.1.0.tgz"],\
+          ["@jsr/effigies__cliffy-command", "npm:1.0.0-dev.8::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Feffigies__cliffy-command%2F1.0.0-dev.8.tgz"],\
+          ["@jsr/effigies__cliffy-table", "npm:1.0.0-dev.5::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Feffigies__cliffy-table%2F1.0.0-dev.5.tgz"],\
+          ["@jsr/libs__xml", "npm:6.0.8::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Flibs__xml%2F6.0.8.tgz"],\
+          ["@jsr/std__fmt", "npm:1.0.8::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Fstd__fmt%2F1.0.8.tgz"],\
+          ["@jsr/std__log", "npm:0.224.14::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Fstd__log%2F0.224.14.tgz"],\
+          ["@jsr/std__path", "npm:1.1.2::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Fstd__path%2F1.1.2.tgz"],\
+          ["@jsr/std__streams", "npm:1.0.13::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Fstd__streams%2F1.0.13.tgz"],\
+          ["@jsr/std__yaml", "npm:1.0.10::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Fstd__yaml%2F1.0.10.tgz"],\
+          ["ajv", "npm:8.17.1"],\
+          ["hed-validator", "npm:4.0.1"],\
+          ["ignore", "npm:7.0.5"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
     ["@chevrotain/types", [\
       ["npm:9.1.0", {\
         "packageLocation": "./.yarn/cache/@chevrotain-types-npm-9.1.0-80ac254cc2-091dbff29f.zip/node_modules/@chevrotain/types/",\
@@ -2454,32 +2476,10 @@ const RAW_RUNTIME_STATE =
       }]\
     ]],\
     ["@jsr/bids__schema", [\
-      ["npm:1.0.4::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Fbids__schema%2F1.0.4.tgz", {\
-        "packageLocation": "./.yarn/cache/@jsr-bids__schema-npm-1.0.4-46711d9141-dc9b35fb6e.zip/node_modules/@jsr/bids__schema/",\
+      ["npm:1.1.0::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Fbids__schema%2F1.1.0.tgz", {\
+        "packageLocation": "./.yarn/cache/@jsr-bids__schema-npm-1.1.0-8de871ce10-37fc9aa3eb.zip/node_modules/@jsr/bids__schema/",\
         "packageDependencies": [\
-          ["@jsr/bids__schema", "npm:1.0.4::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Fbids__schema%2F1.0.4.tgz"]\
-        ],\
-        "linkType": "HARD"\
-      }]\
-    ]],\
-    ["@jsr/bids__validator", [\
-      ["npm:2.0.8::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Fbids__validator%2F2.0.8.tgz", {\
-        "packageLocation": "./.yarn/cache/@jsr-bids__validator-npm-2.0.8-3f162aa2ce-5e45246ccc.zip/node_modules/@jsr/bids__validator/",\
-        "packageDependencies": [\
-          ["@bids/nifti-reader-js", "npm:0.6.9"],\
-          ["@jsr/bids__schema", "npm:1.0.4::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Fbids__schema%2F1.0.4.tgz"],\
-          ["@jsr/bids__validator", "npm:2.0.8::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Fbids__validator%2F2.0.8.tgz"],\
-          ["@jsr/effigies__cliffy-command", "npm:1.0.0-dev.8::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Feffigies__cliffy-command%2F1.0.0-dev.8.tgz"],\
-          ["@jsr/effigies__cliffy-table", "npm:1.0.0-dev.5::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Feffigies__cliffy-table%2F1.0.0-dev.5.tgz"],\
-          ["@jsr/libs__xml", "npm:6.0.4::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Flibs__xml%2F6.0.4.tgz"],\
-          ["@jsr/std__fmt", "npm:1.0.6::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Fstd__fmt%2F1.0.6.tgz"],\
-          ["@jsr/std__log", "npm:0.224.14::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Fstd__log%2F0.224.14.tgz"],\
-          ["@jsr/std__path", "npm:1.0.8::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Fstd__path%2F1.0.8.tgz"],\
-          ["@jsr/std__streams", "npm:1.0.9::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Fstd__streams%2F1.0.9.tgz"],\
-          ["@jsr/std__yaml", "npm:1.0.5::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Fstd__yaml%2F1.0.5.tgz"],\
-          ["ajv", "npm:8.17.1"],\
-          ["hed-validator", "npm:4.0.1"],\
-          ["ignore", "npm:7.0.3"]\
+          ["@jsr/bids__schema", "npm:1.1.0::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Fbids__schema%2F1.1.0.tgz"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -2540,10 +2540,10 @@ const RAW_RUNTIME_STATE =
       }]\
     ]],\
     ["@jsr/libs__xml", [\
-      ["npm:6.0.4::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Flibs__xml%2F6.0.4.tgz", {\
-        "packageLocation": "./.yarn/cache/@jsr-libs__xml-npm-6.0.4-2a1d53ca29-9e17a8e322.zip/node_modules/@jsr/libs__xml/",\
+      ["npm:6.0.8::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Flibs__xml%2F6.0.8.tgz", {\
+        "packageLocation": "./.yarn/cache/@jsr-libs__xml-npm-6.0.8-a471b733af-40a6b82333.zip/node_modules/@jsr/libs__xml/",\
         "packageDependencies": [\
-          ["@jsr/libs__xml", "npm:6.0.4::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Flibs__xml%2F6.0.4.tgz"]\
+          ["@jsr/libs__xml", "npm:6.0.8::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Flibs__xml%2F6.0.8.tgz"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -2553,6 +2553,13 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./.yarn/cache/@jsr-std__bytes-npm-1.0.5-65ec6f83d6-5d2b562ccf.zip/node_modules/@jsr/std__bytes/",\
         "packageDependencies": [\
           ["@jsr/std__bytes", "npm:1.0.5::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Fstd__bytes%2F1.0.5.tgz"]\
+        ],\
+        "linkType": "HARD"\
+      }],\
+      ["npm:1.0.6::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Fstd__bytes%2F1.0.6.tgz", {\
+        "packageLocation": "./.yarn/cache/@jsr-std__bytes-npm-1.0.6-ad6f468b60-b0d2d637dc.zip/node_modules/@jsr/std__bytes/",\
+        "packageDependencies": [\
+          ["@jsr/std__bytes", "npm:1.0.6::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Fstd__bytes%2F1.0.6.tgz"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -2572,10 +2579,10 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "HARD"\
       }],\
-      ["npm:1.0.6::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Fstd__fmt%2F1.0.6.tgz", {\
-        "packageLocation": "./.yarn/cache/@jsr-std__fmt-npm-1.0.6-a2d925486b-c8e77ec4f7.zip/node_modules/@jsr/std__fmt/",\
+      ["npm:1.0.8::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Fstd__fmt%2F1.0.8.tgz", {\
+        "packageLocation": "./.yarn/cache/@jsr-std__fmt-npm-1.0.8-3d90d9bb74-021a1d7cee.zip/node_modules/@jsr/std__fmt/",\
         "packageDependencies": [\
-          ["@jsr/std__fmt", "npm:1.0.6::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Fstd__fmt%2F1.0.6.tgz"]\
+          ["@jsr/std__fmt", "npm:1.0.8::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Fstd__fmt%2F1.0.8.tgz"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -2586,6 +2593,15 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["@jsr/std__fs", "npm:1.0.13::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Fstd__fs%2F1.0.13.tgz"],\
           ["@jsr/std__path", "npm:1.0.8::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Fstd__path%2F1.0.8.tgz"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["@jsr/std__internal", [\
+      ["npm:1.0.12::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Fstd__internal%2F1.0.12.tgz", {\
+        "packageLocation": "./.yarn/cache/@jsr-std__internal-npm-1.0.12-fe0cc43a57-14489cb28c.zip/node_modules/@jsr/std__internal/",\
+        "packageDependencies": [\
+          ["@jsr/std__internal", "npm:1.0.12::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Fstd__internal%2F1.0.12.tgz"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -2619,14 +2635,22 @@ const RAW_RUNTIME_STATE =
           ["@jsr/std__path", "npm:1.0.8::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Fstd__path%2F1.0.8.tgz"]\
         ],\
         "linkType": "HARD"\
+      }],\
+      ["npm:1.1.2::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Fstd__path%2F1.1.2.tgz", {\
+        "packageLocation": "./.yarn/cache/@jsr-std__path-npm-1.1.2-b917eaf50a-e674a48454.zip/node_modules/@jsr/std__path/",\
+        "packageDependencies": [\
+          ["@jsr/std__internal", "npm:1.0.12::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Fstd__internal%2F1.0.12.tgz"],\
+          ["@jsr/std__path", "npm:1.1.2::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Fstd__path%2F1.1.2.tgz"]\
+        ],\
+        "linkType": "HARD"\
       }]\
     ]],\
     ["@jsr/std__streams", [\
-      ["npm:1.0.9::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Fstd__streams%2F1.0.9.tgz", {\
-        "packageLocation": "./.yarn/cache/@jsr-std__streams-npm-1.0.9-8c2768dc60-ea744fbd58.zip/node_modules/@jsr/std__streams/",\
+      ["npm:1.0.13::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Fstd__streams%2F1.0.13.tgz", {\
+        "packageLocation": "./.yarn/cache/@jsr-std__streams-npm-1.0.13-08c536209e-27c0b61c76.zip/node_modules/@jsr/std__streams/",\
         "packageDependencies": [\
-          ["@jsr/std__bytes", "npm:1.0.5::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Fstd__bytes%2F1.0.5.tgz"],\
-          ["@jsr/std__streams", "npm:1.0.9::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Fstd__streams%2F1.0.9.tgz"]\
+          ["@jsr/std__bytes", "npm:1.0.6::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Fstd__bytes%2F1.0.6.tgz"],\
+          ["@jsr/std__streams", "npm:1.0.13::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Fstd__streams%2F1.0.13.tgz"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -2641,10 +2665,10 @@ const RAW_RUNTIME_STATE =
       }]\
     ]],\
     ["@jsr/std__yaml", [\
-      ["npm:1.0.5::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Fstd__yaml%2F1.0.5.tgz", {\
-        "packageLocation": "./.yarn/cache/@jsr-std__yaml-npm-1.0.5-500660c0bb-4073d72d1d.zip/node_modules/@jsr/std__yaml/",\
+      ["npm:1.0.10::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Fstd__yaml%2F1.0.10.tgz", {\
+        "packageLocation": "./.yarn/cache/@jsr-std__yaml-npm-1.0.10-aff7bb829b-ccb277db0f.zip/node_modules/@jsr/std__yaml/",\
         "packageDependencies": [\
-          ["@jsr/std__yaml", "npm:1.0.5::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Fstd__yaml%2F1.0.5.tgz"]\
+          ["@jsr/std__yaml", "npm:1.0.10::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Fstd__yaml%2F1.0.10.tgz"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -3863,10 +3887,7 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["@apollo/client", "virtual:4112afb9dad10978c159910bf10db9840b981b1333117623c8a4a8cf77481344a0a24735a5506e2920c18e3cfa2cc179489824b6a56c988bb070f4f60da40974#npm:3.13.8"],\
           ["@artsy/fresnel", "virtual:4112afb9dad10978c159910bf10db9840b981b1333117623c8a4a8cf77481344a0a24735a5506e2920c18e3cfa2cc179489824b6a56c988bb070f4f60da40974#npm:1.9.0"],\
-          ["@bids/validator", [\
-            "@jsr/bids__validator",\
-            "npm:2.0.8::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Fbids__validator%2F2.0.8.tgz"\
-          ]],\
+          ["@bids/validator", "jsr:2.1.1::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Fbids__validator%2F2.1.1.tgz"],\
           ["@emotion/react", "virtual:dfc8861fb483e7f9493811b738b55fee97a3c3e2cb836e82763f82cb601d9955d5ee09c520fd30825cc5220c166a2003feb13430de5559fb2a330912125de5c2#npm:11.11.1"],\
           ["@emotion/styled", "virtual:dfc8861fb483e7f9493811b738b55fee97a3c3e2cb836e82763f82cb601d9955d5ee09c520fd30825cc5220c166a2003feb13430de5559fb2a330912125de5c2#npm:11.11.0"],\
           ["@niivue/niivue", "npm:0.57.0"],\
@@ -14490,10 +14511,10 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "HARD"\
       }],\
-      ["npm:7.0.3", {\
-        "packageLocation": "./.yarn/cache/ignore-npm-7.0.3-6ded2ddf1c-ce5e812af3.zip/node_modules/ignore/",\
+      ["npm:7.0.5", {\
+        "packageLocation": "./.yarn/cache/ignore-npm-7.0.5-dea34ee430-f134b96a4d.zip/node_modules/ignore/",\
         "packageDependencies": [\
-          ["ignore", "npm:7.0.3"]\
+          ["ignore", "npm:7.0.5"]\
         ],\
         "linkType": "HARD"\
       }]\

--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -1259,28 +1259,6 @@ const RAW_RUNTIME_STATE =
         "linkType": "HARD"\
       }]\
     ]],\
-    ["@bids/validator", [\
-      ["jsr:2.1.1::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Fbids__validator%2F2.1.1.tgz", {\
-        "packageLocation": "./.yarn/cache/@jsr-bids__validator-npm-2.1.1-8108dda95d-c189ea5dd8.zip/node_modules/@jsr/bids__validator/",\
-        "packageDependencies": [\
-          ["@bids/nifti-reader-js", "npm:0.6.9"],\
-          ["@bids/validator", "jsr:2.1.1::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Fbids__validator%2F2.1.1.tgz"],\
-          ["@jsr/bids__schema", "npm:1.1.0::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Fbids__schema%2F1.1.0.tgz"],\
-          ["@jsr/effigies__cliffy-command", "npm:1.0.0-dev.8::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Feffigies__cliffy-command%2F1.0.0-dev.8.tgz"],\
-          ["@jsr/effigies__cliffy-table", "npm:1.0.0-dev.5::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Feffigies__cliffy-table%2F1.0.0-dev.5.tgz"],\
-          ["@jsr/libs__xml", "npm:6.0.8::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Flibs__xml%2F6.0.8.tgz"],\
-          ["@jsr/std__fmt", "npm:1.0.8::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Fstd__fmt%2F1.0.8.tgz"],\
-          ["@jsr/std__log", "npm:0.224.14::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Fstd__log%2F0.224.14.tgz"],\
-          ["@jsr/std__path", "npm:1.1.2::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Fstd__path%2F1.1.2.tgz"],\
-          ["@jsr/std__streams", "npm:1.0.13::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Fstd__streams%2F1.0.13.tgz"],\
-          ["@jsr/std__yaml", "npm:1.0.10::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Fstd__yaml%2F1.0.10.tgz"],\
-          ["ajv", "npm:8.17.1"],\
-          ["hed-validator", "npm:4.0.1"],\
-          ["ignore", "npm:7.0.5"]\
-        ],\
-        "linkType": "HARD"\
-      }]\
-    ]],\
     ["@chevrotain/types", [\
       ["npm:9.1.0", {\
         "packageLocation": "./.yarn/cache/@chevrotain-types-npm-9.1.0-80ac254cc2-091dbff29f.zip/node_modules/@chevrotain/types/",\
@@ -2480,6 +2458,28 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./.yarn/cache/@jsr-bids__schema-npm-1.1.0-8de871ce10-37fc9aa3eb.zip/node_modules/@jsr/bids__schema/",\
         "packageDependencies": [\
           ["@jsr/bids__schema", "npm:1.1.0::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Fbids__schema%2F1.1.0.tgz"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["@jsr/bids__validator", [\
+      ["npm:2.1.1::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Fbids__validator%2F2.1.1.tgz", {\
+        "packageLocation": "./.yarn/cache/@jsr-bids__validator-npm-2.1.1-8108dda95d-c189ea5dd8.zip/node_modules/@jsr/bids__validator/",\
+        "packageDependencies": [\
+          ["@bids/nifti-reader-js", "npm:0.6.9"],\
+          ["@jsr/bids__schema", "npm:1.1.0::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Fbids__schema%2F1.1.0.tgz"],\
+          ["@jsr/bids__validator", "npm:2.1.1::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Fbids__validator%2F2.1.1.tgz"],\
+          ["@jsr/effigies__cliffy-command", "npm:1.0.0-dev.8::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Feffigies__cliffy-command%2F1.0.0-dev.8.tgz"],\
+          ["@jsr/effigies__cliffy-table", "npm:1.0.0-dev.5::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Feffigies__cliffy-table%2F1.0.0-dev.5.tgz"],\
+          ["@jsr/libs__xml", "npm:6.0.8::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Flibs__xml%2F6.0.8.tgz"],\
+          ["@jsr/std__fmt", "npm:1.0.8::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Fstd__fmt%2F1.0.8.tgz"],\
+          ["@jsr/std__log", "npm:0.224.14::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Fstd__log%2F0.224.14.tgz"],\
+          ["@jsr/std__path", "npm:1.1.2::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Fstd__path%2F1.1.2.tgz"],\
+          ["@jsr/std__streams", "npm:1.0.13::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Fstd__streams%2F1.0.13.tgz"],\
+          ["@jsr/std__yaml", "npm:1.0.10::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Fstd__yaml%2F1.0.10.tgz"],\
+          ["ajv", "npm:8.17.1"],\
+          ["hed-validator", "npm:4.0.1"],\
+          ["ignore", "npm:7.0.5"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -3887,7 +3887,10 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["@apollo/client", "virtual:4112afb9dad10978c159910bf10db9840b981b1333117623c8a4a8cf77481344a0a24735a5506e2920c18e3cfa2cc179489824b6a56c988bb070f4f60da40974#npm:3.13.8"],\
           ["@artsy/fresnel", "virtual:4112afb9dad10978c159910bf10db9840b981b1333117623c8a4a8cf77481344a0a24735a5506e2920c18e3cfa2cc179489824b6a56c988bb070f4f60da40974#npm:1.9.0"],\
-          ["@bids/validator", "jsr:2.1.1::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Fbids__validator%2F2.1.1.tgz"],\
+          ["@bids/validator", [\
+            "@jsr/bids__validator",\
+            "npm:2.1.1::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Fbids__validator%2F2.1.1.tgz"\
+          ]],\
           ["@emotion/react", "virtual:dfc8861fb483e7f9493811b738b55fee97a3c3e2cb836e82763f82cb601d9955d5ee09c520fd30825cc5220c166a2003feb13430de5559fb2a330912125de5c2#npm:11.11.1"],\
           ["@emotion/styled", "virtual:dfc8861fb483e7f9493811b738b55fee97a3c3e2cb836e82763f82cb601d9955d5ee09c520fd30825cc5220c166a2003feb13430de5559fb2a330912125de5c2#npm:11.11.0"],\
           ["@niivue/niivue", "npm:0.57.0"],\

--- a/cli/deno.json
+++ b/cli/deno.json
@@ -17,7 +17,7 @@
     "coverage": "deno test --allow-read --allow-write --allow-net --allow-env --allow-sys --coverage ./ && deno coverage ./coverage --lcov > ./coverage.lcov"
   },
   "imports": {
-    "@bids/validator": "jsr:@bids/validator@^2.0.8",
+    "@bids/validator": "jsr:@bids/validator@^2.0.9",
     "@cliffy/command": "jsr:@effigies/cliffy-command@1.0.0-dev.8",
     "@cliffy/prompt": "jsr:@cliffy/prompt@^1.0.0-rc.8",
     "@deno-library/progress": "jsr:@deno-library/progress@^1.5.1",

--- a/cli/deno.json
+++ b/cli/deno.json
@@ -17,7 +17,7 @@
     "coverage": "deno test --allow-read --allow-write --allow-net --allow-env --allow-sys --coverage ./ && deno coverage ./coverage --lcov > ./coverage.lcov"
   },
   "imports": {
-    "@bids/validator": "jsr:@bids/validator@^2.0.9",
+    "@bids/validator": "jsr:@bids/validator@^2.1.1",
     "@cliffy/command": "jsr:@effigies/cliffy-command@1.0.0-dev.8",
     "@cliffy/prompt": "jsr:@cliffy/prompt@^1.0.0-rc.8",
     "@deno-library/progress": "jsr:@deno-library/progress@^1.5.1",

--- a/cli/deno.lock
+++ b/cli/deno.lock
@@ -1,49 +1,42 @@
 {
   "version": "5",
   "specifiers": {
-    "jsr:@bids/schema@1.0.4": "1.0.4",
-    "jsr:@bids/validator@^2.0.8": "2.0.8",
+    "jsr:@bids/schema@~1.0.14": "1.0.14",
+    "jsr:@bids/validator@^2.0.9": "2.0.9",
     "jsr:@cliffy/ansi@1.0.0-rc.8": "1.0.0-rc.8",
     "jsr:@cliffy/flags@1.0.0-rc.7": "1.0.0-rc.7",
     "jsr:@cliffy/internal@1.0.0-rc.7": "1.0.0-rc.7",
     "jsr:@cliffy/internal@1.0.0-rc.8": "1.0.0-rc.8",
     "jsr:@cliffy/keycode@1.0.0-rc.8": "1.0.0-rc.8",
     "jsr:@cliffy/prompt@^1.0.0-rc.8": "1.0.0-rc.8",
-    "jsr:@cliffy/table@1.0.0-rc.7": "1.0.0-rc.7",
     "jsr:@deno-library/progress@^1.5.1": "1.5.1",
     "jsr:@effigies/cliffy-command@1.0.0-dev.8": "1.0.0-dev.8",
     "jsr:@effigies/cliffy-table@1.0.0-dev.5": "1.0.0-dev.5",
     "jsr:@effigies/cliffy-table@^1.0.0-dev.5": "1.0.0-dev.5",
     "jsr:@libs/xml@6.0.4": "6.0.4",
-    "jsr:@std/assert@^1.0.13": "1.0.14",
-    "jsr:@std/assert@^1.0.14": "1.0.14",
     "jsr:@std/assert@~1.0.6": "1.0.14",
     "jsr:@std/bytes@^1.0.5": "1.0.6",
     "jsr:@std/bytes@^1.0.6": "1.0.6",
-    "jsr:@std/data-structures@^1.0.9": "1.0.9",
     "jsr:@std/encoding@0.221": "0.221.0",
     "jsr:@std/encoding@^1.0.10": "1.0.10",
     "jsr:@std/encoding@~1.0.5": "1.0.10",
     "jsr:@std/fmt@1.0.3": "1.0.3",
     "jsr:@std/fmt@1.0.6": "1.0.6",
-    "jsr:@std/fmt@^1.0.5": "1.0.8",
-    "jsr:@std/fmt@~1.0.2": "1.0.8",
+    "jsr:@std/fmt@^1.0.5": "1.0.6",
+    "jsr:@std/fmt@~1.0.2": "1.0.6",
     "jsr:@std/fs@^1.0.11": "1.0.19",
     "jsr:@std/fs@^1.0.19": "1.0.19",
     "jsr:@std/internal@^1.0.10": "1.0.10",
-    "jsr:@std/internal@^1.0.9": "1.0.10",
     "jsr:@std/io@0.225.0": "0.225.0",
-    "jsr:@std/io@~0.224.9": "0.224.9",
     "jsr:@std/io@~0.225.2": "0.225.2",
     "jsr:@std/log@0.224.14": "0.224.14",
     "jsr:@std/log@~0.224.14": "0.224.14",
     "jsr:@std/path@1.0.8": "1.0.8",
     "jsr:@std/path@^1.1.1": "1.1.2",
     "jsr:@std/path@^1.1.2": "1.1.2",
-    "jsr:@std/path@~1.0.6": "1.0.9",
+    "jsr:@std/path@~1.0.6": "1.0.8",
     "jsr:@std/streams@1.0.9": "1.0.9",
     "jsr:@std/streams@^1.0.11": "1.0.11",
-    "jsr:@std/testing@^1.0.15": "1.0.15",
     "jsr:@std/text@~1.0.7": "1.0.16",
     "jsr:@std/yaml@^1.0.5": "1.0.9",
     "jsr:@wok/djwt@^3.0.2": "3.0.2",
@@ -58,11 +51,11 @@
     "npm:isomorphic-git@1.27.1": "1.27.1"
   },
   "jsr": {
-    "@bids/schema@1.0.4": {
-      "integrity": "54fae7e87e2cc150203b41f69c19ad21263dba078ef990211ee2f8d7683b1828"
+    "@bids/schema@1.0.14": {
+      "integrity": "973d1a939b570a36009a5e842d9035d3113ea79c19fb544ab6216b0f9210e426"
     },
-    "@bids/validator@2.0.8": {
-      "integrity": "bec46ef1489b613c079429c5253d60b6345295aaa3bf113f1883c9325e0ce904",
+    "@bids/validator@2.0.9": {
+      "integrity": "73e809c028ab864d5621609a22dcaf7a21e49f5c01e64e2405b00bedc67ad7b6",
       "dependencies": [
         "jsr:@bids/schema",
         "jsr:@effigies/cliffy-command",
@@ -83,8 +76,7 @@
       "integrity": "ba37f10ce55bbfbdd8ddd987f91f029b17bce88385b98ba3058870f3b007b80c",
       "dependencies": [
         "jsr:@cliffy/internal@1.0.0-rc.8",
-        "jsr:@std/encoding@~1.0.5",
-        "jsr:@std/io@~0.224.9"
+        "jsr:@std/encoding@~1.0.5"
       ]
     },
     "@cliffy/flags@1.0.0-rc.7": {
@@ -108,17 +100,10 @@
         "jsr:@cliffy/ansi",
         "jsr:@cliffy/internal@1.0.0-rc.8",
         "jsr:@cliffy/keycode",
-        "jsr:@std/assert@~1.0.6",
+        "jsr:@std/assert",
         "jsr:@std/fmt@~1.0.2",
-        "jsr:@std/io@~0.224.9",
         "jsr:@std/path@~1.0.6",
         "jsr:@std/text"
-      ]
-    },
-    "@cliffy/table@1.0.0-rc.7": {
-      "integrity": "9fdd9776eda28a0b397981c400eeb1aa36da2371b43eefe12e6ff555290e3180",
-      "dependencies": [
-        "jsr:@std/fmt@~1.0.2"
       ]
     },
     "@deno-library/progress@1.5.1": {
@@ -133,7 +118,6 @@
       "dependencies": [
         "jsr:@cliffy/flags",
         "jsr:@cliffy/internal@1.0.0-rc.7",
-        "jsr:@cliffy/table",
         "jsr:@effigies/cliffy-table@^1.0.0-dev.5",
         "jsr:@std/fmt@~1.0.2",
         "jsr:@std/text"
@@ -149,16 +133,10 @@
       "integrity": "c896f17016dbf5f2d62496e0bd6cd7db145c05987d0e45d4dd2c87785a60f528"
     },
     "@std/assert@1.0.14": {
-      "integrity": "68d0d4a43b365abc927f45a9b85c639ea18a9fab96ad92281e493e4ed84abaa4",
-      "dependencies": [
-        "jsr:@std/internal@^1.0.10"
-      ]
+      "integrity": "68d0d4a43b365abc927f45a9b85c639ea18a9fab96ad92281e493e4ed84abaa4"
     },
     "@std/bytes@1.0.6": {
       "integrity": "f6ac6adbd8ccd99314045f5703e23af0a68d7f7e58364b47d2c7f408aeb5820a"
-    },
-    "@std/data-structures@1.0.9": {
-      "integrity": "033d6e17e64bf1f84a614e647c1b015fa2576ae3312305821e1a4cb20674bb4d"
     },
     "@std/encoding@0.221.0": {
       "integrity": "d1dd76ef0dc5d14088411e6dc1dede53bf8308c95d1537df1214c97137208e45"
@@ -172,21 +150,14 @@
     "@std/fmt@1.0.6": {
       "integrity": "a2c56a69a2369876ddb3ad6a500bb6501b5bad47bb3ea16bfb0c18974d2661fc"
     },
-    "@std/fmt@1.0.8": {
-      "integrity": "71e1fc498787e4434d213647a6e43e794af4fd393ef8f52062246e06f7e372b7"
-    },
     "@std/fs@1.0.19": {
       "integrity": "051968c2b1eae4d2ea9f79a08a3845740ef6af10356aff43d3e2ef11ed09fb06",
       "dependencies": [
-        "jsr:@std/internal@^1.0.9",
         "jsr:@std/path@^1.1.1"
       ]
     },
     "@std/internal@1.0.10": {
       "integrity": "e3be62ce42cab0e177c27698e5d9800122f67b766a0bea6ca4867886cbde8cf7"
-    },
-    "@std/io@0.224.9": {
-      "integrity": "4414664b6926f665102e73c969cfda06d2c4c59bd5d0c603fd4f1b1c840d6ee3"
     },
     "@std/io@0.225.0": {
       "integrity": "c1db7c5e5a231629b32d64b9a53139445b2ca640d828c26bf23e1c55f8c079b3"
@@ -205,13 +176,10 @@
     "@std/path@1.0.8": {
       "integrity": "548fa456bb6a04d3c1a1e7477986b6cffbce95102d0bb447c67c4ee70e0364be"
     },
-    "@std/path@1.0.9": {
-      "integrity": "260a49f11edd3db93dd38350bf9cd1b4d1366afa98e81b86167b4e3dd750129e"
-    },
     "@std/path@1.1.2": {
       "integrity": "c0b13b97dfe06546d5e16bf3966b1cadf92e1cc83e56ba5476ad8b498d9e3038",
       "dependencies": [
-        "jsr:@std/internal@^1.0.10"
+        "jsr:@std/internal"
       ]
     },
     "@std/streams@1.0.9": {
@@ -224,16 +192,6 @@
       "integrity": "db583d27e28d133f389f1eec318cffdf4998305e5134c1d4b1c56b361cee6018",
       "dependencies": [
         "jsr:@std/bytes@^1.0.6"
-      ]
-    },
-    "@std/testing@1.0.15": {
-      "integrity": "a490169f5ccb0f3ae9c94fbc69d2cd43603f2cffb41713a85f99bbb0e3087cbc",
-      "dependencies": [
-        "jsr:@std/assert@^1.0.13",
-        "jsr:@std/data-structures",
-        "jsr:@std/fs@^1.0.19",
-        "jsr:@std/internal@^1.0.10",
-        "jsr:@std/path@^1.1.1"
       ]
     },
     "@std/text@1.0.16": {
@@ -370,9 +328,6 @@
     "inherits@2.0.3": {
       "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw=="
     },
-    "inherits@2.0.4": {
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-    },
     "isomorphic-git@1.27.1": {
       "integrity": "sha512-X32ph5zIWfT75QAqW2l3JCIqnx9/GWd17bRRehmn3qmWc34OYbSXY6Cxv0o9bIIY+CWugoN4nQFHNA+2uYf2nA==",
       "dependencies": [
@@ -442,7 +397,7 @@
     "readable-stream@3.6.2": {
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "dependencies": [
-        "inherits@2.0.4",
+        "inherits",
         "string_decoder",
         "util-deprecate"
       ]
@@ -463,7 +418,7 @@
     "sha.js@2.4.11": {
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "dependencies": [
-        "inherits@2.0.4",
+        "inherits",
         "safe-buffer"
       ],
       "bin": true
@@ -500,7 +455,7 @@
     "util@0.10.4": {
       "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
       "dependencies": [
-        "inherits@2.0.3"
+        "inherits"
       ]
     },
     "webidl-conversions@3.0.1": {
@@ -529,7 +484,7 @@
   },
   "workspace": {
     "dependencies": [
-      "jsr:@bids/validator@^2.0.8",
+      "jsr:@bids/validator@^2.0.9",
       "jsr:@cliffy/prompt@^1.0.0-rc.8",
       "jsr:@deno-library/progress@^1.5.1",
       "jsr:@effigies/cliffy-command@1.0.0-dev.8",

--- a/cli/deno.lock
+++ b/cli/deno.lock
@@ -1,82 +1,56 @@
 {
   "version": "5",
   "specifiers": {
-    "jsr:@bids/schema@~1.0.14": "1.0.14",
-    "jsr:@bids/validator@^2.0.9": "2.0.9",
     "jsr:@cliffy/ansi@1.0.0-rc.8": "1.0.0-rc.8",
     "jsr:@cliffy/flags@1.0.0-rc.7": "1.0.0-rc.7",
     "jsr:@cliffy/internal@1.0.0-rc.7": "1.0.0-rc.7",
     "jsr:@cliffy/internal@1.0.0-rc.8": "1.0.0-rc.8",
     "jsr:@cliffy/keycode@1.0.0-rc.8": "1.0.0-rc.8",
     "jsr:@cliffy/prompt@^1.0.0-rc.8": "1.0.0-rc.8",
+    "jsr:@cliffy/table@1.0.0-rc.7": "1.0.0-rc.7",
     "jsr:@deno-library/progress@^1.5.1": "1.5.1",
     "jsr:@effigies/cliffy-command@1.0.0-dev.8": "1.0.0-dev.8",
-    "jsr:@effigies/cliffy-table@1.0.0-dev.5": "1.0.0-dev.5",
     "jsr:@effigies/cliffy-table@^1.0.0-dev.5": "1.0.0-dev.5",
-    "jsr:@libs/xml@6.0.4": "6.0.4",
+    "jsr:@std/assert@^1.0.13": "1.0.14",
+    "jsr:@std/assert@^1.0.14": "1.0.14",
     "jsr:@std/assert@~1.0.6": "1.0.14",
-    "jsr:@std/bytes@^1.0.5": "1.0.6",
+    "jsr:@std/async@^1.0.13": "1.0.13",
     "jsr:@std/bytes@^1.0.6": "1.0.6",
+    "jsr:@std/data-structures@^1.0.9": "1.0.9",
     "jsr:@std/encoding@0.221": "0.221.0",
     "jsr:@std/encoding@^1.0.10": "1.0.10",
     "jsr:@std/encoding@~1.0.5": "1.0.10",
     "jsr:@std/fmt@1.0.3": "1.0.3",
-    "jsr:@std/fmt@1.0.6": "1.0.6",
-    "jsr:@std/fmt@^1.0.5": "1.0.6",
-    "jsr:@std/fmt@~1.0.2": "1.0.6",
+    "jsr:@std/fmt@^1.0.5": "1.0.8",
+    "jsr:@std/fmt@~1.0.2": "1.0.8",
     "jsr:@std/fs@^1.0.11": "1.0.19",
     "jsr:@std/fs@^1.0.19": "1.0.19",
-    "jsr:@std/internal@^1.0.10": "1.0.10",
+    "jsr:@std/internal@^1.0.10": "1.0.12",
+    "jsr:@std/internal@^1.0.9": "1.0.12",
     "jsr:@std/io@0.225.0": "0.225.0",
+    "jsr:@std/io@~0.224.9": "0.224.9",
     "jsr:@std/io@~0.225.2": "0.225.2",
-    "jsr:@std/log@0.224.14": "0.224.14",
     "jsr:@std/log@~0.224.14": "0.224.14",
-    "jsr:@std/path@1.0.8": "1.0.8",
     "jsr:@std/path@^1.1.1": "1.1.2",
     "jsr:@std/path@^1.1.2": "1.1.2",
-    "jsr:@std/path@~1.0.6": "1.0.8",
-    "jsr:@std/streams@1.0.9": "1.0.9",
+    "jsr:@std/path@~1.0.6": "1.0.9",
     "jsr:@std/streams@^1.0.11": "1.0.11",
+    "jsr:@std/testing@^1.0.15": "1.0.15",
     "jsr:@std/text@~1.0.7": "1.0.16",
-    "jsr:@std/yaml@^1.0.5": "1.0.9",
     "jsr:@wok/djwt@^3.0.2": "3.0.2",
-    "npm:@bids/nifti-reader-js@0.6.9": "0.6.9",
     "npm:@sentry/deno@^8.55.0": "8.55.0",
     "npm:@types/node@*": "22.10.7",
-    "npm:ajv@8.17.1": "8.17.1",
     "npm:hash-wasm@^4.12.0": "4.12.0",
-    "npm:hed-validator@4.0.1": "4.0.1",
-    "npm:ignore@7.0.3": "7.0.3",
     "npm:ignore@^5.3.0": "5.3.2",
     "npm:isomorphic-git@1.27.1": "1.27.1"
   },
   "jsr": {
-    "@bids/schema@1.0.14": {
-      "integrity": "973d1a939b570a36009a5e842d9035d3113ea79c19fb544ab6216b0f9210e426"
-    },
-    "@bids/validator@2.0.9": {
-      "integrity": "73e809c028ab864d5621609a22dcaf7a21e49f5c01e64e2405b00bedc67ad7b6",
-      "dependencies": [
-        "jsr:@bids/schema",
-        "jsr:@effigies/cliffy-command",
-        "jsr:@effigies/cliffy-table@1.0.0-dev.5",
-        "jsr:@libs/xml",
-        "jsr:@std/fmt@1.0.6",
-        "jsr:@std/log@0.224.14",
-        "jsr:@std/path@1.0.8",
-        "jsr:@std/streams@1.0.9",
-        "jsr:@std/yaml",
-        "npm:@bids/nifti-reader-js",
-        "npm:ajv",
-        "npm:hed-validator",
-        "npm:ignore@7.0.3"
-      ]
-    },
     "@cliffy/ansi@1.0.0-rc.8": {
       "integrity": "ba37f10ce55bbfbdd8ddd987f91f029b17bce88385b98ba3058870f3b007b80c",
       "dependencies": [
         "jsr:@cliffy/internal@1.0.0-rc.8",
-        "jsr:@std/encoding@~1.0.5"
+        "jsr:@std/encoding@~1.0.5",
+        "jsr:@std/io@~0.224.9"
       ]
     },
     "@cliffy/flags@1.0.0-rc.7": {
@@ -100,10 +74,17 @@
         "jsr:@cliffy/ansi",
         "jsr:@cliffy/internal@1.0.0-rc.8",
         "jsr:@cliffy/keycode",
-        "jsr:@std/assert",
+        "jsr:@std/assert@~1.0.6",
         "jsr:@std/fmt@~1.0.2",
+        "jsr:@std/io@~0.224.9",
         "jsr:@std/path@~1.0.6",
         "jsr:@std/text"
+      ]
+    },
+    "@cliffy/table@1.0.0-rc.7": {
+      "integrity": "9fdd9776eda28a0b397981c400eeb1aa36da2371b43eefe12e6ff555290e3180",
+      "dependencies": [
+        "jsr:@std/fmt@~1.0.2"
       ]
     },
     "@deno-library/progress@1.5.1": {
@@ -118,7 +99,8 @@
       "dependencies": [
         "jsr:@cliffy/flags",
         "jsr:@cliffy/internal@1.0.0-rc.7",
-        "jsr:@effigies/cliffy-table@^1.0.0-dev.5",
+        "jsr:@cliffy/table",
+        "jsr:@effigies/cliffy-table",
         "jsr:@std/fmt@~1.0.2",
         "jsr:@std/text"
       ]
@@ -129,14 +111,20 @@
         "jsr:@std/fmt@~1.0.2"
       ]
     },
-    "@libs/xml@6.0.4": {
-      "integrity": "c896f17016dbf5f2d62496e0bd6cd7db145c05987d0e45d4dd2c87785a60f528"
-    },
     "@std/assert@1.0.14": {
-      "integrity": "68d0d4a43b365abc927f45a9b85c639ea18a9fab96ad92281e493e4ed84abaa4"
+      "integrity": "68d0d4a43b365abc927f45a9b85c639ea18a9fab96ad92281e493e4ed84abaa4",
+      "dependencies": [
+        "jsr:@std/internal@^1.0.10"
+      ]
+    },
+    "@std/async@1.0.13": {
+      "integrity": "1d76ca5d324aef249908f7f7fe0d39aaf53198e5420604a59ab5c035adc97c96"
     },
     "@std/bytes@1.0.6": {
       "integrity": "f6ac6adbd8ccd99314045f5703e23af0a68d7f7e58364b47d2c7f408aeb5820a"
+    },
+    "@std/data-structures@1.0.9": {
+      "integrity": "033d6e17e64bf1f84a614e647c1b015fa2576ae3312305821e1a4cb20674bb4d"
     },
     "@std/encoding@0.221.0": {
       "integrity": "d1dd76ef0dc5d14088411e6dc1dede53bf8308c95d1537df1214c97137208e45"
@@ -147,17 +135,21 @@
     "@std/fmt@1.0.3": {
       "integrity": "97765c16aa32245ff4e2204ecf7d8562496a3cb8592340a80e7e554e0bb9149f"
     },
-    "@std/fmt@1.0.6": {
-      "integrity": "a2c56a69a2369876ddb3ad6a500bb6501b5bad47bb3ea16bfb0c18974d2661fc"
+    "@std/fmt@1.0.8": {
+      "integrity": "71e1fc498787e4434d213647a6e43e794af4fd393ef8f52062246e06f7e372b7"
     },
     "@std/fs@1.0.19": {
       "integrity": "051968c2b1eae4d2ea9f79a08a3845740ef6af10356aff43d3e2ef11ed09fb06",
       "dependencies": [
+        "jsr:@std/internal@^1.0.9",
         "jsr:@std/path@^1.1.1"
       ]
     },
-    "@std/internal@1.0.10": {
-      "integrity": "e3be62ce42cab0e177c27698e5d9800122f67b766a0bea6ca4867886cbde8cf7"
+    "@std/internal@1.0.12": {
+      "integrity": "972a634fd5bc34b242024402972cd5143eac68d8dffaca5eaa4dba30ce17b027"
+    },
+    "@std/io@0.224.9": {
+      "integrity": "4414664b6926f665102e73c969cfda06d2c4c59bd5d0c603fd4f1b1c840d6ee3"
     },
     "@std/io@0.225.0": {
       "integrity": "c1db7c5e5a231629b32d64b9a53139445b2ca640d828c26bf23e1c55f8c079b3"
@@ -173,32 +165,34 @@
         "jsr:@std/io@~0.225.2"
       ]
     },
-    "@std/path@1.0.8": {
-      "integrity": "548fa456bb6a04d3c1a1e7477986b6cffbce95102d0bb447c67c4ee70e0364be"
+    "@std/path@1.0.9": {
+      "integrity": "260a49f11edd3db93dd38350bf9cd1b4d1366afa98e81b86167b4e3dd750129e"
     },
     "@std/path@1.1.2": {
       "integrity": "c0b13b97dfe06546d5e16bf3966b1cadf92e1cc83e56ba5476ad8b498d9e3038",
       "dependencies": [
-        "jsr:@std/internal"
-      ]
-    },
-    "@std/streams@1.0.9": {
-      "integrity": "a9d26b1988cdd7aa7b1f4b51e1c36c1557f3f252880fa6cc5b9f37078b1a5035",
-      "dependencies": [
-        "jsr:@std/bytes@^1.0.5"
+        "jsr:@std/internal@^1.0.10"
       ]
     },
     "@std/streams@1.0.11": {
       "integrity": "db583d27e28d133f389f1eec318cffdf4998305e5134c1d4b1c56b361cee6018",
       "dependencies": [
-        "jsr:@std/bytes@^1.0.6"
+        "jsr:@std/bytes"
+      ]
+    },
+    "@std/testing@1.0.15": {
+      "integrity": "a490169f5ccb0f3ae9c94fbc69d2cd43603f2cffb41713a85f99bbb0e3087cbc",
+      "dependencies": [
+        "jsr:@std/assert@^1.0.13",
+        "jsr:@std/async",
+        "jsr:@std/data-structures",
+        "jsr:@std/fs@^1.0.19",
+        "jsr:@std/internal@^1.0.10",
+        "jsr:@std/path@^1.1.1"
       ]
     },
     "@std/text@1.0.16": {
       "integrity": "ddb9853b75119a2473857d691cf1ec02ad90793a2e8b4a4ac49d7354281a0cf8"
-    },
-    "@std/yaml@1.0.9": {
-      "integrity": "6bad3dc766dd85b4b37eabcba81b6aa4eac7a392792ae29abcfb0f90602d55bb"
     },
     "@wok/djwt@3.0.2": {
       "integrity": "e1c8afe6e321941edda40d91b089e93738469b994d53f41f82e0e7fcd7dde259",
@@ -208,12 +202,6 @@
     }
   },
   "npm": {
-    "@bids/nifti-reader-js@0.6.9": {
-      "integrity": "sha512-3KWpGKrgUUvT5Bbl25K9TTQ77DRS5DUpcyhZlAblCPdP1YMy0tCzrxarRTixWM9tDN6sWUOBbf6zQpPyVe11Lw==",
-      "dependencies": [
-        "fflate"
-      ]
-    },
     "@sentry/core@8.55.0": {
       "integrity": "sha512-6g7jpbefjHYs821Z+EBJ8r4Z7LT5h80YSWRJaylGS4nW5W5Z2KXzpdnyFarv37O7QjauzVC2E+PABmpkw5/JGA=="
     },
@@ -229,50 +217,44 @@
         "undici-types"
       ]
     },
-    "ajv@8.17.1": {
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
-      "dependencies": [
-        "fast-deep-equal",
-        "fast-uri",
-        "json-schema-traverse",
-        "require-from-string"
-      ]
-    },
     "async-lock@1.4.1": {
       "integrity": "sha512-Az2ZTpuytrtqENulXwO3GGv1Bztugx6TT37NIo7imr/Qo0gsYiGtSdBa2B6fsXhTpVZDNfu1Qn3pk531e3q+nQ=="
     },
-    "base64-js@1.5.1": {
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
-    },
-    "buffer@6.0.3": {
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+    "available-typed-arrays@1.0.7": {
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
       "dependencies": [
-        "base64-js",
-        "ieee754"
+        "possible-typed-array-names"
+      ]
+    },
+    "call-bind-apply-helpers@1.0.2": {
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dependencies": [
+        "es-errors",
+        "function-bind"
+      ]
+    },
+    "call-bind@1.0.8": {
+      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+      "dependencies": [
+        "call-bind-apply-helpers",
+        "es-define-property",
+        "get-intrinsic",
+        "set-function-length"
+      ]
+    },
+    "call-bound@1.0.4": {
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dependencies": [
+        "call-bind-apply-helpers",
+        "get-intrinsic"
       ]
     },
     "clean-git-ref@2.0.1": {
       "integrity": "sha512-bLSptAy2P0s6hU4PzuIMKmMJJSE6gLXGH1cntDu7bWJUksvuM+7ReOK61mozULErYvP6a15rnYl0zFDef+pyPw=="
     },
-    "core-js-pure@3.45.0": {
-      "integrity": "sha512-OtwjqcDpY2X/eIIg1ol/n0y/X8A9foliaNt1dSK0gV3J2/zw+89FcNG3mPK+N8YWts4ZFUPxnrAzsxs/lf8yDA==",
-      "scripts": true
-    },
     "crc-32@1.2.2": {
       "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
       "bin": true
-    },
-    "cross-fetch@4.1.0": {
-      "integrity": "sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw==",
-      "dependencies": [
-        "node-fetch"
-      ]
-    },
-    "date-and-time@3.6.0": {
-      "integrity": "sha512-V99gLaMqNQxPCObBumb31Bfy3OByXnpqUM0yHPi/aBQE61g42A2rGk6Z2CDnpLrWsOFLQwOgl4Vgshw6D44ebw=="
-    },
-    "date-fns@4.1.0": {
-      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg=="
     },
     "decompress-response@6.0.0": {
       "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
@@ -280,53 +262,112 @@
         "mimic-response"
       ]
     },
+    "define-data-property@1.1.4": {
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dependencies": [
+        "es-define-property",
+        "es-errors",
+        "gopd"
+      ]
+    },
     "diff3@0.0.3": {
       "integrity": "sha512-iSq8ngPOt0K53A6eVr4d5Kn6GNrM2nQZtC740pzIriHtn4pOQ2lyzEXQMBeVcWERN0ye7fhBsk9PbLLQOnUx/g=="
     },
-    "events@3.3.0": {
-      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="
+    "dunder-proto@1.0.1": {
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dependencies": [
+        "call-bind-apply-helpers",
+        "es-errors",
+        "gopd"
+      ]
     },
-    "fast-deep-equal@3.1.3": {
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+    "es-define-property@1.0.1": {
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="
     },
-    "fast-uri@3.0.6": {
-      "integrity": "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw=="
+    "es-errors@1.3.0": {
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="
     },
-    "fflate@0.8.2": {
-      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A=="
+    "es-object-atoms@1.1.1": {
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dependencies": [
+        "es-errors"
+      ]
+    },
+    "for-each@0.3.5": {
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "dependencies": [
+        "is-callable"
+      ]
+    },
+    "function-bind@1.1.2": {
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
+    },
+    "get-intrinsic@1.3.0": {
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dependencies": [
+        "call-bind-apply-helpers",
+        "es-define-property",
+        "es-errors",
+        "es-object-atoms",
+        "function-bind",
+        "get-proto",
+        "gopd",
+        "has-symbols",
+        "hasown",
+        "math-intrinsics"
+      ]
+    },
+    "get-proto@1.0.1": {
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dependencies": [
+        "dunder-proto",
+        "es-object-atoms"
+      ]
+    },
+    "gopd@1.2.0": {
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="
+    },
+    "has-property-descriptors@1.0.2": {
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dependencies": [
+        "es-define-property"
+      ]
+    },
+    "has-symbols@1.1.0": {
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="
+    },
+    "has-tostringtag@1.0.2": {
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dependencies": [
+        "has-symbols"
+      ]
     },
     "hash-wasm@4.12.0": {
       "integrity": "sha512-+/2B2rYLb48I/evdOIhP+K/DD2ca2fgBjp6O+GBEnCDk2e4rpeXIK8GvIyRPjTezgmWn9gmKwkQjjx6BtqDHVQ=="
     },
-    "hed-validator@4.0.1": {
-      "integrity": "sha512-JISoDcsm3IjK3l5+sbAd9DBOno9TWyk2EC2kXAaX5JLo9RIZH3e/sWgI7spMxR60VOT69/CCo/YD3ak3/AhkCw==",
+    "hasown@2.0.2": {
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
       "dependencies": [
-        "buffer",
-        "core-js-pure",
-        "cross-fetch",
-        "date-and-time",
-        "date-fns",
-        "events",
-        "lodash",
-        "path",
-        "pluralize",
-        "semver",
-        "string_decoder",
-        "unicode-name",
-        "xml2js"
+        "function-bind"
       ]
-    },
-    "ieee754@1.2.1": {
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
     },
     "ignore@5.3.2": {
       "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="
     },
-    "ignore@7.0.3": {
-      "integrity": "sha512-bAH5jbK/F3T3Jls4I0SO1hmPR0dKU0a7+SY6n1yzRtG54FLO8d6w/nxLFX2Nb7dBu6cCWXPaAME6cYqFUMmuCA=="
+    "inherits@2.0.4": {
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
-    "inherits@2.0.3": {
-      "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw=="
+    "is-callable@1.2.7": {
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA=="
+    },
+    "is-typed-array@1.1.15": {
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "dependencies": [
+        "which-typed-array"
+      ]
+    },
+    "isarray@2.0.5": {
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
     },
     "isomorphic-git@1.27.1": {
       "integrity": "sha512-X32ph5zIWfT75QAqW2l3JCIqnx9/GWd17bRRehmn3qmWc34OYbSXY6Cxv0o9bIIY+CWugoN4nQFHNA+2uYf2nA==",
@@ -335,7 +376,7 @@
         "clean-git-ref",
         "crc-32",
         "diff3",
-        "ignore@5.3.2",
+        "ignore",
         "minimisted",
         "pako",
         "pify",
@@ -345,11 +386,8 @@
       ],
       "bin": true
     },
-    "json-schema-traverse@1.0.0": {
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
-    },
-    "lodash@4.17.21": {
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    "math-intrinsics@1.1.0": {
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="
     },
     "mimic-response@3.1.0": {
       "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ=="
@@ -363,12 +401,6 @@
         "minimist"
       ]
     },
-    "node-fetch@2.7.0": {
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "dependencies": [
-        "whatwg-url"
-      ]
-    },
     "once@1.4.0": {
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "dependencies": [
@@ -378,21 +410,11 @@
     "pako@1.0.11": {
       "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
     },
-    "path@0.12.7": {
-      "integrity": "sha512-aXXC6s+1w7otVF9UletFkFcDsJeO7lSZBPUQhtb5O0xJe8LtYhj/GxldoL09bBj9+ZmE2hNoHqQSFMN5fikh4Q==",
-      "dependencies": [
-        "process",
-        "util"
-      ]
-    },
     "pify@4.0.1": {
       "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
     },
-    "pluralize@8.0.0": {
-      "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA=="
-    },
-    "process@0.11.10": {
-      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="
+    "possible-typed-array-names@1.1.0": {
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="
     },
     "readable-stream@3.6.2": {
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
@@ -402,24 +424,26 @@
         "util-deprecate"
       ]
     },
-    "require-from-string@2.0.2": {
-      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
-    },
     "safe-buffer@5.2.1": {
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
     },
-    "sax@1.4.1": {
-      "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg=="
+    "set-function-length@1.2.2": {
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dependencies": [
+        "define-data-property",
+        "es-errors",
+        "function-bind",
+        "get-intrinsic",
+        "gopd",
+        "has-property-descriptors"
+      ]
     },
-    "semver@7.7.2": {
-      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
-      "bin": true
-    },
-    "sha.js@2.4.11": {
-      "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+    "sha.js@2.4.12": {
+      "integrity": "sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==",
       "dependencies": [
         "inherits",
-        "safe-buffer"
+        "safe-buffer",
+        "to-buffer"
       ],
       "bin": true
     },
@@ -440,51 +464,47 @@
         "safe-buffer"
       ]
     },
-    "tr46@0.0.3": {
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    "to-buffer@1.2.2": {
+      "integrity": "sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==",
+      "dependencies": [
+        "isarray",
+        "safe-buffer",
+        "typed-array-buffer"
+      ]
+    },
+    "typed-array-buffer@1.0.3": {
+      "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+      "dependencies": [
+        "call-bound",
+        "es-errors",
+        "is-typed-array"
+      ]
     },
     "undici-types@6.20.0": {
       "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg=="
     },
-    "unicode-name@1.0.4": {
-      "integrity": "sha512-Y8KWGWHyZo5MVHsdjSFIshZesmQbLkh0l7RAv4uFNgVMjBIaCWVZAzch5b9jKaMHDnhroebDoM79/lLpzBLKvQ=="
-    },
     "util-deprecate@1.0.2": {
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
-    "util@0.10.4": {
-      "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
+    "which-typed-array@1.1.19": {
+      "integrity": "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==",
       "dependencies": [
-        "inherits"
-      ]
-    },
-    "webidl-conversions@3.0.1": {
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
-    },
-    "whatwg-url@5.0.0": {
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "dependencies": [
-        "tr46",
-        "webidl-conversions"
+        "available-typed-arrays",
+        "call-bind",
+        "call-bound",
+        "for-each",
+        "get-proto",
+        "gopd",
+        "has-tostringtag"
       ]
     },
     "wrappy@1.0.2": {
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
-    },
-    "xml2js@0.6.2": {
-      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
-      "dependencies": [
-        "sax",
-        "xmlbuilder"
-      ]
-    },
-    "xmlbuilder@11.0.1": {
-      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
     }
   },
   "workspace": {
     "dependencies": [
-      "jsr:@bids/validator@^2.0.9",
+      "jsr:@bids/validator@^2.1.1",
       "jsr:@cliffy/prompt@^1.0.0-rc.8",
       "jsr:@deno-library/progress@^1.5.1",
       "jsr:@effigies/cliffy-command@1.0.0-dev.8",

--- a/cli/deno.lock
+++ b/cli/deno.lock
@@ -1,6 +1,8 @@
 {
   "version": "5",
   "specifiers": {
+    "jsr:@bids/schema@1.1": "1.1.0",
+    "jsr:@bids/validator@^2.1.1": "2.1.1",
     "jsr:@cliffy/ansi@1.0.0-rc.8": "1.0.0-rc.8",
     "jsr:@cliffy/flags@1.0.0-rc.7": "1.0.0-rc.7",
     "jsr:@cliffy/internal@1.0.0-rc.7": "1.0.0-rc.7",
@@ -10,10 +12,12 @@
     "jsr:@cliffy/table@1.0.0-rc.7": "1.0.0-rc.7",
     "jsr:@deno-library/progress@^1.5.1": "1.5.1",
     "jsr:@effigies/cliffy-command@1.0.0-dev.8": "1.0.0-dev.8",
+    "jsr:@effigies/cliffy-table@1.0.0-dev.5": "1.0.0-dev.5",
     "jsr:@effigies/cliffy-table@^1.0.0-dev.5": "1.0.0-dev.5",
+    "jsr:@libs/xml@^6.0.8": "6.0.8",
     "jsr:@std/assert@^1.0.13": "1.0.14",
     "jsr:@std/assert@^1.0.14": "1.0.14",
-    "jsr:@std/assert@~1.0.6": "1.0.14",
+    "jsr:@std/assert@~1.0.6": "1.0.15",
     "jsr:@std/async@^1.0.13": "1.0.13",
     "jsr:@std/bytes@^1.0.6": "1.0.6",
     "jsr:@std/data-structures@^1.0.9": "1.0.9",
@@ -22,6 +26,7 @@
     "jsr:@std/encoding@~1.0.5": "1.0.10",
     "jsr:@std/fmt@1.0.3": "1.0.3",
     "jsr:@std/fmt@^1.0.5": "1.0.8",
+    "jsr:@std/fmt@^1.0.8": "1.0.8",
     "jsr:@std/fmt@~1.0.2": "1.0.8",
     "jsr:@std/fs@^1.0.11": "1.0.19",
     "jsr:@std/fs@^1.0.19": "1.0.19",
@@ -34,17 +39,44 @@
     "jsr:@std/path@^1.1.1": "1.1.2",
     "jsr:@std/path@^1.1.2": "1.1.2",
     "jsr:@std/path@~1.0.6": "1.0.9",
-    "jsr:@std/streams@^1.0.11": "1.0.11",
+    "jsr:@std/streams@^1.0.11": "1.0.13",
+    "jsr:@std/streams@^1.0.12": "1.0.13",
     "jsr:@std/testing@^1.0.15": "1.0.15",
     "jsr:@std/text@~1.0.7": "1.0.16",
+    "jsr:@std/yaml@^1.0.9": "1.0.10",
     "jsr:@wok/djwt@^3.0.2": "3.0.2",
+    "npm:@bids/nifti-reader-js@~0.6.9": "0.6.9",
     "npm:@sentry/deno@^8.55.0": "8.55.0",
     "npm:@types/node@*": "22.10.7",
+    "npm:ajv@^8.17.1": "8.17.1",
     "npm:hash-wasm@^4.12.0": "4.12.0",
+    "npm:hed-validator@~4.0.1": "4.0.1",
     "npm:ignore@^5.3.0": "5.3.2",
+    "npm:ignore@^7.0.5": "7.0.5",
     "npm:isomorphic-git@1.27.1": "1.27.1"
   },
   "jsr": {
+    "@bids/schema@1.1.0": {
+      "integrity": "7687c6fc3fdaaec8bba0c21b09e98175167d20e97ddaa29c03af8d2551f95fcd"
+    },
+    "@bids/validator@2.1.1": {
+      "integrity": "2fabcf6ac507c8509caa9ef109bfe0461511dc1323df6b14abea18af7121c310",
+      "dependencies": [
+        "jsr:@bids/schema",
+        "jsr:@effigies/cliffy-command",
+        "jsr:@effigies/cliffy-table@1.0.0-dev.5",
+        "jsr:@libs/xml",
+        "jsr:@std/fmt@^1.0.8",
+        "jsr:@std/log",
+        "jsr:@std/path@^1.1.2",
+        "jsr:@std/streams@^1.0.12",
+        "jsr:@std/yaml",
+        "npm:@bids/nifti-reader-js",
+        "npm:ajv",
+        "npm:hed-validator",
+        "npm:ignore@^7.0.5"
+      ]
+    },
     "@cliffy/ansi@1.0.0-rc.8": {
       "integrity": "ba37f10ce55bbfbdd8ddd987f91f029b17bce88385b98ba3058870f3b007b80c",
       "dependencies": [
@@ -100,7 +132,7 @@
         "jsr:@cliffy/flags",
         "jsr:@cliffy/internal@1.0.0-rc.7",
         "jsr:@cliffy/table",
-        "jsr:@effigies/cliffy-table",
+        "jsr:@effigies/cliffy-table@^1.0.0-dev.5",
         "jsr:@std/fmt@~1.0.2",
         "jsr:@std/text"
       ]
@@ -111,11 +143,17 @@
         "jsr:@std/fmt@~1.0.2"
       ]
     },
+    "@libs/xml@6.0.8": {
+      "integrity": "7aac7438ddd460fede488d6420e4973438919b54b8e882e851ed9a234716baa3"
+    },
     "@std/assert@1.0.14": {
       "integrity": "68d0d4a43b365abc927f45a9b85c639ea18a9fab96ad92281e493e4ed84abaa4",
       "dependencies": [
         "jsr:@std/internal@^1.0.10"
       ]
+    },
+    "@std/assert@1.0.15": {
+      "integrity": "d64018e951dbdfab9777335ecdb000c0b4e3df036984083be219ce5941e4703b"
     },
     "@std/async@1.0.13": {
       "integrity": "1d76ca5d324aef249908f7f7fe0d39aaf53198e5420604a59ab5c035adc97c96"
@@ -180,6 +218,12 @@
         "jsr:@std/bytes"
       ]
     },
+    "@std/streams@1.0.13": {
+      "integrity": "772d208cd0d3e5dac7c1d9e6cdb25842846d136eea4a41a62e44ed4ab0c8dd9e",
+      "dependencies": [
+        "jsr:@std/bytes"
+      ]
+    },
     "@std/testing@1.0.15": {
       "integrity": "a490169f5ccb0f3ae9c94fbc69d2cd43603f2cffb41713a85f99bbb0e3087cbc",
       "dependencies": [
@@ -194,6 +238,9 @@
     "@std/text@1.0.16": {
       "integrity": "ddb9853b75119a2473857d691cf1ec02ad90793a2e8b4a4ac49d7354281a0cf8"
     },
+    "@std/yaml@1.0.10": {
+      "integrity": "245706ea3511cc50c8c6d00339c23ea2ffa27bd2c7ea5445338f8feff31fa58e"
+    },
     "@wok/djwt@3.0.2": {
       "integrity": "e1c8afe6e321941edda40d91b089e93738469b994d53f41f82e0e7fcd7dde259",
       "dependencies": [
@@ -202,6 +249,12 @@
     }
   },
   "npm": {
+    "@bids/nifti-reader-js@0.6.9": {
+      "integrity": "sha512-3KWpGKrgUUvT5Bbl25K9TTQ77DRS5DUpcyhZlAblCPdP1YMy0tCzrxarRTixWM9tDN6sWUOBbf6zQpPyVe11Lw==",
+      "dependencies": [
+        "fflate"
+      ]
+    },
     "@sentry/core@8.55.0": {
       "integrity": "sha512-6g7jpbefjHYs821Z+EBJ8r4Z7LT5h80YSWRJaylGS4nW5W5Z2KXzpdnyFarv37O7QjauzVC2E+PABmpkw5/JGA=="
     },
@@ -217,6 +270,15 @@
         "undici-types"
       ]
     },
+    "ajv@8.17.1": {
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "dependencies": [
+        "fast-deep-equal",
+        "fast-uri",
+        "json-schema-traverse",
+        "require-from-string"
+      ]
+    },
     "async-lock@1.4.1": {
       "integrity": "sha512-Az2ZTpuytrtqENulXwO3GGv1Bztugx6TT37NIo7imr/Qo0gsYiGtSdBa2B6fsXhTpVZDNfu1Qn3pk531e3q+nQ=="
     },
@@ -224,6 +286,16 @@
       "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
       "dependencies": [
         "possible-typed-array-names"
+      ]
+    },
+    "base64-js@1.5.1": {
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+    },
+    "buffer@6.0.3": {
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "dependencies": [
+        "base64-js",
+        "ieee754"
       ]
     },
     "call-bind-apply-helpers@1.0.2": {
@@ -252,9 +324,25 @@
     "clean-git-ref@2.0.1": {
       "integrity": "sha512-bLSptAy2P0s6hU4PzuIMKmMJJSE6gLXGH1cntDu7bWJUksvuM+7ReOK61mozULErYvP6a15rnYl0zFDef+pyPw=="
     },
+    "core-js-pure@3.46.0": {
+      "integrity": "sha512-NMCW30bHNofuhwLhYPt66OLOKTMbOhgTTatKVbaQC3KRHpTCiRIBYvtshr+NBYSnBxwAFhjW/RfJ0XbIjS16rw==",
+      "scripts": true
+    },
     "crc-32@1.2.2": {
       "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
       "bin": true
+    },
+    "cross-fetch@4.1.0": {
+      "integrity": "sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw==",
+      "dependencies": [
+        "node-fetch"
+      ]
+    },
+    "date-and-time@3.6.0": {
+      "integrity": "sha512-V99gLaMqNQxPCObBumb31Bfy3OByXnpqUM0yHPi/aBQE61g42A2rGk6Z2CDnpLrWsOFLQwOgl4Vgshw6D44ebw=="
+    },
+    "date-fns@4.1.0": {
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg=="
     },
     "decompress-response@6.0.0": {
       "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
@@ -292,6 +380,18 @@
       "dependencies": [
         "es-errors"
       ]
+    },
+    "events@3.3.0": {
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="
+    },
+    "fast-deep-equal@3.1.3": {
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+    },
+    "fast-uri@3.1.0": {
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="
+    },
+    "fflate@0.8.2": {
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A=="
     },
     "for-each@0.3.5": {
       "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
@@ -351,8 +451,35 @@
         "function-bind"
       ]
     },
+    "hed-validator@4.0.1": {
+      "integrity": "sha512-JISoDcsm3IjK3l5+sbAd9DBOno9TWyk2EC2kXAaX5JLo9RIZH3e/sWgI7spMxR60VOT69/CCo/YD3ak3/AhkCw==",
+      "dependencies": [
+        "buffer",
+        "core-js-pure",
+        "cross-fetch",
+        "date-and-time",
+        "date-fns",
+        "events",
+        "lodash",
+        "path",
+        "pluralize",
+        "semver",
+        "string_decoder",
+        "unicode-name",
+        "xml2js"
+      ]
+    },
+    "ieee754@1.2.1": {
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
+    },
     "ignore@5.3.2": {
       "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="
+    },
+    "ignore@7.0.5": {
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="
+    },
+    "inherits@2.0.3": {
+      "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw=="
     },
     "inherits@2.0.4": {
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
@@ -376,7 +503,7 @@
         "clean-git-ref",
         "crc-32",
         "diff3",
-        "ignore",
+        "ignore@5.3.2",
         "minimisted",
         "pako",
         "pify",
@@ -385,6 +512,12 @@
         "simple-get"
       ],
       "bin": true
+    },
+    "json-schema-traverse@1.0.0": {
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    },
+    "lodash@4.17.21": {
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "math-intrinsics@1.1.0": {
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="
@@ -401,6 +534,12 @@
         "minimist"
       ]
     },
+    "node-fetch@2.7.0": {
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dependencies": [
+        "whatwg-url"
+      ]
+    },
     "once@1.4.0": {
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "dependencies": [
@@ -410,22 +549,45 @@
     "pako@1.0.11": {
       "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
     },
+    "path@0.12.7": {
+      "integrity": "sha512-aXXC6s+1w7otVF9UletFkFcDsJeO7lSZBPUQhtb5O0xJe8LtYhj/GxldoL09bBj9+ZmE2hNoHqQSFMN5fikh4Q==",
+      "dependencies": [
+        "process",
+        "util"
+      ]
+    },
     "pify@4.0.1": {
       "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
+    },
+    "pluralize@8.0.0": {
+      "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA=="
     },
     "possible-typed-array-names@1.1.0": {
       "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="
     },
+    "process@0.11.10": {
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="
+    },
     "readable-stream@3.6.2": {
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "dependencies": [
-        "inherits",
+        "inherits@2.0.4",
         "string_decoder",
         "util-deprecate"
       ]
     },
+    "require-from-string@2.0.2": {
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
+    },
     "safe-buffer@5.2.1": {
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+    },
+    "sax@1.4.1": {
+      "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg=="
+    },
+    "semver@7.7.3": {
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "bin": true
     },
     "set-function-length@1.2.2": {
       "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
@@ -441,7 +603,7 @@
     "sha.js@2.4.12": {
       "integrity": "sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==",
       "dependencies": [
-        "inherits",
+        "inherits@2.0.4",
         "safe-buffer",
         "to-buffer"
       ],
@@ -472,6 +634,9 @@
         "typed-array-buffer"
       ]
     },
+    "tr46@0.0.3": {
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
     "typed-array-buffer@1.0.3": {
       "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
       "dependencies": [
@@ -483,8 +648,27 @@
     "undici-types@6.20.0": {
       "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg=="
     },
+    "unicode-name@1.1.0": {
+      "integrity": "sha512-2XBI32vZP6a1tJmMDSUBabiIZuY+1udwZUoS7i5BTSU2c4ELMy6YJrTPF9uvYOVMU4vTMlHH6HG/TsHjCEsazA=="
+    },
     "util-deprecate@1.0.2": {
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+    },
+    "util@0.10.4": {
+      "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
+      "dependencies": [
+        "inherits@2.0.3"
+      ]
+    },
+    "webidl-conversions@3.0.1": {
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "whatwg-url@5.0.0": {
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": [
+        "tr46",
+        "webidl-conversions"
+      ]
     },
     "which-typed-array@1.1.19": {
       "integrity": "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==",
@@ -500,6 +684,16 @@
     },
     "wrappy@1.0.2": {
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+    },
+    "xml2js@0.6.2": {
+      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
+      "dependencies": [
+        "sax",
+        "xmlbuilder"
+      ]
+    },
+    "xmlbuilder@11.0.1": {
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
     }
   },
   "workspace": {

--- a/cli/src/commands/upload.ts
+++ b/cli/src/commands/upload.ts
@@ -69,6 +69,9 @@ export async function uploadAction(
     `upload ${dataset_directory} resolved to ${dataset_directory_abs}`,
   )
 
+  // Match OpenNeuro's server side rules for datasetTypes overriding user settings
+  options.datasetTypes = ["raw", "derivative"]
+
   const schemaResult = await validate(
     await readFileTree(dataset_directory_abs),
     options,

--- a/packages/openneuro-app/package.json
+++ b/packages/openneuro-app/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@apollo/client": "3.13.8",
     "@artsy/fresnel": "^1.3.1",
-    "@bids/validator": "npm:@jsr/bids__validator@^2.0.9",
+    "@bids/validator": "jsr:^2.1.1",
     "@emotion/react": "11.11.1",
     "@emotion/styled": "11.11.0",
     "@niivue/niivue": "0.57.0",

--- a/packages/openneuro-app/package.json
+++ b/packages/openneuro-app/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@apollo/client": "3.13.8",
     "@artsy/fresnel": "^1.3.1",
-    "@bids/validator": "jsr:^2.1.1",
+    "@bids/validator": "npm:@jsr/bids__validator@^2.1.1",
     "@emotion/react": "11.11.1",
     "@emotion/styled": "11.11.0",
     "@niivue/niivue": "0.57.0",

--- a/packages/openneuro-app/package.json
+++ b/packages/openneuro-app/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@apollo/client": "3.13.8",
     "@artsy/fresnel": "^1.3.1",
-    "@bids/validator": "npm:@jsr/bids__validator@^2.0.8",
+    "@bids/validator": "npm:@jsr/bids__validator@^2.0.9",
     "@emotion/react": "11.11.1",
     "@emotion/styled": "11.11.0",
     "@niivue/niivue": "0.57.0",

--- a/packages/openneuro-app/src/scripts/workers/schema.worker.ts
+++ b/packages/openneuro-app/src/scripts/workers/schema.worker.ts
@@ -11,6 +11,7 @@ const options: ValidatorOptions = {
   json: true,
   blacklistModalities: ["micr"],
   debug: "INFO",
+  datasetTypes: ["raw", "derivative"],
 }
 
 export async function runValidator(

--- a/services/datalad/datalad_service/tasks/validator.py
+++ b/services/datalad/datalad_service/tasks/validator.py
@@ -11,7 +11,7 @@ from datalad_service.broker import broker
 
 logger = logging.getLogger('datalad_service.' + __name__)
 
-DENO_VALIDATOR_VERSION = '2.0.9'
+DENO_VALIDATOR_VERSION = '2.1.1'
 
 DENO_METADATA = {'validator': 'schema', 'version': DENO_VALIDATOR_VERSION}
 

--- a/services/datalad/datalad_service/tasks/validator.py
+++ b/services/datalad/datalad_service/tasks/validator.py
@@ -59,6 +59,8 @@ async def validate_dataset_deno_call(dataset_path, ref, logger=logger):
             dataset_path,
             '--blacklistModalities',
             'micr',
+            '--datasetTypes',
+            'raw,derivative',
         ],
         logger=logger,
     )

--- a/services/datalad/datalad_service/tasks/validator.py
+++ b/services/datalad/datalad_service/tasks/validator.py
@@ -11,7 +11,7 @@ from datalad_service.broker import broker
 
 logger = logging.getLogger('datalad_service.' + __name__)
 
-DENO_VALIDATOR_VERSION = '2.0.8'
+DENO_VALIDATOR_VERSION = '2.0.9'
 
 DENO_METADATA = {'validator': 'schema', 'version': DENO_VALIDATOR_VERSION}
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -849,7 +849,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@bids/nifti-reader-js@npm:0.6.9":
+"@bids/nifti-reader-js@npm:^0.6.9":
   version: 0.6.9
   resolution: "@bids/nifti-reader-js@npm:0.6.9"
   dependencies:
@@ -858,24 +858,45 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@bids/validator@npm:@jsr/bids__validator@^2.0.9":
-  version: 2.0.9
-  resolution: "@jsr/bids__validator@npm:2.0.9::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Fbids__validator%2F2.0.9.tgz"
+"@bids/validator@jsr:^2.1.1":
+  version: 2.1.1
+  resolution: "@bids/validator@jsr:2.1.1::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Fbids__validator%2F2.1.1.tgz"
   dependencies:
-    "@bids/nifti-reader-js": "npm:0.6.9"
-    "@jsr/bids__schema": "npm:~1.0.14"
+    "@bids/nifti-reader-js": "npm:^0.6.9"
+    "@jsr/bids__schema": "npm:~1.1.0"
     "@jsr/effigies__cliffy-command": "npm:1.0.0-dev.8"
     "@jsr/effigies__cliffy-table": "npm:1.0.0-dev.5"
-    "@jsr/libs__xml": "npm:6.0.4"
-    "@jsr/std__fmt": "npm:1.0.6"
-    "@jsr/std__log": "npm:0.224.14"
-    "@jsr/std__path": "npm:1.0.8"
-    "@jsr/std__streams": "npm:1.0.9"
-    "@jsr/std__yaml": "npm:^1.0.5"
-    ajv: "npm:8.17.1"
-    hed-validator: "npm:4.0.1"
-    ignore: "npm:7.0.3"
-  checksum: 10/c72b5cc225f31d00316fc03621c3d8dd1277d3184d24b661c85dbc4a9772ec0a4dc9b9ee7ec1509173ba42104c0a8dbedaf5a7d1e20f40f9a379f23bc658f3fa
+    "@jsr/libs__xml": "npm:^6.0.8"
+    "@jsr/std__fmt": "npm:^1.0.8"
+    "@jsr/std__log": "npm:^0.224.14"
+    "@jsr/std__path": "npm:^1.1.2"
+    "@jsr/std__streams": "npm:^1.0.12"
+    "@jsr/std__yaml": "npm:^1.0.9"
+    ajv: "npm:^8.17.1"
+    hed-validator: "npm:~4.0.1"
+    ignore: "npm:^7.0.5"
+  checksum: 10/c189ea5dd81edaa7cef741e2e161fb9d11119b423a87602c7d4cc36a0581eae645e2b53bffe075b2e3c80cb177a288b1548430d578195661a1bb560aaa573aa3
+  languageName: node
+  linkType: hard
+
+"@bids/validator@npm:@jsr/bids__validator@^2.1.1":
+  version: 2.1.1
+  resolution: "@jsr/bids__validator@npm:2.1.1::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Fbids__validator%2F2.1.1.tgz"
+  dependencies:
+    "@bids/nifti-reader-js": "npm:^0.6.9"
+    "@jsr/bids__schema": "npm:~1.1.0"
+    "@jsr/effigies__cliffy-command": "npm:1.0.0-dev.8"
+    "@jsr/effigies__cliffy-table": "npm:1.0.0-dev.5"
+    "@jsr/libs__xml": "npm:^6.0.8"
+    "@jsr/std__fmt": "npm:^1.0.8"
+    "@jsr/std__log": "npm:^0.224.14"
+    "@jsr/std__path": "npm:^1.1.2"
+    "@jsr/std__streams": "npm:^1.0.12"
+    "@jsr/std__yaml": "npm:^1.0.9"
+    ajv: "npm:^8.17.1"
+    hed-validator: "npm:~4.0.1"
+    ignore: "npm:^7.0.5"
+  checksum: 10/c189ea5dd81edaa7cef741e2e161fb9d11119b423a87602c7d4cc36a0581eae645e2b53bffe075b2e3c80cb177a288b1548430d578195661a1bb560aaa573aa3
   languageName: node
   linkType: hard
 
@@ -1781,10 +1802,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jsr/bids__schema@npm:~1.0.14":
-  version: 1.0.14
-  resolution: "@jsr/bids__schema@npm:1.0.14::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Fbids__schema%2F1.0.14.tgz"
-  checksum: 10/f176ee8ae61ba559e0dea630f441c0d536d61a550c1558ada1f6f4d3bddb7b0f6d82b222993c501c74f6917a360883ecc150006d326387a9a1f57633c0d7fd10
+"@jsr/bids__schema@npm:~1.1.0":
+  version: 1.1.0
+  resolution: "@jsr/bids__schema@npm:1.1.0::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Fbids__schema%2F1.1.0.tgz"
+  checksum: 10/37fc9aa3eb55ac9838fe714b382835e3a098c8f0f87f603ea80590b618ad7b738dec732414d1867bcce170c7b040eba98d3ac6733933a84b99fb50489740b1eb
   languageName: node
   linkType: hard
 
@@ -1838,10 +1859,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jsr/libs__xml@npm:6.0.4":
-  version: 6.0.4
-  resolution: "@jsr/libs__xml@npm:6.0.4::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Flibs__xml%2F6.0.4.tgz"
-  checksum: 10/9e17a8e322efb2ec058637cb94d5e46456c536c95736be089f678be74093271bf3a54dd88861db83f0263cee8009887ddba61b4bba32b83a77d37460081bba0a
+"@jsr/libs__xml@npm:^6.0.8":
+  version: 6.0.8
+  resolution: "@jsr/libs__xml@npm:6.0.8::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Flibs__xml%2F6.0.8.tgz"
+  checksum: 10/40a6b82333aeee27c14a3779f40c84c029ba85c3ad0c02ceb3b1c683a980ecefb0900ad0713baeebb6da16ce3def5fdae403752f077192972b34039ac0ba695c
   languageName: node
   linkType: hard
 
@@ -1852,10 +1873,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jsr/std__fmt@npm:1.0.6":
+"@jsr/std__bytes@npm:^1.0.6":
   version: 1.0.6
-  resolution: "@jsr/std__fmt@npm:1.0.6::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Fstd__fmt%2F1.0.6.tgz"
-  checksum: 10/c8e77ec4f7e2b5f86034183e5d950e9e20f85cd681d1f313c8df48a36b8b3b14bc55939082e576fb64102c4d163c2b6b9655459cf834c2f8b16a48ed5758c963
+  resolution: "@jsr/std__bytes@npm:1.0.6::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Fstd__bytes%2F1.0.6.tgz"
+  checksum: 10/b0d2d637dce5d0cf474e02d3c36c8ddbf1119c1ddb88b6b3ba71b1ed1f7f77fbef4bb58d18303e17d04756aac9b295a88c4e9f853dd00cf8bf8d5da9d43c03ba
   languageName: node
   linkType: hard
 
@@ -1863,6 +1884,13 @@ __metadata:
   version: 1.0.5
   resolution: "@jsr/std__fmt@npm:1.0.5::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Fstd__fmt%2F1.0.5.tgz"
   checksum: 10/a0b62adda7d7ed24093577a3d75820a7adc73d448a669a46cab8435d1c9645ea67d5e0356da4d91c6bf02c3cedb6e9df7faa0a3d7b8569864bad2b5a039f2c7f
+  languageName: node
+  linkType: hard
+
+"@jsr/std__fmt@npm:^1.0.8":
+  version: 1.0.8
+  resolution: "@jsr/std__fmt@npm:1.0.8::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Fstd__fmt%2F1.0.8.tgz"
+  checksum: 10/021a1d7ceea294d5644b9c0cb55bc0d56be3b8afb52f3fa6a021bf161b527810280f8cf7d696e24aee0831a17910207d5efda6fe227fcf97929771645cdc4e66
   languageName: node
   linkType: hard
 
@@ -1882,6 +1910,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jsr/std__internal@npm:^1.0.10":
+  version: 1.0.12
+  resolution: "@jsr/std__internal@npm:1.0.12::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Fstd__internal%2F1.0.12.tgz"
+  checksum: 10/14489cb28cf5467811fcee18be529ef5a101c51dd74de510df2c0c4bcea4bc6a4f663bd566ec27a7344178da433fa69fae9aec96eaba570f92fa07969ae3e665
+  languageName: node
+  linkType: hard
+
 "@jsr/std__io@npm:^0.225.2":
   version: 0.225.2
   resolution: "@jsr/std__io@npm:0.225.2::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Fstd__io%2F0.225.2.tgz"
@@ -1891,7 +1926,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jsr/std__log@npm:0.224.14":
+"@jsr/std__log@npm:^0.224.14":
   version: 0.224.14
   resolution: "@jsr/std__log@npm:0.224.14::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Fstd__log%2F0.224.14.tgz"
   dependencies:
@@ -1902,19 +1937,28 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jsr/std__path@npm:1.0.8, @jsr/std__path@npm:^1.0.8":
+"@jsr/std__path@npm:^1.0.8":
   version: 1.0.8
   resolution: "@jsr/std__path@npm:1.0.8::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Fstd__path%2F1.0.8.tgz"
   checksum: 10/4c09d127e85fb7836c1dea934f3eb3ea30408a766c44f8a9ec86f03582242e761e8aafe7fd7ed963022845e0c920ca04bdc89bbc34a82f6d3ef130f017db1bfa
   languageName: node
   linkType: hard
 
-"@jsr/std__streams@npm:1.0.9":
-  version: 1.0.9
-  resolution: "@jsr/std__streams@npm:1.0.9::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Fstd__streams%2F1.0.9.tgz"
+"@jsr/std__path@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "@jsr/std__path@npm:1.1.2::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Fstd__path%2F1.1.2.tgz"
   dependencies:
-    "@jsr/std__bytes": "npm:^1.0.5"
-  checksum: 10/ea744fbd589296c13f4f10dce352bed38eabdb777ff09548b2339c3e4c665031d5867cdc8a72ead8c9903d1f73b8122d1ace566b394d99a36c820965f294baf7
+    "@jsr/std__internal": "npm:^1.0.10"
+  checksum: 10/e674a48454f6b59d3311ca3f34141da1cc9be426b020c2f7d955d1fed2244893482a4ac9821c6830f12b0bb794134f3b11ed05290b246560dc8a6a9a9482724a
+  languageName: node
+  linkType: hard
+
+"@jsr/std__streams@npm:^1.0.12":
+  version: 1.0.13
+  resolution: "@jsr/std__streams@npm:1.0.13::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Fstd__streams%2F1.0.13.tgz"
+  dependencies:
+    "@jsr/std__bytes": "npm:^1.0.6"
+  checksum: 10/27c0b61c76c6eb6874448610d35290916bd10d1f3033d9774a6eb323c8cc939be890444d366f06d98cf48f98b23f770c36928b2dcf156d25333b754fa707d7c2
   languageName: node
   linkType: hard
 
@@ -1925,10 +1969,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jsr/std__yaml@npm:^1.0.5":
-  version: 1.0.5
-  resolution: "@jsr/std__yaml@npm:1.0.5::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Fstd__yaml%2F1.0.5.tgz"
-  checksum: 10/4073d72d1d1c5fcd0dcecb5aa42189b6147add2bb23843f00931f341e0f427c0397a8b4adc5e3e1f0cf77eb7712a2f1499f2a289b3eef4ed4ce1810f6e2973ca
+"@jsr/std__yaml@npm:^1.0.9":
+  version: 1.0.10
+  resolution: "@jsr/std__yaml@npm:1.0.10::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Fstd__yaml%2F1.0.10.tgz"
+  checksum: 10/ccb277db0fbc017d25c0df4b710eda416922b2bcdb773c4e78616844db573e6fa5072727896f87c604c6c3c310d6414d0732014416e78b8b65e80a8d12cd856f
   languageName: node
   linkType: hard
 
@@ -3028,7 +3072,7 @@ __metadata:
   dependencies:
     "@apollo/client": "npm:3.13.8"
     "@artsy/fresnel": "npm:^1.3.1"
-    "@bids/validator": "npm:@jsr/bids__validator@^2.0.9"
+    "@bids/validator": "jsr:^2.1.1"
     "@emotion/react": "npm:11.11.1"
     "@emotion/styled": "npm:11.11.0"
     "@niivue/niivue": "npm:0.57.0"
@@ -6324,18 +6368,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ajv@npm:8.17.1":
-  version: 8.17.1
-  resolution: "ajv@npm:8.17.1"
-  dependencies:
-    fast-deep-equal: "npm:^3.1.3"
-    fast-uri: "npm:^3.0.1"
-    json-schema-traverse: "npm:^1.0.0"
-    require-from-string: "npm:^2.0.2"
-  checksum: 10/ee3c62162c953e91986c838f004132b6a253d700f1e51253b99791e2dbfdb39161bc950ebdc2f156f8568035bb5ed8be7bd78289cd9ecbf3381fe8f5b82e3f33
-  languageName: node
-  linkType: hard
-
 "ajv@npm:^6.12.3, ajv@npm:^6.12.4":
   version: 6.12.6
   resolution: "ajv@npm:6.12.6"
@@ -6345,6 +6377,18 @@ __metadata:
     json-schema-traverse: "npm:^0.4.1"
     uri-js: "npm:^4.2.2"
   checksum: 10/48d6ad21138d12eb4d16d878d630079a2bda25a04e745c07846a4ad768319533031e28872a9b3c5790fa1ec41aabdf2abed30a56e5a03ebc2cf92184b8ee306c
+  languageName: node
+  linkType: hard
+
+"ajv@npm:^8.17.1":
+  version: 8.17.1
+  resolution: "ajv@npm:8.17.1"
+  dependencies:
+    fast-deep-equal: "npm:^3.1.3"
+    fast-uri: "npm:^3.0.1"
+    json-schema-traverse: "npm:^1.0.0"
+    require-from-string: "npm:^2.0.2"
+  checksum: 10/ee3c62162c953e91986c838f004132b6a253d700f1e51253b99791e2dbfdb39161bc950ebdc2f156f8568035bb5ed8be7bd78289cd9ecbf3381fe8f5b82e3f33
   languageName: node
   linkType: hard
 
@@ -11464,7 +11508,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hed-validator@npm:4.0.1":
+"hed-validator@npm:~4.0.1":
   version: 4.0.1
   resolution: "hed-validator@npm:4.0.1"
   dependencies:
@@ -11776,13 +11820,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ignore@npm:7.0.3":
-  version: 7.0.3
-  resolution: "ignore@npm:7.0.3"
-  checksum: 10/ce5e812af3acd6607a3fe0a9f9b5f01d53f009a5ace8cbf5b6491d05a481b55d65186e6a7eaa13126e93f15276bcf3d1e8d6ff3ce5549c312f9bb313fff33365
-  languageName: node
-  linkType: hard
-
 "ignore@npm:^4.0.3":
   version: 4.0.6
   resolution: "ignore@npm:4.0.6"
@@ -11808,6 +11845,13 @@ __metadata:
   version: 5.3.1
   resolution: "ignore@npm:5.3.1"
   checksum: 10/0a884c2fbc8c316f0b9f92beaf84464253b73230a4d4d286697be45fca081199191ca33e1c2e82d9e5f851f5e9a48a78e25a35c951e7eb41e59f150db3530065
+  languageName: node
+  linkType: hard
+
+"ignore@npm:^7.0.5":
+  version: 7.0.5
+  resolution: "ignore@npm:7.0.5"
+  checksum: 10/f134b96a4de0af419196f52c529d5c6120c4456ff8a6b5a14ceaaa399f883e15d58d2ce651c9b69b9388491d4669dda47285d307e827de9304a53a1824801bc6
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -858,27 +858,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@bids/validator@jsr:^2.1.1":
-  version: 2.1.1
-  resolution: "@bids/validator@jsr:2.1.1::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Fbids__validator%2F2.1.1.tgz"
-  dependencies:
-    "@bids/nifti-reader-js": "npm:^0.6.9"
-    "@jsr/bids__schema": "npm:~1.1.0"
-    "@jsr/effigies__cliffy-command": "npm:1.0.0-dev.8"
-    "@jsr/effigies__cliffy-table": "npm:1.0.0-dev.5"
-    "@jsr/libs__xml": "npm:^6.0.8"
-    "@jsr/std__fmt": "npm:^1.0.8"
-    "@jsr/std__log": "npm:^0.224.14"
-    "@jsr/std__path": "npm:^1.1.2"
-    "@jsr/std__streams": "npm:^1.0.12"
-    "@jsr/std__yaml": "npm:^1.0.9"
-    ajv: "npm:^8.17.1"
-    hed-validator: "npm:~4.0.1"
-    ignore: "npm:^7.0.5"
-  checksum: 10/c189ea5dd81edaa7cef741e2e161fb9d11119b423a87602c7d4cc36a0581eae645e2b53bffe075b2e3c80cb177a288b1548430d578195661a1bb560aaa573aa3
-  languageName: node
-  linkType: hard
-
 "@bids/validator@npm:@jsr/bids__validator@^2.1.1":
   version: 2.1.1
   resolution: "@jsr/bids__validator@npm:2.1.1::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Fbids__validator%2F2.1.1.tgz"
@@ -3072,7 +3051,7 @@ __metadata:
   dependencies:
     "@apollo/client": "npm:3.13.8"
     "@artsy/fresnel": "npm:^1.3.1"
-    "@bids/validator": "jsr:^2.1.1"
+    "@bids/validator": "npm:@jsr/bids__validator@^2.1.1"
     "@emotion/react": "npm:11.11.1"
     "@emotion/styled": "npm:11.11.0"
     "@niivue/niivue": "npm:0.57.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -858,12 +858,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@bids/validator@npm:@jsr/bids__validator@^2.0.8":
-  version: 2.0.8
-  resolution: "@jsr/bids__validator@npm:2.0.8::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Fbids__validator%2F2.0.8.tgz"
+"@bids/validator@npm:@jsr/bids__validator@^2.0.9":
+  version: 2.0.9
+  resolution: "@jsr/bids__validator@npm:2.0.9::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Fbids__validator%2F2.0.9.tgz"
   dependencies:
     "@bids/nifti-reader-js": "npm:0.6.9"
-    "@jsr/bids__schema": "npm:1.0.4"
+    "@jsr/bids__schema": "npm:~1.0.14"
     "@jsr/effigies__cliffy-command": "npm:1.0.0-dev.8"
     "@jsr/effigies__cliffy-table": "npm:1.0.0-dev.5"
     "@jsr/libs__xml": "npm:6.0.4"
@@ -875,7 +875,7 @@ __metadata:
     ajv: "npm:8.17.1"
     hed-validator: "npm:4.0.1"
     ignore: "npm:7.0.3"
-  checksum: 10/5e45246ccc41b25c2b271e710884b40849448c753cba27cea7a63002e01f6c203b5b10754f3ad26230a15ce1671d9b1e0b75056dc35a946c104c4f64f4924c84
+  checksum: 10/c72b5cc225f31d00316fc03621c3d8dd1277d3184d24b661c85dbc4a9772ec0a4dc9b9ee7ec1509173ba42104c0a8dbedaf5a7d1e20f40f9a379f23bc658f3fa
   languageName: node
   linkType: hard
 
@@ -1781,10 +1781,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jsr/bids__schema@npm:1.0.4":
-  version: 1.0.4
-  resolution: "@jsr/bids__schema@npm:1.0.4::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Fbids__schema%2F1.0.4.tgz"
-  checksum: 10/dc9b35fb6e77532b9bcd970fde6d83371d227d1adda7c70d45735f836e79052eadc07dc22ca18c209447ee58c430f40b7e4a4facfd7944a0fb969ea3ddecf3f6
+"@jsr/bids__schema@npm:~1.0.14":
+  version: 1.0.14
+  resolution: "@jsr/bids__schema@npm:1.0.14::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Fbids__schema%2F1.0.14.tgz"
+  checksum: 10/f176ee8ae61ba559e0dea630f441c0d536d61a550c1558ada1f6f4d3bddb7b0f6d82b222993c501c74f6917a360883ecc150006d326387a9a1f57633c0d7fd10
   languageName: node
   linkType: hard
 
@@ -3028,7 +3028,7 @@ __metadata:
   dependencies:
     "@apollo/client": "npm:3.13.8"
     "@artsy/fresnel": "npm:^1.3.1"
-    "@bids/validator": "npm:@jsr/bids__validator@^2.0.8"
+    "@bids/validator": "npm:@jsr/bids__validator@^2.0.9"
     "@emotion/react": "npm:11.11.1"
     "@emotion/styled": "npm:11.11.0"
     "@niivue/niivue": "npm:0.57.0"


### PR DESCRIPTION
Update to [@bids/validator 2.1.1](https://github.com/bids-standard/bids-validator/releases/tag/2.1.1).