### PR TITLE
fix(worker): Enable retries with backoff for failing tasks

### DIFF
--- a/services/datalad/datalad_service/broker/__init__.py
+++ b/services/datalad/datalad_service/broker/__init__.py
@@ -1,6 +1,6 @@
 import sys
 
-from taskiq import InMemoryBroker
+from taskiq import InMemoryBroker, SmartRetryMiddleware
 from taskiq_redis import RedisAsyncResultBackend, RedisStreamBroker
 
 
@@ -19,8 +19,20 @@ else:
         redis_url=redis_url,
         result_ex_time=5000,
     )
-    broker = RedisStreamBroker(
-        url=redis_url,
-        queue_name=worker_name,
-    ).with_result_backend(result_backend)
-    broker.add_middlewares(WorkerMiddleware(worker_id))
+    broker = (
+        RedisStreamBroker(
+            url=redis_url,
+            queue_name=worker_name,
+        )
+        .with_result_backend(result_backend)
+        .with_middlewares(
+            WorkerMiddleware(worker_id),
+            SmartRetryMiddleware(
+                default_retry_count=3,
+                default_delay=10,
+                use_jitter=True,
+                use_delay_exponent=True,
+                max_delay_exponent=120,
+            ),
+        )
+    )


### PR DESCRIPTION
Adding the [SmartRetryMiddleware](https://taskiq-python.github.io/available-components/middlewares.html#smart-retry-middleware) fixes a couple issues with worker background tasks.

1. It's possible for Kubernetes to kill the underlying worker process (node migration or health checks) while a task is running and currently this results in the task never finishing. With this change the same worker will pick up the task again after a process restart.
2. In some cases we could schedule the same task twice (e.g. snapshots generate two fsck checks) and this would rarely cause git-annex to exit. Retrying with some delay ensures we always check both commits in this case.

I chose a low limit of 3 retries because outside of the above scenarios failing tasks will continue to fail here, so excessive retries would waste significant resources. This should be sufficient for the expected interruptions.