### PR TITLE
Log task execution for workers to MongoDB

### DIFF
--- a/packages/openneuro-server/src/graphql/permissions.ts
+++ b/packages/openneuro-server/src/graphql/permissions.ts
@@ -169,3 +169,12 @@ export const checkAdmin = (userId, userInfo) =>
   userId && userInfo.admin
     ? Promise.resolve(true)
     : Promise.reject(states.ADMIN.errorMessage)
+
+/**
+ * Check if the user is a worker
+ * @param userInfo User context
+ */
+export const checkWorker = (userInfo) => {
+  if (userInfo?.worker) return true
+  else throw new Error("You must be a worker to make this request.")
+}

--- a/packages/openneuro-server/src/graphql/resolvers/mutation.ts
+++ b/packages/openneuro-server/src/graphql/resolvers/mutation.ts
@@ -46,6 +46,7 @@ import {
 import { saveAdminNote } from "./datasetEvents"
 import { createGitEvent } from "./gitEvents"
 import { updateFileCheck } from "./fileCheck"
+import { updateWorkerTask } from "./worker"
 
 const Mutation = {
   createDataset,
@@ -95,6 +96,7 @@ const Mutation = {
   saveAdminNote,
   createGitEvent,
   updateFileCheck,
+  updateWorkerTask,
 }
 
 export default Mutation

--- a/packages/openneuro-server/src/graphql/resolvers/worker.ts
+++ b/packages/openneuro-server/src/graphql/resolvers/worker.ts
@@ -1,0 +1,23 @@
+import WorkerTask from "../../models/worker-task"
+import { checkWorker } from "../permissions"
+
+/**
+ * Update a worker task record
+ *
+ * This can be called for new tasks, or to update existing tasks.
+ */
+export const updateWorkerTask = async (obj, args, { userInfo }) => {
+  checkWorker(userInfo)
+  const { id, ...updateData } = args
+
+  // Don't allow null values to unset fields
+  const update = Object.fromEntries(
+    Object.entries(updateData).filter(([, value]) => value != null),
+  )
+
+  const task = await WorkerTask.findOneAndUpdate({ id }, { $set: update }, {
+    new: true,
+    upsert: true,
+  }).exec()
+  return task
+}

--- a/packages/openneuro-server/src/graphql/schema.ts
+++ b/packages/openneuro-server/src/graphql/schema.ts
@@ -214,6 +214,19 @@ export const typeDefs = `
       annexFsck: [AnnexFsckInput!]!
       remote: String
     ): FileCheck
+    # Update worker task queue status
+    updateWorkerTask(
+      id: ID!,
+      args: JSON,
+      kwargs: JSON,
+      taskName: String,
+      worker: String,
+      queuedAt: DateTime,
+      startedAt: DateTime,
+      finishedAt: DateTime,
+      error: String,
+      executionTime: Int,
+    ): WorkerTask
   }
 
   # Anonymous dataset reviewer
@@ -969,6 +982,18 @@ export const typeDefs = `
     input: [String]
   }
 
+  type WorkerTask {
+    id: ID!
+    args: JSON
+    kwargs: JSON
+    taskName: String
+    worker: String
+    queuedAt: DateTime
+    startedAt: DateTime
+    finishedAt: DateTime
+    error: String
+    executionTime: Int
+  }
 `
 
 schemaComposer.addTypeDefs(typeDefs)

--- a/packages/openneuro-server/src/models/worker-task.ts
+++ b/packages/openneuro-server/src/models/worker-task.ts
@@ -1,0 +1,38 @@
+import mongoose from "mongoose"
+import type { Document } from "mongoose"
+const { Schema, model } = mongoose
+
+export interface WorkerTaskDocument extends Document {
+  id: string
+  args?: Record<string, unknown>
+  kwargs?: Record<string, unknown>
+  taskName?: string
+  worker?: string
+  queuedAt?: Date
+  startedAt?: Date
+  finishedAt?: Date
+  error?: string
+  executionTime?: number
+}
+
+const workerTaskSchema = new Schema({
+  id: { type: String, required: true, unique: true },
+  args: { type: Object },
+  kwargs: { type: Object },
+  taskName: { type: String },
+  worker: { type: String },
+  queuedAt: { type: Date },
+  startedAt: { type: Date },
+  finishedAt: { type: Date },
+  error: { type: String },
+  executionTime: { type: Number },
+})
+
+workerTaskSchema.index({ id: 1 })
+
+const WorkerTaskModel = model<WorkerTaskDocument>(
+  "WorkerTask",
+  workerTaskSchema,
+)
+
+export default WorkerTaskModel

--- a/services/datalad/datalad_service/broker/worker_middleware.py
+++ b/services/datalad/datalad_service/broker/worker_middleware.py
@@ -1,19 +1,83 @@
 import random
+from datetime import datetime, timedelta, timezone, UTC
+from typing import Any
+import httpx
+import logging
+import jwt
 
-from taskiq import TaskiqMessage, TaskiqMiddleware
+from taskiq import TaskiqMessage, TaskiqMiddleware, TaskiqResult
+
 
 from datalad_service import config
+
+logger = logging.getLogger('datalad_service.' + __name__)
+
+_UPDATE_WORKER_TASK_MUTATION = """
+mutation UpdateWorkerTask(
+  $id: ID!
+  $args: JSON
+  $kwargs: JSON
+  $taskName: String
+  $worker: String
+  $queuedAt: DateTime
+  $startedAt: DateTime
+  $finishedAt: DateTime
+  $error: String
+  $executionTime: Int
+) {
+  updateWorkerTask(
+    id: $id
+    args: $args
+    kwargs: $kwargs
+    taskName: $taskName
+    worker: $worker
+    queuedAt: $queuedAt
+    startedAt: $startedAt
+    finishedAt: $finishedAt
+    error: $error
+    executionTime: $executionTime
+  ) {
+    id
+  }
+}
+"""
+
+
+def _update_worker_task_body(**kwargs):
+    """Create a GraphQL mutation body for updateWorkerTask."""
+    return {
+        'query': _UPDATE_WORKER_TASK_MUTATION,
+        'variables': kwargs,
+        'operationName': 'UpdateWorkerTask',
+    }
+
+
+def generate_worker_token():
+    utc_now = datetime.now(timezone.utc)
+    one_day_ahead = utc_now + timedelta(hours=24)
+    return jwt.encode(
+        {
+            'sub': 'dataset-worker',
+            'iat': int(utc_now.timestamp()),
+            'exp': int(one_day_ahead.timestamp()),
+            'scopes': ['dataset:worker'],
+        },
+        config.JWT_SECRET,
+        algorithm='HS256',
+    )
 
 
 class WorkerMiddleware(TaskiqMiddleware):
     """
-    This middleware adds a custom worker label to outgoing tasks scheduled by workers.
+    This middleware adds a custom worker label to outgoing tasks scheduled by workers
+    and reports task status back to the OpenNeuro API.
     """
 
     def __init__(self, worker_id=None):
         self.worker_id = worker_id
 
     async def pre_send(self, message: TaskiqMessage) -> TaskiqMessage:
+        """Assign new tasks to the correct worker."""
         if self.worker_id:
             message.labels['queue_name'] = f'worker-{self.worker_id}'
         else:
@@ -22,3 +86,58 @@ class WorkerMiddleware(TaskiqMiddleware):
                 f'worker-{random.randint(0, config.DATALAD_WORKERS - 1)}'
             )
         return message
+
+    async def _update_task_status(self, **kwargs):
+        """Helper to send updates to the GraphQL API."""
+        api_token = generate_worker_token()
+        body = _update_worker_task_body(**kwargs)
+        try:
+            async with httpx.AsyncClient() as client:
+                response = await client.post(
+                    url=config.GRAPHQL_ENDPOINT,
+                    json=body,
+                    headers={'Authorization': f'Bearer {api_token}'},
+                )
+                response.raise_for_status()
+                response_json = response.json()
+                if 'errors' in response_json:
+                    logger.error(
+                        f'GraphQL error updating task status: {response_json["errors"]}',
+                    )
+        except httpx.HTTPError as e:
+            logger.error(f'HTTP error updating task status: {e}')
+            logger.error(f'Response: {e.response.text}')
+        except Exception as e:
+            logger.error(f'Unexpected error updating task status: {e}')
+
+    async def post_send(self, message: TaskiqMessage):
+        """Called after a task is sent to the broker."""
+        now = datetime.now(UTC).isoformat()
+        await self._update_task_status(
+            id=message.task_id,
+            args=message.args,
+            kwargs=message.kwargs,
+            taskName=message.task_name,
+            worker=message.labels.get('queue_name'),
+            queuedAt=now,
+        )
+
+    async def pre_execute(self, message: TaskiqMessage) -> TaskiqMessage:
+        """Called before a worker executes a task."""
+        now = datetime.now(UTC).isoformat()
+        await self._update_task_status(id=message.task_id, startedAt=now)
+        return message
+
+    async def post_execute(
+        self,
+        message: TaskiqMessage,
+        result: TaskiqResult[Any],
+    ):
+        """Called after a worker executes a task."""
+        now = datetime.now(UTC).isoformat()
+        await self._update_task_status(
+            id=message.task_id,
+            finishedAt=now,
+            error=None if result.error is None else repr(result.error),
+            executionTime=round(result.execution_time * 1000),
+        )

--- a/services/datalad/pyproject.toml
+++ b/services/datalad/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "taskiq[reload]>=0.11.18",
     "taskiq-redis>=1.0.9",
     "uvicorn[standard]>=0.34.3",
+    "httpx>=0.28.1",
 ]
 dynamic = ["version"]
 

--- a/services/datalad/uv.lock
+++ b/services/datalad/uv.lock
@@ -291,6 +291,7 @@ dependencies = [
     { name = "charset-normalizer" },
     { name = "dnspython" },
     { name = "falcon" },
+    { name = "httpx" },
     { name = "pygit2" },
     { name = "pygithub" },
     { name = "pyjwt" },
@@ -322,6 +323,7 @@ requires-dist = [
     { name = "charset-normalizer", specifier = ">=3.4.2" },
     { name = "dnspython", specifier = ">=2.7.0" },
     { name = "falcon", specifier = ">=4.0.2" },
+    { name = "httpx", specifier = ">=0.28.1" },
     { name = "pygit2", specifier = ">=1.18.0" },
     { name = "pygithub", specifier = ">=2.6.1" },
     { name = "pyjwt", specifier = ">=2.10.1" },
@@ -434,6 +436,19 @@ wheels = [
 ]
 
 [[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
 name = "httptools"
 version = "0.6.4"
 source = { registry = "https://pypi.org/simple" }
@@ -446,6 +461,21 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/8a/0a/0d4df132bfca1507114198b766f1737d57580c9ad1cf93c1ff673e3387be/httptools-0.6.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:342dd6946aa6bda4b8f18c734576106b8a31f2fe31492881a9a160ec84ff4bd5", size = 448858, upload-time = "2024-10-16T19:44:43.959Z" },
     { url = "https://files.pythonhosted.org/packages/1e/6a/787004fdef2cabea27bad1073bf6a33f2437b4dbd3b6fb4a9d71172b1c7c/httptools-0.6.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4b36913ba52008249223042dca46e69967985fb4051951f94357ea681e1f5dc0", size = 452042, upload-time = "2024-10-16T19:44:45.071Z" },
     { url = "https://files.pythonhosted.org/packages/4d/dc/7decab5c404d1d2cdc1bb330b1bf70e83d6af0396fd4fc76fc60c0d522bf/httptools-0.6.4-cp313-cp313-win_amd64.whl", hash = "sha256:28908df1b9bb8187393d5b5db91435ccc9c8e891657f9cbb42a2541b44c82fc8", size = 87682, upload-time = "2024-10-16T19:44:46.46Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This keeps a persistent MongoDB collection of dataset worker task status. This is only the server component so we can start having a better log of these, if it's useful this could be used to add a visual dashboard for the workers of tasks showing pending or recently completed tasks.

Based on the example from https://github.com/taskiq-python/taskiq-admin