### PR TITLE
fix(cli): Support annex keys with all valid filename characters

### DIFF
--- a/cli/src/worker/annex.test.ts
+++ b/cli/src/worker/annex.test.ts
@@ -1,6 +1,11 @@
 import { assertEquals } from "@std/assert/equals"
 import { join } from "@std/path/join"
-import { annexRelativePath, hashDirLower, hashDirMixed } from "./annex.ts"
+import {
+  annexKeyRegex,
+  annexRelativePath,
+  hashDirLower,
+  hashDirMixed,
+} from "./annex.ts"
 
 Deno.test("annexRelativePath() returns appropriate paths", () => {
   assertEquals(
@@ -24,5 +29,30 @@ Deno.test("hashDirMixed() returns the correct key prefix", async () => {
       "SHA256E-s311112--c3527d7944a9619afb57863a34e6af7ec3fe4f108e56c860d9e700699ff806fb.nii.gz",
     ),
     ["Xk", "Mx"],
+  )
+})
+
+Deno.test("annexKeyRegex matches valid keys", () => {
+  // Typical key
+  assertEquals(
+    "SHA256E-s311112--c3527d7944a9619afb57863a34e6af7ec3fe4f108e56c860d9e700699ff806fb.nii.gz"
+      .match(annexKeyRegex)?.slice(1, 5),
+    [
+      "SHA256E",
+      "311112",
+      "c3527d7944a9619afb57863a34e6af7ec3fe4f108e56c860d9e700699ff806fb",
+      ".nii.gz",
+    ],
+  )
+  // Filenames with other characters
+  assertEquals(
+    "SHA256E-s6148--e53302cf7b8beb7c5b908c070618bb11e2590719465d0869522716ecc2cfecd8.DS_Store"
+      .match(annexKeyRegex)?.slice(1, 5),
+    [
+      "SHA256E",
+      "6148",
+      "e53302cf7b8beb7c5b908c070618bb11e2590719465d0869522716ecc2cfecd8",
+      ".DS_Store",
+    ],
   )
 })

--- a/cli/src/worker/annex.ts
+++ b/cli/src/worker/annex.ts
@@ -24,6 +24,16 @@ const computeHashMD5 = await createMD5()
 const computeHashSHA256 = await createSHA256()
 
 /**
+ * Matches valid git-annex keys
+ * Example input: SHA256E-s311112--c3527d7944a9619afb57863a34e6af7ec3fe4f108e56c860d9e700699ff806fb.nii.gz
+ * Group 1: SHA256E
+ * Group 2: 311112
+ * Group 3: c3527d7944a9619afb57863a34e6af7ec3fe4f108e56c860d9e700699ff806fb
+ * Group 4: .nii.gz
+ */
+export const annexKeyRegex = /^([A-Z0-9]+)-s(\d+)--([0-9a-fA-F]+)(\.[\w\-. ]*)?/
+
+/**
  * git-annex hashDirLower implementation based on https://git-annex.branchable.com/internals/hashing/
  * Compute the directory path from a git-annex filename
  */
@@ -196,7 +206,7 @@ export async function getAnnexKeys(
           // Check that annexKey conforms to the git-annex key format
           // Other symlinks are allowed but may be rejected on push if they point outside of the repo
           if (
-            annexKey.match(/^[A-Z0-9]+-s\d+--[0-9a-fA-F]+(\.[a-zA-Z0-9.]*)?$/)
+            annexKey.match(annexKeyRegex)
           ) {
             logger.info(`Found key "${annexKey}" in HEAD.`)
             annexKeys[annexKey] = filepath


### PR DESCRIPTION
Fix an issue where the command line tool uploader would fail to recognize annex keys with underscores in file extensions.