### PR TITLE
Run dataset exports as background tasks

### DIFF
--- a/services/datalad/datalad_service/broker/worker_middleware.py
+++ b/services/datalad/datalad_service/broker/worker_middleware.py
@@ -62,7 +62,7 @@ def generate_worker_token():
             'exp': int(one_day_ahead.timestamp()),
             'scopes': ['dataset:worker'],
         },
-        config.JWT_SECRET,
+        config.get_jwt_secret(),
         algorithm='HS256',
     )
 

--- a/services/datalad/datalad_service/config.py
+++ b/services/datalad/datalad_service/config.py
@@ -18,7 +18,6 @@ AWS_REGION = os.getenv('AWS_REGION')
 AWS_ACCOUNT_ID = os.getenv('AWS_ACCOUNT_ID')
 AWS_S3_PRIVATE_BUCKET = os.getenv('AWS_S3_PRIVATE_BUCKET')
 AWS_S3_PUBLIC_BUCKET = os.getenv('AWS_S3_PUBLIC_BUCKET')
-JWT_SECRET = os.getenv('JWT_SECRET')
 
 # GraphQL URL - override if not docker-compose
 GRAPHQL_ENDPOINT = os.getenv('GRAPHQL_ENDPOINT', 'http://server:8111/crn/graphql')
@@ -26,9 +25,12 @@ GRAPHQL_ENDPOINT = os.getenv('GRAPHQL_ENDPOINT', 'http://server:8111/crn/graphql
 # Site URL
 CRN_SERVER_URL = os.getenv('CRN_SERVER_URL')
 
-# Request secret for API calls
-JWT_SECRET = os.getenv('JWT_SECRET')
 
 # Redit connection for task queue
 REDIS_HOST = os.getenv('REDIS_HOST')
 REDIS_PORT = os.getenv('REDIS_PORT')
+
+
+def get_jwt_secret():
+    """Returns the JWT_SECRET from environment variables."""
+    return os.getenv('JWT_SECRET')

--- a/services/datalad/datalad_service/handlers/publish.py
+++ b/services/datalad/datalad_service/handlers/publish.py
@@ -1,12 +1,6 @@
-import asyncio
-from concurrent.futures import ProcessPoolExecutor
-
 import falcon
 
 from datalad_service.tasks.publish import create_remotes_and_export
-
-
-executor = ProcessPoolExecutor(4)
 
 
 class PublishResource:
@@ -17,6 +11,6 @@ class PublishResource:
 
     async def on_post(self, req, resp, dataset):
         dataset_path = self.store.get_dataset_path(dataset)
-        executor.submit(create_remotes_and_export, dataset_path, cookies=req.cookies)
+        await create_remotes_and_export.kiq(dataset_path, cookies=req.cookies)
         resp.media = {}
         resp.status = falcon.HTTP_OK

--- a/services/datalad/datalad_service/handlers/publish.py
+++ b/services/datalad/datalad_service/handlers/publish.py
@@ -11,6 +11,6 @@ class PublishResource:
 
     async def on_post(self, req, resp, dataset):
         dataset_path = self.store.get_dataset_path(dataset)
-        await create_remotes_and_export.kiq(dataset_path, cookies=req.cookies)
+        await create_remotes_and_export.kiq(dataset_path)
         resp.media = {}
         resp.status = falcon.HTTP_OK

--- a/services/datalad/datalad_service/handlers/snapshots.py
+++ b/services/datalad/datalad_service/handlers/snapshots.py
@@ -1,4 +1,3 @@
-import asyncio
 import os
 import logging
 
@@ -13,7 +12,10 @@ from datalad_service.tasks.snapshots import (
     SnapshotExistsException,
 )
 from datalad_service.tasks.files import get_tree
-from datalad_service.tasks.publish import export_dataset, monitor_remote_configs
+from datalad_service.tasks.publish import (
+    export_dataset,
+    monitor_remote_configs,
+)
 
 
 class SnapshotResource:
@@ -65,9 +67,7 @@ class SnapshotResource:
             if not skip_publishing:
                 monitor_remote_configs(ds_path)
                 # Publish after response
-                asyncio.get_event_loop().run_in_executor(
-                    None, export_dataset, ds_path, req.cookies
-                )
+                await export_dataset.kiq(ds_path)
         except SnapshotExistsException as err:
             resp.media = {'error': repr(err)}
             resp.status = falcon.HTTP_CONFLICT

--- a/services/datalad/datalad_service/tasks/publish.py
+++ b/services/datalad/datalad_service/tasks/publish.py
@@ -25,6 +25,7 @@ from datalad_service.common.s3 import (
     get_s3_bucket,
     update_s3_sibling,
 )
+from datalad_service.broker import broker
 
 logger = logging.getLogger('datalad_service.' + __name__)
 
@@ -50,6 +51,7 @@ def s3_sibling(dataset_path):
         datalad_service.common.s3.setup_s3_sibling(dataset_path)
 
 
+@broker.task
 def create_remotes_and_export(dataset_path, cookies=None):
     """
     Create public S3 and GitHub remotes and export to them.

--- a/services/datalad/datalad_service/tasks/publish.py
+++ b/services/datalad/datalad_service/tasks/publish.py
@@ -52,14 +52,14 @@ def s3_sibling(dataset_path):
 
 
 @broker.task
-def create_remotes_and_export(dataset_path, cookies=None):
+def create_remotes_and_export(dataset_path):
     """
     Create public S3 and GitHub remotes and export to them.
 
     Called by publish handler to make a dataset public initially.
     """
     create_remotes(dataset_path)
-    export_dataset(dataset_path, cookies)
+    export_dataset(dataset_path)
 
 
 def create_remotes(dataset_path):
@@ -68,9 +68,9 @@ def create_remotes(dataset_path):
     github_sibling(dataset_path, dataset)
 
 
+@broker.task
 def export_dataset(
     dataset_path,
-    cookies=None,
     s3_export=s3_export,
     github_export=github_export,
     update_s3_sibling=update_s3_sibling,
@@ -95,7 +95,7 @@ def export_dataset(
                 # Perform all GitHub export steps
                 github_export(dataset_id, dataset_path, tags[-1].name)
         # Drop cache once all exports are complete
-        clear_dataset_cache(dataset_id, tags[-1].name, cookies)
+        clear_dataset_cache(dataset_id, tags[-1].name)
 
 
 def check_remote_has_version(dataset_path, remote, tag):

--- a/services/datalad/tests/test_draft.py
+++ b/services/datalad/tests/test_draft.py
@@ -5,14 +5,14 @@ import json
 import jwt
 
 
-def test_add_commit_info(client):
+def test_add_commit_info(client, monkeypatch):
     ds_id = 'ds000001'
     file_data = 'Test annotating requests with user info'
     name = 'Test User'
     email = 'user@example.com'
     user = {'name': name, 'email': email, 'sub': '123456', 'admin': False}
     jwt_secret = 'shhhhh'
-    os.environ['JWT_SECRET'] = jwt_secret
+    monkeypatch.setenv('JWT_SECRET', jwt_secret)
     access_token = jwt.encode(user, jwt_secret)
     cookie = f'accessToken={access_token}'
     headers = {'Cookie': cookie}


### PR DESCRIPTION
This moves the export out of the uvicorn process and into the taskiq worker. They will now be more reliably retried and the lifetime for exports is maintained in the worker tasks model.

Now uses a worker token instead of a user token for cache clear after publish. This avoids the need to pass the token in as a task queue argument.