### PR TITLE
fix(server): Raise maximum HTTP request body size to 100mb

### DIFF
--- a/packages/openneuro-server/src/app.ts
+++ b/packages/openneuro-server/src/app.ts
@@ -50,8 +50,8 @@ export async function expressApolloSetup() {
   })
   app.use(morgan("short"))
   app.use(cookieParser())
-  app.use(urlencoded({ extended: false, limit: "50mb" }))
-  app.use(json({ limit: "50mb" }))
+  app.use(urlencoded({ extended: false, limit: "100mb" }))
+  app.use(json({ limit: "100mb" }))
 
   // routing ---------------------------------------------------------
   app.use("/sitemap.xml", sitemapHandler)


### PR DESCRIPTION
This limit is being hit by the schema validator and 100mb should be within reason still.