### PR TITLE
refactor(server): Use cacheClear for admin cache clear actions

### DIFF
--- a/packages/openneuro-server/src/graphql/resolvers/cache.ts
+++ b/packages/openneuro-server/src/graphql/resolvers/cache.ts
@@ -1,23 +1,27 @@
 import { redis } from "../../libs/redis.js"
-import CacheItem from "../../cache/item"
-import { CacheType } from "../../cache/types"
 
 /**
- * Clear the snapshotDownload cache after exports
+ * Clear all cache entries for a given datasetId
  */
 export async function cacheClear(
   obj: Record<string, unknown>,
-  { datasetId, tag }: { datasetId: string; tag: string },
+  { datasetId }: { datasetId: string },
   { userInfo }: { userInfo: { admin: boolean } },
 ): Promise<boolean> {
   // Check for admin and validate datasetId argument
   if (userInfo?.admin && datasetId.length == 8 && datasetId.startsWith("ds")) {
-    const downloadCache = new CacheItem(redis, CacheType.snapshotDownload, [
-      datasetId,
-      tag,
-    ])
     try {
-      await downloadCache.drop()
+      const stream = redis.scanStream({
+        // Scan for any keys that include the datasetId
+        match: `*${datasetId}*`,
+      })
+      const pipeline = redis.pipeline()
+      for await (const keys of stream) {
+        for (const key of keys) {
+          pipeline.del(key)
+        }
+      }
+      await pipeline.exec()
       return true
     } catch (_err) {
       return false

--- a/packages/openneuro-server/src/graphql/schema.ts
+++ b/packages/openneuro-server/src/graphql/schema.ts
@@ -176,8 +176,8 @@ export const typeDefs = `
     prepareUpload(datasetId: ID!, uploadId: ID!): UploadMetadata
     # Add files from a completed upload to the dataset draft
     finishUpload(uploadId: ID!): Boolean
-    # Drop download cache for a snapshot - requires site admin access
-    cacheClear(datasetId: ID!, tag: String!): Boolean
+    # Drop cached data for a dataset - requires site admin access
+    cacheClear(datasetId: ID!): Boolean
     # Rerun the latest validator on a given commit
     revalidate(datasetId: ID!, ref: String!): Boolean
     # Request a temporary token for git access

--- a/services/datalad/datalad_service/common/openneuro.py
+++ b/services/datalad/datalad_service/common/openneuro.py
@@ -23,19 +23,19 @@ def generate_service_token(dataset_id):
     )
 
 
-def cache_clear_mutation(dataset_id, tag):
+def cache_clear_mutation(dataset_id):
     """Update the draft HEAD reference to an new git commit id (hexsha)."""
     return {
-        'query': 'mutation ($datasetId: ID!) { cacheClear(datasetId: $datasetId, tag: $tag) }',
-        'variables': {'datasetId': dataset_id, 'tag': tag},
+        'query': 'mutation ($datasetId: ID!) { cacheClear(datasetId: $datasetId) }',
+        'variables': {'datasetId': dataset_id},
     }
 
 
-def clear_dataset_cache(dataset_id, tag):
+def clear_dataset_cache(dataset_id):
     """Post a cacheClear event to OpenNeuro to allow the API to query new data after changes"""
     r = requests.post(
         url=GRAPHQL_ENDPOINT,
-        json=cache_clear_mutation(dataset_id, tag),
+        json=cache_clear_mutation(dataset_id),
         headers={'authorization': f'Bearer {generate_service_token(dataset_id)}'},
     )
     if r.status_code != 200:

--- a/services/datalad/datalad_service/tasks/publish.py
+++ b/services/datalad/datalad_service/tasks/publish.py
@@ -95,7 +95,7 @@ def export_dataset(
                 # Perform all GitHub export steps
                 github_export(dataset_id, dataset_path, tags[-1].name)
         # Drop cache once all exports are complete
-        clear_dataset_cache(dataset_id, tags[-1].name)
+        clear_dataset_cache(dataset_id)
 
 
 def check_remote_has_version(dataset_path, remote, tag):


### PR DESCRIPTION
Updates the cache clear mutation to remove all dataset related caches. This is less expensive than when it was originally setup and can be used for admin and export cache clears without a high performance cost. A scan and pipeline is used to prevent the keys call from blocking Redis.