### PR TITLE
Feature/ mutations for event adding contributors and accept/deny adding contributors

### DIFF
--- a/packages/openneuro-app/src/scripts/dataset/components/dataset-event-item.tsx
+++ b/packages/openneuro-app/src/scripts/dataset/components/dataset-event-item.tsx
@@ -148,6 +148,12 @@ export const DatasetEventItem: React.FC<DatasetEventItemProps> = ({
             {event.note}
           </>
         )
+      } else if (event.event.type === "contributorCitation") {
+        return (
+          <>
+            {event.event.resolutionStatus} contributorship
+          </>
+        )
       } else {
         return event.event.type
       }

--- a/packages/openneuro-server/src/graphql/resolvers/datasetEvents.ts
+++ b/packages/openneuro-server/src/graphql/resolvers/datasetEvents.ts
@@ -1,5 +1,6 @@
 import DatasetEvent from "../../models/datasetEvents"
-import User, { UserDocument } from "../../models/user"
+import User from "../../models/user"
+import type { UserDocument } from "../../models/user"
 import { checkDatasetAdmin } from "../permissions"
 import type {
   DatasetEventContributorCitation,
@@ -378,11 +379,8 @@ export async function processContributorCitation(
     throw new Error("Authentication required to process contributor citation.")
   }
 
-  console.log("processContributorCitation called", { eventId, status, user })
-
   // Fetch the citation event
   const citationEvent = await DatasetEvent.findOne({ id: eventId })
-  console.log("Fetched citationEvent:", citationEvent?.toObject())
 
   if (!citationEvent || citationEvent.event.type !== "contributorCitation") {
     throw new Error("Contributor citation event not found.")
@@ -397,16 +395,8 @@ export async function processContributorCitation(
   const isAdmin = userInfo?.admin === true
 
   if (!isTargetUser && !isAdmin) {
-    console.log("Authorization failed:", {
-      targetUserId: citationEvent.event.targetUserId,
-      user,
-      userOrcid: currentUser?.orcid,
-      isAdmin,
-    })
     throw new Error("Not authorized to respond to this contributor citation.")
   }
-
-  console.log("Authorization passed. Creating response event...")
 
   // Must still be pending
   if (citationEvent.event.resolutionStatus !== "pending") {

--- a/packages/openneuro-server/src/graphql/resolvers/datasetEvents.ts
+++ b/packages/openneuro-server/src/graphql/resolvers/datasetEvents.ts
@@ -51,9 +51,6 @@ export type EnrichedDatasetEvent =
 /**
  * Get all events for a dataset
  */
-
-/** Unified datasetEvents query */
-// --- Query: all dataset events ---
 export async function datasetEvents(
   obj,
   _,
@@ -359,10 +356,6 @@ export async function createContributorCitationEvent(
 /**
  * Process a contributor citation (approve or deny)
  * Only the target user can approve/deny
- */
-/**
- * Process a contributor citation (approve or deny)
- * Only the target user or an admin can approve/deny
  */
 export async function processContributorCitation(
   obj,

--- a/packages/openneuro-server/src/graphql/resolvers/mutation.ts
+++ b/packages/openneuro-server/src/graphql/resolvers/mutation.ts
@@ -44,6 +44,7 @@ import {
   importRemoteDataset,
 } from "./importRemoteDataset"
 import {
+  createContributorCitationEvent,
   createContributorRequestEvent,
   processContributorRequest,
   saveAdminNote,
@@ -100,6 +101,7 @@ const Mutation = {
   updateUser,
   saveAdminNote,
   createContributorRequestEvent,
+  createContributorCitationEvent,
   processContributorRequest,
   createGitEvent,
   updateFileCheck,

--- a/packages/openneuro-server/src/graphql/resolvers/mutation.ts
+++ b/packages/openneuro-server/src/graphql/resolvers/mutation.ts
@@ -46,6 +46,7 @@ import {
 import {
   createContributorCitationEvent,
   createContributorRequestEvent,
+  processContributorCitation,
   processContributorRequest,
   saveAdminNote,
   updateEventStatus,
@@ -103,6 +104,7 @@ const Mutation = {
   createContributorRequestEvent,
   createContributorCitationEvent,
   processContributorRequest,
+  processContributorCitation,
   createGitEvent,
   updateFileCheck,
   updateEventStatus,

--- a/packages/openneuro-server/src/graphql/resolvers/user.ts
+++ b/packages/openneuro-server/src/graphql/resolvers/user.ts
@@ -1,7 +1,7 @@
-import { PipelineStage } from "mongoose"
+import type { PipelineStage } from "mongoose"
 import User from "../../models/user"
 import DatasetEvent from "../../models/datasetEvents"
-import { UserNotificationStatusDocument } from "../../models/userNotificationStatus"
+import type { UserNotificationStatusDocument } from "../../models/userNotificationStatus"
 
 function isValidOrcid(orcid: string): boolean {
   return /^[0-9]{4}-[0-9]{4}-[0-9]{4}-[0-9]{3}[0-9X]$/.test(orcid || "")
@@ -22,7 +22,6 @@ export async function user(
   }
 
   if (!user) {
-    console.warn(`User not found for id: ${id}`)
     return null // Fail silently
   }
 

--- a/packages/openneuro-server/src/graphql/resolvers/user.ts
+++ b/packages/openneuro-server/src/graphql/resolvers/user.ts
@@ -1,7 +1,6 @@
 import { PipelineStage } from "mongoose"
 import User from "../../models/user"
 import DatasetEvent from "../../models/datasetEvents"
-import Permission from "../../models/permission"
 import { UserNotificationStatusDocument } from "../../models/userNotificationStatus"
 
 function isValidOrcid(orcid: string): boolean {

--- a/packages/openneuro-server/src/graphql/schema.ts
+++ b/packages/openneuro-server/src/graphql/schema.ts
@@ -230,6 +230,12 @@ export const typeDefs = `
       datasetId: String!
       newContributors: [ContributorInput!]!
     ): UpdateContributorsPayload!
+    createContributorCitationEvent(
+      datasetId: ID!
+      targetUserId: ID!
+      contributorType: String!
+      contributorData: ContributorInput!
+    ): DatasetEvent
   }
 
   # Anonymous dataset reviewer
@@ -949,6 +955,8 @@ export const typeDefs = `
     reason: String
     datasetId: ID
     resolutionStatus: String
+    contributorType: String
+    contributorData: Contributor
   }
 
  # Possible statuses for user notification/events

--- a/packages/openneuro-server/src/graphql/schema.ts
+++ b/packages/openneuro-server/src/graphql/schema.ts
@@ -233,8 +233,11 @@ export const typeDefs = `
     createContributorCitationEvent(
       datasetId: ID!
       targetUserId: ID!
-      contributorType: String!
       contributorData: ContributorInput!
+    ): DatasetEvent
+    processContributorCitation(
+      eventId: ID!
+      status: String!
     ): DatasetEvent
   }
 
@@ -361,7 +364,7 @@ export const typeDefs = `
 
   # OpenNeuro user records from all providers
   type User {
-    id: ID!
+    id: ID
     provider: UserProvider
     avatar: String
     orcid: String
@@ -946,11 +949,11 @@ export const typeDefs = `
     version: String
     public: Boolean
     target: User
+    targetUserId: ID
     level: String
     ref: String
     message: String
     requestId: ID
-    targetUserId: ID
     status: String
     reason: String
     datasetId: ID
@@ -959,19 +962,7 @@ export const typeDefs = `
     contributorData: Contributor
   }
 
- # Possible statuses for user notification/events
-  enum NotificationStatusType {
-    UNREAD
-    SAVED
-    ARCHIVED
-  }
-
-  # User's notification status
-  type UserNotificationStatus {
-    status: NotificationStatusType!
-  }
-
-  # Dataset events
+    # Dataset events
   type DatasetEvent {
     # Unique identifier for the event
     id: ID
@@ -992,6 +983,21 @@ export const typeDefs = `
     responseStatus: String
     hasBeenRespondedTo: Boolean
   }
+
+
+ # Possible statuses for user notification/events
+  enum NotificationStatusType {
+    UNREAD
+    SAVED
+    ARCHIVED
+  }
+
+  # User's notification status
+  type UserNotificationStatus {
+    status: NotificationStatusType!
+  }
+
+
 
   type FileCheck {
     datasetId: String!

--- a/packages/openneuro-server/src/models/datasetEvents.ts
+++ b/packages/openneuro-server/src/models/datasetEvents.ts
@@ -17,6 +17,7 @@ const _datasetEventTypes = [
   "note",
   "contributorRequest",
   "contributorResponse",
+  "contributorCitation",
 ] as const
 
 /**
@@ -91,6 +92,13 @@ export type DatasetEventContributorRequest = DatasetEventCommon & {
   requestId?: string
   resolutionStatus?: "pending" | "accepted" | "denied"
   datasetId?: string
+  contributorType: string
+  contributorData: {
+    orcid?: string
+    name?: string
+    email?: string
+    userId?: string
+  }
 }
 
 export type DatasetEventContributorResponse = DatasetEventCommon & {
@@ -100,6 +108,21 @@ export type DatasetEventContributorResponse = DatasetEventCommon & {
   status: "accepted" | "denied"
   reason?: string
   datasetId?: string
+}
+
+export type DatasetEventContributorCitation = DatasetEventCommon & {
+  type: "contributorCitation"
+  datasetId: string
+  addedBy: OpenNeuroUserId
+  targetUserId: OpenNeuroUserId
+  contributorType: string
+  contributorData: {
+    orcid?: string
+    name?: string
+    email?: string
+    userId?: string
+  }
+  resolutionStatus: "pending" | "approved" | "denied"
 }
 
 /**
@@ -116,6 +139,7 @@ export type DatasetEventType =
   | DatasetEventNote
   | DatasetEventContributorRequest
   | DatasetEventContributorResponse
+  | DatasetEventContributorCitation
 
 /**
  * Dataset events log changes to a dataset
@@ -154,8 +178,13 @@ const datasetEventSchema = new Schema<DatasetEventDocument>(
       datasetId: { type: String },
       resolutionStatus: {
         type: String,
-        enum: ["pending", "accepted", "denied"],
+        enum: ["pending", "approved", "denied"],
         default: "pending",
+      },
+      contributorType: { type: String }, // e.g., "Researcher", "Data Curator"
+      contributorData: {
+        type: Object,
+        default: {},
       },
     },
     success: { type: Boolean, default: false },

--- a/packages/openneuro-server/src/models/datasetEvents.ts
+++ b/packages/openneuro-server/src/models/datasetEvents.ts
@@ -181,7 +181,7 @@ const datasetEventSchema = new Schema<DatasetEventDocument>(
         enum: ["pending", "approved", "denied"],
         default: "pending",
       },
-      contributorType: { type: String }, // e.g., "Researcher", "Data Curator"
+      contributorType: { type: String },
       contributorData: {
         type: Object,
         default: {},

--- a/packages/openneuro-server/src/types/datacite.ts
+++ b/packages/openneuro-server/src/types/datacite.ts
@@ -32,6 +32,7 @@ export interface Contributor {
   orcid?: string
   contributorType?: string
   order?: number
+  userId?: string
 }
 
 /**

--- a/packages/openneuro-server/src/utils/datacite-utils.ts
+++ b/packages/openneuro-server/src/utils/datacite-utils.ts
@@ -11,6 +11,7 @@ import type {
   RawDataciteYml,
 } from "../types/datacite"
 import { validateOrcid } from "../utils/orcid-utils"
+
 /**
  * Returns a minimal datacite.yml structure
  */


### PR DESCRIPTION
What is working
- New mutations exist for sending events to users to accept contributor/author roles and be added to a dataset.
- Approving these requests will create a new item in Datacite and an associated event.

What needs to happen next
- Allow the mutation to accept contributorType.
- Finish the contributor request feature and integrate it with processContributor.
- Build frontend UI for interactions:
  - Both dataset and user notifications need a UI.
  - Dataset needs “approve/deny” UI for contributor request events.

Need a way for admins to add users to the author list and then send the user an event.
Discussion points / potential next steps
- If a user already has an ORCID from an uploaded datacite.yml, should we send a notification immediately, or provide a simple UI for sending the notification manually?
- The main question: should the system handle notifications automatically, or should it be up to the dataset admin to request manually?