### PR TITLE
helm: Update to Redis 8.2.1 and bitnamilegacy temporarily

### DIFF
--- a/helm/openneuro/Chart.yaml
+++ b/helm/openneuro/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: openneuro
-version: 1.6.0
+version: 1.7.0
 description: OpenNeuro production deployment chart
 home: https://openneuro.org
 sources:
@@ -8,5 +8,5 @@ sources:
 appVersion: 4.38.3
 dependencies:
   - name: redis
-    version: 17.1.4
+    version: 22.0.7
     repository: https://charts.bitnami.com/bitnami

--- a/helm/openneuro/requirements.lock
+++ b/helm/openneuro/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 17.1.4
-digest: sha256:7e7d63886296a858981054168160d78ed785ea99c89f2f04ad0f22b9447268fb
-generated: "2022-09-13T14:04:03.820425553-07:00"
+  version: 22.0.7
+digest: sha256:a43c85791db075a37ed56c419ac198028042968353e2093074cc77002f50a038
+generated: "2025-10-04T06:58:11.225838698-07:00"

--- a/helm/openneuro/values-production.yaml
+++ b/helm/openneuro/values-production.yaml
@@ -62,6 +62,10 @@ workerDiskSize:
 
 # Disable Redis password for testing
 redis:
+  image:
+    registry: docker.io
+    repository: bitnamilegacy/redis
+    tag: 8.2.1
   architecture: standalone
   auth:
     enabled: false

--- a/helm/openneuro/values.yaml
+++ b/helm/openneuro/values.yaml
@@ -63,6 +63,10 @@ workerDiskSize:
 
 # Disable Redis password for testing
 redis:
+  image:
+    registry: docker.io
+    repository: bitnamilegacy/redis
+    tag: 8.2.1
   architecture: standalone
   auth:
     enabled: false


### PR DESCRIPTION
Critical update to our Redis chart as Bitnami has removed the image we were using. This is a temporary fix, we should move to our own template for Redis or another chart soon.