### PR TITLE
fix(api): Dataset deletion would not remove the MongoDB record correctly

### DIFF
--- a/packages/openneuro-server/src/datalad/dataset.ts
+++ b/packages/openneuro-server/src/datalad/dataset.ts
@@ -124,7 +124,7 @@ export const deleteDataset = async (datasetId, user) => {
   )
   await request
     .del(`${getDatasetWorker(datasetId)}/datasets/${datasetId}`)
-  await Dataset.deleteOne({ datasetId }).exec()
+  await Dataset.deleteOne({ id: datasetId }).exec()
   await updateEvent(event)
   return true
 }


### PR DESCRIPTION
This collection uses id for datasetId and this will silently not delete anything when a dataset is removed. Aggregates will then accidentally include removed datasets.

Fixes #3590 and will require a database update to remove the existing failures once this has been deployed.