### PR TITLE
feat(worker): Drop annexed data after export

### DIFF
--- a/services/datalad/datalad_service/app.py
+++ b/services/datalad/datalad_service/app.py
@@ -9,6 +9,7 @@ import datalad_service.version
 from datalad_service.datalad import DataladStore
 from datalad_service.handlers.dataset import DatasetResource
 from datalad_service.handlers.draft import DraftResource
+from datalad_service.handlers.drop import DropResource
 from datalad_service.handlers.description import DescriptionResource
 from datalad_service.handlers.files import FilesResource
 from datalad_service.handlers.objects import ObjectsResource
@@ -83,6 +84,7 @@ def create_app():
     dataset_draft = DraftResource(store)
     dataset_validation = ValidationResource(store)
     dataset_history = HistoryResource(store)
+    dataset_drop = DropResource(store)
     dataset_description = DescriptionResource(store)
     dataset_files = FilesResource(store)
     dataset_objects = ObjectsResource(store)
@@ -107,6 +109,7 @@ def create_app():
 
     app.add_route('/datasets/{dataset}/draft', dataset_draft)
     app.add_route('/datasets/{dataset}/history', dataset_history)
+    app.add_route('/datasets/{dataset}/drop', dataset_drop)
     app.add_route('/datasets/{dataset}/description', dataset_description)
     app.add_route('/datasets/{dataset}/validate/{hexsha}', dataset_validation)
     app.add_route('/datasets/{dataset}/reset/{hexsha}', dataset_reset_resource)

--- a/services/datalad/datalad_service/common/annex.py
+++ b/services/datalad/datalad_service/common/annex.py
@@ -29,7 +29,11 @@ class EditAnnexedFileException(Exception):
 
 def init_annex(dataset_path):
     """Setup git-annex within an existing git repo"""
-    subprocess.run(['git-annex', 'init', 'OpenNeuro'], check=True, cwd=dataset_path)
+    subprocess.run(
+        ['git-annex', 'init', 'OpenNeuro', '--numcopies=2'],
+        check=True,
+        cwd=dataset_path,
+    )
 
 
 def compute_git_hash(path, size):

--- a/services/datalad/datalad_service/common/asyncio.py
+++ b/services/datalad/datalad_service/common/asyncio.py
@@ -1,0 +1,15 @@
+import asyncio
+import subprocess
+
+
+async def run_check(command, dataset_path):
+    """Helper to run an async command and check for failure"""
+    process = await asyncio.create_subprocess_exec(
+        *command,
+        cwd=dataset_path,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    stdout, stderr = await process.communicate()
+    if process.returncode != 0:
+        raise subprocess.CalledProcessError(process.returncode, command, stdout, stderr)

--- a/services/datalad/datalad_service/handlers/drop.py
+++ b/services/datalad/datalad_service/handlers/drop.py
@@ -1,0 +1,16 @@
+import falcon
+
+from datalad_service.tasks.publish import annex_drop
+
+
+class DropResource:
+    """git-annex drop API wrapper"""
+
+    def __init__(self, store):
+        self.store = store
+
+    async def on_post(self, req, resp, dataset):
+        dataset_path = self.store.get_dataset_path(dataset)
+        await annex_drop.kiq(dataset_path)
+        resp.media = {}
+        resp.status = falcon.HTTP_OK


### PR DESCRIPTION
This initializes datasets with numcopies raised to 2 and drops local annexed content after every export. Adds an API endpoint to manually trigger a drop on existing datasets.

For many older datasets we have an s3-PRIVATE remote that was used for analysis jobs. This remote has not been active for years but we mark it dead before every drop to ensure inaccessible files in this remote are not counted by the numcopies setting.