### PR TITLE
Support nested duplicate git trees

### DIFF
--- a/packages/openneuro-app/src/scripts/dataset/files/__tests__/file-tree-unloaded-directory.spec.jsx
+++ b/packages/openneuro-app/src/scripts/dataset/files/__tests__/file-tree-unloaded-directory.spec.jsx
@@ -38,7 +38,7 @@ describe("FileTreeUnloadedDirectory component", () => {
       expect(
         mergeNewFiles(dir)(defaultObj, { fetchMoreResult: updatedObj }).dataset
           .draft.files,
-      ).toEqual([a, b, { ...c, filename: "sub-01:c" }])
+      ).toEqual([a, b, { ...c, id: "sub-01:91011", filename: "sub-01:c" }])
     })
     it("works with snapshots", () => {
       const dir = { filename: "sub-01", directory: true }
@@ -50,7 +50,11 @@ describe("FileTreeUnloadedDirectory component", () => {
       expect(
         mergeNewFiles(dir, "1.0.0")(defaultObj, { fetchMoreResult: updatedObj })
           .snapshot.files,
-      ).toEqual([dir, a, b, { ...c, filename: "sub-01:c" }])
+      ).toEqual([dir, a, b, {
+        ...c,
+        id: "sub-01:91011",
+        filename: "sub-01:c",
+      }])
     })
   })
 })

--- a/packages/openneuro-app/src/scripts/dataset/files/file-tree-unloaded-directory.jsx
+++ b/packages/openneuro-app/src/scripts/dataset/files/file-tree-unloaded-directory.jsx
@@ -43,6 +43,8 @@ export const SNAPSHOT_FILES_QUERY = gql`
  */
 export const nestFiles = (path) => (file) => ({
   ...file,
+  // Generate a unique id for any nested files to avoid overwriting trees with two parents
+  id: `${path}:${file.id}`,
   filename: `${path}:${file.filename}`,
 })
 

--- a/packages/openneuro-app/src/scripts/dataset/files/file-tree-unloaded-directory.jsx
+++ b/packages/openneuro-app/src/scripts/dataset/files/file-tree-unloaded-directory.jsx
@@ -74,7 +74,7 @@ export const fetchMoreDirectory = (
 ) =>
   fetchMore({
     query: snapshotTag ? SNAPSHOT_FILES_QUERY : DRAFT_FILES_QUERY,
-    variables: { datasetId, snapshotTag, tree: directory.id },
+    variables: { datasetId, snapshotTag, tree: directory.key },
     updateQuery: mergeNewFiles(directory, snapshotTag),
   })
 

--- a/services/datalad/datalad_service/common/annex.py
+++ b/services/datalad/datalad_service/common/annex.py
@@ -83,7 +83,9 @@ def read_ls_tree_line(gitTreeLine, files, symlinkFilenames, symlinkObjects):
             # Tree objects do not have sizes and are never annexed
             files.append(
                 {
-                    'id': obj_hash,
+                    # Computing an id here is important but the client needs to manage the cache merge since only the client knows the parent directory
+                    'id': compute_file_hash(obj_hash, filename),
+                    'key': obj_hash,
                     'filename': filename,
                     'directory': True,
                     'annexed': False,

--- a/services/datalad/tests/test_files.py
+++ b/services/datalad/tests/test_files.py
@@ -210,7 +210,8 @@ def test_file_indexing(client, new_dataset):
             'directory': False,
         },
         {
-            'id': '2f8451ae1016f936999aaacc0b3d79fb284ac3ea',
+            'id': 'c645e39adc3bd84b8d9a30635efb2c0df3b3e0cc',
+            'key': '2f8451ae1016f936999aaacc0b3d79fb284ac3ea',
             'filename': 'sub-01',
             'directory': True,
             'annexed': False,
@@ -224,7 +225,7 @@ def test_file_indexing(client, new_dataset):
         '/datasets/{}/tree/{}'.format(
             ds_id,
             next(
-                (f['id'] for f in root_content['files'] if f['filename'] == 'sub-01'),
+                (f['key'] for f in root_content['files'] if f['filename'] == 'sub-01'),
                 None,
             ),
         )
@@ -236,7 +237,8 @@ def test_file_indexing(client, new_dataset):
         '/datasets/{}/tree/{}'.format(
             ds_id,
             next(
-                (f['id'] for f in sub_content['files'] if f['filename'] == 'anat'), None
+                (f['key'] for f in sub_content['files'] if f['filename'] == 'anat'),
+                None,
             ),
         )
     )
@@ -318,7 +320,7 @@ def test_duplicate_file_id(client, new_dataset):
     assert response.status == falcon.HTTP_OK
     response_content = json.loads(response.content)
     derivatives_tree = next(
-        (f['id'] for f in response_content['files'] if f['filename'] == 'derivatives'),
+        (f['key'] for f in response_content['files'] if f['filename'] == 'derivatives'),
         None,
     )
     response = client.simulate_get(f'/datasets/{ds_id}/tree/{derivatives_tree}')


### PR DESCRIPTION
Several bugs with loading file trees and updating files could occur when a git tree existed in two or more locations. This allows loading both copies of the tree independently and prevents attributing changes to the wrong location on the React app side.

Requires dropping the Redis file tree cache for deployment.