### PR TITLE
feat(worker): Add backup remote for exported data

### DIFF
--- a/config.env.example
+++ b/config.env.example
@@ -39,6 +39,11 @@ AWS_ACCOUNT_ID=
 AWS_BATCH_QUEUE=
 AWS_BATCH_COMPUTE_ENVIRONMENT=
 
+# GCP API keys for S3-compatible access
+GCP_ACCESS_KEY_ID=
+GCP_SECRET_ACCESS_KEY=
+GCP_S3_BACKUP_BUCKET=
+
 # Dataset unpublished/published buckets - used by DataLad service
 AWS_S3_PRIVATE_BUCKET=
 AWS_S3_PUBLIC_BUCKET=

--- a/helm/openneuro/templates/secret.yaml
+++ b/helm/openneuro/templates/secret.yaml
@@ -27,6 +27,9 @@ stringData:
   AWS_REGION: {{ required "AWS_REGION is required" .Values.secrets.aws.AWS_REGION | quote }}
   AWS_ACCOUNT_ID: {{ required "AWS_ACCOUNT_ID is required" .Values.secrets.aws.AWS_ACCOUNT_ID | quote }}
   AWS_ACCESS_KEY_ID: {{ required "AWS_ACCESS_KEY_ID is required" .Values.secrets.aws.AWS_ACCESS_KEY_ID | quote }}
+  GCP_ACCESS_KEY_ID: {{ required "GCP_ACCESS_KEY_ID is required" .Values.secrets.aws.GCP_ACCESS_KEY_ID | quote }}
+  GCP_SECRET_ACCESS_KEY: {{ required "GCP_SECRET_ACCESS_KEY is required" .Values.secrets.aws.GCP_SECRET_ACCESS_KEY | quote }}
+  GCP_S3_BACKUP_BUCKET: {{ required "GCP_S3_BACKUP_BUCKET is required" .Values.secrets.aws.GCP_S3_BACKUP_BUCKET | quote }}
   AWS_SECRET_ACCESS_KEY: {{ required "AWS_SECRET_ACCESS_KEY is required" .Values.secrets.aws.AWS_SECRET_ACCESS_KEY | quote }}
   AWS_S3_PRIVATE_BUCKET: {{ required "AWS_REGION is required" .Values.secrets.aws.AWS_S3_PRIVATE_BUCKET | quote }}
   AWS_S3_PUBLIC_BUCKET: {{ required "AWS_REGION is required" .Values.secrets.aws.AWS_S3_PUBLIC_BUCKET | quote }}

--- a/services/datalad/datalad_service/config.py
+++ b/services/datalad/datalad_service/config.py
@@ -19,6 +19,12 @@ AWS_ACCOUNT_ID = os.getenv('AWS_ACCOUNT_ID')
 AWS_S3_PRIVATE_BUCKET = os.getenv('AWS_S3_PRIVATE_BUCKET')
 AWS_S3_PUBLIC_BUCKET = os.getenv('AWS_S3_PUBLIC_BUCKET')
 
+# GCP S3 compatible object storage
+GCP_ACCESS_KEY_ID = os.getenv('GCP_ACCESS_KEY_ID')
+GCP_SECRET_ACCESS_KEY = os.getenv('GCP_SECRET_ACCESS_KEY')
+GCP_S3_BACKUP_BUCKET = os.getenv('GCP_S3_BACKUP_BUCKET')
+
+
 # GraphQL URL - override if not docker-compose
 GRAPHQL_ENDPOINT = os.getenv('GRAPHQL_ENDPOINT', 'http://server:8111/crn/graphql')
 

--- a/services/datalad/tests/conftest.py
+++ b/services/datalad/tests/conftest.py
@@ -136,6 +136,21 @@ def no_init_remote(monkeypatch, tmpdir_factory):
             check=True,
             cwd=dataset_path,
         )
+        path = tmpdir_factory.mktemp('fake_s3_backup_remote')
+        subprocess.run(
+            [
+                'git',
+                'annex',
+                'initremote',
+                's3-BACKUP',
+                'type=directory',
+                f'directory={path}',
+                'encryption=none',
+                'exporttree=no',
+            ],
+            check=True,
+            cwd=dataset_path,
+        )
 
     def mock_github_remote_setup(dataset_path, dataset_id):
         path = tmpdir_factory.mktemp('fake_github_remote')
@@ -182,6 +197,14 @@ def no_publish(monkeypatch):
 def s3_creds(monkeypatch):
     monkeypatch.setenv('AWS_S3_PUBLIC_BUCKET', 'a-fake-test-public-bucket')
     monkeypatch.setenv('AWS_S3_PRIVATE_BUCKET', 'a-fake-test-private-bucket')
+
+
+@pytest.fixture(autouse=True)
+def access_keys(monkeypatch):
+    monkeypatch.setenv('AWS_ACCESS_KEY_ID', 'aws-id')
+    monkeypatch.setenv('AWS_SECRET_ACCESS_KEY', 'aws-secret')
+    monkeypatch.setenv('GCP_ACCESS_KEY_ID', 'gcp-id')
+    monkeypatch.setenv('GCP_SECRET_ACCESS_KEY', 'gcp-secret')
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
Adds a new git-annex remote called s3-BACKUP to provide a second copy of all annexed objects for redundancy with s3-PUBLIC.