### PR TITLE
Backup remote export fixes

### DIFF
--- a/services/datalad/datalad_service/common/onchange.py
+++ b/services/datalad/datalad_service/common/onchange.py
@@ -8,4 +8,4 @@ async def on_head(dataset_path):
 
 async def on_tag(dataset_path, tag):
     """Called after any new tag."""
-    await git_annex_fsck_remote.kiq(dataset_path, tag)
+    pass

--- a/services/datalad/datalad_service/common/s3.py
+++ b/services/datalad/datalad_service/common/s3.py
@@ -70,6 +70,10 @@ def setup_s3_sibling(dataset_path):
         + generate_s3_annex_options(dataset_path),
         cwd=dataset_path,
     )
+
+
+def setup_s3_backup_sibling(dataset_path):
+    """Add a sibling for an S3 backup bucket."""
     # Backup remote
     subprocess.run(
         ['git-annex', 'initremote', get_s3_backup_remote()]

--- a/services/datalad/datalad_service/tasks/publish.py
+++ b/services/datalad/datalad_service/tasks/publish.py
@@ -27,6 +27,7 @@ from datalad_service.common.s3 import (
     s3_export,
     s3_backup_push,
     get_s3_remote,
+    get_s3_backup_remote,
     get_s3_bucket,
     get_s3_backup_bucket,
     update_s3_sibling,
@@ -55,6 +56,8 @@ def s3_sibling(dataset_path):
     """
     if not is_git_annex_remote(dataset_path, get_s3_remote()):
         datalad_service.common.s3.setup_s3_sibling(dataset_path)
+    if not is_git_annex_remote(dataset_path, get_s3_backup_remote()):
+        datalad_service.common.s3.setup_s3_backup_sibling(dataset_path)
 
 
 @broker.task

--- a/services/datalad/datalad_service/tasks/publish.py
+++ b/services/datalad/datalad_service/tasks/publish.py
@@ -58,14 +58,14 @@ def s3_sibling(dataset_path):
 
 
 @broker.task
-def create_remotes_and_export(dataset_path):
+async def create_remotes_and_export(dataset_path):
     """
     Create public S3 and GitHub remotes and export to them.
 
     Called by publish handler to make a dataset public initially.
     """
     create_remotes(dataset_path)
-    export_dataset(dataset_path)
+    await export_dataset(dataset_path)
 
 
 def create_remotes(dataset_path):


### PR DESCRIPTION
Includes a few smaller fixes for the new second s3 remote.

* Don't fsck exports twice and avoid fsck on the backup remote.
* Call export_dataset as a coroutine as intended.
* Configure either remote (s3-PUBLIC or s3-BACKUP) if one or both are missing.