### PR TITLE
Workaround failure with initremote when an GCP Object Bucket is populated with another fileprefix

### DIFF
--- a/services/datalad/datalad_service/common/s3.py
+++ b/services/datalad/datalad_service/common/s3.py
@@ -140,7 +140,6 @@ def s3_export(dataset_path, target, treeish):
 
 def s3_backup_push(dataset_path):
     """Perform an S3 push to the backup remote on a git-annex repo."""
-    print(backup_remote_env())
     subprocess.check_call(
         ['git-annex', 'push', get_s3_backup_remote()],
         cwd=dataset_path,

--- a/services/datalad/datalad_service/common/s3.py
+++ b/services/datalad/datalad_service/common/s3.py
@@ -58,18 +58,13 @@ def generate_s3_annex_options(dataset_path, backup=False):
 def backup_remote_env():
     """Copy and modify the environment for setup/modification of backup remote settings."""
     backup_remote_env = os.environ.copy()
-    # Overwrite the AWS keys with the GCP key
-    backup_remote_env['AWS_ACCESS_KEY_ID'] = backup_remote_env['GCP_ACCESS_KEY_ID']
-    backup_remote_env['AWS_SECRET_ACCESS_KEY'] = backup_remote_env[
-        'GCP_SECRET_ACCESS_KEY'
-    ]
-    # Overwrite the AWS keys with the GCP keys from config
-    backup_remote_env['AWS_ACCESS_KEY_ID'] = getattr(
-        datalad_service.config, 'GCP_ACCESS_KEY_ID'
-    )
-    backup_remote_env['AWS_SECRET_ACCESS_KEY'] = getattr(
-        datalad_service.config, 'GCP_SECRET_ACCESS_KEY'
-    )
+    gcp_access_key_id = getattr(datalad_service.config, 'GCP_ACCESS_KEY_ID')
+    gcp_secret_access_key = getattr(datalad_service.config, 'GCP_SECRET_ACCESS_KEY')
+    if gcp_access_key_id:
+        backup_remote_env['AWS_ACCESS_KEY_ID'] = gcp_access_key_id
+    if gcp_secret_access_key:
+        backup_remote_env['AWS_SECRET_ACCESS_KEY'] = gcp_secret_access_key
+
     return backup_remote_env
 
 

--- a/services/datalad/datalad_service/tasks/publish.py
+++ b/services/datalad/datalad_service/tasks/publish.py
@@ -57,7 +57,7 @@ def s3_sibling(dataset_path):
     if not is_git_annex_remote(dataset_path, get_s3_remote()):
         datalad_service.common.s3.setup_s3_sibling(dataset_path)
     if not is_git_annex_remote(dataset_path, get_s3_backup_remote()):
-        datalad_service.common.s3.setup_s3_backup_sibling(dataset_path)
+        datalad_service.common.s3.setup_s3_backup_sibling_workaround(dataset_path)
 
 
 @broker.task

--- a/services/datalad/tests/conftest.py
+++ b/services/datalad/tests/conftest.py
@@ -107,6 +107,12 @@ def new_dataset(datalad_store):
 class MockResponse:
     status_code = 200
 
+    def raise_for_status(self):
+        pass
+
+    def json(self):
+        return {}
+
 
 @pytest.fixture(autouse=True)
 def no_posts(monkeypatch):


### PR DESCRIPTION
When a fileprefix is used for an S3 special remote on GCP object storage, initremote will not succeed after the first prefix in the bucket is populated. Creating the remote manually and relying on enableremote allows this remote to function as an S3 special remote after initial creation.