### PR TITLE
fix(server): Filter routine events from notifications

### DIFF
--- a/packages/openneuro-server/src/graphql/resolvers/user.ts
+++ b/packages/openneuro-server/src/graphql/resolvers/user.ts
@@ -314,6 +314,15 @@ export async function notifications(obj, _, { userInfo }) {
       case "contributorRequestResponse":
       case "contributorCitationResponse":
         return isDatasetAdmin || isTargetUser
+      // Reduce the notification noise by hiding non-actionable events
+      case "created":
+      case "versioned":
+      case "deleted":
+      case "published":
+      case "permissionChange":
+      case "git":
+      case "upload":
+        return false
       default:
         return isDatasetAdmin
     }


### PR DESCRIPTION
This limits notifications to the more actionable events to reduce the amount a user might have to respond to.