### PR TITLE
Refactor/contributor citation events

### DIFF
--- a/packages/openneuro-app/src/scripts/authentication/profile.ts
+++ b/packages/openneuro-app/src/scripts/authentication/profile.ts
@@ -3,6 +3,7 @@ import jwtDecode from "jwt-decode"
 export interface OpenNeuroTokenProfile {
   sub: string
   admin: boolean
+  email?: string
   iat: number
   exp: number
   scopes?: string[]

--- a/packages/openneuro-app/src/scripts/contributors/__tests__/contributor-list.spec.tsx
+++ b/packages/openneuro-app/src/scripts/contributors/__tests__/contributor-list.spec.tsx
@@ -4,6 +4,8 @@ import { MockedProvider } from "@apollo/client/testing"
 import { ContributorsListDisplay } from "../contributors-list"
 import { GET_USERS } from "../../queries/users"
 import type { Contributor } from "../../types/datacite"
+import * as profileModule from "../../authentication/profile"
+import { vi } from "vitest"
 
 describe("ContributorsListDisplay", () => {
   const baseContributors: Contributor[] = [
@@ -34,13 +36,15 @@ describe("ContributorsListDisplay", () => {
       result: {
         data: {
           users: {
-            users: [{
-              id: "1",
-              name: "Jane Doe",
-              avatar: "",
-              orcid: "",
-              __typename: "User",
-            }],
+            users: [
+              {
+                id: "1",
+                name: "Jane Doe",
+                avatar: "",
+                orcid: "",
+                __typename: "User",
+              },
+            ],
             totalCount: 1,
             __typename: "UsersResponse",
           },
@@ -55,13 +59,15 @@ describe("ContributorsListDisplay", () => {
       result: {
         data: {
           users: {
-            users: [{
-              id: "2",
-              name: "John Smith",
-              avatar: "",
-              orcid: "",
-              __typename: "User",
-            }],
+            users: [
+              {
+                id: "2",
+                name: "John Smith",
+                avatar: "",
+                orcid: "",
+                __typename: "User",
+              },
+            ],
             totalCount: 1,
             __typename: "UsersResponse",
           },
@@ -81,6 +87,13 @@ describe("ContributorsListDisplay", () => {
     },
   ]
 
+  // Mock getProfile so hasEdit === true
+  beforeEach(() => {
+    vi.spyOn(profileModule, "getProfile").mockReturnValue({
+      email: "test@example.com",
+    })
+  })
+
   const renderComponent = (props = {}) =>
     render(
       <MockedProvider mocks={mocks} addTypename={false}>
@@ -95,14 +108,12 @@ describe("ContributorsListDisplay", () => {
 
   it("renders contributors list", async () => {
     renderComponent()
-    // Match Jane Doe
     expect(
       await screen.findByText((content) =>
         ["Jane", "Doe"].every((part) => content.includes(part))
       ),
     ).toBeInTheDocument()
 
-    // Match John Smith
     expect(
       screen.getByText((content) =>
         ["John", "Smith"].every((part) => content.includes(part))
@@ -136,9 +147,10 @@ describe("ContributorsListDisplay", () => {
     const addButton = await screen.findByText("Add Contributor")
     fireEvent.click(addButton)
 
-    expect(
-      await screen.findAllByPlaceholderText("Type name or ORCID (or add new)"),
-    ).toHaveLength(3)
+    const nameInputs = await screen.findAllByPlaceholderText(
+      "Type name or ORCID (or add new)",
+    )
+    expect(nameInputs).toHaveLength(3)
   })
 
   it("shows an error when trying to submit with empty name", async () => {

--- a/packages/openneuro-app/src/scripts/contributors/__tests__/contributor-list.spec.tsx
+++ b/packages/openneuro-app/src/scripts/contributors/__tests__/contributor-list.spec.tsx
@@ -90,7 +90,11 @@ describe("ContributorsListDisplay", () => {
   // Mock getProfile so hasEdit === true
   beforeEach(() => {
     vi.spyOn(profileModule, "getProfile").mockReturnValue({
+      sub: "123",
       email: "test@example.com",
+      admin: false,
+      iat: Math.floor(Date.now() / 1000),
+      exp: Math.floor(Date.now() / 1000) + 3600,
     })
   })
 

--- a/packages/openneuro-app/src/scripts/dataset/components/dataset-event-item.tsx
+++ b/packages/openneuro-app/src/scripts/dataset/components/dataset-event-item.tsx
@@ -149,7 +149,6 @@ export const DatasetEventItem: React.FC<DatasetEventItemProps> = ({
           </>
         )
       } else if (event.event.type === "contributorCitation") {
-        console.log(event)
         return (
           <>
             Contributor added to authors

--- a/packages/openneuro-app/src/scripts/dataset/components/dataset-event-item.tsx
+++ b/packages/openneuro-app/src/scripts/dataset/components/dataset-event-item.tsx
@@ -149,9 +149,10 @@ export const DatasetEventItem: React.FC<DatasetEventItemProps> = ({
           </>
         )
       } else if (event.event.type === "contributorCitation") {
+        console.log(event)
         return (
           <>
-            {event.event.resolutionStatus} contributorship
+            Contributor added to authors
           </>
         )
       } else {

--- a/packages/openneuro-app/src/scripts/types/event-types.ts
+++ b/packages/openneuro-app/src/scripts/types/event-types.ts
@@ -98,7 +98,7 @@ export const mapRawEventToMappedNotification = (
       needsReview = approval === "pending"
       break
     case "contributorCitation":
-      title = "is requesting"
+      title = "added"
       adminUser = user
       // fallback to rawNotification.user if target is missing (but not the admin)
       targetUser = target ||

--- a/packages/openneuro-app/src/scripts/users/notifications/user-notification-accordion-header.tsx
+++ b/packages/openneuro-app/src/scripts/users/notifications/user-notification-accordion-header.tsx
@@ -42,7 +42,7 @@ export const NotificationHeader: React.FC<NotificationHeaderProps> = ({
               <>
                 <Username user={adminUser} /> {title}{" "}
                 <Username user={targetUser} />
-                {" be added to "}
+                {" as a contributor to "}
               </>
             )
             : (
@@ -63,7 +63,7 @@ export const NotificationHeader: React.FC<NotificationHeaderProps> = ({
           <a href={datasetLink} className={styles.titlelink}>
             {datasetId}
           </a>{" "}
-          {resStatus}
+          {type != "contributorCitation" ? resStatus : ""}
         </span>
       )
     }

--- a/packages/openneuro-app/src/scripts/users/notifications/user-notifications-accordion-body.tsx
+++ b/packages/openneuro-app/src/scripts/users/notifications/user-notifications-accordion-body.tsx
@@ -58,6 +58,15 @@ export const NotificationBodyContent: React.FC<NotificationBodyContentProps> = (
     )
   }
 
+  if (approval === "accepted" && isContributorCitation) {
+    return (
+      <div>
+        The following user has been added as a contributor to {datasetId}.
+        {renderContribInfo()}
+      </div>
+    )
+  }
+
   if (approval === "accepted" && isContributorRequest) {
     return (
       <div>

--- a/packages/openneuro-server/src/graphql/resolvers/__tests__/user.spec.ts
+++ b/packages/openneuro-server/src/graphql/resolvers/__tests__/user.spec.ts
@@ -133,9 +133,24 @@ describe("user resolvers", () => {
   })
 
   describe("users()", () => {
-    it("rejects data for non-admin context", async () => {
-      await expect(users(null, {}, nonAdminContext)).rejects.toThrow(
-        "You must be a site admin to retrieve users",
+    it("returns sanitized data for non-admin context", async () => {
+      const result = await users(null, {}, nonAdminContext)
+
+      // Should return all non-migrated users (same as admin)
+      expect(result.users.length).toBe(6)
+      expect(result.totalCount).toBe(6)
+
+      // Sensitive fields should be hidden
+      result.users.forEach((u) => {
+        expect(u.email).toBeNull()
+        expect(u.blocked).toBeNull()
+        expect(u.admin).toBeNull()
+      })
+
+      // Non-sensitive fields should still be populated
+      const userIds = result.users.map((u) => u.id)
+      expect(userIds).toEqual(
+        expect.arrayContaining(["u1", "u2", "u3", "u4", "u6", "u7"]),
       )
     })
 


### PR DESCRIPTION
refactors contributor events to be approved during the create event and only send a notification that a user has been added, instead of requiring approval. 

users resolver not allows for searching of users by non admin, only admin can see email, admin, and blocked fields

adds a hasEdit check for dataset editing of the contributor list/form