### PR TITLE
fix(worker): Run full remote fsck instead of fast and check objects at most every 30 days

### DIFF
--- a/services/datalad/datalad_service/tasks/fsck.py
+++ b/services/datalad/datalad_service/tasks/fsck.py
@@ -86,10 +86,9 @@ def git_annex_fsck_remote(dataset_path, branch=None, remote='s3-PUBLIC'):
         'fsck',
         f'--branch={branch}',
         '--from={remote}',
-        '--fast',
         '--json',
         '--json-error-messages',
-        '--incremental-schedule=7d',
+        '--incremental-schedule=30d',
     )
     annex_process = subprocess.Popen(
         annex_command, cwd=dataset_path, stdout=subprocess.PIPE


### PR DESCRIPTION
Run remote git-annex fsck with checksums instead of fast and only recheck objects after 30 days.