### PR TITLE
docs: Update API docs for 4.39.0

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -128,8 +128,8 @@ This will return a listing of files at the top level of the dataset.
           "annexed": false
         },
         {
-          "id": "10834f1acb4897eaed5b29fc642718451100721b",
-          "key": null,
+          "id": "1882d325538b14729e3c715d8ccf1aede77a6143",
+          "key": "db72baeb3665a309db35d6ef649e117eb45a8a87",
           "filename": "sub-01",
           "size": 0,
           "directory": true,
@@ -141,12 +141,12 @@ This will return a listing of files at the top level of the dataset.
 }
 ```
 
-In this example, you can see that sub-01 has the `"directory": true`. This means the directory `id` field can be used to retrieve additional trees.
+In this example, you can see that sub-01 has the `"directory": true`. This means the directory `key` field can be used to retrieve additional trees.
 
 ```graphql
 query snapshotFiles {
   snapshot(datasetId: "ds000001", tag: "1.0.0") {
-    files(tree: "10834f1acb4897eaed5b29fc642718451100721b") {
+    files(tree: "db72baeb3665a309db35d6ef649e117eb45a8a87") {
       id
       key
       filename
@@ -166,16 +166,16 @@ This will return any files below sub-01 in the tree for this version.
     "snapshot": {
       "files": [
         {
-          "id": "c63eeb1e0f41fea629f34269025f9d8225a2f3ff",
-          "key": null,
+          "id": "1156b949676f8afcbded143b695ebaa1d18027f1",
+          "key": "26d2ff4f763308d462f151c53e3e06f6b7d2aaaa",
           "filename": "anat",
           "size": 0,
           "directory": true,
           "annexed": false
         },
         {
-          "id": "309cd8eae8896096c8734b024ac52be4743c9f44",
-          "key": null,
+          "id": "5e262c7c950f44a21f44a096f07e6727c8c747af",
+          "key": "4113b1609e2b0ea2e0a04e0800204d2ee6aab578",
           "filename": "func",
           "size": 0,
           "directory": true,


### PR DESCRIPTION
Update the API docs for the tree key change in 4.39.0 introduced in https://github.com/OpenNeuroOrg/openneuro/pull/3601.