### PR TITLE
fix(cli): Set exit code and shutdown signal for pending async tasks when actions are complete

### DIFF
--- a/cli/mod.ts
+++ b/cli/mod.ts
@@ -20,6 +20,7 @@ export async function main() {
   } else {
     await commandLine(Deno.args)
   }
+  Deno.exit(0)
 }
 
 await main()

--- a/cli/src/commands/download.ts
+++ b/cli/src/commands/download.ts
@@ -57,11 +57,14 @@ export async function downloadAction(
   // Close after all tasks are queued
   worker.postMessage({ command: "done" })
 
-  worker.addEventListener("message", (event) => {
-    if (event.data.command === "closed") {
-      console.log(
-        "Download complete. To download all data files, use `datalad get` or `git-annex get`.",
-      )
+  await new Promise<void>((resolve) => {
+    worker.onmessage = (event) => {
+      if (event.data.command === "closed") {
+        console.log(
+          "Download complete. To download all data files, use `datalad get` or `git-annex get`.",
+        )
+        resolve()
+      }
     }
   })
 }

--- a/cli/src/commands/upload.ts
+++ b/cli/src/commands/upload.ts
@@ -153,6 +153,14 @@ export async function uploadAction(
 
   // Close after all tasks are queued
   worker.postMessage({ command: "done" })
+
+  await new Promise<void>((resolve) => {
+    worker.onmessage = (event) => {
+      if (event.data.command === "closed") {
+        resolve()
+      }
+    }
+  })
 }
 
 /**


### PR DESCRIPTION
Somewhere in a dependency the event loop is blocked preventing commands from finishing. If we reach end of execution during commands, Deno.exit should be safe to exit and set exit code 0. This also requires the upload/download actions to block until completed.