### PR TITLE
update sentry to only log if dataset has datacite

### DIFF
--- a/packages/openneuro-server/src/datalad/contributors.ts
+++ b/packages/openneuro-server/src/datalad/contributors.ts
@@ -68,7 +68,11 @@ export const contributors = async (
 
     // --- Dataset type but no contributors ---
     // Only log if a Datacite file actually exists
-    if (dataciteData && resourceType === "Dataset") {
+    if (
+      dataciteData?.data?.attributes &&
+      resourceType === "Dataset" &&
+      !attributes?.contributors?.length
+    ) {
       Sentry.captureMessage(
         `Datacite file for ${datasetId}:${revisionShort} is Dataset type but provided no contributors.`,
       )

--- a/packages/openneuro-server/src/datalad/contributors.ts
+++ b/packages/openneuro-server/src/datalad/contributors.ts
@@ -67,7 +67,8 @@ export const contributors = async (
     }
 
     // --- Dataset type but no contributors ---
-    if (resourceType === "Dataset") {
+    // Only log if a Datacite file actually exists
+    if (dataciteData && resourceType === "Dataset") {
       Sentry.captureMessage(
         `Datacite file for ${datasetId}:${revisionShort} is Dataset type but provided no contributors.`,
       )


### PR DESCRIPTION
update sentry log so sentry is not spammed with info level notices even when datacite.yml is not present 