### PR TITLE
fix(cli): Checkout latest snapshot by default and allow version for download action

### DIFF
--- a/cli/src/graphq.ts
+++ b/cli/src/graphq.ts
@@ -92,3 +92,26 @@ export async function prepareUpload(
 
 export async function finishUpload() {
 }
+
+export async function getLatestSnapshotVersion(datasetId: string) {
+  const query = `
+  query($datasetId: ID!) {
+    dataset(id: $datasetId) {
+      latestSnapshot {
+        id
+        tag
+      }
+    }
+  }
+  `
+  const res = await request(query, { datasetId })
+  const body = await res.json()
+  if (body.errors) {
+    throw new ResponseError(JSON.stringify(body.errors))
+  }
+  if (body.data) {
+    return body.data.dataset.latestSnapshot.tag
+  } else {
+    throw new QueryError("Invalid response")
+  }
+}

--- a/cli/src/worker/types/git-context.ts
+++ b/cli/src/worker/types/git-context.ts
@@ -104,7 +104,26 @@ export interface GitWorkerEventAdd {
   }
 }
 
+/** Clone event to clone or fetch a version */
+export interface GitWorkerEventClone {
+  data: {
+    command: "clone"
+    // Version to clone
+    version?: string
+  }
+}
+
+export interface GitWorkerEventRemoteSetup {
+  data: {
+    command: "remoteSetup"
+    // Version to checkout after setup
+    version?: string
+  }
+}
+
 export type GitWorkerEvent =
   | GitWorkerEventSetup
   | GitWorkerEventGeneric
   | GitWorkerEventAdd
+  | GitWorkerEventClone
+  | GitWorkerEventRemoteSetup


### PR DESCRIPTION
The download option would always fetch the draft regardless of options provided. This changes the default to fetch the most recent snapshot (still the draft if none exist) and handles the version option as intended.

Fixes #3625.