### PR TITLE
fix(cli): When downloading a dataset with no snapshots, checkout draft branch instead of detached commit

### DIFF
--- a/cli/src/commands/download.ts
+++ b/cli/src/commands/download.ts
@@ -53,6 +53,12 @@ export async function downloadAction(
     version = options.version
   } else if (!options.draft) {
     version = await getLatestSnapshotVersion(datasetId)
+    if (
+      version.length === 40 /* sha1 */ || version.length === 64 /* sha256 */
+    ) {
+      // Commit hash -> get the draft instead
+      version = undefined
+    }
   }
 
   // Clone the repo


### PR DESCRIPTION
This will checkout the main (or master) branch if no snapshots exist, instead of checking out a detached commit at HEAD.