### PR TITLE
fix(worker): Update DropResource to run fsck and drop for each snapshot

### DIFF
--- a/services/datalad/datalad_service/handlers/drop.py
+++ b/services/datalad/datalad_service/handlers/drop.py
@@ -1,6 +1,6 @@
 import falcon
 
-from datalad_service.tasks.publish import annex_drop
+from datalad_service.tasks.publish import export_backup_and_drop
 
 
 class DropResource:
@@ -11,6 +11,6 @@ class DropResource:
 
     async def on_post(self, req, resp, dataset):
         dataset_path = self.store.get_dataset_path(dataset)
-        await annex_drop.kiq(dataset_path)
+        await export_backup_and_drop.kiq(dataset_path)
         resp.media = {}
         resp.status = falcon.HTTP_OK


### PR DESCRIPTION
This adjusts the drop API to run for each snapshot separately and then drop only once a full fsck is complete (the same process used for new exports).