### PR TITLE
Export all datasets and manage object tags for access control

### DIFF
--- a/services/datalad/datalad_service/common/s3.py
+++ b/services/datalad/datalad_service/common/s3.py
@@ -72,6 +72,7 @@ def backup_remote_env():
 def setup_s3_sibling(dataset_path):
     """Add a sibling for an S3 bucket publish."""
     # Public remote
+    # TODO set ['x-amz-tagging=access=private'] if tagging is supported in git-annex
     subprocess.run(
         ['git-annex', 'initremote', get_s3_remote()]
         + generate_s3_annex_options(dataset_path),

--- a/services/datalad/datalad_service/handlers/dataset.py
+++ b/services/datalad/datalad_service/handlers/dataset.py
@@ -41,7 +41,7 @@ class DatasetResource:
                 author = pygit2.Signature(name, email)
             else:
                 author = None
-            hexsha = await create_dataset(self.store, dataset, author)
+            hexsha = await create_dataset(ds_path, author)
             resp.media = {'hexsha': hexsha}
             resp.status = falcon.HTTP_OK
 

--- a/services/datalad/datalad_service/handlers/publish.py
+++ b/services/datalad/datalad_service/handlers/publish.py
@@ -5,7 +5,7 @@ from taskiq_pipelines import Pipeline
 from datalad_service.broker import broker
 from datalad_service.tasks.publish import (
     create_remotes_and_export,
-    set_access_access_tag,
+    set_s3_access_tag,
 )
 
 
@@ -20,7 +20,7 @@ class PublishResource:
         # Pipeline create and export -> set access tag to public
         await (
             Pipeline(broker, create_remotes_and_export)
-            .call_after(set_access_access_tag, dataset=dataset, value='public')
+            .call_after(set_s3_access_tag, dataset=dataset, value='public')
             .kiq(dataset_path)  # create_remotes_and_export
         )
         resp.media = {}

--- a/services/datalad/datalad_service/handlers/publish.py
+++ b/services/datalad/datalad_service/handlers/publish.py
@@ -1,6 +1,12 @@
 import falcon
 
-from datalad_service.tasks.publish import create_remotes_and_export
+from taskiq_pipelines import Pipeline
+
+from datalad_service.broker import broker
+from datalad_service.tasks.publish import (
+    create_remotes_and_export,
+    set_access_access_tag,
+)
 
 
 class PublishResource:
@@ -11,6 +17,11 @@ class PublishResource:
 
     async def on_post(self, req, resp, dataset):
         dataset_path = self.store.get_dataset_path(dataset)
-        await create_remotes_and_export.kiq(dataset_path)
+        # Pipeline create and export -> set access tag to public
+        await (
+            Pipeline(broker, create_remotes_and_export)
+            .call_after(set_access_access_tag, dataset=dataset, value='public')
+            .kiq(dataset_path)  # create_remotes_and_export
+        )
         resp.media = {}
         resp.status = falcon.HTTP_OK

--- a/services/datalad/datalad_service/tasks/dataset.py
+++ b/services/datalad/datalad_service/tasks/dataset.py
@@ -13,6 +13,7 @@ import pygit2
 
 from datalad_service.common.annex import init_annex
 from datalad_service.common.git import git_commit, COMMITTER_EMAIL, COMMITTER_NAME
+from datalad_service.tasks.publish import create_remotes
 
 # A list of patterns to avoid annexing in BIDS datasets
 GIT_ATTRIBUTES = """* annex.backend=SHA256E
@@ -44,12 +45,11 @@ def create_datalad_config(dataset_path):
         configfile.write(config)
 
 
-async def create_dataset(store, dataset, author=None, initial_head='main'):
+async def create_dataset(dataset_path, author=None, initial_head='main'):
     """Create a DataLad git-annex repo for a new dataset.
 
     initial_head is only meant for tests and is overridden by the implementation of git_commit
     """
-    dataset_path = store.get_dataset_path(dataset)
     if os.path.isdir(dataset_path):
         raise Exception('Dataset already exists')
     if not author:
@@ -70,6 +70,7 @@ async def create_dataset(store, dataset, author=None, initial_head='main'):
         '[OpenNeuro] Dataset created',
         parents=[],
     )
+    create_remotes(dataset_path)
     return str(repo.head.target)
 
 

--- a/services/datalad/tests/conftest.py
+++ b/services/datalad/tests/conftest.py
@@ -4,6 +4,7 @@ import os
 import json
 import subprocess
 import random
+from unittest import mock
 
 import pytest
 from falcon import testing
@@ -249,3 +250,11 @@ def mock_validate_dataset_task(monkeypatch):
     monkeypatch.setattr(
         'datalad_service.tasks.files.validate_dataset', async_noop_validator
     )
+
+
+@pytest.fixture(autouse=True)
+def is_public_dataset_mock(monkeypatch):
+    def _mock(dataset_id):
+        return True
+
+    monkeypatch.setattr('datalad_service.tasks.publish.is_public_dataset', _mock)

--- a/services/datalad/tests/test_common_s3.py
+++ b/services/datalad/tests/test_common_s3.py
@@ -37,6 +37,26 @@ def test_s3_annex_options(monkeypatch):
     # Check prefix and bucket strings are interpolated right
     assert 'fileprefix=test00001/' in options
     assert 'bucket=a-fake-test-public-bucket' in options
+    # Check that the private tag is applied by default
+    # assert 'x-amz-tagging=access=private' in options
+
+
+def test_s3_annex_backup_options(monkeypatch):
+    monkeypatch.setattr(
+        datalad_service.config, 'AWS_S3_PUBLIC_BUCKET', 'a-fake-test-public-bucket'
+    )
+    monkeypatch.setattr(datalad_service.config, 'GCP_S3_BACKUP_BUCKET', 'backup-bucket')
+    options = generate_s3_annex_options(
+        '/tmp/dataset/does/not/exist/test00001', backup=True
+    )
+    assert 'type=S3' in options
+    # Verify public=no (ACL deprecation)
+    assert 'public=no' in options
+    # Verify autoenable=true is not present
+    assert 'autoenable=true' not in options
+    # Check prefix and bucket strings are interpolated right
+    assert 'fileprefix=test00001/' in options
+    assert 'bucket=backup-bucket' in options
 
 
 def test_update_s3_sibling(monkeypatch, no_init_remote, new_dataset):

--- a/services/datalad/tests/test_datalad.py
+++ b/services/datalad/tests/test_datalad.py
@@ -16,7 +16,8 @@ from datalad_service.tasks.files import commit_files
 async def test_create_dataset(datalad_store):
     ds_id = 'ds000002'
     author = pygit2.Signature('test author', 'test@example.com')
-    await create_dataset(datalad_store, ds_id, author)
+    ds_path = os.path.join(datalad_store.annex_path, ds_id)
+    await create_dataset(ds_path, author)
     ds = Dataset(os.path.join(datalad_store.annex_path, ds_id))
     assert ds.repo is not None
     # Verify the dataset is created with datalad config
@@ -52,10 +53,11 @@ async def test_create_dataset_master(datalad_store):
 async def test_create_dataset_unusual_default_branch(datalad_store):
     ds_id = 'ds000026'
     author = pygit2.Signature('test author', 'test@example.com')
+    ds_path = os.path.join(datalad_store.annex_path, ds_id)
     # Create dataset will commit data and this should fail since HEAD is something 'unusual'
     # (such as the git-annex branch as a plausible example)
     with pytest.raises(OpenNeuroGitError) as e:
-        await create_dataset(datalad_store, ds_id, author, 'unusual')
+        await create_dataset(ds_path, author, 'unusual')
 
 
 async def test_delete_dataset(datalad_store, new_dataset):


### PR DESCRIPTION
This will setup remotes on dataset creation instead of publish. Instead of relying on the remote configuration state to determine if a dataset is published, an API call is made to check with the API service. Tags are applied by iterating over all versions of all objects in a given prefix. Ideally we would manage these tags with git-annex. All versions created will now export to both remotes. For private datasets, the client will fallback to requesting these objects from OpenNeuro directly. This separately requires support for streaming those in case they are not available locally (not in this PR).