### PR TITLE
fix(worker): Avoid Pipelines for taskiq drops

### DIFF
--- a/services/datalad/datalad_service/broker/__init__.py
+++ b/services/datalad/datalad_service/broker/__init__.py
@@ -2,7 +2,6 @@ import sys
 
 from taskiq import InMemoryBroker, SmartRetryMiddleware
 from taskiq_redis import RedisAsyncResultBackend, RedisStreamBroker
-from taskiq_pipelines import PipelineMiddleware
 
 
 from datalad_service import config
@@ -38,6 +37,5 @@ else:
                 use_delay_exponent=True,
                 max_delay_exponent=120,
             ),
-            PipelineMiddleware(),
         )
     )

--- a/services/datalad/datalad_service/common/onchange.py
+++ b/services/datalad/datalad_service/common/onchange.py
@@ -1,4 +1,4 @@
-from datalad_service.tasks.fsck import git_annex_fsck_local, git_annex_fsck_remote
+from datalad_service.tasks.fsck import git_annex_fsck_local
 
 
 async def on_head(dataset_path):

--- a/services/datalad/datalad_service/handlers/publish.py
+++ b/services/datalad/datalad_service/handlers/publish.py
@@ -1,11 +1,7 @@
 import falcon
 
-from taskiq_pipelines import Pipeline
-
-from datalad_service.broker import broker
 from datalad_service.tasks.publish import (
     create_remotes_and_export,
-    set_s3_access_tag,
 )
 
 
@@ -18,10 +14,6 @@ class PublishResource:
     async def on_post(self, req, resp, dataset):
         dataset_path = self.store.get_dataset_path(dataset)
         # Pipeline create and export -> set access tag to public
-        await (
-            Pipeline(broker, create_remotes_and_export)
-            .call_after(set_s3_access_tag, dataset=dataset, value='public')
-            .kiq(dataset_path)  # create_remotes_and_export
-        )
+        await create_remotes_and_export.kiq(dataset_path, public=True)
         resp.media = {}
         resp.status = falcon.HTTP_OK

--- a/services/datalad/datalad_service/tasks/fsck.py
+++ b/services/datalad/datalad_service/tasks/fsck.py
@@ -57,7 +57,7 @@ def git_annex_fsck_local(dataset_path):
 
 
 @broker.task
-def git_annex_fsck_remote(dataset_path, branch, remote='s3-PUBLIC'):
+async def git_annex_fsck_remote(dataset_path, branch, remote='s3-PUBLIC'):
     """
     Run incremental fsck for one branch (tag) and remote.
 

--- a/services/datalad/pyproject.toml
+++ b/services/datalad/pyproject.toml
@@ -20,7 +20,6 @@ dependencies = [
     "taskiq-redis>=1.0.9",
     "uvicorn[standard]>=0.34.3",
     "httpx>=0.28.1",
-    "taskiq-pipelines>=0.1.4",
 ]
 dynamic = ["version"]
 

--- a/services/datalad/uv.lock
+++ b/services/datalad/uv.lock
@@ -370,7 +370,6 @@ dependencies = [
     { name = "requests" },
     { name = "sentry-sdk", extra = ["falcon"] },
     { name = "taskiq", extra = ["reload"] },
-    { name = "taskiq-pipelines" },
     { name = "taskiq-redis" },
     { name = "uvicorn", extra = ["standard"] },
 ]
@@ -403,7 +402,6 @@ requires-dist = [
     { name = "requests", specifier = ">=2.32.3" },
     { name = "sentry-sdk", extras = ["falcon"], specifier = ">=2.29.1" },
     { name = "taskiq", extras = ["reload"], specifier = ">=0.11.18" },
-    { name = "taskiq-pipelines", specifier = ">=0.1.4" },
     { name = "taskiq-redis", specifier = ">=1.0.9" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.34.3" },
 ]
@@ -1197,20 +1195,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/47/90/47a627696e53bfdcacabc3e8c05b73bf1424685bcb5f17209cb8b12da1bf/taskiq_dependencies-1.5.7.tar.gz", hash = "sha256:0d3b240872ef152b719153b9526d866d2be978aeeaea6600e878414babc2dcb4", size = 14875, upload-time = "2025-02-26T22:07:39.876Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/99/6d/4a012f2de002c2e93273f5e7d3e3feea02f7fdbb7b75ca2ca1dd10703091/taskiq_dependencies-1.5.7-py3-none-any.whl", hash = "sha256:6fcee5d159bdb035ef915d4d848826169b6f06fe57cc2297a39b62ea3e76036f", size = 13801, upload-time = "2025-02-26T22:07:38.622Z" },
-]
-
-[[package]]
-name = "taskiq-pipelines"
-version = "0.1.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pydantic" },
-    { name = "taskiq" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/57/79/b099aec44fed65f077d88fa4e4a876b7f5b3b50f46f408feb36a4b3c3a71/taskiq_pipelines-0.1.4.tar.gz", hash = "sha256:0ccc58a7d5bc0f19457bf25aec6e8b3d82ce5e63ae4416bc85b47f027aede84b", size = 12885, upload-time = "2025-03-05T02:18:40.615Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e3/e2/0ba3c3797f466cebd5431d8ac70146704cc34346332127a19b2d5f6b28ac/taskiq_pipelines-0.1.4-py3-none-any.whl", hash = "sha256:09b4999f79e74552e4a751f4670c1829eaf494a28ee06d3f47ec5f6f5bf5105d", size = 15810, upload-time = "2025-03-05T02:18:39.041Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This would sometimes schedule tasks on the wrong worker, avoiding the pipeline construct solves this. Instead we use one longer running tasks which also has an easier to track lifetime.