### PR TITLE
fix(worker): Backup push requires --all

### DIFF
--- a/services/datalad/datalad_service/common/s3.py
+++ b/services/datalad/datalad_service/common/s3.py
@@ -190,7 +190,7 @@ async def s3_export(dataset_path, target, treeish):
 async def s3_backup_push(dataset_path):
     """Perform an S3 push to the backup remote on a git-annex repo."""
     await run_check(
-        ['git-annex', 'push', get_s3_backup_remote()],
+        ['git-annex', 'push', '--all', get_s3_backup_remote()],
         dataset_path,
         env=backup_remote_env(),
     )


### PR DESCRIPTION
This is needed to push an objects not present at HEAD.