### PR TITLE
fix(worker): Skip re-export on drop if remote contains all files for a branch or tag

### DIFF
--- a/services/datalad/datalad_service/common/asyncio.py
+++ b/services/datalad/datalad_service/common/asyncio.py
@@ -22,3 +22,4 @@ async def run_check(command, dataset_path, env=None):
     stdout, stderr = await process.communicate()
     if process.returncode != 0:
         raise subprocess.CalledProcessError(process.returncode, command, stdout, stderr)
+    return stdout.decode('utf-8')


### PR DESCRIPTION
Prevents this from being stateful and re-exporting successfully exported tags. Check public datasets as well.