### PR TITLE
chore: Add inline dependencies for Python scripts

### DIFF
--- a/scripts/dataset-owner-query.py
+++ b/scripts/dataset-owner-query.py
@@ -1,3 +1,9 @@
+# /// script
+# requires-python = ">=3.13"
+# dependencies = [
+#     "pymongo",
+# ]
+# ///
 import argparse
 import csv
 from pymongo import MongoClient

--- a/scripts/s3-acl-fix.py
+++ b/scripts/s3-acl-fix.py
@@ -1,3 +1,9 @@
+# /// script
+# requires-python = ">=3.13"
+# dependencies = [
+#     "boto3",
+# ]
+# ///
 import argparse
 import os
 import re

--- a/scripts/s3-delete-all-versions.py
+++ b/scripts/s3-delete-all-versions.py
@@ -1,3 +1,9 @@
+# /// script
+# requires-python = ">=3.13"
+# dependencies = [
+#     "boto3",
+# ]
+# ///
 import argparse
 import logging
 


### PR DESCRIPTION
Small QoL improvement. Allows the Python scripts to be run with `uv run` without preparing an environment manually.

All comments, so no impact on existing workflows.