### PR TITLE
fix: Create GitHub siblings if enabled

### DIFF
--- a/services/datalad/datalad_service/common/github.py
+++ b/services/datalad/datalad_service/common/github.py
@@ -11,9 +11,10 @@ from datalad_service.config import DATALAD_GITHUB_EXPORTS_ENABLED
 
 def create_github_repo(dataset_path, dataset_id):
     """Setup a github sibling / remote."""
+    if not DATALAD_GITHUB_EXPORTS_ENABLED:
+        return
     try:
-        if not DATALAD_GITHUB_EXPORTS_ENABLED:
-            return create_sibling_github(dataset_path, dataset_id)
+        return create_sibling_github(dataset_path, dataset_id)
     except KeyError:
         raise Exception(
             'DATALAD_GITHUB_TOKEN and DATALAD_GITHUB_ORG must be defined to create remote repos'


### PR DESCRIPTION
ds006943 did not have its GitHub sibling created, and 3ea1777a0994a79d001a46c065b6b5abaa43821e looks to be the cause. I think the `not` should have been removed, but to fix this I just moved the check to an early `return`. That branch seems worth keeping in place, as we might want to do something else in the future, such as emit a warning or a logging event.