### PR TITLE
fix: Smudge non-annexed files, ensuring eol enforcement

### DIFF
--- a/services/datalad/datalad_service/common/git.py
+++ b/services/datalad/datalad_service/common/git.py
@@ -176,10 +176,14 @@ async def git_commit_index(
     committer = pygit2.Signature(COMMITTER_NAME, COMMITTER_EMAIL)
     if not author:
         author = committer
-    if parents is None:
-        parent_commits = [str(repo.head.target)]
-    else:
-        parent_commits = parents
+
+    parent_commits = [repo.head.target] if parents is None else parents
+    if len(parent_commits) == 1 and not any(
+        repo.index.diff_to_tree(repo.get(parent_commits[0]).tree)
+    ):
+        # No changes to commit
+        return
+
     tree = repo.index.write_tree()
     commit = repo.create_commit(
         'refs/heads/main', author, committer, message, tree, parent_commits

--- a/services/datalad/datalad_service/common/git.py
+++ b/services/datalad/datalad_service/common/git.py
@@ -163,6 +163,9 @@ async def git_commit(
         sentry_sdk.capture_exception(e)
         logger.error(f'Failed to read index after git-annex add: {e}')
         raise OpenNeuroGitError(f'Failed to read index: {e}') from e
+    # Ensure non-annexed files are smudged, e.g., update end-of-lines
+    # but do not "fix" unrelated paths
+    repo.index.add_all(file_paths)
     return await git_commit_index(repo, author, message, parents)
 
 


### PR DESCRIPTION
This patch should avoid further pollution of repositories with CRLF end-of-line markers. What seems to be happening is that `git annex add` ensures that we efficiently hash files, but does not ensure that non-annexed files pass through the smudge filters. Adding a second `add_all` should be a cheap fix for this.

I also skip empty commits.

With these two changes, I think the following would fix old datasets: `git_commit(repo, '.', message='[OpenNeuro] Apply smudge filters')`. I'm not sure if this is something that should be put onto the task queue?

Fixes: #3257
Fixes: #3531