### PR TITLE
fix: Prefer s3-PUBLIC remote for validating remote content

### DIFF
--- a/services/datalad/datalad_service/tasks/validator.py
+++ b/services/datalad/datalad_service/tasks/validator.py
@@ -59,6 +59,8 @@ async def validate_dataset_deno_call(dataset_path, ref, logger=logger):
             str(config_path),
             '--json',
             dataset_path,
+            '--preferredRemote',
+            's3-PUBLIC',
             '--blacklistModalities',
             'micr',
             '--datasetTypes',


### PR DESCRIPTION
@nellh The validator defaults to the most recent S3 remote, which is probably going to be the S3-BACKUP, significantly slowing down (and making more expensive) validation.

I suspect this is the root cause of #3671.