### PR TITLE
Support base64 encoded rmet paths for file URLs

### DIFF
--- a/services/datalad/datalad_service/common/annex.py
+++ b/services/datalad/datalad_service/common/annex.py
@@ -146,27 +146,23 @@ def parse_remote_line(remoteLine):
 
 def parse_rmet_line(remote, rmetLine):
     """Read one rmet line and return a valid URL for this object"""
-    try:
-        remoteContext, remoteData = rmetLine.split('V +')
-        slash = '' if remote['url'][-1] == '/' else '/'
-        if remoteData[0] == '!':
-            try:
-                remoteData = base64.b64decode(remoteData[1:]).decode('utf-8')
-            except UnicodeDecodeError:
-                return None
-        s3version, path = remoteData.split('#')
-        if remote['name'] == get_s3_remote():
-            # Presigned via OpenNeuro's credentials
-            url = presign_remote_url(path, s3version)
-            return url
-        else:
-            # Anonymous access for any other buckets
-            return encode_remote_url(
-                '{}{}{}?versionId={}'.format(remote['url'], slash, path, s3version)
-            )
-    except:
-        raise
-        return None
+    remoteContext, remoteData = rmetLine.split('V +')
+    slash = '' if remote['url'][-1] == '/' else '/'
+    if remoteData[0] == '!':
+        try:
+            remoteData = base64.b64decode(remoteData[1:]).decode('utf-8')
+        except UnicodeDecodeError:
+            return None
+    s3version, path = remoteData.split('#')
+    if remote['name'] == get_s3_remote():
+        # Presigned via OpenNeuro's credentials
+        url = presign_remote_url(path, s3version)
+        return url
+    else:
+        # Anonymous access for any other buckets
+        return encode_remote_url(
+            '{}{}{}?versionId={}'.format(remote['url'], slash, path, s3version)
+        )
 
 
 def read_rmet_file(remote, catFile):

--- a/services/datalad/datalad_service/common/annex.py
+++ b/services/datalad/datalad_service/common/annex.py
@@ -1,3 +1,4 @@
+import base64
 import hashlib
 import io
 import json
@@ -148,6 +149,11 @@ def parse_rmet_line(remote, rmetLine):
     try:
         remoteContext, remoteData = rmetLine.split('V +')
         slash = '' if remote['url'][-1] == '/' else '/'
+        if remoteData[0] == '!':
+            try:
+                remoteData = base64.b64decode(remoteData[1:]).decode('utf-8')
+            except UnicodeDecodeError:
+                return None
         s3version, path = remoteData.split('#')
         if remote['name'] == get_s3_remote():
             # Presigned via OpenNeuro's credentials

--- a/services/datalad/tests/test_annex.py
+++ b/services/datalad/tests/test_annex.py
@@ -188,6 +188,23 @@ def test_parse_rmet_line_https():
     assert 'Signature=' in url
 
 
+def test_parse_rmet_line_base64():
+    remote = {
+        'name': 's3-PUBLIC',
+        'url': 'https://s3.amazonaws.com/openneuro.org',
+        'uuid': '57894849-d0c8-4c62-8418-3627be18a196',
+    }
+    url = parse_rmet_line(
+        remote,
+        """1590213748.042921433s 57894849-d0c8-4c62-8418-3627be18a196:V +!aVZjRWsxOGUzSjJXUXlzNHpyX0FOYVRQZnBVdWZXNFkjZHMwMDI3NzgvZGF0YXNldF9kZXNjcmlwdGlvbi5qc29u""",
+    )
+    assert (
+        'https://s3.amazonaws.com/a-fake-test-public-bucket/ds002778/dataset_description.json?versionId=iVcEk18e3J2WQys4zr_ANaTPfpUufW4Y&AWSAccessKeyId=aws-id'
+        in url
+    )
+    assert 'Signature=' in url
+
+
 def test_read_rmet_file():
     remote = {
         'name': 's3-PUBLIC',


### PR DESCRIPTION
Some objects the URL is base64 encoded. Try to decode this and return None if the decoded value is invalid utf-8.