### PR TITLE
fix(worker): Fix missing URLs for annexed objects with a shared key

### DIFF
--- a/services/datalad/datalad_service/common/annex.py
+++ b/services/datalad/datalad_service/common/annex.py
@@ -7,6 +7,7 @@ import os
 import urllib.parse
 import time
 import uuid
+from collections import defaultdict
 
 import aiofiles
 import pygit2
@@ -202,19 +203,19 @@ def get_repo_urls(path, files):
         # Skip searching for URLs if no remote.log is present
         return files
     rmetPaths = []
-    rmetFiles = {}
+    rmetFiles = defaultdict(list)
     for f in files:
         if 'key' in f:
             rmetPath = compute_rmet(f['key'])
             if rmetPath in rmetObjects:
                 # Keep a reference to the files so we can add URLs later
-                rmetFiles[rmetPath] = f
+                rmetFiles[rmetPath].append(f)
                 rmetPaths.append(rmetPath)
             else:
                 # Check for alternate path used by older versions of git-annex
                 rmetPath = compute_rmet(f['key'], legacy=True)
                 if rmetPath in rmetObjects:
-                    rmetFiles[rmetPath] = f
+                    rmetFiles[rmetPath].append(f)
                     rmetPaths.append(rmetPath)
     # Then read those objects with git cat-file --batch
     gitObjects = ''
@@ -271,7 +272,9 @@ def get_repo_urls(path, files):
         for path in rmetPaths:
             url = read_rmet_file(remote, catFile)
             if url:
-                rmetFiles[path]['urls'].append(url)
+                # Add this URL to all files that reference this rmet
+                for file in rmetFiles[path]:
+                    file['urls'].append(url)
     return files
 
 


### PR DESCRIPTION
When reading rmet files, two files sharing the same git-annex key could be overwritten if they existed in the same tree, resulting in one with duplicate URLs and one missing a URL. Instead we should track the collection of files and add the URL to each file in the collection once the rmet is parsed.

Fixes #3665