### PR TITLE
feat(worker): Add endpoint for git-annex info commands

### DIFF
--- a/services/datalad/datalad_service/app.py
+++ b/services/datalad/datalad_service/app.py
@@ -31,6 +31,7 @@ from datalad_service.handlers.annex import GitAnnexResource
 from datalad_service.handlers.reexporter import ReexporterResource
 from datalad_service.handlers.reset import ResetResource
 from datalad_service.handlers.remote_import import RemoteImportResource
+from datalad_service.handlers.info import InfoResource
 from datalad_service.middleware.auth import AuthenticateMiddleware
 from datalad_service.middleware.error import CustomErrorHandlerMiddleware
 
@@ -101,6 +102,7 @@ def create_app():
     dataset_reexporter_resources = ReexporterResource(store)
     dataset_reset_resource = ResetResource(store)
     dataset_remote_import_resource = RemoteImportResource(store)
+    dataset_info_resource = InfoResource(store)
 
     app.add_route('/heartbeat', heartbeat)
 
@@ -113,7 +115,8 @@ def create_app():
     app.add_route('/datasets/{dataset}/description', dataset_description)
     app.add_route('/datasets/{dataset}/validate/{hexsha}', dataset_validation)
     app.add_route('/datasets/{dataset}/reset/{hexsha}', dataset_reset_resource)
-
+    app.add_route('/datasets/{dataset}/info', dataset_info_resource)
+    app.add_route('/datasets/{dataset}/info/{name}', dataset_info_resource)
     app.add_route('/datasets/{dataset}/files', dataset_files)
     app.add_route('/datasets/{dataset}/files/{filename:path}', dataset_files)
     app.add_route('/datasets/{dataset}/tree/{tree}', dataset_tree)

--- a/services/datalad/datalad_service/handlers/info.py
+++ b/services/datalad/datalad_service/handlers/info.py
@@ -1,0 +1,34 @@
+import json
+import falcon
+import subprocess
+
+from datalad_service.common.asyncio import run_check
+
+
+class InfoResource:
+    def __init__(self, store):
+        self.store = store
+
+    async def on_get(self, req, resp, dataset, name=None):
+        """Return git-annex info output for a given dataset.
+
+        Name can be a tag, branch, commit hash, or special remote name.
+        """
+        if dataset:
+            command = ['git', 'annex', 'info', '--json', '--bytes']
+            if name:
+                command.append(name)
+            try:
+                dataset_path = self.store.get_dataset_path(dataset)
+                output = await run_check(command, dataset_path)
+                try:
+                    json_output = json.loads(output)
+                except json.JSONDecodeError:
+                    json_output = {'error': output}
+                resp.media = json_output
+                resp.status = falcon.HTTP_OK
+            except subprocess.CalledProcessError:
+                resp.status = falcon.HTTP_INTERNAL_SERVER_ERROR
+        else:
+            resp.media = {'error': 'Missing or malformed dataset parameter in request.'}
+            resp.status = falcon.HTTP_UNPROCESSABLE_ENTITY

--- a/services/datalad/tests/test_info.py
+++ b/services/datalad/tests/test_info.py
@@ -1,0 +1,30 @@
+import json
+import os
+
+import falcon
+import pygit2
+
+
+def test_info(client, new_dataset):
+    ds_id = os.path.basename(new_dataset.path)
+    response = client.simulate_get(f'/datasets/{ds_id}/info')
+    assert response.status == falcon.HTTP_OK
+    info = json.loads(response.content) if response.content else None
+    assert info is not None
+    assert info['success'] is True
+    assert info['annexed files in working tree'] == 0
+    assert info['local annex keys'] == 0
+
+
+def test_info_tag(client, new_dataset):
+    ds_id = os.path.basename(new_dataset.path)
+    # Create a snapshot so we test tag reference
+    response = client.simulate_post(f'/datasets/{ds_id}/snapshots/1.0.0', body='')
+    assert response.status == falcon.HTTP_OK
+    response = client.simulate_get(f'/datasets/{ds_id}/info/1.0.0')
+    assert response.status == falcon.HTTP_OK
+    info = json.loads(response.content) if response.content else None
+    assert info is not None
+    assert info['success'] is True
+    assert info['tree'] == '1.0.0'
+    assert info['local annex keys'] == 0


### PR DESCRIPTION
Used to report the broad status of annexed objects stored on a per remote or per branch/tag basis.