### PR TITLE
feat(app): Add clipboard button to shell example component

### DIFF
--- a/packages/openneuro-app/src/scripts/dataset/download/__tests__/__snapshots__/download-command-line.spec.jsx.snap
+++ b/packages/openneuro-app/src/scripts/dataset/download/__tests__/__snapshots__/download-command-line.spec.jsx.snap
@@ -3,7 +3,7 @@
 exports[`dataset/download > DownloadSampleCommand component > renders successfully 1`] = `
 <DocumentFragment>
   <pre
-    class="css-xak41w"
+    class="css-msttpq"
     role="figure"
   >
     # Login by following the prompts
@@ -13,6 +13,14 @@ exports[`dataset/download > DownloadSampleCommand component > renders successful
     # Download the repository
     <br />
     deno run -A jsr:@openneuro/cli download --draft ds000001 ds000001-download/
+    <button
+      aria-label="Copy to clipboard"
+      class="css-cbg4lo"
+    >
+      <i
+        class="fa fa-clipboard"
+      />
+    </button>
   </pre>
 </DocumentFragment>
 `;

--- a/packages/openneuro-app/src/scripts/dataset/download/__tests__/__snapshots__/shell-example.spec.jsx.snap
+++ b/packages/openneuro-app/src/scripts/dataset/download/__tests__/__snapshots__/shell-example.spec.jsx.snap
@@ -3,7 +3,17 @@
 exports[`dataset/download/ShellExample > renders successfully 1`] = `
 <DocumentFragment>
   <pre
-    class="css-xak41w"
-  />
+    class="css-msttpq"
+    role="figure"
+  >
+    <button
+      aria-label="Copy to clipboard"
+      class="css-cbg4lo"
+    >
+      <i
+        class="fa fa-clipboard"
+      />
+    </button>
+  </pre>
 </DocumentFragment>
 `;

--- a/packages/openneuro-app/src/scripts/dataset/download/download-command-line.jsx
+++ b/packages/openneuro-app/src/scripts/dataset/download/download-command-line.jsx
@@ -3,7 +3,7 @@ import PropTypes from "prop-types"
 import ShellExample from "./shell-example.jsx"
 
 export const DownloadSampleCommand = ({ datasetId, snapshotTag }) => (
-  <ShellExample role="figure">
+  <ShellExample>
     # Login by following the prompts<br />
     deno run -A jsr:@openneuro/cli login<br />
     # Download the repository<br />

--- a/packages/openneuro-app/src/scripts/dataset/download/shell-example.jsx
+++ b/packages/openneuro-app/src/scripts/dataset/download/shell-example.jsx
@@ -1,12 +1,55 @@
+import React, { useRef, useState } from "react"
 import styled from "@emotion/styled"
 
-const ShellExample = styled.pre`
+const ShellExamplePre = styled.pre`
   max-width: 80em;
   white-space: pre-wrap;
   word-break: keep-all;
   border: 1px solid #ddd;
   background: #eee;
   padding: 10px;
+  padding-right: 40px; /* space for clipboard button */
+  position: relative;
 `
+
+const CopyButton = styled.button`
+  position: absolute;
+  top: 0;
+  right: 0;
+  border: none;
+  background: transparent;
+  padding: 10px;
+  cursor: pointer;
+  color: #888;
+  &:hover {
+    color: #333;
+  }
+`
+
+function ShellExample({ children }) {
+  const [copied, setCopied] = useState(false)
+  const preRef = useRef(null)
+
+  const copy = () => {
+    const text = typeof children === "string"
+      ? children
+      : preRef.current.innerText
+    navigator.clipboard.writeText(text).then(() => {
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    })
+  }
+
+  return (
+    <ShellExamplePre ref={preRef} role="figure">
+      {children}
+      <CopyButton onClick={copy} aria-label="Copy to clipboard">
+        {copied
+          ? <i className="fa fa-check"></i>
+          : <i className="fa fa-clipboard"></i>}
+      </CopyButton>
+    </ShellExamplePre>
+  )
+}
 
 export default ShellExample


### PR DESCRIPTION
Adds a clipboard button to the ShellExample component in the upper right corner.

<img width="497" height="63" alt="Screenshot From 2025-12-10 13-02-42" src="https://github.com/user-attachments/assets/81ff360a-eacf-49c7-8350-ef79d9adc709" />

Fixes #3684 