### PR TITLE
fix(cli): Apply eol git attributes during upload on local repo

### DIFF
--- a/cli/deno.lock
+++ b/cli/deno.lock
@@ -1,6 +1,8 @@
 {
   "version": "5",
   "specifiers": {
+    "jsr:@bids/schema@~1.1.3": "1.1.3",
+    "jsr:@bids/validator@^2.2.5": "2.2.5",
     "jsr:@cliffy/ansi@1.0.0-rc.8": "1.0.0-rc.8",
     "jsr:@cliffy/flags@1.0.0-rc.7": "1.0.0-rc.7",
     "jsr:@cliffy/internal@1.0.0-rc.7": "1.0.0-rc.7",
@@ -10,7 +12,9 @@
     "jsr:@cliffy/table@1.0.0-rc.7": "1.0.0-rc.7",
     "jsr:@deno-library/progress@^1.5.1": "1.5.1",
     "jsr:@effigies/cliffy-command@1.0.0-dev.8": "1.0.0-dev.8",
+    "jsr:@effigies/cliffy-table@1.0.0-dev.5": "1.0.0-dev.5",
     "jsr:@effigies/cliffy-table@^1.0.0-dev.5": "1.0.0-dev.5",
+    "jsr:@libs/xml@^7.0.3": "7.0.3",
     "jsr:@std/assert@^1.0.14": "1.0.16",
     "jsr:@std/assert@^1.0.15": "1.0.16",
     "jsr:@std/assert@~1.0.6": "1.0.16",
@@ -22,6 +26,7 @@
     "jsr:@std/encoding@~1.0.5": "1.0.10",
     "jsr:@std/fmt@1.0.3": "1.0.3",
     "jsr:@std/fmt@^1.0.5": "1.0.8",
+    "jsr:@std/fmt@^1.0.8": "1.0.8",
     "jsr:@std/fmt@~1.0.2": "1.0.8",
     "jsr:@std/fs@^1.0.11": "1.0.20",
     "jsr:@std/fs@^1.0.19": "1.0.20",
@@ -34,16 +39,46 @@
     "jsr:@std/path@^1.1.3": "1.1.3",
     "jsr:@std/path@~1.0.6": "1.0.9",
     "jsr:@std/streams@^1.0.11": "1.0.14",
+    "jsr:@std/streams@^1.0.14": "1.0.14",
     "jsr:@std/testing@^1.0.15": "1.0.16",
     "jsr:@std/text@~1.0.7": "1.0.16",
+    "jsr:@std/yaml@^1.0.10": "1.0.10",
     "jsr:@wok/djwt@^3.0.2": "3.0.2",
+    "npm:@bids/nifti-reader-js@~0.6.9": "0.6.9",
     "npm:@sentry/deno@^8.55.0": "8.55.0",
     "npm:@types/node@*": "22.10.7",
+    "npm:ajv@^8.17.1": "8.17.1",
     "npm:hash-wasm@^4.12.0": "4.12.0",
+    "npm:hed-validator@~4.1.4": "4.1.4",
     "npm:ignore@^5.3.0": "5.3.2",
-    "npm:isomorphic-git@1.27.1": "1.27.1"
+    "npm:ignore@^7.0.5": "7.0.5",
+    "npm:isomorphic-git@1.27.1": "1.27.1",
+    "npm:isomorphic-git@^1.35.1": "1.36.0"
   },
   "jsr": {
+    "@bids/schema@1.1.3": {
+      "integrity": "cdac75e809079c7defa3c31df79889c3a793efffcba0ecfaf2415d2d522e8aa4"
+    },
+    "@bids/validator@2.2.5": {
+      "integrity": "15c248d5654d5325b5b6dd9cf9672045375248516b9dac7f39d42ef6987af603",
+      "dependencies": [
+        "jsr:@bids/schema",
+        "jsr:@effigies/cliffy-command",
+        "jsr:@effigies/cliffy-table@1.0.0-dev.5",
+        "jsr:@libs/xml",
+        "jsr:@std/fmt@^1.0.8",
+        "jsr:@std/log",
+        "jsr:@std/path@^1.1.3",
+        "jsr:@std/streams@^1.0.14",
+        "jsr:@std/yaml",
+        "npm:@bids/nifti-reader-js",
+        "npm:ajv",
+        "npm:hash-wasm",
+        "npm:hed-validator",
+        "npm:ignore@^7.0.5",
+        "npm:isomorphic-git@^1.35.1"
+      ]
+    },
     "@cliffy/ansi@1.0.0-rc.8": {
       "integrity": "ba37f10ce55bbfbdd8ddd987f91f029b17bce88385b98ba3058870f3b007b80c",
       "dependencies": [
@@ -99,7 +134,7 @@
         "jsr:@cliffy/flags",
         "jsr:@cliffy/internal@1.0.0-rc.7",
         "jsr:@cliffy/table",
-        "jsr:@effigies/cliffy-table",
+        "jsr:@effigies/cliffy-table@^1.0.0-dev.5",
         "jsr:@std/fmt@~1.0.2",
         "jsr:@std/text"
       ]
@@ -109,6 +144,9 @@
       "dependencies": [
         "jsr:@std/fmt@~1.0.2"
       ]
+    },
+    "@libs/xml@7.0.3": {
+      "integrity": "4caad75dfec0a4dd4ad5dc87dc559d9aa25ac53f17373923a9cd006f6c8d42e6"
     },
     "@std/assert@1.0.15": {
       "integrity": "d64018e951dbdfab9777335ecdb000c0b4e3df036984083be219ce5941e4703b"
@@ -205,6 +243,9 @@
     "@std/text@1.0.16": {
       "integrity": "ddb9853b75119a2473857d691cf1ec02ad90793a2e8b4a4ac49d7354281a0cf8"
     },
+    "@std/yaml@1.0.10": {
+      "integrity": "245706ea3511cc50c8c6d00339c23ea2ffa27bd2c7ea5445338f8feff31fa58e"
+    },
     "@wok/djwt@3.0.2": {
       "integrity": "e1c8afe6e321941edda40d91b089e93738469b994d53f41f82e0e7fcd7dde259",
       "dependencies": [
@@ -213,6 +254,12 @@
     }
   },
   "npm": {
+    "@bids/nifti-reader-js@0.6.9": {
+      "integrity": "sha512-3KWpGKrgUUvT5Bbl25K9TTQ77DRS5DUpcyhZlAblCPdP1YMy0tCzrxarRTixWM9tDN6sWUOBbf6zQpPyVe11Lw==",
+      "dependencies": [
+        "fflate"
+      ]
+    },
     "@sentry/core@8.55.0": {
       "integrity": "sha512-6g7jpbefjHYs821Z+EBJ8r4Z7LT5h80YSWRJaylGS4nW5W5Z2KXzpdnyFarv37O7QjauzVC2E+PABmpkw5/JGA=="
     },
@@ -228,6 +275,21 @@
         "undici-types"
       ]
     },
+    "abort-controller@3.0.0": {
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dependencies": [
+        "event-target-shim"
+      ]
+    },
+    "ajv@8.17.1": {
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "dependencies": [
+        "fast-deep-equal",
+        "fast-uri",
+        "json-schema-traverse",
+        "require-from-string"
+      ]
+    },
     "async-lock@1.4.1": {
       "integrity": "sha512-Az2ZTpuytrtqENulXwO3GGv1Bztugx6TT37NIo7imr/Qo0gsYiGtSdBa2B6fsXhTpVZDNfu1Qn3pk531e3q+nQ=="
     },
@@ -235,6 +297,16 @@
       "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
       "dependencies": [
         "possible-typed-array-names"
+      ]
+    },
+    "base64-js@1.5.1": {
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+    },
+    "buffer@6.0.3": {
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "dependencies": [
+        "base64-js",
+        "ieee754"
       ]
     },
     "call-bind-apply-helpers@1.0.2": {
@@ -262,6 +334,10 @@
     },
     "clean-git-ref@2.0.1": {
       "integrity": "sha512-bLSptAy2P0s6hU4PzuIMKmMJJSE6gLXGH1cntDu7bWJUksvuM+7ReOK61mozULErYvP6a15rnYl0zFDef+pyPw=="
+    },
+    "core-js-pure@3.47.0": {
+      "integrity": "sha512-BcxeDbzUrRnXGYIVAGFtcGQVNpFcUhVjr6W7F8XktvQW2iJP9e66GP6xdKotCRFlrxBvNIBrhwKteRXqMV86Nw==",
+      "scripts": true
     },
     "crc-32@1.2.2": {
       "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
@@ -303,6 +379,28 @@
       "dependencies": [
         "es-errors"
       ]
+    },
+    "event-target-shim@5.0.1": {
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
+    },
+    "events@3.3.0": {
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="
+    },
+    "fast-deep-equal@3.1.3": {
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+    },
+    "fast-uri@3.1.0": {
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="
+    },
+    "fast-xml-parser@5.3.2": {
+      "integrity": "sha512-n8v8b6p4Z1sMgqRmqLJm3awW4NX7NkaKPfb3uJIBTSH7Pdvufi3PQ3/lJLQrvxcMYl7JI2jnDO90siPEpD8JBA==",
+      "dependencies": [
+        "strnum"
+      ],
+      "bin": true
+    },
+    "fflate@0.8.2": {
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A=="
     },
     "for-each@0.3.5": {
       "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
@@ -362,8 +460,25 @@
         "function-bind"
       ]
     },
+    "hed-validator@4.1.4": {
+      "integrity": "sha512-Cyprv/TCXUP1FC5c/h1Yi3k2XawlDP1YJ5kxI724WSRg67Xz/RlYnMxJposhAIZMFPWMdDkATtoM5fro68k7RA==",
+      "dependencies": [
+        "core-js-pure",
+        "fast-xml-parser",
+        "lodash",
+        "pluralize",
+        "semver",
+        "unicode-name"
+      ]
+    },
+    "ieee754@1.2.1": {
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
+    },
     "ignore@5.3.2": {
       "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="
+    },
+    "ignore@7.0.5": {
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="
     },
     "inherits@2.0.4": {
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
@@ -387,15 +502,38 @@
         "clean-git-ref",
         "crc-32",
         "diff3",
-        "ignore",
+        "ignore@5.3.2",
         "minimisted",
         "pako",
         "pify",
-        "readable-stream",
+        "readable-stream@3.6.2",
         "sha.js",
         "simple-get"
       ],
       "bin": true
+    },
+    "isomorphic-git@1.36.0": {
+      "integrity": "sha512-22tU165ptowHYoDEwYJy5EKRzpHiuLMliaR01fH9ZwaUj1z/IqE++tGpjw/pD6eCWoxiOp6TPWX434aJ9zA4Lg==",
+      "dependencies": [
+        "async-lock",
+        "clean-git-ref",
+        "crc-32",
+        "diff3",
+        "ignore@5.3.2",
+        "minimisted",
+        "pako",
+        "pify",
+        "readable-stream@4.7.0",
+        "sha.js",
+        "simple-get"
+      ],
+      "bin": true
+    },
+    "json-schema-traverse@1.0.0": {
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    },
+    "lodash@4.17.21": {
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "math-intrinsics@1.1.0": {
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="
@@ -424,8 +562,14 @@
     "pify@4.0.1": {
       "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
     },
+    "pluralize@8.0.0": {
+      "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA=="
+    },
     "possible-typed-array-names@1.1.0": {
       "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="
+    },
+    "process@0.11.10": {
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="
     },
     "readable-stream@3.6.2": {
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
@@ -435,8 +579,25 @@
         "util-deprecate"
       ]
     },
+    "readable-stream@4.7.0": {
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "dependencies": [
+        "abort-controller",
+        "buffer",
+        "events",
+        "process",
+        "string_decoder"
+      ]
+    },
+    "require-from-string@2.0.2": {
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
+    },
     "safe-buffer@5.2.1": {
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+    },
+    "semver@7.7.3": {
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "bin": true
     },
     "set-function-length@1.2.2": {
       "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
@@ -475,6 +636,9 @@
         "safe-buffer"
       ]
     },
+    "strnum@2.1.1": {
+      "integrity": "sha512-7ZvoFTiCnGxBtDqJ//Cu6fWtZtc7Y3x+QOirG15wztbdngGSkht27o2pyGWrVy0b4WAy3jbKmnoK6g5VlVNUUw=="
+    },
     "to-buffer@1.2.2": {
       "integrity": "sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==",
       "dependencies": [
@@ -493,6 +657,9 @@
     },
     "undici-types@6.20.0": {
       "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg=="
+    },
+    "unicode-name@1.1.0": {
+      "integrity": "sha512-2XBI32vZP6a1tJmMDSUBabiIZuY+1udwZUoS7i5BTSU2c4ELMy6YJrTPF9uvYOVMU4vTMlHH6HG/TsHjCEsazA=="
     },
     "util-deprecate@1.0.2": {
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="

--- a/cli/src/gitattributes.ts
+++ b/cli/src/gitattributes.ts
@@ -12,6 +12,8 @@ export interface GitAnnexAttributeOptions {
   largefiles?: number
   backend?: GitAnnexBackend
   match: ignore.Ignore
+  text?: "auto"
+  eol?: "lf" | "crlf"
 }
 
 /**
@@ -62,6 +64,10 @@ export function parseGitAttributes(gitattributes: string): GitAnnexAttributes {
         }
       } else if (key === "annex.backend") {
         attributesObject[prefix].backend = value as GitAnnexBackend
+      } else if (key === "text") {
+        attributesObject[prefix].text = value as "auto"
+      } else if (key === "eol") {
+        attributesObject[prefix].eol = value as "lf" | "crlf"
       }
     }
   }
@@ -71,6 +77,8 @@ export function parseGitAttributes(gitattributes: string): GitAnnexAttributes {
 interface MatchingAnnexAttributes {
   backend?: GitAnnexBackend
   largefiles?: number
+  text?: "auto"
+  eol?: "lf" | "crlf"
 }
 
 /**
@@ -88,6 +96,12 @@ export function matchGitAttributes(
       }
       if ("largefiles" in attr) {
         matching.largefiles = attr.largefiles
+      }
+      if ("text" in attr) {
+        matching.text = attr.text as "auto"
+      }
+      if ("eol" in attr) {
+        matching.eol = attr.eol as "lf" | "crlf"
       }
     }
   }

--- a/cli/src/worker/transformEol.test.ts
+++ b/cli/src/worker/transformEol.test.ts
@@ -1,0 +1,135 @@
+import { assertEquals } from "@std/assert"
+import { transformEol } from "./transformEol.ts"
+import type { FileHandle } from "node:fs/promises"
+
+// Mock FileHandle for reading
+class MockReadHandle {
+  private data: Uint8Array
+  private pos: number = 0
+  private chunkSize: number
+
+  constructor(content: string, chunkSize: number = 65536) {
+    this.data = new TextEncoder().encode(content)
+    this.chunkSize = chunkSize
+  }
+
+  // Matches fs.promises.FileHandle.read signature used in transformEol
+  async read(
+    buffer: Uint8Array,
+    offset: number,
+    length: number,
+    _position: number | null,
+  ) {
+    if (this.pos >= this.data.length) {
+      return { bytesRead: 0, buffer }
+    }
+    const size = Math.min(length, this.chunkSize, this.data.length - this.pos)
+    buffer.set(this.data.subarray(this.pos, this.pos + size), offset)
+    this.pos += size
+    return { bytesRead: size, buffer }
+  }
+
+  async close() {}
+}
+
+// Mock FileHandle for writing
+class MockWriteHandle {
+  public chunks: Uint8Array[] = []
+
+  async write(
+    buffer: Uint8Array,
+    offset: number,
+    length: number,
+    _position: number | null,
+  ) {
+    const chunk = buffer.slice(offset, offset + length)
+    this.chunks.push(chunk)
+    return { bytesWritten: length, buffer }
+  }
+
+  async close() {}
+
+  get content(): string {
+    const totalLength = this.chunks.reduce((acc, c) => acc + c.length, 0)
+    const result = new Uint8Array(totalLength)
+    let offset = 0
+    for (const chunk of this.chunks) {
+      result.set(chunk, offset)
+      offset += chunk.length
+    }
+    return new TextDecoder().decode(result)
+  }
+}
+
+Deno.test("transformEol() basic CRLF to LF", async () => {
+  const input = "line1\r\nline2\r\nline3"
+  const expected = "line1\nline2\nline3"
+  const read = new MockReadHandle(input) as unknown as FileHandle
+  const write = new MockWriteHandle()
+
+  await transformEol(read, write as unknown as FileHandle)
+  assertEquals(write.content, expected)
+})
+
+Deno.test("transformEol() split CRLF across chunks", async () => {
+  const input = "line1\r\nline2"
+  const expected = "line1\nline2"
+  // Chunk size 6 ensures split happens around \r\n for "line1\r\n" (length 7)
+  // "line1\r" (6) -> next chunk "\nline2"
+  const read = new MockReadHandle(input, 6) as unknown as FileHandle
+  const write = new MockWriteHandle()
+
+  await transformEol(read, write as unknown as FileHandle)
+  assertEquals(write.content, expected)
+})
+
+Deno.test("transformEol() standalone CR preserved", async () => {
+  const input = "line1\rline2"
+  const expected = "line1\rline2"
+  const read = new MockReadHandle(input, 3) as unknown as FileHandle
+  const write = new MockWriteHandle()
+
+  await transformEol(read, write as unknown as FileHandle)
+  assertEquals(write.content, expected)
+})
+
+Deno.test("transformEol() CR at end of file preserved", async () => {
+  const input = "line1\r"
+  const expected = "line1\r"
+  const read = new MockReadHandle(input) as unknown as FileHandle
+  const write = new MockWriteHandle()
+
+  await transformEol(read, write as unknown as FileHandle)
+  assertEquals(write.content, expected)
+})
+
+Deno.test("transformEol() mixed content with small chunks", async () => {
+  const input = "A\r\nB\rC\r\nD\r"
+  const expected = "A\nB\rC\nD\r"
+  // Force small chunks to test state machine
+  const read = new MockReadHandle(input, 1) as unknown as FileHandle
+  const write = new MockWriteHandle()
+
+  await transformEol(read, write as unknown as FileHandle)
+  assertEquals(write.content, expected)
+})
+
+Deno.test("transformEol() empty file", async () => {
+  const input = ""
+  const expected = ""
+  const read = new MockReadHandle(input) as unknown as FileHandle
+  const write = new MockWriteHandle()
+
+  await transformEol(read, write as unknown as FileHandle)
+  assertEquals(write.content, expected)
+})
+
+Deno.test("transformEol() multibyte characters", async () => {
+  const input = "👍\r\nTest"
+  const expected = "👍\nTest"
+  const read = new MockReadHandle(input, 1) as unknown as FileHandle
+  const write = new MockWriteHandle()
+
+  await transformEol(read, write as unknown as FileHandle)
+  assertEquals(write.content, expected)
+})

--- a/cli/src/worker/transformEol.test.ts
+++ b/cli/src/worker/transformEol.test.ts
@@ -71,6 +71,17 @@ Deno.test("transformEol() basic CRLF to LF", async () => {
   assertEquals(write.content, expected)
 })
 
+Deno.test("transformEol() binary file with null byte", async () => {
+  const input = "line1\r\n\0line2"
+  // Expect no transformation because of the null byte
+  const expected = "line1\r\n\0line2"
+  const read = new MockReadHandle(input) as unknown as FileHandle
+  const write = new MockWriteHandle()
+
+  await transformEol(read, write as unknown as FileHandle)
+  assertEquals(write.content, expected)
+})
+
 Deno.test("transformEol() split CRLF across chunks", async () => {
   const input = "line1\r\nline2"
   const expected = "line1\nline2"

--- a/cli/src/worker/transformEol.ts
+++ b/cli/src/worker/transformEol.ts
@@ -1,0 +1,73 @@
+import type { FileHandle } from "node:fs/promises"
+
+/**
+ * Streaming transformation of EOL characters from CRLF to LF.
+ * @param readHandle fs.open FileHandle for reading the original file
+ * @param writeHandle fs.open FileHandle for writing the transformed result
+ */
+export async function transformEol(
+  readHandle: FileHandle,
+  writeHandle: FileHandle,
+) {
+  const fileStream = new ReadableStream({
+    async pull(controller) {
+      const buffer = new Uint8Array(65536)
+      const { bytesRead } = await readHandle.read(
+        buffer,
+        0,
+        buffer.length,
+        null,
+      )
+      if (bytesRead === 0) {
+        controller.close()
+        await readHandle.close()
+      } else {
+        controller.enqueue(buffer.subarray(0, bytesRead))
+      }
+    },
+    async cancel() {
+      await readHandle.close()
+    },
+  })
+  const targetStream = new WritableStream({
+    async write(chunk) {
+      await writeHandle.write(chunk, 0, chunk.length, null)
+    },
+    async close() {
+      await writeHandle.close()
+    },
+    async abort() {
+      await writeHandle.close()
+    },
+  })
+  let lastCharWasCR = false
+  const transformStream = new TransformStream({
+    transform(chunk, controller) {
+      if (chunk.length === 0) return
+      let text = chunk
+      if (lastCharWasCR) {
+        if (!text.startsWith("\n")) {
+          controller.enqueue("\r")
+        }
+        lastCharWasCR = false
+      }
+      if (text.endsWith("\r")) {
+        lastCharWasCR = true
+        text = text.slice(0, -1)
+      }
+      if (text.length > 0) {
+        controller.enqueue(text.replace(/\r\n/g, "\n"))
+      }
+    },
+    flush(controller) {
+      if (lastCharWasCR) {
+        controller.enqueue("\r")
+      }
+    },
+  })
+  await fileStream
+    .pipeThrough(new TextDecoderStream())
+    .pipeThrough(transformStream)
+    .pipeThrough(new TextEncoderStream())
+    .pipeTo(targetStream)
+}


### PR DESCRIPTION
We need to apply the EOL filter before adding these files to the index on the local side. This avoids some churn when mixing edits using web app and the command line tool as well, since the transformed file will be the same locally and remotely.

Fix for #3686.