### PR TITLE
refactor(server): Keep validation issues/warnings counts cached indefinitely

### DIFF
--- a/packages/openneuro-server/src/graphql/resolvers/snapshots.ts
+++ b/packages/openneuro-server/src/graphql/resolvers/snapshots.ts
@@ -311,7 +311,7 @@ const Snapshot = {
   analytics: (snapshot) => analytics(snapshot),
   issues: (snapshot) => snapshotIssues(snapshot),
   issuesStatus: (snapshot) => issuesSnapshotStatus(snapshot),
-  validation: (snapshot) => snapshotValidation(snapshot),
+  validation: snapshotValidation,
   contributors: (snapshot) => {
     const datasetId = snapshot.datasetId
     return contributors({


### PR DESCRIPTION
Always lazy load issues and code messages from MongoDB. This avoids the expensive MongoDB scan on cache misses when requesting just the counts in aggregate queries.