### PR TITLE
fix(server): Set a 5 day cache lifetime for caches that contain signed S3 URLs

### DIFF
--- a/packages/openneuro-server/src/datalad/files.ts
+++ b/packages/openneuro-server/src/datalad/files.ts
@@ -89,7 +89,7 @@ export const getFiles = (datasetId, treeish): Promise<[DatasetFile?]> => {
   const cache = new CacheItem(redis, CacheType.commitFiles, [
     datasetId,
     treeish.substring(0, 7),
-  ])
+  ], 432000)
   return cache.get(
     async (doNotCache): Promise<[DatasetFile?]> => {
       const response = await fetch(

--- a/packages/openneuro-server/src/datalad/snapshots.ts
+++ b/packages/openneuro-server/src/datalad/snapshots.ts
@@ -222,7 +222,12 @@ export const getSnapshot = (
       datasetId,
     )
   }/datasets/${datasetId}/snapshots/${commitRef}`
-  const cache = new CacheItem(redis, CacheType.snapshot, [datasetId, commitRef])
+  const cache = new CacheItem(
+    redis,
+    CacheType.snapshot,
+    [datasetId, commitRef],
+    432000,
+  )
   return cache.get(() =>
     request
       .get(url)
@@ -281,7 +286,7 @@ export const downloadFiles = (datasetId, tag) => {
   const downloadCache = new CacheItem(redis, CacheType.snapshotDownload, [
     datasetId,
     tag,
-  ])
+  ], 432000)
   // Return an existing cache object if we have one
   return downloadCache.get(async () => {
     // If not, fetch all trees sequentially and cache the result (hopefully some or all trees are cached)


### PR DESCRIPTION
These are valid for 7 days, so this gives at least 48 hours where the URLs are valid before the cache is regenerated.

Fixes #3690