### PR TITLE
Allow users to request rechecking files when creating a version

### DIFF
--- a/packages/openneuro-app/src/scripts/dataset/mutations/__tests__/fsck-dataset.spec.tsx
+++ b/packages/openneuro-app/src/scripts/dataset/mutations/__tests__/fsck-dataset.spec.tsx
@@ -1,0 +1,129 @@
+import React from "react"
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { vi } from "vitest"
+import { MockedProvider } from "@apollo/client/testing"
+import { FSCK_DATASET, FsckDataset } from "../fsck-dataset"
+
+// Mock the Button component to isolate the unit test
+vi.mock("../../../components/button/Button", () => ({
+  Button: ({ label, onClick, disabled, icon }) => (
+    <button onClick={onClick} disabled={disabled} data-testid="fsck-button">
+      <i className={icon} />
+      {label}
+    </button>
+  ),
+}))
+
+const datasetId = "ds001"
+
+const successMock = {
+  request: {
+    query: FSCK_DATASET,
+    variables: { datasetId },
+  },
+  result: {
+    data: {
+      fsckDataset: true,
+    },
+  },
+}
+
+const failureMock = {
+  request: {
+    query: FSCK_DATASET,
+    variables: { datasetId },
+  },
+  result: {
+    data: {
+      fsckDataset: false,
+    },
+  },
+}
+
+const errorMock = {
+  request: {
+    query: FSCK_DATASET,
+    variables: { datasetId },
+  },
+  error: new Error("Network error"),
+}
+
+describe("FsckDataset Component", () => {
+  it("renders with initial state", () => {
+    render(
+      <MockedProvider mocks={[]} addTypename={false}>
+        <FsckDataset datasetId={datasetId} disabled={false} />
+      </MockedProvider>,
+    )
+    const button = screen.getByTestId("fsck-button")
+    expect(button).toHaveTextContent("Rerun File Checks")
+    expect(button).not.toBeDisabled()
+  })
+
+  it("handles disabled prop", () => {
+    render(
+      <MockedProvider mocks={[]} addTypename={false}>
+        <FsckDataset datasetId={datasetId} disabled={true} />
+      </MockedProvider>,
+    )
+    const button = screen.getByTestId("fsck-button")
+    expect(button).toBeDisabled()
+  })
+
+  it("handles successful mutation", async () => {
+    render(
+      <MockedProvider mocks={[successMock]} addTypename={false}>
+        <FsckDataset datasetId={datasetId} disabled={false} />
+      </MockedProvider>,
+    )
+
+    const button = screen.getByTestId("fsck-button")
+    fireEvent.click(button)
+
+    // Loading state
+    expect(button).toHaveTextContent("Running...")
+    expect(button).toBeDisabled()
+
+    // Success state
+    await waitFor(() => {
+      expect(button).toHaveTextContent("Success")
+    })
+    expect(button.querySelector(".fa-check")).toBeInTheDocument()
+  })
+
+  it("handles logical failure (false response)", async () => {
+    render(
+      <MockedProvider mocks={[failureMock]} addTypename={false}>
+        <FsckDataset datasetId={datasetId} disabled={false} />
+      </MockedProvider>,
+    )
+
+    const button = screen.getByTestId("fsck-button")
+    fireEvent.click(button)
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Too many recent requests, please try again later."),
+      ).toBeInTheDocument()
+    })
+    expect(button).toHaveTextContent("Rerun File Checks")
+    expect(button.querySelector(".fa-exclamation-triangle")).toBeInTheDocument()
+  })
+
+  it("handles network error", async () => {
+    render(
+      <MockedProvider mocks={[errorMock]} addTypename={false}>
+        <FsckDataset datasetId={datasetId} disabled={false} />
+      </MockedProvider>,
+    )
+
+    const button = screen.getByTestId("fsck-button")
+    fireEvent.click(button)
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Too many recent requests, please try again later."),
+      ).toBeInTheDocument()
+    })
+  })
+})

--- a/packages/openneuro-app/src/scripts/dataset/mutations/fsck-dataset.tsx
+++ b/packages/openneuro-app/src/scripts/dataset/mutations/fsck-dataset.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from "react"
 import { gql, useMutation } from "@apollo/client"
 import { Button } from "../../components/button/Button"
 
-const FSCK_DATASET = gql`
+export const FSCK_DATASET = gql`
   mutation fsckDataset($datasetId: ID!) {
     fsckDataset(datasetId: $datasetId)
   }

--- a/packages/openneuro-app/src/scripts/dataset/mutations/fsck-dataset.tsx
+++ b/packages/openneuro-app/src/scripts/dataset/mutations/fsck-dataset.tsx
@@ -1,7 +1,7 @@
-import React from "react"
-import { gql } from "@apollo/client"
-import { Mutation } from "@apollo/client/react/components"
+import React, { useEffect, useState } from "react"
+import { gql, useMutation } from "@apollo/client"
 import { Button } from "../../components/button/Button"
+
 const FSCK_DATASET = gql`
   mutation fsckDataset($datasetId: ID!) {
     fsckDataset(datasetId: $datasetId)
@@ -10,26 +10,60 @@ const FSCK_DATASET = gql`
 
 type FsckDatasetProps = {
   datasetId: string
+  disabled: boolean
 }
 
-export const FsckDataset = ({ datasetId }: FsckDatasetProps) => (
-  <Mutation mutation={FSCK_DATASET}>
-    {(fsckDataset) => (
-      <span>
-        <Button
-          icon="fa fa-repeat"
-          label="Rerun File Checks"
-          primary={true}
-          size="small"
-          onClick={() => {
-            fsckDataset({
+export const FsckDataset = ({ datasetId, disabled }: FsckDatasetProps) => {
+  const [fsckDataset, { loading }] = useMutation(FSCK_DATASET)
+  const [status, setStatus] = useState<"idle" | "success" | "failure">("idle")
+
+  useEffect(() => {
+    if (status === "success") {
+      const timer = setTimeout(() => setStatus("idle"), 2000)
+      return () => clearTimeout(timer)
+    }
+  }, [status])
+
+  return (
+    <span>
+      <Button
+        icon={loading
+          ? "fa fa-spin fa-repeat"
+          : status === "success"
+          ? "fa fa-check"
+          : status === "failure"
+          ? "fa fa-exclamation-triangle"
+          : "fa fa-repeat"}
+        label={loading
+          ? "Running..."
+          : status === "success"
+          ? "Success"
+          : "Rerun File Checks"}
+        primary={true}
+        size="small"
+        disabled={disabled || loading}
+        onClick={async () => {
+          try {
+            const { data } = await fsckDataset({
               variables: {
                 datasetId,
               },
             })
-          }}
-        />
-      </span>
-    )}
-  </Mutation>
-)
+            if (data.fsckDataset) {
+              setStatus("success")
+            } else {
+              setStatus("failure")
+            }
+          } catch (e) {
+            setStatus("failure")
+          }
+        }}
+      />
+      {status === "failure" && (
+        <span style={{ display: "block", color: "red", marginTop: "5px" }}>
+          Too many recent requests, please try again later.
+        </span>
+      )}
+    </span>
+  )
+}

--- a/packages/openneuro-app/src/scripts/dataset/mutations/fsck-dataset.tsx
+++ b/packages/openneuro-app/src/scripts/dataset/mutations/fsck-dataset.tsx
@@ -1,0 +1,35 @@
+import React from "react"
+import { gql } from "@apollo/client"
+import { Mutation } from "@apollo/client/react/components"
+import { Button } from "../../components/button/Button"
+const FSCK_DATASET = gql`
+  mutation fsckDataset($datasetId: ID!) {
+    fsckDataset(datasetId: $datasetId)
+  }
+`
+
+type FsckDatasetProps = {
+  datasetId: string
+}
+
+export const FsckDataset = ({ datasetId }: FsckDatasetProps) => (
+  <Mutation mutation={FSCK_DATASET}>
+    {(fsckDataset) => (
+      <span>
+        <Button
+          icon="fa fa-repeat"
+          label="Rerun File Checks"
+          primary={true}
+          size="small"
+          onClick={() => {
+            fsckDataset({
+              variables: {
+                datasetId,
+              },
+            })
+          }}
+        />
+      </span>
+    )}
+  </Mutation>
+)

--- a/packages/openneuro-app/src/scripts/dataset/mutations/fsck-dataset.tsx
+++ b/packages/openneuro-app/src/scripts/dataset/mutations/fsck-dataset.tsx
@@ -54,7 +54,7 @@ export const FsckDataset = ({ datasetId, disabled }: FsckDatasetProps) => {
             } else {
               setStatus("failure")
             }
-          } catch (e) {
+          } catch (_err) {
             setStatus("failure")
           }
         }}

--- a/packages/openneuro-app/src/scripts/dataset/routes/snapshot.tsx
+++ b/packages/openneuro-app/src/scripts/dataset/routes/snapshot.tsx
@@ -31,6 +31,8 @@ export const NoErrors = (
   const currentTime = new Date().getTime()
   const thirtyMinutesAgo = currentTime - thirtyMinutes
   const recheckEnabled = modifiedTime < thirtyMinutesAgo
+  const timeDiff = modifiedTime + thirtyMinutes - currentTime
+  const minutesDiff = Math.round(timeDiff / (1000 * 60))
 
   if (noBadFiles && noErrors && hasAuthor) {
     return children
@@ -54,11 +56,16 @@ export const NoErrors = (
         {includedMessages.length !== 0 && (
           <p>The above issues must be corrected to create a version.</p>
         )}
-        {fileCheckFinish && !noBadFiles && (
+        {!noBadFiles && (
           <span>
-            {recheckEnabled && <FsckDataset datasetId={datasetId} />}
-            <FileCheckList fileCheck={fileCheck} />
+            <FsckDataset datasetId={datasetId} disabled={!recheckEnabled} />
+            {!recheckEnabled && (
+              <p>A recheck can be requested in {minutesDiff} minutes.</p>
+            )}
           </span>
+        )}
+        {fileCheckFinish && !noBadFiles && (
+          <FileCheckList fileCheck={fileCheck} />
         )}
       </span>
     )

--- a/packages/openneuro-app/src/scripts/dataset/routes/tab-routes-draft.tsx
+++ b/packages/openneuro-app/src/scripts/dataset/routes/tab-routes-draft.tsx
@@ -45,6 +45,7 @@ export const TabRoutesDraft = ({ dataset, hasEdit }) => {
         element={
           <Snapshot
             datasetId={dataset.id}
+            modified={dataset.draft.modified}
             snapshots={dataset.snapshots}
             validation={dataset.draft.validation}
             description={dataset.draft.description}

--- a/packages/openneuro-server/src/graphql/resolvers/fileCheck.ts
+++ b/packages/openneuro-server/src/graphql/resolvers/fileCheck.ts
@@ -28,7 +28,7 @@ export const fsckUrl = (datasetId) => {
   }/datasets/${datasetId}/fsck`
 }
 
-export const fsckDataset = async (datasetId, _, { user, userInfo }) => {
+export const fsckDataset = async (_, { datasetId }, { user, userInfo }) => {
   // Anonymous users can't trigger fsck
   try {
     await checkDatasetWrite(datasetId, user, userInfo)

--- a/packages/openneuro-server/src/graphql/resolvers/fileCheck.ts
+++ b/packages/openneuro-server/src/graphql/resolvers/fileCheck.ts
@@ -37,7 +37,7 @@ export const fsckDataset = async (_, { datasetId }, { user, userInfo }) => {
   }
   try {
     // Lock for 30 minutes to avoid stacking fsck requests
-    await redlock.lock(`openneuro:recheck-lock:${datasetId}`, 1800000)
+    await redlock.lock(`openneuro:fsck-local-lock:${datasetId}`, 1800000)
     const response = await fetch(fsckUrl(datasetId), {
       method: "POST",
       body: JSON.stringify({}),

--- a/packages/openneuro-server/src/graphql/resolvers/fileCheck.ts
+++ b/packages/openneuro-server/src/graphql/resolvers/fileCheck.ts
@@ -1,5 +1,9 @@
+import config from "../../config"
+import { generateDataladCookie } from "../../libs/authentication/jwt"
+import { getDatasetWorker } from "../../libs/datalad-service"
+import { redlock } from "../../libs/redis"
 import FileCheck from "../../models/fileCheck"
-import { checkDatasetAdmin } from "../permissions"
+import { checkDatasetAdmin, checkDatasetWrite } from "../permissions"
 
 export const updateFileCheck = async (
   obj,
@@ -14,4 +18,42 @@ export const updateFileCheck = async (
   )
     .lean()
     .exec()
+}
+
+export const fsckUrl = (datasetId) => {
+  return `http://${
+    getDatasetWorker(
+      datasetId,
+    )
+  }/datasets/${datasetId}/fsck`
+}
+
+export const fsckDataset = async (datasetId, _, { user, userInfo }) => {
+  // Anonymous users can't trigger fsck
+  try {
+    await checkDatasetWrite(datasetId, user, userInfo)
+  } catch {
+    return false
+  }
+  try {
+    // Lock for 30 minutes to avoid stacking fsck requests
+    await redlock.lock(`openneuro:recheck-lock:${datasetId}`, 1800000)
+    const response = await fetch(fsckUrl(datasetId), {
+      method: "POST",
+      body: JSON.stringify({}),
+      headers: {
+        cookie: generateDataladCookie(config)(userInfo),
+      },
+    })
+    if (response.status === 200) {
+      return true
+    } else {
+      return false
+    }
+  } catch (err) {
+    // Backend unavailable or lock failed
+    if (err) {
+      return false
+    }
+  }
 }

--- a/packages/openneuro-server/src/graphql/resolvers/mutation.ts
+++ b/packages/openneuro-server/src/graphql/resolvers/mutation.ts
@@ -55,6 +55,7 @@ import { createGitEvent } from "./gitEvents"
 import { updateFileCheck } from "./fileCheck"
 import { updateContributors } from "../../datalad/contributors"
 import { updateWorkerTask } from "./worker"
+import { fsckDataset } from "./fileCheck"
 
 const Mutation = {
   createDataset,
@@ -91,6 +92,7 @@ const Mutation = {
   finishUpload,
   cacheClear,
   revalidate,
+  fsckDataset,
   prepareRepoAccess,
   reexportRemotes,
   resetDraft,

--- a/packages/openneuro-server/src/graphql/resolvers/mutation.ts
+++ b/packages/openneuro-server/src/graphql/resolvers/mutation.ts
@@ -52,10 +52,9 @@ import {
   updateEventStatus,
 } from "./datasetEvents"
 import { createGitEvent } from "./gitEvents"
-import { updateFileCheck } from "./fileCheck"
+import { fsckDataset, updateFileCheck } from "./fileCheck"
 import { updateContributors } from "../../datalad/contributors"
 import { updateWorkerTask } from "./worker"
-import { fsckDataset } from "./fileCheck"
 
 const Mutation = {
   createDataset,

--- a/packages/openneuro-server/src/graphql/schema.ts
+++ b/packages/openneuro-server/src/graphql/schema.ts
@@ -178,6 +178,8 @@ export const typeDefs = `
     finishUpload(uploadId: ID!): Boolean
     # Drop cached data for a dataset - requires site admin access
     cacheClear(datasetId: ID!): Boolean
+    # Rerun fsck on a dataset if 30 minutes have passed since last request
+    fsckDataset(datasetId: ID!): Boolean
     # Rerun the latest validator on a given commit
     revalidate(datasetId: ID!, ref: String!): Boolean
     # Request a temporary token for git access

--- a/services/datalad/datalad_service/app.py
+++ b/services/datalad/datalad_service/app.py
@@ -32,6 +32,7 @@ from datalad_service.handlers.reexporter import ReexporterResource
 from datalad_service.handlers.reset import ResetResource
 from datalad_service.handlers.remote_import import RemoteImportResource
 from datalad_service.handlers.info import InfoResource
+from datalad_service.handlers.fsck import FsckResource
 from datalad_service.middleware.auth import AuthenticateMiddleware
 from datalad_service.middleware.error import CustomErrorHandlerMiddleware
 
@@ -103,6 +104,7 @@ def create_app():
     dataset_reset_resource = ResetResource(store)
     dataset_remote_import_resource = RemoteImportResource(store)
     dataset_info_resource = InfoResource(store)
+    dataset_fsck_resource = FsckResource(store)
 
     app.add_route('/heartbeat', heartbeat)
 
@@ -115,6 +117,7 @@ def create_app():
     app.add_route('/datasets/{dataset}/description', dataset_description)
     app.add_route('/datasets/{dataset}/validate/{hexsha}', dataset_validation)
     app.add_route('/datasets/{dataset}/reset/{hexsha}', dataset_reset_resource)
+    app.add_route('/datasets/{dataset}/fsck', dataset_fsck_resource)
     app.add_route('/datasets/{dataset}/info', dataset_info_resource)
     app.add_route('/datasets/{dataset}/info/{name}', dataset_info_resource)
     app.add_route('/datasets/{dataset}/files', dataset_files)

--- a/services/datalad/datalad_service/handlers/fsck.py
+++ b/services/datalad/datalad_service/handlers/fsck.py
@@ -1,0 +1,15 @@
+import falcon
+import logging
+
+from datalad_service.tasks.fsck import git_annex_fsck_local
+
+
+class FsckResource:
+    def __init__(self, store):
+        self.store = store
+        self.logger = logging.getLogger('datalad_service.' + __name__)
+
+    async def on_post(self, req, resp, dataset):
+        dataset_path = self.store.get_dataset_path(dataset)
+        await git_annex_fsck_local.kiq(dataset_path)
+        resp.status = falcon.HTTP_OK


### PR DESCRIPTION
This adds a button to rerun file checks on the version creation route. Any user with write access or site admins can request these checks are rerun once every 30 minutes (as long as the last change to the dataset is at least 30 minutes old as checks are automatically run on every change). This is useful in the case where only annexed objects were missing and you've uploaded those objects.

<img width="967" height="139" alt="Screenshot From 2025-12-17 12-01-33" src="https://github.com/user-attachments/assets/5d3a2d09-1a31-492d-866c-fc5abbf9427d" />
