### PR TITLE
fix(app): Update download query for id/key changes

### DIFF
--- a/packages/openneuro-app/src/scripts/dataset/download/download-native.js
+++ b/packages/openneuro-app/src/scripts/dataset/download/download-native.js
@@ -68,7 +68,7 @@ const downloadTree = async (
           toastId,
         },
         downloadPath,
-        file.id,
+        file.key,
       )
     } else {
       // Regular file

--- a/packages/openneuro-app/src/scripts/dataset/download/download-query.js
+++ b/packages/openneuro-app/src/scripts/dataset/download/download-query.js
@@ -8,6 +8,7 @@ query downloadDraft($datasetId: ID!, $tree: String) {
       id
       files(tree: $tree) {
         id
+        key
         directory
         filename
         size
@@ -24,6 +25,7 @@ export const DOWNLOAD_SNAPSHOT = gql`
       id
       files(tree: $tree) {
         id
+        key
         directory
         filename
         size


### PR DESCRIPTION
This query would request trees using the wrong field for the current release of OpenNeuro. Fixes downloads in Chrome based browsers.

Fixes #3701
