### PR TITLE
fix(app): Prevent failure to update cache with additional file query results

### DIFF
--- a/packages/openneuro-app/src/scripts/dataset/files/__tests__/file-tree-unloaded-directory.spec.jsx
+++ b/packages/openneuro-app/src/scripts/dataset/files/__tests__/file-tree-unloaded-directory.spec.jsx
@@ -56,5 +56,36 @@ describe("FileTreeUnloadedDirectory component", () => {
         filename: "sub-01:c",
       }])
     })
+    it("handles snapshot with undefined files array", () => {
+      const dir = { filename: "sub-01", directory: true }
+      const c = { id: "91011", filename: "c", directory: false }
+      const defaultObj = { snapshot: {} } // files array is undefined
+      const updatedObj = { snapshot: { files: [c] } }
+
+      expect(
+        mergeNewFiles(dir, "1.0.0")(defaultObj, { fetchMoreResult: updatedObj })
+          .snapshot.files,
+      ).toEqual([{
+        ...c,
+        id: "sub-01:91011",
+        filename: "sub-01:c",
+      }])
+    })
+
+    it("handles draft with undefined files array", () => {
+      const dir = { filename: "sub-01", directory: true }
+      const c = { id: "91011", filename: "c", directory: false }
+      const defaultObj = { dataset: { draft: {} } } // files array is undefined
+      const updatedObj = { dataset: { draft: { files: [c] } } }
+
+      expect(
+        mergeNewFiles(dir)(defaultObj, { fetchMoreResult: updatedObj })
+          .dataset.draft.files,
+      ).toEqual([{
+        ...c,
+        id: "sub-01:91011",
+        filename: "sub-01:c",
+      }])
+    })
   })
 })

--- a/packages/openneuro-app/src/scripts/dataset/files/file-tree-unloaded-directory.jsx
+++ b/packages/openneuro-app/src/scripts/dataset/files/file-tree-unloaded-directory.jsx
@@ -56,6 +56,17 @@ export const mergeNewFiles =
     // Deep clone the old dataset object
     const path = directory.filename
     const newDatasetObj = JSON.parse(JSON.stringify(past))
+
+    if (snapshotTag) {
+      if (!newDatasetObj.snapshot.files) {
+        newDatasetObj.snapshot.files = []
+      }
+    } else {
+      if (!newDatasetObj.dataset.draft.files) {
+        newDatasetObj.dataset.draft.files = []
+      }
+    }
+
     const newFiles = snapshotTag
       ? newDatasetObj.snapshot.files
       : newDatasetObj.dataset.draft.files


### PR DESCRIPTION
This handles the case where the cache has no loaded yet but we've received a query result for loading a subdirectory.