### PR TITLE
chore(server): Don't record sentry traces for expected exceptions

### DIFF
--- a/packages/openneuro-server/src/sentry.ts
+++ b/packages/openneuro-server/src/sentry.ts
@@ -21,4 +21,8 @@ Sentry.init({
     }
     return event
   },
+  ignoreErrors: [
+    "You do not have access to read this dataset.",
+    "You do not have access to modify this dataset.",
+  ],
 })


### PR DESCRIPTION
A couple of the most common errors but expected when a user attempts to read or write to a dataset without permissions.