### PR TITLE
fix: Allow /api in addition to /crn

### DIFF
--- a/helm/openneuro/templates/ingress.yaml
+++ b/helm/openneuro/templates/ingress.yaml
@@ -28,6 +28,13 @@ spec:
                 name: {{ .Release.Name }}-api
                 port:
                   number: 8111
+          - path: /api/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: {{ .Release.Name }}-api
+                port:
+                  number: 8111
           - path: /sitemap.xml
             pathType: ImplementationSpecific
             backend:

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -54,7 +54,7 @@ server {
     location /google91f984197a997590.html {return 200 "google-site-verification: google91f984197a997590.html";}
 
     # crn-server proxy
-    location /crn {
+    location ^/(api|crn) {
         client_max_body_size 0;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;

--- a/nginx/nginx.dev.conf
+++ b/nginx/nginx.dev.conf
@@ -26,17 +26,7 @@ server {
     }
 
     # crn-server proxy
-    location /crn {
-        client_max_body_size 0;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header Connection "";
-        proxy_http_version 1.1;
-        proxy_request_buffering off;
-        proxy_pass http://server:8111;
-    }
-
-    location /api {
+    location ^/(api|crn) {
         client_max_body_size 0;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
This is already broadly supported, enable `/api` as an alternative path for the requests.