### PR TITLE
feat(cli): Allow specifying URL options for git credential helper

### DIFF
--- a/cli/src/commands/git-credential.test.ts
+++ b/cli/src/commands/git-credential.test.ts
@@ -13,6 +13,7 @@ Deno.test("git-credential parses stdin correctly", async () => {
     },
   })
   const output = await gitCredentialAction(
+    "staging.openneuro.org",
     stdin,
     async () => ({ token: "token", endpoint: 2 }),
   )

--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -18,8 +18,10 @@ export function getConfigPath(): string {
 /**
  * Get credentials from local storage
  */
-export function getConfig(): ClientConfig {
-  const url = Deno.env.get("OPENNEURO_URL") || "https://openneuro.org"
+export function getConfig(
+  instance: string = "https://openneuro.org",
+): ClientConfig {
+  const url = Deno.env.get("OPENNEURO_URL") || instance
   const configPath = getConfigPath()
   const config = JSON.parse(
     new TextDecoder().decode(Deno.readFileSync(configPath)),

--- a/docs/git.md
+++ b/docs/git.md
@@ -45,6 +45,8 @@ Once you have logged in with `deno run -A jsr:@openneuro/cli`, you can configure
 git config --global credential.https://openneuro.org.useHttpPath true
 # Point git at the @openneuro/cli tool (this must be an absolute path)
 git config --global credential.https://openneuro.org.helper "/path/to/deno -A jsr:@openneuro/cli git-credential"
+# For OpenNeuro instances other than https://openneuro.org
+git config --global credential.https://staging.openneuro.org.helper "/path/to/deno -A jsr:@openneuro/cli git-credential --url https://staging.openneuro.org"
 ```
 
 If you are using [Git Credential Manager](https://github.com/git-ecosystem/git-credential-manager) add the provider entry to avoid duplicating entries.


### PR DESCRIPTION
Add `openneuro git-credential` argument to allow specifying the URL. This simplifies having several instances defined with different credentials in the git config. Adds an example of how to use it to the git access documentation.