### PR TITLE
feat(api): Provide /api/git/<accessionNumber> paths for git access

### DIFF
--- a/packages/openneuro-app/src/scripts/dataset/components/DatasetGitAccess.tsx
+++ b/packages/openneuro-app/src/scripts/dataset/components/DatasetGitAccess.tsx
@@ -24,7 +24,7 @@ export const DatasetGitAccess = ({
   hasEdit,
 }: DatasetGitAccessProps) => {
   const workerId = worker?.split("-").pop()
-  const url = `${configUrl}/git/${workerId}/${datasetId}`
+  const url = `${configUrl}/api/git/${datasetId}`
   const readURL = `https://github.com/${configGithub}/${datasetId}.git`
   return (
     <div className="dataset-git-access">

--- a/packages/openneuro-server/src/handlers/datalad.ts
+++ b/packages/openneuro-server/src/handlers/datalad.ts
@@ -2,7 +2,7 @@ import request from "superagent"
 import { Readable } from "node:stream"
 import mime from "mime-types"
 import { getFiles } from "../datalad/files"
-import { getDatasetWorker } from "../libs/datalad-service"
+import { getDatasetEndpoint, getDatasetWorker } from "../libs/datalad-service"
 import { getDraftRevision } from "../datalad/draft"
 
 /**
@@ -102,4 +102,17 @@ export const getObject = (req, res) => {
       error: "Key must be a git object hash or git-annex key",
     })
   }
+}
+
+/**
+ * Redirect to the appropriate git endpoint for a dataset
+ */
+export function gitRepo(req, res) {
+  const { datasetId } = req.params
+  const worker = getDatasetEndpoint(datasetId)
+  const newUrl = req.originalUrl.replace(
+    `${req.baseUrl}/git/`,
+    `/git/${worker}/`,
+  )
+  return res.redirect(301, newUrl)
 }

--- a/packages/openneuro-server/src/routes.ts
+++ b/packages/openneuro-server/src/routes.ts
@@ -187,6 +187,11 @@ const routes = [
     url: "/sitemap",
     handler: sitemapHandler,
   },
+  // git redirect routes
+  { method: "get", url: "/git/:datasetId", handler: datalad.gitRepo },
+  { method: "post", url: "/git/:datasetId", handler: datalad.gitRepo },
+  { method: "get", url: "/git/:datasetId/*", handler: datalad.gitRepo },
+  { method: "post", url: "/git/:datasetId/*", handler: datalad.gitRepo },
 ]
 
 // initialize routes -------------------------------


### PR DESCRIPTION
Allows access to git datasets without needing to specify the worker id in the URL. This works best with DataLad because the redirect is preserved in the remote configuration but it does work with most other git clients. It is still possible to use the worker id URL in the case a client does not handle redirects for HTTP git repositories.

Fixes #1967