### PR TITLE
fix(worker): Move validation locking to worker and lock on first run

### DIFF
--- a/packages/openneuro-server/src/graphql/resolvers/issues.ts
+++ b/packages/openneuro-server/src/graphql/resolvers/issues.ts
@@ -18,7 +18,7 @@ export const issues = async (dataset, _, { userInfo }) => {
     .exec()
     .then((data) => {
       if (!data && userInfo) {
-        // If no results were found, acquire a lock and run validation
+        // If no results were found, request to run validation
         revalidate(
           null,
           { datasetId: dataset.id, ref: dataset.revision },

--- a/packages/openneuro-server/src/graphql/resolvers/validation.ts
+++ b/packages/openneuro-server/src/graphql/resolvers/validation.ts
@@ -2,7 +2,7 @@ import config from "../../config"
 import { generateDataladCookie } from "../../libs/authentication/jwt"
 import { getDatasetWorker } from "../../libs/datalad-service"
 import Validation from "../../models/validation"
-import { redis, redlock } from "../../libs/redis"
+import { redis } from "../../libs/redis"
 import CacheItem from "../../cache/item"
 import { CacheType } from "../../cache/types"
 
@@ -134,8 +134,6 @@ export const validationUrl = (datasetId, ref) => {
  */
 export const revalidate = async (obj, { datasetId, ref }, { userInfo }) => {
   try {
-    // Lock for five minutes to avoid stacking up multiple validation requests
-    await redlock.lock(`openneuro:revalidate-lock:${datasetId}:${ref}`, 300000)
     const response = await fetch(validationUrl(datasetId, ref), {
       method: "POST",
       body: JSON.stringify({}),

--- a/services/datalad/datalad_service/common/redis.py
+++ b/services/datalad/datalad_service/common/redis.py
@@ -1,0 +1,7 @@
+import redis.asyncio as redis
+
+from datalad_service import config
+
+
+def redis_client():
+    return redis.from_url(f'redis://{config.REDIS_HOST}:{config.REDIS_PORT}/8')

--- a/services/datalad/datalad_service/middleware/profiling.py
+++ b/services/datalad/datalad_service/middleware/profiling.py
@@ -1,0 +1,51 @@
+import cProfile
+import io
+import logging
+import pstats
+import time
+import tracemalloc
+
+logger = logging.getLogger('datalad_service.middleware.profiling')
+
+
+class ProfilingMiddleware:
+    def __init__(self):
+        if not tracemalloc.is_tracing():
+            tracemalloc.start()
+
+    async def process_request(self, req, resp):
+        req.context['start_time'] = time.time()
+        req.context['tracemalloc_snapshot'] = tracemalloc.take_snapshot()
+        profiler = cProfile.Profile(time.process_time)
+        try:
+            profiler.enable()
+            req.context['cprofile'] = profiler
+        except ValueError:
+            pass
+
+    async def process_response(self, req, resp, resource, req_succeeded):
+        if 'cprofile' in req.context:
+            req.context['cprofile'].disable()
+        if 'start_time' in req.context:
+            elapsed = time.time() - req.context['start_time']
+            if elapsed > 0.3:
+                logger.info(f'Request {req.method} {req.path} took {elapsed:.3f}s')
+                if 'cprofile' in req.context:
+                    s = io.StringIO()
+                    ps = pstats.Stats(req.context['cprofile'], stream=s).sort_stats(
+                        'tottime'
+                    )
+                    ps.print_stats(10)
+                    logger.info(
+                        f'Top 10 CPU consuming functions for {req.method} {req.path}:'
+                    )
+                    logger.info(s.getvalue())
+        if 'tracemalloc_snapshot' in req.context:
+            snapshot = tracemalloc.take_snapshot()
+            top_stats = snapshot.compare_to(
+                req.context['tracemalloc_snapshot'], 'lineno'
+            )
+            if sum(stat.size_diff for stat in top_stats) > 1024 * 1024:
+                logger.info(f'Top 10 memory usage for {req.method} {req.path}:')
+                for stat in top_stats[:10]:
+                    logger.info(stat)


### PR DESCRIPTION
Moves the validation lock out of the API and into the worker. This means it locks on the first run and won't immediately stack a second call and this lock is released immediately when validation finishes instead of after 5 minutes, allowing it to live longer for long running validation tasks.