### PR TITLE
refactor(worker): Switch to asyncio for get_repo_files

### DIFF
--- a/services/datalad/datalad_service/handlers/snapshots.py
+++ b/services/datalad/datalad_service/handlers/snapshots.py
@@ -30,7 +30,7 @@ class SnapshotResource:
         if not os.path.exists(self.store.get_dataset_path(dataset)):
             resp.status = falcon.HTTP_NOT_FOUND
         elif snapshot:
-            files = get_tree(self.store, dataset, snapshot)
+            files = await get_tree(self.store, dataset, snapshot)
             try:
                 response = get_snapshot(self.store, dataset, snapshot)
                 response['files'] = files

--- a/services/datalad/datalad_service/handlers/tree.py
+++ b/services/datalad/datalad_service/handlers/tree.py
@@ -16,7 +16,7 @@ class TreeResource:
         # Return a list of file objects
         # {name, path, size}
         try:
-            files = get_tree(self.store, dataset, tree)
+            files = await get_tree(self.store, dataset, tree)
             files.sort(key=dataset_sort)
             resp.status = falcon.HTTP_OK
             resp.media = {'files': files}

--- a/services/datalad/datalad_service/tasks/files.py
+++ b/services/datalad/datalad_service/tasks/files.py
@@ -41,10 +41,10 @@ async def commit_files(store, dataset, files, name=None, email=None, cookies=Non
     return ref
 
 
-def get_tree(store, dataset, tree):
+async def get_tree(store, dataset, tree):
     """Get the working tree, optionally a branch tree."""
     dataset_path = store.get_dataset_path(dataset)
-    return get_repo_files(dataset, dataset_path, tree)
+    return await get_repo_files(dataset, dataset_path, tree)
 
 
 async def remove_files(store, dataset, paths, name=None, email=None, cookies=None):


### PR DESCRIPTION
Migrate get_repo_files and get_repo_urls to asyncio. This avoids blocking the uvicorn process for expensive trees that can sometimes result in a health check exceeding the timeout and restarting the worker unnecessarily.