### PR TITLE
FIX getRepoAccess() callers to pass instance URL as first argument

### DIFF
--- a/cli/src/commands/download.ts
+++ b/cli/src/commands/download.ts
@@ -28,7 +28,7 @@ export async function downloadAction(
 ) {
   const datasetId = accession_number
   const clientConfig = readConfig()
-  const { token, endpoint } = await getRepoAccess(datasetId)
+  const { token, endpoint } = await getRepoAccess(clientConfig.url, datasetId)
 
   // Create the git worker
   const worker = new Worker(new URL("../worker/git.ts", import.meta.url).href, {

--- a/cli/src/commands/special-remote.ts
+++ b/cli/src/commands/special-remote.ts
@@ -83,7 +83,8 @@ export const response = () => {
         // Obtain the filename (no extensions) in url value
         const datasetId = url.substring(url.lastIndexOf("/") + 1, url.length)
         state.url = url
-        const { token } = await getRepoAccess(datasetId)
+        const instanceUrl = new URL(url).origin
+        const { token } = await getRepoAccess(instanceUrl, datasetId)
         state.token = token
       } catch (_err) {
         state.url = ""

--- a/cli/src/commands/upload.ts
+++ b/cli/src/commands/upload.ts
@@ -124,7 +124,7 @@ export async function uploadAction(
   })
 
   const repoPath = join(repoDir, datasetId)
-  const { token, endpoint } = await getRepoAccess(datasetId)
+  const { token, endpoint } = await getRepoAccess(clientConfig.url, datasetId)
   await Deno.mkdir(repoPath, { recursive: true })
   // Configure worker
   worker.postMessage({


### PR DESCRIPTION
I was trying to upload a new dataset with the CLI (v4.4.0), but kept getting login errors despite having logged in multiple times. The following was fixed with Claude. Now I'm able to upload the dataset (ongoing).

---
Claude's comment:

> Commit 2fae59b13 changed getRepoAccess() signature to require an instance URL as the first parameter, but these three callers were not updated. This caused getConfig(instance) to look up tokens using the dataset ID instead of the URL, resulting in "Run openneuro login" errors.