### PR TITLE
fix(server): Avoid calling worker snapshots requests on non-existing datasets

### DIFF
--- a/packages/openneuro-server/src/datalad/snapshots.ts
+++ b/packages/openneuro-server/src/datalad/snapshots.ts
@@ -100,7 +100,9 @@ const postSnapshot = async (
  * @param {string} datasetId Dataset accession number
  * @returns {Promise<import('../models/snapshot').SnapshotDocument[]>}
  */
-export const getSnapshots = (datasetId): Promise<SnapshotDocument[]> => {
+export const getSnapshots = async (datasetId): Promise<SnapshotDocument[]> => {
+  const dataset = await Dataset.findOne({ id: datasetId })
+  if (!dataset) return null
   const url = `${getDatasetWorker(datasetId)}/datasets/${datasetId}/snapshots`
   return request
     .get(url)


### PR DESCRIPTION
Add a guard to prevent creating excessive worker requests for snapshots that don't exist.