### PR TITLE
fix(server): Reduce repeat requests for draft info by sharing the short live cache

### DIFF
--- a/packages/openneuro-server/src/datalad/dataset.ts
+++ b/packages/openneuro-server/src/datalad/dataset.ts
@@ -14,7 +14,7 @@ import * as subscriptions from "../handlers/subscriptions"
 import { generateDataladCookie } from "../libs/authentication/jwt"
 import { redis } from "../libs/redis"
 import CacheItem, { CacheType } from "../cache/item"
-import { updateDatasetRevision } from "./draft"
+import { getDraftRevision, updateDatasetRevision } from "./draft"
 import { encodeFilePath, filesUrl, fileUrl, getFileName } from "./files"
 import { getAccessionNumber } from "../libs/dataset"
 import Dataset from "../models/dataset"
@@ -80,28 +80,6 @@ export const createDataset = async (
   }
 }
 
-interface WorkerDraftFields {
-  // Commit id hash
-  ref: string
-  // Commit tree ref
-  tree: string
-  // Commit message
-  message: string
-  // Commit author time
-  modified: string
-}
-
-/**
- * Return the latest commit
- * @param {string} id Dataset accession number
- */
-export const getDraftHead = async (id): Promise<WorkerDraftFields> => {
-  const draftRes = await request
-    .get(`${getDatasetWorker(id)}/datasets/${id}/draft`)
-    .set("Accept", "application/json")
-  return draftRes.body
-}
-
 /**
  * Fetch dataset document and related fields
  */
@@ -109,7 +87,7 @@ export const getDataset = async (id) => {
   const dataset = await Dataset.findOne({ id }).lean()
   return {
     ...dataset,
-    revision: (await getDraftHead(id)).ref,
+    revision: getDraftRevision(id),
   }
 }
 

--- a/packages/openneuro-server/src/graphql/resolvers/dataset.ts
+++ b/packages/openneuro-server/src/graphql/resolvers/dataset.ts
@@ -24,6 +24,7 @@ import { derivatives } from "./derivatives"
 import { promiseTimeout } from "../../utils/promiseTimeout"
 import { datasetEvents } from "./datasetEvents"
 import semver from "semver"
+import { getDraftInfo } from "../../datalad/draft"
 
 export const dataset = async (obj, { id }, { user, userInfo }) => {
   await checkDatasetRead(id, user, userInfo)
@@ -280,7 +281,7 @@ const worker = (obj) => getDatasetWorker(obj.id)
 const Dataset = {
   uploader: (ds, _, context) => user(ds, { id: ds.uploader }, context),
   draft: async (obj) => {
-    const draftHead = await datalad.getDraftHead(obj.id)
+    const draftHead = await getDraftInfo(obj.id)
     return {
       id: obj.id,
       revision: draftHead.ref,

--- a/packages/openneuro-server/src/graphql/resolvers/snapshots.ts
+++ b/packages/openneuro-server/src/graphql/resolvers/snapshots.ts
@@ -14,11 +14,11 @@ import DeprecatedSnapshot from "../../models/deprecatedSnapshot"
 import { redis } from "../../libs/redis"
 import CacheItem, { CacheType } from "../../cache/item"
 import { normalizeDOI } from "../../libs/doi/normalize"
-import { getDraftHead } from "../../datalad/dataset"
 import { downloadFiles } from "../../datalad/snapshots"
 import { snapshotValidation } from "./validation"
 import { advancedDatasetSearchConnection } from "./dataset-search"
 import { contributors } from "../../datalad/contributors"
+import { getDraftInfo } from "../../datalad/draft"
 
 export const snapshots = (obj) => {
   return datalad.getSnapshots(obj.id)
@@ -279,7 +279,7 @@ export const latestSnapshot = async (obj, _, context) => {
     // In the case where there are no real snapshots, return most recent commit as snapshot
     return await snapshot(
       obj,
-      { datasetId: obj.id, tag: (await getDraftHead(obj.id)).ref },
+      { datasetId: obj.id, tag: (await getDraftInfo(obj.id)).ref },
       context,
     )
   }


### PR DESCRIPTION
This fixes extra requests being made for the worker draft endpoint and prevents blocking in some cases when the worker is busy.