### PR TITLE
fix(server): Fix analytics reporting upserting for unknown datasets

### DIFF
--- a/packages/openneuro-server/src/datalad/analytics.ts
+++ b/packages/openneuro-server/src/datalad/analytics.ts
@@ -17,9 +17,6 @@ export const trackAnalytics = async (datasetId, tag, type) => {
           views: 1,
         },
       },
-      {
-        upsert: true,
-      },
     ).exec()
   } else if (type === "downloads") {
     return Dataset.updateOne(
@@ -30,9 +27,6 @@ export const trackAnalytics = async (datasetId, tag, type) => {
         $inc: {
           downloads: 1,
         },
-      },
-      {
-        upsert: true,
       },
     ).exec()
   }

--- a/packages/openneuro-server/src/datalad/dataset.ts
+++ b/packages/openneuro-server/src/datalad/dataset.ts
@@ -503,7 +503,6 @@ export async function updatePublic(datasetId, publicFlag, user) {
   await Dataset.updateOne(
     { id: datasetId },
     { public: publicFlag, publishDate: new Date() },
-    { upsert: true },
   ).exec()
   await updateEvent(event)
 }


### PR DESCRIPTION
It is not necessary to upsert these as they only apply to existing objects.