### PR TITLE
fix: Improve snapshot iteration performance

### DIFF
--- a/services/datalad/datalad_service/handlers/snapshots.py
+++ b/services/datalad/datalad_service/handlers/snapshots.py
@@ -30,10 +30,8 @@ class SnapshotResource:
         if not os.path.exists(self.store.get_dataset_path(dataset)):
             resp.status = falcon.HTTP_NOT_FOUND
         elif snapshot:
-            files = await get_tree(self.store, dataset, snapshot)
             try:
                 response = get_snapshot(self.store, dataset, snapshot)
-                response['files'] = files
                 resp.media = response
                 resp.status = falcon.HTTP_OK
             except KeyError:

--- a/services/datalad/tests/test_snapshots.py
+++ b/services/datalad/tests/test_snapshots.py
@@ -16,34 +16,7 @@ def test_get_snapshot(client):
         '/datasets/{}/snapshots/{}'.format('ds000001', '000001')
     )
     result_doc = json.loads(response.content)
-
-    for f in result_doc['files']:
-        print(f['filename'], f['urls'])
     assert response.status == falcon.HTTP_OK
-    assert result_doc['files'] == [
-        {
-            'filename': 'CHANGES',
-            'size': 41,
-            'id': '0daaa69260ab1f1fa8cfd0e17a4c1993d6d46e54',
-            'key': '63f4f8294caf64dccfedcb5300dee70e3fe3a7c5',
-            'urls': [
-                'http://localhost:9876/crn/datasets/ds000001/objects/63f4f8294caf64dccfedcb5300dee70e3fe3a7c5'
-            ],
-            'annexed': False,
-            'directory': False,
-        },
-        {
-            'filename': 'dataset_description.json',
-            'size': 97,
-            'id': '9c946a75b4c24c14e65d746b2ff295a904845aa3',
-            'key': '85b9ddf2bfaf1d9300d612dc29774a98cc1d5e25',
-            'urls': [
-                'http://localhost:9876/crn/datasets/ds000001/objects/85b9ddf2bfaf1d9300d612dc29774a98cc1d5e25'
-            ],
-            'annexed': False,
-            'directory': False,
-        },
-    ]
     assert result_doc['tag'] == '000001'
     assert result_doc['id'] == '{}:{}'.format('ds000001', '000001')
     assert type(result_doc['created']) == int


### PR DESCRIPTION
Avoid requesting the list of snapshots for datasets from the worker on every access and when this is accessed, skip a redundant iteration of the git tree.