### PR TITLE
fix(worker): Avoid recursing into git subtrees while scanning annex URLs

### DIFF
--- a/services/datalad/datalad_service/common/annex.py
+++ b/services/datalad/datalad_service/common/annex.py
@@ -196,7 +196,6 @@ async def get_repo_urls(path, files):
         'git',
         'ls-tree',
         '-l',
-        '-r',
         'git-annex',
         cwd=path,
         stdout=asyncio.subprocess.PIPE,


### PR DESCRIPTION
Loading a tree would recurse into child trees and prepare URLs for them and then discard those in the output. This improves performance of the tree endpoint for higher level trees that may have many subtrees.