### PR TITLE
feat(app): Re-enable code splitting

### DIFF
--- a/packages/openneuro-app/src/scripts/dataset/files/file-viewer-type.jsx
+++ b/packages/openneuro-app/src/scripts/dataset/files/file-viewer-type.jsx
@@ -1,54 +1,70 @@
-import React from "react"
+import React, { Suspense } from "react"
 import PropTypes from "prop-types"
-import FileViewerText from "./viewers/file-viewer-text.jsx"
-import FileViewerNifti from "./viewers/file-viewer-nifti"
-import FileViewerJson from "./viewers/file-viewer-json.jsx"
-import FileViewerTsv from "./viewers/file-viewer-tsv.jsx"
-import FileViewerCsv from "./viewers/file-viewer-csv.jsx"
-import FileViewerHtml from "./viewers/file-viewer-html.jsx"
-import { FileViewerNeurosift } from "./viewers/file-viewer-neurosift"
+import { Loading } from "../../components/loading/Loading"
 import { isNifti } from "./file-types"
-import FileViewerMarkdown from "./viewers/file-viewer-markdown"
+
+const FileViewerText = React.lazy(() =>
+  import("./viewers/file-viewer-text.jsx")
+)
+const FileViewerNifti = React.lazy(() => import("./viewers/file-viewer-nifti"))
+const FileViewerJson = React.lazy(() =>
+  import("./viewers/file-viewer-json.jsx")
+)
+const FileViewerTsv = React.lazy(() => import("./viewers/file-viewer-tsv.jsx"))
+const FileViewerCsv = React.lazy(() => import("./viewers/file-viewer-csv.jsx"))
+const FileViewerHtml = React.lazy(() =>
+  import("./viewers/file-viewer-html.jsx")
+)
+const FileViewerMarkdown = React.lazy(() =>
+  import("./viewers/file-viewer-markdown")
+)
+const FileViewerNeurosift = React.lazy(() =>
+  import("./viewers/file-viewer-neurosift").then((module) => ({
+    default: module.FileViewerNeurosift,
+  }))
+)
 
 /**
  * Choose the right viewer for each file type
  */
 const FileViewerType = ({ path, url, data }) => {
-  if (
-    path.endsWith("README") ||
-    path.endsWith("CHANGES") ||
-    path.endsWith(".bidsignore") ||
-    path.endsWith(".gitignore") ||
-    path.endsWith(".txt") ||
-    path.endsWith(".rst") ||
-    path.endsWith(".yml") || path.endsWith(".yaml")
-  ) {
-    return <FileViewerText data={data} />
-  } else if (
-    isNifti(path)
-  ) {
-    return <FileViewerNifti imageUrl={url} />
-  } else if (path.endsWith(".md")) {
-    return <FileViewerMarkdown data={data} />
-  } else if (path.endsWith(".json")) {
-    return <FileViewerJson data={data} />
-  } else if (path.endsWith(".tsv")) {
-    return <FileViewerTsv data={data} />
-  } else if (path.endsWith(".csv")) {
-    return <FileViewerCsv data={data} />
-  } else if (path.endsWith(".html")) {
-    return <FileViewerHtml data={data} />
-  } else if (path.endsWith(".edf")) {
-    return <FileViewerNeurosift url={url} filetype="edf" />
-  } else if (path.endsWith(".nwb")) {
-    return <FileViewerNeurosift url={url} filetype="nwb" />
-  } else {
-    return (
-      <div className="file-viewer-fallback">
-        This file must be downloaded to view it.
-      </div>
-    )
-  }
+  const viewer = (() => {
+    if (
+      path.endsWith("README") ||
+      path.endsWith("CHANGES") ||
+      path.endsWith(".bidsignore") ||
+      path.endsWith(".gitignore") ||
+      path.endsWith(".txt") ||
+      path.endsWith(".rst") ||
+      path.endsWith(".yml") ||
+      path.endsWith(".yaml")
+    ) {
+      return <FileViewerText data={data} />
+    } else if (isNifti(path)) {
+      return <FileViewerNifti imageUrl={url} />
+    } else if (path.endsWith(".md")) {
+      return <FileViewerMarkdown data={data} />
+    } else if (path.endsWith(".json")) {
+      return <FileViewerJson data={data} />
+    } else if (path.endsWith(".tsv")) {
+      return <FileViewerTsv data={data} />
+    } else if (path.endsWith(".csv")) {
+      return <FileViewerCsv data={data} />
+    } else if (path.endsWith(".html")) {
+      return <FileViewerHtml data={data} />
+    } else if (path.endsWith(".edf")) {
+      return <FileViewerNeurosift url={url} filetype="edf" />
+    } else if (path.endsWith(".nwb")) {
+      return <FileViewerNeurosift url={url} filetype="nwb" />
+    } else {
+      return (
+        <div className="file-viewer-fallback">
+          This file must be downloaded to view it.
+        </div>
+      )
+    }
+  })()
+  return <Suspense fallback={<Loading />}>{viewer}</Suspense>
 }
 
 FileViewerType.propTypes = {

--- a/packages/openneuro-app/src/scripts/routes.tsx
+++ b/packages/openneuro-app/src/scripts/routes.tsx
@@ -1,61 +1,83 @@
-import React from "react"
+import React, { lazy, Suspense } from "react"
 import { Navigate, Route, Routes } from "react-router-dom"
-
-// TODO - Re-enable code splitting these when we can
-import DatasetQuery from "./dataset/dataset-query"
-//import PreRefactorDatasetProps from './dataset/dataset-pre-refactor-container'
+import { Loading } from "./components/loading/Loading"
 import { isAdmin } from "./authentication/admin-user.jsx"
-import FaqPage from "./pages/faq/faq"
-import FrontPageContainer from "./pages/front-page/front-page"
-import Admin from "./pages/admin/admin"
-import SearchRoutes from "./search/search-routes"
-import APIKey from "./pages/api"
-import ErrorRoute from "./errors/errorRoute"
-import { PETRedirect } from "./pages/pet-redirect"
-import Citation from "./pages/citation-page"
-import FourOFourPage from "./errors/404page"
-import { ImportDataset } from "./pages/import-dataset"
-import { DatasetMetadata } from "./pages/metadata/dataset-metadata"
-import { TermsPage } from "./pages/terms"
-import { ImageAttribution } from "./pages/image-attribution"
-import { UserQuery } from "./users/user-query"
-import { OrcidLinkPage } from "./pages/orcid-link"
-import FourOThreePage from "./errors/403page"
+
+const DatasetQuery = lazy(() => import("./dataset/dataset-query"))
+const FaqPage = lazy(() => import("./pages/faq/faq"))
+const FrontPageContainer = lazy(() => import("./pages/front-page/front-page"))
+const Admin = lazy(() => import("./pages/admin/admin"))
+const SearchRoutes = lazy(() => import("./search/search-routes"))
+const APIKey = lazy(() => import("./pages/api"))
+const ErrorRoute = lazy(() => import("./errors/errorRoute"))
+const PETRedirect = lazy(() =>
+  import("./pages/pet-redirect").then((module) => ({
+    default: module.PETRedirect,
+  }))
+)
+const Citation = lazy(() => import("./pages/citation-page"))
+const FourOFourPage = lazy(() => import("./errors/404page"))
+const ImportDataset = lazy(() =>
+  import("./pages/import-dataset").then((module) => ({
+    default: module.ImportDataset,
+  }))
+)
+const DatasetMetadata = lazy(() =>
+  import("./pages/metadata/dataset-metadata").then((module) => ({
+    default: module.DatasetMetadata,
+  }))
+)
+const TermsPage = lazy(() =>
+  import("./pages/terms").then((module) => ({ default: module.TermsPage }))
+)
+const ImageAttribution = lazy(() =>
+  import("./pages/image-attribution").then((module) => ({
+    default: module.ImageAttribution,
+  }))
+)
+const UserQuery = lazy(() =>
+  import("./users/user-query").then((module) => ({ default: module.UserQuery }))
+)
+const OrcidLinkPage = lazy(() =>
+  import("./pages/orcid-link").then((module) => ({
+    default: module.OrcidLinkPage,
+  }))
+)
+const FourOThreePage = lazy(() => import("./errors/403page"))
 
 const AppRoutes: React.VoidFunctionComponent = () => (
-  <Routes>
-    <Route path="/" element={<FrontPageContainer />} />
-    <Route path="/faq" element={<FaqPage />} />
-    <Route path="/keygen" element={<APIKey />} />
-    <Route path="/datasets/:datasetId/*" element={<DatasetQuery />} />
-    <Route path="/search/*" element={<SearchRoutes />} />
-    <Route
-      path="/admin/*"
-      element={isAdmin() ? <Admin /> : <FourOThreePage />}
-    />
-    <Route path="/error/*" element={<ErrorRoute />} />
-    <Route path="/pet" element={<PETRedirect />} />
-    <Route path="/cite" element={<Citation />} />
-    <Route path="/terms" element={<TermsPage />} />
-    <Route path="/image-attribution" element={<ImageAttribution />} />
-    <Route path="/import" element={<ImportDataset />} />
-    <Route path="/metadata" element={<DatasetMetadata />} />
-    <Route path="/public" element={<Navigate to="/search" replace />} />
-    <Route path="/orcid-link" element={<OrcidLinkPage />} />
-    <Route
-      path="/user/:orcid/*"
-      element={<UserQuery />}
-    />
-    <Route
-      path="/saved"
-      element={<Navigate to="/search?bookmarks" replace />}
-    />
-    <Route
-      path="/dashboard"
-      element={<Navigate to="/search?mydatasets" replace />}
-    />
-    <Route path="/*" element={<FourOFourPage />} />
-  </Routes>
+  <Suspense fallback={<Loading />}>
+    <Routes>
+      <Route path="/" element={<FrontPageContainer />} />
+      <Route path="/faq" element={<FaqPage />} />
+      <Route path="/keygen" element={<APIKey />} />
+      <Route path="/datasets/:datasetId/*" element={<DatasetQuery />} />
+      <Route path="/search/*" element={<SearchRoutes />} />
+      <Route
+        path="/admin/*"
+        element={isAdmin() ? <Admin /> : <FourOThreePage />}
+      />
+      <Route path="/error/*" element={<ErrorRoute />} />
+      <Route path="/pet" element={<PETRedirect />} />
+      <Route path="/cite" element={<Citation />} />
+      <Route path="/terms" element={<TermsPage />} />
+      <Route path="/image-attribution" element={<ImageAttribution />} />
+      <Route path="/import" element={<ImportDataset />} />
+      <Route path="/metadata" element={<DatasetMetadata />} />
+      <Route path="/public" element={<Navigate to="/search" replace />} />
+      <Route path="/orcid-link" element={<OrcidLinkPage />} />
+      <Route path="/user/:orcid/*" element={<UserQuery />} />
+      <Route
+        path="/saved"
+        element={<Navigate to="/search?bookmarks" replace />}
+      />
+      <Route
+        path="/dashboard"
+        element={<Navigate to="/search?mydatasets" replace />}
+      />
+      <Route path="/*" element={<FourOFourPage />} />
+    </Routes>
+  </Suspense>
 )
 
 export default AppRoutes

--- a/packages/openneuro-app/src/scripts/uploader/upload-issues.tsx
+++ b/packages/openneuro-app/src/scripts/uploader/upload-issues.tsx
@@ -3,7 +3,6 @@ import pluralize from "pluralize"
 import { Loading } from "../components/loading/Loading"
 import { ValidationResultsDisplay } from "../validation/validation-results"
 import UploaderContext from "./uploader-context.js"
-import { validation } from "../workers/schema.js"
 import type { ValidationResult } from "@bids/validator/main"
 import { DatasetIssues } from "@bids/validator/issues"
 
@@ -80,12 +79,17 @@ class UploadValidator
   extends React.Component<UploadValidatorProps, UploadValidatorState> {
   constructor(props) {
     super(props)
+    const schemaValidator = import("../workers/schema.js")
     this.state = {
       validating: true,
       issues: new DatasetIssues(),
       summary: {},
     }
-    validation(Array.from(this.props.files)).then(this.done)
+    schemaValidator.then((schemaValidatorModule) => {
+      schemaValidatorModule.validation(Array.from(this.props.files)).then(
+        this.done,
+      )
+    })
   }
 
   /**


### PR DESCRIPTION
This enables code splitting that was temporarily disabled around the redesign due to some upstream bugs that have since been fixed.

The main routes, BIDS validator, and file viewers are code split as this gives a balanced number of chunks and offloads the largest dependencies to the pages that require them (BIDS + HED validators and niivue).

Before (the largest chunk is always loaded):
```
dist/assets/chunk-INHXZS53-D3tQiqtZ.js                0.42 kB │ gzip:     0.30 kB │ map:      1.73 kB
dist/assets/lz4-B_Exjfmr.js                          36.36 kB │ gzip:    15.75 kB │ map:     71.71 kB
dist/assets/blosc-CrUiACa7.js                       603.19 kB │ gzip:   204.66 kB │ map:    641.98 kB
dist/assets/zstd-u5eweWyS.js                        747.21 kB │ gzip:   242.94 kB │ map:    781.82 kB
dist/assets/index-CnOYEe-q.js                    12,817.75 kB │ gzip: 2,511.35 kB │ map: 27,190.61 kB
```

After (most of these chunks are now lazy loaded only on the required routes):
```
dist/assets/contributors-list-CECIblwB.js            10.69 kB │ gzip:     4.48 kB │ map:     41.39 kB
dist/assets/admin-SnW-lAc3.js                        12.21 kB │ gzip:     3.45 kB │ map:     37.35 kB
dist/assets/lz4-B_Exjfmr.js                          36.36 kB │ gzip:    15.75 kB │ map:     71.71 kB
dist/assets/front-page-DBouibmx.js                   42.03 kB │ gzip:    13.21 kB │ map:    115.40 kB
dist/assets/user-query-D37_xpzH.js                   44.02 kB │ gzip:    17.27 kB │ map:    142.57 kB
dist/assets/search-routes-CtD-GL4m.js                55.43 kB │ gzip:    14.08 kB │ map:    182.63 kB
dist/assets/data-table-CDee0YUu.js                   85.86 kB │ gzip:    20.60 kB │ map:    434.38 kB
dist/assets/validationUtils-BImUMj4Q.js             353.89 kB │ gzip:   106.96 kB │ map:  1,677.14 kB
dist/assets/dataset-query-b6PBCXWA.js               384.66 kB │ gzip:   123.40 kB │ map:  1,608.72 kB
dist/assets/blosc-CrUiACa7.js                       603.19 kB │ gzip:   204.66 kB │ map:    641.98 kB
dist/assets/file-viewer-nifti-9t8QmD6e.js           738.17 kB │ gzip:   281.75 kB │ map:  2,361.26 kB
dist/assets/zstd-u5eweWyS.js                        747.21 kB │ gzip:   242.94 kB │ map:    781.82 kB
dist/assets/index-IiYNDznV.js                       977.29 kB │ gzip:   315.13 kB │ map:  4,077.27 kB
dist/assets/schema-Cseg-4U5.js                   10,049.51 kB │ gzip: 1,595.35 kB │ map: 16,333.43 kB
```