### PR TITLE
chore: Add cooldown to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,8 @@ updates:
       actions-infrastructure:
         patterns:
           - "actions/*"
+    cooldown:
+      default-days: 7
   - package-ecosystem: "uv"
     directory: "/services/datalad"
     schedule:
@@ -16,3 +18,5 @@ updates:
       datalad:
         patterns:
           - "*"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
Small patch to keep dependabot from bumping to bleeding edge if it coincides with our schedule. This should help avoid buggy `X.Y.0` releases that are quickly followed up, and mitigates supply chain attacks: https://blog.yossarian.net/2025/11/21/We-should-all-be-using-dependency-cooldowns