### PR TITLE
chore(deps): Bump @apollo/server from 4.12.1 to 4.13.0

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -149,10 +149,10 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "SOFT"\
       }],\
-      ["virtual:651e4dac1252520fdeb4f43991af364559116b6d7632724cdb1b23350c3e3ccb08428face60d3343f5312dd96517e94a882916efa9e7c96062dbdf979f12338d#npm:1.0.3", {\
-        "packageLocation": "./.yarn/__virtual__/@apollo-cache-control-types-virtual-326ecdf567/0/cache/@apollo-cache-control-types-npm-1.0.3-2a44d8278e-a588e52bfa.zip/node_modules/@apollo/cache-control-types/",\
+      ["virtual:882c2eff7939d1f77340ea1471d188eba18a0e6b39c63c370281627e91ceb4538a098858893f18a8f14a0265bf75a5fbd7b61bd1f0bdcea0afa7ed83c1986d4d#npm:1.0.3", {\
+        "packageLocation": "./.yarn/__virtual__/@apollo-cache-control-types-virtual-6228cb909c/0/cache/@apollo-cache-control-types-npm-1.0.3-2a44d8278e-a588e52bfa.zip/node_modules/@apollo/cache-control-types/",\
         "packageDependencies": [\
-          ["@apollo/cache-control-types", "virtual:651e4dac1252520fdeb4f43991af364559116b6d7632724cdb1b23350c3e3ccb08428face60d3343f5312dd96517e94a882916efa9e7c96062dbdf979f12338d#npm:1.0.3"],\
+          ["@apollo/cache-control-types", "virtual:882c2eff7939d1f77340ea1471d188eba18a0e6b39c63c370281627e91ceb4538a098858893f18a8f14a0265bf75a5fbd7b61bd1f0bdcea0afa7ed83c1986d4d#npm:1.0.3"],\
           ["@types/graphql", null],\
           ["graphql", "npm:16.8.1"]\
         ],\
@@ -416,33 +416,34 @@ const RAW_RUNTIME_STATE =
       }]\
     ]],\
     ["@apollo/server", [\
-      ["npm:4.12.1", {\
-        "packageLocation": "./.yarn/cache/@apollo-server-npm-4.12.1-f11c78cfec-674f796ead.zip/node_modules/@apollo/server/",\
+      ["npm:4.13.0", {\
+        "packageLocation": "./.yarn/cache/@apollo-server-npm-4.13.0-19007d3214-7dbe6b7f2f.zip/node_modules/@apollo/server/",\
         "packageDependencies": [\
-          ["@apollo/server", "npm:4.12.1"]\
+          ["@apollo/server", "npm:4.13.0"]\
         ],\
         "linkType": "SOFT"\
       }],\
-      ["virtual:6d9c0fee0b376eb0bb6824eb7a3246834ef21d870b31f75eebe59bb4d027e50f2607ba168fd29d446567f4e9c2a5cad2442c4741fa92c92e0b7e9145c3a3e3a7#npm:4.12.1", {\
-        "packageLocation": "./.yarn/__virtual__/@apollo-server-virtual-651e4dac12/0/cache/@apollo-server-npm-4.12.1-f11c78cfec-674f796ead.zip/node_modules/@apollo/server/",\
+      ["virtual:6d9c0fee0b376eb0bb6824eb7a3246834ef21d870b31f75eebe59bb4d027e50f2607ba168fd29d446567f4e9c2a5cad2442c4741fa92c92e0b7e9145c3a3e3a7#npm:4.13.0", {\
+        "packageLocation": "./.yarn/__virtual__/@apollo-server-virtual-882c2eff79/0/cache/@apollo-server-npm-4.13.0-19007d3214-7dbe6b7f2f.zip/node_modules/@apollo/server/",\
         "packageDependencies": [\
-          ["@apollo/cache-control-types", "virtual:651e4dac1252520fdeb4f43991af364559116b6d7632724cdb1b23350c3e3ccb08428face60d3343f5312dd96517e94a882916efa9e7c96062dbdf979f12338d#npm:1.0.3"],\
-          ["@apollo/server", "virtual:6d9c0fee0b376eb0bb6824eb7a3246834ef21d870b31f75eebe59bb4d027e50f2607ba168fd29d446567f4e9c2a5cad2442c4741fa92c92e0b7e9145c3a3e3a7#npm:4.12.1"],\
-          ["@apollo/server-gateway-interface", "virtual:651e4dac1252520fdeb4f43991af364559116b6d7632724cdb1b23350c3e3ccb08428face60d3343f5312dd96517e94a882916efa9e7c96062dbdf979f12338d#npm:1.1.1"],\
+          ["@apollo/cache-control-types", "virtual:882c2eff7939d1f77340ea1471d188eba18a0e6b39c63c370281627e91ceb4538a098858893f18a8f14a0265bf75a5fbd7b61bd1f0bdcea0afa7ed83c1986d4d#npm:1.0.3"],\
+          ["@apollo/server", "virtual:6d9c0fee0b376eb0bb6824eb7a3246834ef21d870b31f75eebe59bb4d027e50f2607ba168fd29d446567f4e9c2a5cad2442c4741fa92c92e0b7e9145c3a3e3a7#npm:4.13.0"],\
+          ["@apollo/server-gateway-interface", "virtual:882c2eff7939d1f77340ea1471d188eba18a0e6b39c63c370281627e91ceb4538a098858893f18a8f14a0265bf75a5fbd7b61bd1f0bdcea0afa7ed83c1986d4d#npm:1.1.1"],\
           ["@apollo/usage-reporting-protobuf", "npm:4.1.1"],\
           ["@apollo/utils.createhash", "npm:2.0.2"],\
           ["@apollo/utils.fetcher", "npm:2.0.1"],\
           ["@apollo/utils.isnodelike", "npm:2.0.1"],\
           ["@apollo/utils.keyvaluecache", "npm:2.1.1"],\
           ["@apollo/utils.logger", "npm:2.0.1"],\
-          ["@apollo/utils.usagereporting", "virtual:651e4dac1252520fdeb4f43991af364559116b6d7632724cdb1b23350c3e3ccb08428face60d3343f5312dd96517e94a882916efa9e7c96062dbdf979f12338d#npm:2.1.0"],\
+          ["@apollo/utils.usagereporting", "virtual:882c2eff7939d1f77340ea1471d188eba18a0e6b39c63c370281627e91ceb4538a098858893f18a8f14a0265bf75a5fbd7b61bd1f0bdcea0afa7ed83c1986d4d#npm:2.1.0"],\
           ["@apollo/utils.withrequired", "npm:2.0.1"],\
-          ["@graphql-tools/schema", "virtual:651e4dac1252520fdeb4f43991af364559116b6d7632724cdb1b23350c3e3ccb08428face60d3343f5312dd96517e94a882916efa9e7c96062dbdf979f12338d#npm:9.0.19"],\
+          ["@graphql-tools/schema", "virtual:882c2eff7939d1f77340ea1471d188eba18a0e6b39c63c370281627e91ceb4538a098858893f18a8f14a0265bf75a5fbd7b61bd1f0bdcea0afa7ed83c1986d4d#npm:9.0.19"],\
           ["@types/express", "npm:4.17.17"],\
           ["@types/express-serve-static-core", "npm:4.17.35"],\
           ["@types/graphql", null],\
           ["@types/node-fetch", "npm:2.6.4"],\
           ["async-retry", "npm:1.3.3"],\
+          ["content-type", "npm:1.0.5"],\
           ["cors", "npm:2.8.5"],\
           ["express", "npm:4.21.2"],\
           ["graphql", "npm:16.8.1"],\
@@ -450,7 +451,7 @@ const RAW_RUNTIME_STATE =
           ["lru-cache", "npm:7.18.3"],\
           ["negotiator", "npm:0.6.3"],\
           ["node-abort-controller", "npm:3.1.1"],\
-          ["node-fetch", "virtual:651e4dac1252520fdeb4f43991af364559116b6d7632724cdb1b23350c3e3ccb08428face60d3343f5312dd96517e94a882916efa9e7c96062dbdf979f12338d#npm:2.6.12"],\
+          ["node-fetch", "virtual:882c2eff7939d1f77340ea1471d188eba18a0e6b39c63c370281627e91ceb4538a098858893f18a8f14a0265bf75a5fbd7b61bd1f0bdcea0afa7ed83c1986d4d#npm:2.6.12"],\
           ["uuid", "npm:9.0.0"],\
           ["whatwg-mimetype", "npm:3.0.0"]\
         ],\
@@ -469,10 +470,10 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "SOFT"\
       }],\
-      ["virtual:651e4dac1252520fdeb4f43991af364559116b6d7632724cdb1b23350c3e3ccb08428face60d3343f5312dd96517e94a882916efa9e7c96062dbdf979f12338d#npm:1.1.1", {\
-        "packageLocation": "./.yarn/__virtual__/@apollo-server-gateway-interface-virtual-0b7169ee2a/0/cache/@apollo-server-gateway-interface-npm-1.1.1-a9440657b6-af0e953992.zip/node_modules/@apollo/server-gateway-interface/",\
+      ["virtual:882c2eff7939d1f77340ea1471d188eba18a0e6b39c63c370281627e91ceb4538a098858893f18a8f14a0265bf75a5fbd7b61bd1f0bdcea0afa7ed83c1986d4d#npm:1.1.1", {\
+        "packageLocation": "./.yarn/__virtual__/@apollo-server-gateway-interface-virtual-cbbf999f40/0/cache/@apollo-server-gateway-interface-npm-1.1.1-a9440657b6-af0e953992.zip/node_modules/@apollo/server-gateway-interface/",\
         "packageDependencies": [\
-          ["@apollo/server-gateway-interface", "virtual:651e4dac1252520fdeb4f43991af364559116b6d7632724cdb1b23350c3e3ccb08428face60d3343f5312dd96517e94a882916efa9e7c96062dbdf979f12338d#npm:1.1.1"],\
+          ["@apollo/server-gateway-interface", "virtual:882c2eff7939d1f77340ea1471d188eba18a0e6b39c63c370281627e91ceb4538a098858893f18a8f14a0265bf75a5fbd7b61bd1f0bdcea0afa7ed83c1986d4d#npm:1.1.1"],\
           ["@apollo/usage-reporting-protobuf", "npm:4.1.1"],\
           ["@apollo/utils.fetcher", "npm:2.0.1"],\
           ["@apollo/utils.keyvaluecache", "npm:2.1.1"],\
@@ -516,10 +517,10 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "SOFT"\
       }],\
-      ["virtual:b02d9d6b722e185b7791cf87abf7c8e02db027cf74a47345143bab851267a195a46ee2ea6ddb8fd09bea6656bd0fbe62701cbf7198a6442666627c4e0d7323b6#npm:2.0.1", {\
-        "packageLocation": "./.yarn/__virtual__/@apollo-utils.dropunuseddefinitions-virtual-23c8869e61/0/cache/@apollo-utils.dropunuseddefinitions-npm-2.0.1-df9dff59af-c12166f255.zip/node_modules/@apollo/utils.dropunuseddefinitions/",\
+      ["virtual:60b0fc6f12fd3694c98bab0978e8a5315a73ba4e67abed80022e1a29750a88b8d396e9ef11b906cccabeb2dff9b06dcca25dbd7c4f2f4c10ffa94d9f26c57d79#npm:2.0.1", {\
+        "packageLocation": "./.yarn/__virtual__/@apollo-utils.dropunuseddefinitions-virtual-8a04fcfcc5/0/cache/@apollo-utils.dropunuseddefinitions-npm-2.0.1-df9dff59af-c12166f255.zip/node_modules/@apollo/utils.dropunuseddefinitions/",\
         "packageDependencies": [\
-          ["@apollo/utils.dropunuseddefinitions", "virtual:b02d9d6b722e185b7791cf87abf7c8e02db027cf74a47345143bab851267a195a46ee2ea6ddb8fd09bea6656bd0fbe62701cbf7198a6442666627c4e0d7323b6#npm:2.0.1"],\
+          ["@apollo/utils.dropunuseddefinitions", "virtual:60b0fc6f12fd3694c98bab0978e8a5315a73ba4e67abed80022e1a29750a88b8d396e9ef11b906cccabeb2dff9b06dcca25dbd7c4f2f4c10ffa94d9f26c57d79#npm:2.0.1"],\
           ["@types/graphql", null],\
           ["graphql", "npm:16.8.1"]\
         ],\
@@ -604,10 +605,10 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "SOFT"\
       }],\
-      ["virtual:b02d9d6b722e185b7791cf87abf7c8e02db027cf74a47345143bab851267a195a46ee2ea6ddb8fd09bea6656bd0fbe62701cbf7198a6442666627c4e0d7323b6#npm:2.0.1", {\
-        "packageLocation": "./.yarn/__virtual__/@apollo-utils.printwithreducedwhitespace-virtual-e7c5a80b33/0/cache/@apollo-utils.printwithreducedwhitespace-npm-2.0.1-7bced48ce5-16cd191e66.zip/node_modules/@apollo/utils.printwithreducedwhitespace/",\
+      ["virtual:60b0fc6f12fd3694c98bab0978e8a5315a73ba4e67abed80022e1a29750a88b8d396e9ef11b906cccabeb2dff9b06dcca25dbd7c4f2f4c10ffa94d9f26c57d79#npm:2.0.1", {\
+        "packageLocation": "./.yarn/__virtual__/@apollo-utils.printwithreducedwhitespace-virtual-ff42ad461c/0/cache/@apollo-utils.printwithreducedwhitespace-npm-2.0.1-7bced48ce5-16cd191e66.zip/node_modules/@apollo/utils.printwithreducedwhitespace/",\
         "packageDependencies": [\
-          ["@apollo/utils.printwithreducedwhitespace", "virtual:b02d9d6b722e185b7791cf87abf7c8e02db027cf74a47345143bab851267a195a46ee2ea6ddb8fd09bea6656bd0fbe62701cbf7198a6442666627c4e0d7323b6#npm:2.0.1"],\
+          ["@apollo/utils.printwithreducedwhitespace", "virtual:60b0fc6f12fd3694c98bab0978e8a5315a73ba4e67abed80022e1a29750a88b8d396e9ef11b906cccabeb2dff9b06dcca25dbd7c4f2f4c10ffa94d9f26c57d79#npm:2.0.1"],\
           ["@types/graphql", null],\
           ["graphql", "npm:16.8.1"]\
         ],\
@@ -626,10 +627,10 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "SOFT"\
       }],\
-      ["virtual:b02d9d6b722e185b7791cf87abf7c8e02db027cf74a47345143bab851267a195a46ee2ea6ddb8fd09bea6656bd0fbe62701cbf7198a6442666627c4e0d7323b6#npm:2.0.1", {\
-        "packageLocation": "./.yarn/__virtual__/@apollo-utils.removealiases-virtual-0d1e30367a/0/cache/@apollo-utils.removealiases-npm-2.0.1-3400c22b9b-2f3f925b23.zip/node_modules/@apollo/utils.removealiases/",\
+      ["virtual:60b0fc6f12fd3694c98bab0978e8a5315a73ba4e67abed80022e1a29750a88b8d396e9ef11b906cccabeb2dff9b06dcca25dbd7c4f2f4c10ffa94d9f26c57d79#npm:2.0.1", {\
+        "packageLocation": "./.yarn/__virtual__/@apollo-utils.removealiases-virtual-81b06e09b8/0/cache/@apollo-utils.removealiases-npm-2.0.1-3400c22b9b-2f3f925b23.zip/node_modules/@apollo/utils.removealiases/",\
         "packageDependencies": [\
-          ["@apollo/utils.removealiases", "virtual:b02d9d6b722e185b7791cf87abf7c8e02db027cf74a47345143bab851267a195a46ee2ea6ddb8fd09bea6656bd0fbe62701cbf7198a6442666627c4e0d7323b6#npm:2.0.1"],\
+          ["@apollo/utils.removealiases", "virtual:60b0fc6f12fd3694c98bab0978e8a5315a73ba4e67abed80022e1a29750a88b8d396e9ef11b906cccabeb2dff9b06dcca25dbd7c4f2f4c10ffa94d9f26c57d79#npm:2.0.1"],\
           ["@types/graphql", null],\
           ["graphql", "npm:16.8.1"]\
         ],\
@@ -648,10 +649,10 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "SOFT"\
       }],\
-      ["virtual:b02d9d6b722e185b7791cf87abf7c8e02db027cf74a47345143bab851267a195a46ee2ea6ddb8fd09bea6656bd0fbe62701cbf7198a6442666627c4e0d7323b6#npm:2.0.1", {\
-        "packageLocation": "./.yarn/__virtual__/@apollo-utils.sortast-virtual-e9eefda483/0/cache/@apollo-utils.sortast-npm-2.0.1-50ae35efaf-b71245558e.zip/node_modules/@apollo/utils.sortast/",\
+      ["virtual:60b0fc6f12fd3694c98bab0978e8a5315a73ba4e67abed80022e1a29750a88b8d396e9ef11b906cccabeb2dff9b06dcca25dbd7c4f2f4c10ffa94d9f26c57d79#npm:2.0.1", {\
+        "packageLocation": "./.yarn/__virtual__/@apollo-utils.sortast-virtual-1291054a44/0/cache/@apollo-utils.sortast-npm-2.0.1-50ae35efaf-b71245558e.zip/node_modules/@apollo/utils.sortast/",\
         "packageDependencies": [\
-          ["@apollo/utils.sortast", "virtual:b02d9d6b722e185b7791cf87abf7c8e02db027cf74a47345143bab851267a195a46ee2ea6ddb8fd09bea6656bd0fbe62701cbf7198a6442666627c4e0d7323b6#npm:2.0.1"],\
+          ["@apollo/utils.sortast", "virtual:60b0fc6f12fd3694c98bab0978e8a5315a73ba4e67abed80022e1a29750a88b8d396e9ef11b906cccabeb2dff9b06dcca25dbd7c4f2f4c10ffa94d9f26c57d79#npm:2.0.1"],\
           ["@types/graphql", null],\
           ["graphql", "npm:16.8.1"],\
           ["lodash.sortby", "npm:4.7.0"]\
@@ -671,10 +672,10 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "SOFT"\
       }],\
-      ["virtual:b02d9d6b722e185b7791cf87abf7c8e02db027cf74a47345143bab851267a195a46ee2ea6ddb8fd09bea6656bd0fbe62701cbf7198a6442666627c4e0d7323b6#npm:2.0.1", {\
-        "packageLocation": "./.yarn/__virtual__/@apollo-utils.stripsensitiveliterals-virtual-6fde890e00/0/cache/@apollo-utils.stripsensitiveliterals-npm-2.0.1-6ee81b6b8c-a3f74af062.zip/node_modules/@apollo/utils.stripsensitiveliterals/",\
+      ["virtual:60b0fc6f12fd3694c98bab0978e8a5315a73ba4e67abed80022e1a29750a88b8d396e9ef11b906cccabeb2dff9b06dcca25dbd7c4f2f4c10ffa94d9f26c57d79#npm:2.0.1", {\
+        "packageLocation": "./.yarn/__virtual__/@apollo-utils.stripsensitiveliterals-virtual-8e36d497c4/0/cache/@apollo-utils.stripsensitiveliterals-npm-2.0.1-6ee81b6b8c-a3f74af062.zip/node_modules/@apollo/utils.stripsensitiveliterals/",\
         "packageDependencies": [\
-          ["@apollo/utils.stripsensitiveliterals", "virtual:b02d9d6b722e185b7791cf87abf7c8e02db027cf74a47345143bab851267a195a46ee2ea6ddb8fd09bea6656bd0fbe62701cbf7198a6442666627c4e0d7323b6#npm:2.0.1"],\
+          ["@apollo/utils.stripsensitiveliterals", "virtual:60b0fc6f12fd3694c98bab0978e8a5315a73ba4e67abed80022e1a29750a88b8d396e9ef11b906cccabeb2dff9b06dcca25dbd7c4f2f4c10ffa94d9f26c57d79#npm:2.0.1"],\
           ["@types/graphql", null],\
           ["graphql", "npm:16.8.1"]\
         ],\
@@ -693,16 +694,16 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "SOFT"\
       }],\
-      ["virtual:651e4dac1252520fdeb4f43991af364559116b6d7632724cdb1b23350c3e3ccb08428face60d3343f5312dd96517e94a882916efa9e7c96062dbdf979f12338d#npm:2.1.0", {\
-        "packageLocation": "./.yarn/__virtual__/@apollo-utils.usagereporting-virtual-b02d9d6b72/0/cache/@apollo-utils.usagereporting-npm-2.1.0-df6b791c39-8af4b23000.zip/node_modules/@apollo/utils.usagereporting/",\
+      ["virtual:882c2eff7939d1f77340ea1471d188eba18a0e6b39c63c370281627e91ceb4538a098858893f18a8f14a0265bf75a5fbd7b61bd1f0bdcea0afa7ed83c1986d4d#npm:2.1.0", {\
+        "packageLocation": "./.yarn/__virtual__/@apollo-utils.usagereporting-virtual-60b0fc6f12/0/cache/@apollo-utils.usagereporting-npm-2.1.0-df6b791c39-8af4b23000.zip/node_modules/@apollo/utils.usagereporting/",\
         "packageDependencies": [\
           ["@apollo/usage-reporting-protobuf", "npm:4.1.1"],\
-          ["@apollo/utils.dropunuseddefinitions", "virtual:b02d9d6b722e185b7791cf87abf7c8e02db027cf74a47345143bab851267a195a46ee2ea6ddb8fd09bea6656bd0fbe62701cbf7198a6442666627c4e0d7323b6#npm:2.0.1"],\
-          ["@apollo/utils.printwithreducedwhitespace", "virtual:b02d9d6b722e185b7791cf87abf7c8e02db027cf74a47345143bab851267a195a46ee2ea6ddb8fd09bea6656bd0fbe62701cbf7198a6442666627c4e0d7323b6#npm:2.0.1"],\
-          ["@apollo/utils.removealiases", "virtual:b02d9d6b722e185b7791cf87abf7c8e02db027cf74a47345143bab851267a195a46ee2ea6ddb8fd09bea6656bd0fbe62701cbf7198a6442666627c4e0d7323b6#npm:2.0.1"],\
-          ["@apollo/utils.sortast", "virtual:b02d9d6b722e185b7791cf87abf7c8e02db027cf74a47345143bab851267a195a46ee2ea6ddb8fd09bea6656bd0fbe62701cbf7198a6442666627c4e0d7323b6#npm:2.0.1"],\
-          ["@apollo/utils.stripsensitiveliterals", "virtual:b02d9d6b722e185b7791cf87abf7c8e02db027cf74a47345143bab851267a195a46ee2ea6ddb8fd09bea6656bd0fbe62701cbf7198a6442666627c4e0d7323b6#npm:2.0.1"],\
-          ["@apollo/utils.usagereporting", "virtual:651e4dac1252520fdeb4f43991af364559116b6d7632724cdb1b23350c3e3ccb08428face60d3343f5312dd96517e94a882916efa9e7c96062dbdf979f12338d#npm:2.1.0"],\
+          ["@apollo/utils.dropunuseddefinitions", "virtual:60b0fc6f12fd3694c98bab0978e8a5315a73ba4e67abed80022e1a29750a88b8d396e9ef11b906cccabeb2dff9b06dcca25dbd7c4f2f4c10ffa94d9f26c57d79#npm:2.0.1"],\
+          ["@apollo/utils.printwithreducedwhitespace", "virtual:60b0fc6f12fd3694c98bab0978e8a5315a73ba4e67abed80022e1a29750a88b8d396e9ef11b906cccabeb2dff9b06dcca25dbd7c4f2f4c10ffa94d9f26c57d79#npm:2.0.1"],\
+          ["@apollo/utils.removealiases", "virtual:60b0fc6f12fd3694c98bab0978e8a5315a73ba4e67abed80022e1a29750a88b8d396e9ef11b906cccabeb2dff9b06dcca25dbd7c4f2f4c10ffa94d9f26c57d79#npm:2.0.1"],\
+          ["@apollo/utils.sortast", "virtual:60b0fc6f12fd3694c98bab0978e8a5315a73ba4e67abed80022e1a29750a88b8d396e9ef11b906cccabeb2dff9b06dcca25dbd7c4f2f4c10ffa94d9f26c57d79#npm:2.0.1"],\
+          ["@apollo/utils.stripsensitiveliterals", "virtual:60b0fc6f12fd3694c98bab0978e8a5315a73ba4e67abed80022e1a29750a88b8d396e9ef11b906cccabeb2dff9b06dcca25dbd7c4f2f4c10ffa94d9f26c57d79#npm:2.0.1"],\
+          ["@apollo/utils.usagereporting", "virtual:882c2eff7939d1f77340ea1471d188eba18a0e6b39c63c370281627e91ceb4538a098858893f18a8f14a0265bf75a5fbd7b61bd1f0bdcea0afa7ed83c1986d4d#npm:2.1.0"],\
           ["@types/graphql", null],\
           ["graphql", "npm:16.8.1"]\
         ],\
@@ -1992,11 +1993,11 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "SOFT"\
       }],\
-      ["virtual:050876b4cbc0be0fb7ef02de8442a4eae77ec2f73378e4bf92b5c58550837cd132cd7c554d5124491c90311b227ba65c4e5ad409738378fc3446bc1d466d9937#npm:8.4.2", {\
-        "packageLocation": "./.yarn/__virtual__/@graphql-tools-merge-virtual-94035ed84f/0/cache/@graphql-tools-merge-npm-8.4.2-26df56fe04-62a4e93812.zip/node_modules/@graphql-tools/merge/",\
+      ["virtual:078b234684187e60b08724caf7f3a7558f81f1284581dd0fd2e0a5c01d8317f1d46af23f0550ed09dbdfd058f504225083aaf1547599e6eaaded1923736928f9#npm:8.4.2", {\
+        "packageLocation": "./.yarn/__virtual__/@graphql-tools-merge-virtual-32c670f1e9/0/cache/@graphql-tools-merge-npm-8.4.2-26df56fe04-62a4e93812.zip/node_modules/@graphql-tools/merge/",\
         "packageDependencies": [\
-          ["@graphql-tools/merge", "virtual:050876b4cbc0be0fb7ef02de8442a4eae77ec2f73378e4bf92b5c58550837cd132cd7c554d5124491c90311b227ba65c4e5ad409738378fc3446bc1d466d9937#npm:8.4.2"],\
-          ["@graphql-tools/utils", "virtual:050876b4cbc0be0fb7ef02de8442a4eae77ec2f73378e4bf92b5c58550837cd132cd7c554d5124491c90311b227ba65c4e5ad409738378fc3446bc1d466d9937#npm:9.2.1"],\
+          ["@graphql-tools/merge", "virtual:078b234684187e60b08724caf7f3a7558f81f1284581dd0fd2e0a5c01d8317f1d46af23f0550ed09dbdfd058f504225083aaf1547599e6eaaded1923736928f9#npm:8.4.2"],\
+          ["@graphql-tools/utils", "virtual:078b234684187e60b08724caf7f3a7558f81f1284581dd0fd2e0a5c01d8317f1d46af23f0550ed09dbdfd058f504225083aaf1547599e6eaaded1923736928f9#npm:9.2.1"],\
           ["@types/graphql", null],\
           ["graphql", "npm:16.8.1"],\
           ["tslib", "npm:2.6.1"]\
@@ -2064,12 +2065,12 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "SOFT"\
       }],\
-      ["virtual:651e4dac1252520fdeb4f43991af364559116b6d7632724cdb1b23350c3e3ccb08428face60d3343f5312dd96517e94a882916efa9e7c96062dbdf979f12338d#npm:9.0.19", {\
-        "packageLocation": "./.yarn/__virtual__/@graphql-tools-schema-virtual-050876b4cb/0/cache/@graphql-tools-schema-npm-9.0.19-2dd6a9ed56-762811fe08.zip/node_modules/@graphql-tools/schema/",\
+      ["virtual:7551ce9da6a1d08fa7e13a80e2f973b491766328bd179cc2db79caffc61371ac135c2ad0ad653010fa4ab35dcca89d6c85968158f6af4813bc27a96b906e116a#npm:10.0.0", {\
+        "packageLocation": "./.yarn/__virtual__/@graphql-tools-schema-virtual-ffeefcb01a/0/cache/@graphql-tools-schema-npm-10.0.0-5ffcf6b81a-dd784bcc46.zip/node_modules/@graphql-tools/schema/",\
         "packageDependencies": [\
-          ["@graphql-tools/merge", "virtual:050876b4cbc0be0fb7ef02de8442a4eae77ec2f73378e4bf92b5c58550837cd132cd7c554d5124491c90311b227ba65c4e5ad409738378fc3446bc1d466d9937#npm:8.4.2"],\
-          ["@graphql-tools/schema", "virtual:651e4dac1252520fdeb4f43991af364559116b6d7632724cdb1b23350c3e3ccb08428face60d3343f5312dd96517e94a882916efa9e7c96062dbdf979f12338d#npm:9.0.19"],\
-          ["@graphql-tools/utils", "virtual:050876b4cbc0be0fb7ef02de8442a4eae77ec2f73378e4bf92b5c58550837cd132cd7c554d5124491c90311b227ba65c4e5ad409738378fc3446bc1d466d9937#npm:9.2.1"],\
+          ["@graphql-tools/merge", "virtual:ffeefcb01a94ecc209d575011147be79722c0ebcafcbce04435dc0063cd956502253ee7389b85184221a04133c4e58c8bb65339bb155bd897a9b75c5ab0bf5ef#npm:9.0.0"],\
+          ["@graphql-tools/schema", "virtual:7551ce9da6a1d08fa7e13a80e2f973b491766328bd179cc2db79caffc61371ac135c2ad0ad653010fa4ab35dcca89d6c85968158f6af4813bc27a96b906e116a#npm:10.0.0"],\
+          ["@graphql-tools/utils", "virtual:7551ce9da6a1d08fa7e13a80e2f973b491766328bd179cc2db79caffc61371ac135c2ad0ad653010fa4ab35dcca89d6c85968158f6af4813bc27a96b906e116a#npm:10.0.4"],\
           ["@types/graphql", null],\
           ["graphql", "npm:16.8.1"],\
           ["tslib", "npm:2.6.1"],\
@@ -2081,12 +2082,12 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "HARD"\
       }],\
-      ["virtual:7551ce9da6a1d08fa7e13a80e2f973b491766328bd179cc2db79caffc61371ac135c2ad0ad653010fa4ab35dcca89d6c85968158f6af4813bc27a96b906e116a#npm:10.0.0", {\
-        "packageLocation": "./.yarn/__virtual__/@graphql-tools-schema-virtual-ffeefcb01a/0/cache/@graphql-tools-schema-npm-10.0.0-5ffcf6b81a-dd784bcc46.zip/node_modules/@graphql-tools/schema/",\
+      ["virtual:882c2eff7939d1f77340ea1471d188eba18a0e6b39c63c370281627e91ceb4538a098858893f18a8f14a0265bf75a5fbd7b61bd1f0bdcea0afa7ed83c1986d4d#npm:9.0.19", {\
+        "packageLocation": "./.yarn/__virtual__/@graphql-tools-schema-virtual-078b234684/0/cache/@graphql-tools-schema-npm-9.0.19-2dd6a9ed56-762811fe08.zip/node_modules/@graphql-tools/schema/",\
         "packageDependencies": [\
-          ["@graphql-tools/merge", "virtual:ffeefcb01a94ecc209d575011147be79722c0ebcafcbce04435dc0063cd956502253ee7389b85184221a04133c4e58c8bb65339bb155bd897a9b75c5ab0bf5ef#npm:9.0.0"],\
-          ["@graphql-tools/schema", "virtual:7551ce9da6a1d08fa7e13a80e2f973b491766328bd179cc2db79caffc61371ac135c2ad0ad653010fa4ab35dcca89d6c85968158f6af4813bc27a96b906e116a#npm:10.0.0"],\
-          ["@graphql-tools/utils", "virtual:7551ce9da6a1d08fa7e13a80e2f973b491766328bd179cc2db79caffc61371ac135c2ad0ad653010fa4ab35dcca89d6c85968158f6af4813bc27a96b906e116a#npm:10.0.4"],\
+          ["@graphql-tools/merge", "virtual:078b234684187e60b08724caf7f3a7558f81f1284581dd0fd2e0a5c01d8317f1d46af23f0550ed09dbdfd058f504225083aaf1547599e6eaaded1923736928f9#npm:8.4.2"],\
+          ["@graphql-tools/schema", "virtual:882c2eff7939d1f77340ea1471d188eba18a0e6b39c63c370281627e91ceb4538a098858893f18a8f14a0265bf75a5fbd7b61bd1f0bdcea0afa7ed83c1986d4d#npm:9.0.19"],\
+          ["@graphql-tools/utils", "virtual:078b234684187e60b08724caf7f3a7558f81f1284581dd0fd2e0a5c01d8317f1d46af23f0550ed09dbdfd058f504225083aaf1547599e6eaaded1923736928f9#npm:9.2.1"],\
           ["@types/graphql", null],\
           ["graphql", "npm:16.8.1"],\
           ["tslib", "npm:2.6.1"],\
@@ -2114,10 +2115,10 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "SOFT"\
       }],\
-      ["virtual:050876b4cbc0be0fb7ef02de8442a4eae77ec2f73378e4bf92b5c58550837cd132cd7c554d5124491c90311b227ba65c4e5ad409738378fc3446bc1d466d9937#npm:9.2.1", {\
-        "packageLocation": "./.yarn/__virtual__/@graphql-tools-utils-virtual-a87a2c6885/0/cache/@graphql-tools-utils-npm-9.2.1-ed63b70392-b1665043c2.zip/node_modules/@graphql-tools/utils/",\
+      ["virtual:078b234684187e60b08724caf7f3a7558f81f1284581dd0fd2e0a5c01d8317f1d46af23f0550ed09dbdfd058f504225083aaf1547599e6eaaded1923736928f9#npm:9.2.1", {\
+        "packageLocation": "./.yarn/__virtual__/@graphql-tools-utils-virtual-4da72380f6/0/cache/@graphql-tools-utils-npm-9.2.1-ed63b70392-b1665043c2.zip/node_modules/@graphql-tools/utils/",\
         "packageDependencies": [\
-          ["@graphql-tools/utils", "virtual:050876b4cbc0be0fb7ef02de8442a4eae77ec2f73378e4bf92b5c58550837cd132cd7c554d5124491c90311b227ba65c4e5ad409738378fc3446bc1d466d9937#npm:9.2.1"],\
+          ["@graphql-tools/utils", "virtual:078b234684187e60b08724caf7f3a7558f81f1284581dd0fd2e0a5c01d8317f1d46af23f0550ed09dbdfd058f504225083aaf1547599e6eaaded1923736928f9#npm:9.2.1"],\
           ["@graphql-typed-document-node/core", "virtual:8233cac6686bf49bf82442079dc25221f6e5a51405accb24796911ef793ef9c58742843f148d9b1b9fc87d90d074c06211d7c3e35b5ce9cc76be6e3ebea9155e#npm:3.1.1"],\
           ["@types/graphql", null],\
           ["graphql", "npm:16.8.1"],\
@@ -4078,7 +4079,7 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./packages/openneuro-server/",\
         "packageDependencies": [\
           ["@apollo/client", "virtual:6d9c0fee0b376eb0bb6824eb7a3246834ef21d870b31f75eebe59bb4d027e50f2607ba168fd29d446567f4e9c2a5cad2442c4741fa92c92e0b7e9145c3a3e3a7#npm:3.13.8"],\
-          ["@apollo/server", "virtual:6d9c0fee0b376eb0bb6824eb7a3246834ef21d870b31f75eebe59bb4d027e50f2607ba168fd29d446567f4e9c2a5cad2442c4741fa92c92e0b7e9145c3a3e3a7#npm:4.12.1"],\
+          ["@apollo/server", "virtual:6d9c0fee0b376eb0bb6824eb7a3246834ef21d870b31f75eebe59bb4d027e50f2607ba168fd29d446567f4e9c2a5cad2442c4741fa92c92e0b7e9145c3a3e3a7#npm:4.13.0"],\
           ["@apollo/utils.keyvadapter", "npm:3.0.0"],\
           ["@elastic/elasticsearch", "npm:8.13.1"],\
           ["@graphql-tools/schema", "virtual:7551ce9da6a1d08fa7e13a80e2f973b491766328bd179cc2db79caffc61371ac135c2ad0ad653010fa4ab35dcca89d6c85968158f6af4813bc27a96b906e116a#npm:10.0.0"],\
@@ -17660,12 +17661,12 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "HARD"\
       }],\
-      ["virtual:651e4dac1252520fdeb4f43991af364559116b6d7632724cdb1b23350c3e3ccb08428face60d3343f5312dd96517e94a882916efa9e7c96062dbdf979f12338d#npm:2.6.12", {\
-        "packageLocation": "./.yarn/__virtual__/node-fetch-virtual-d0737acba6/0/cache/node-fetch-npm-2.6.12-48619ce9d6-370ed4d906.zip/node_modules/node-fetch/",\
+      ["virtual:882c2eff7939d1f77340ea1471d188eba18a0e6b39c63c370281627e91ceb4538a098858893f18a8f14a0265bf75a5fbd7b61bd1f0bdcea0afa7ed83c1986d4d#npm:2.6.12", {\
+        "packageLocation": "./.yarn/__virtual__/node-fetch-virtual-04f2e45335/0/cache/node-fetch-npm-2.6.12-48619ce9d6-370ed4d906.zip/node_modules/node-fetch/",\
         "packageDependencies": [\
           ["@types/encoding", null],\
           ["encoding", null],\
-          ["node-fetch", "virtual:651e4dac1252520fdeb4f43991af364559116b6d7632724cdb1b23350c3e3ccb08428face60d3343f5312dd96517e94a882916efa9e7c96062dbdf979f12338d#npm:2.6.12"],\
+          ["node-fetch", "virtual:882c2eff7939d1f77340ea1471d188eba18a0e6b39c63c370281627e91ceb4538a098858893f18a8f14a0265bf75a5fbd7b61bd1f0bdcea0afa7ed83c1986d4d#npm:2.6.12"],\
           ["whatwg-url", "npm:5.0.0"]\
         ],\
         "packagePeers": [\

--- a/packages/openneuro-server/package.json
+++ b/packages/openneuro-server/package.json
@@ -16,7 +16,7 @@
   "author": "Squishymedia",
   "dependencies": {
     "@apollo/client": "3.13.8",
-    "@apollo/server": "4.12.1",
+    "@apollo/server": "~4.13.0",
     "@apollo/utils.keyvadapter": "3.0.0",
     "@elastic/elasticsearch": "8.13.1",
     "@graphql-tools/schema": "^10.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -212,9 +212,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@apollo/server@npm:4.12.1":
-  version: 4.12.1
-  resolution: "@apollo/server@npm:4.12.1"
+"@apollo/server@npm:~4.13.0":
+  version: 4.13.0
+  resolution: "@apollo/server@npm:4.13.0"
   dependencies:
     "@apollo/cache-control-types": "npm:^1.0.3"
     "@apollo/server-gateway-interface": "npm:^1.1.1"
@@ -231,6 +231,7 @@ __metadata:
     "@types/express-serve-static-core": "npm:^4.17.30"
     "@types/node-fetch": "npm:^2.6.1"
     async-retry: "npm:^1.2.1"
+    content-type: "npm:^1.0.5"
     cors: "npm:^2.8.5"
     express: "npm:^4.21.1"
     loglevel: "npm:^1.6.8"
@@ -242,7 +243,7 @@ __metadata:
     whatwg-mimetype: "npm:^3.0.0"
   peerDependencies:
     graphql: ^16.6.0
-  checksum: 10/674f796eadf554d4c250cc88ec1ad0c67ae53a0060e419555bd5093b69f803117d7204ad7ffb36c046f9b3e39aac6a18d4eef7fd60062567fcd3d82d2d178b9d
+  checksum: 10/7dbe6b7f2ff8dc3d397310c90fb0da281cec744346e9b7591066c2102c72f98b300df5b1c5b526eef8ed443a5d88123a19fdd53ec44c064598799cc73bc91469
   languageName: node
   linkType: hard
 
@@ -3112,7 +3113,7 @@ __metadata:
   resolution: "@openneuro/server@workspace:packages/openneuro-server"
   dependencies:
     "@apollo/client": "npm:3.13.8"
-    "@apollo/server": "npm:4.12.1"
+    "@apollo/server": "npm:~4.13.0"
     "@apollo/utils.keyvadapter": "npm:3.0.0"
     "@elastic/elasticsearch": "npm:8.13.1"
     "@graphql-tools/schema": "npm:^10.0.0"
@@ -7518,17 +7519,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"content-type@npm:^1.0.5, content-type@npm:~1.0.5":
+  version: 1.0.5
+  resolution: "content-type@npm:1.0.5"
+  checksum: 10/585847d98dc7fb8035c02ae2cb76c7a9bd7b25f84c447e5ed55c45c2175e83617c8813871b4ee22f368126af6b2b167df655829007b21aa10302873ea9c62662
+  languageName: node
+  linkType: hard
+
 "content-type@npm:~1.0.4":
   version: 1.0.4
   resolution: "content-type@npm:1.0.4"
   checksum: 10/5ea85c5293475c0cdf2f84e2c71f0519ced565840fb8cbda35997cb67cc45b879d5b9dbd37760c4041ca7415a3687f8a5f2f87b556b2aaefa49c0f3436a346d4
-  languageName: node
-  linkType: hard
-
-"content-type@npm:~1.0.5":
-  version: 1.0.5
-  resolution: "content-type@npm:1.0.5"
-  checksum: 10/585847d98dc7fb8035c02ae2cb76c7a9bd7b25f84c447e5ed55c45c2175e83617c8813871b4ee22f368126af6b2b167df655829007b21aa10302873ea9c62662
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
IDK why dependabot is insisting on upgrading to 5.4 instead of 4.13. I suspect this will work.

Addresses https://github.com/OpenNeuroOrg/openneuro/security/dependabot/379.