### PR TITLE
refactor(cli): Build git-annex branch without a checkout

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -34,4 +34,5 @@ jobs:
       - uses: codecov/codecov-action@v5
         if: ${{ always() }}
         with:
-          files: coverage.lcov
+          files: cli/coverage.lcov
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/cli/src/worker/commitBuilder.test.ts
+++ b/cli/src/worker/commitBuilder.test.ts
@@ -1,0 +1,113 @@
+import { assertEquals, assertExists } from "@std/assert"
+import { CommitBuilder } from "./commitBuilder.ts"
+import { GitWorkerContext } from "./types/git-context.ts"
+import { default as git } from "isomorphic-git"
+
+Deno.test("CommitBuilder", async (t) => {
+  const testDir = await Deno.makeTempDir()
+  const context = new GitWorkerContext(
+    "ds000000",
+    testDir,
+    testDir,
+    "http://localhost",
+    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJmNjZhNzRjNS05ZDhmLTQ2M2MtOGE2ZS1lYTE3ODljYTNiOTIiLCJlbWFpbCI6Im5lbGxAZGV2LW5lbGwuY29tIiwicHJvdmlkZXIiOiJnb29nbGUiLCJuYW1lIjoiTmVsbCBIYXJkY2FzdGxlIiwiYWRtaW4iOnRydWUsImlhdCI6MTcwMDUyNDIzNCwiZXhwIjoxNzMyMDYwMjM0fQ.5glc_uoxqcRJ4KWn2EvRR0hH-ono2MPJH0wqvcXBIOg",
+  )
+
+  // Initialize a repo for testing
+  await git.init({ ...context.config(), defaultBranch: "main" })
+
+  await t.step("creates a new commit on a new branch", async () => {
+    const builder = new CommitBuilder(context)
+    builder.add("file1.txt", "content1")
+    builder.add("dir/file2.txt", "content2")
+
+    const commitOid = await builder.commit("main", "initial commit")
+    assertExists(commitOid)
+
+    const log = await git.log({ ...context.config(), ref: "main" })
+    assertEquals(log[0].commit.message, "initial commit\n")
+
+    const { blob: b1 } = await git.readBlob({
+      ...context.config(),
+      oid: commitOid!,
+      filepath: "file1.txt",
+    })
+    assertEquals(new TextDecoder().decode(b1), "content1")
+
+    const { blob: b2 } = await git.readBlob({
+      ...context.config(),
+      oid: commitOid!,
+      filepath: "dir/file2.txt",
+    })
+    assertEquals(new TextDecoder().decode(b2), "content2")
+  })
+
+  await t.step("updates existing tree with new commit", async () => {
+    const builder = new CommitBuilder(context)
+    // Update existing file and add a new one
+    builder.add("file1.txt", "updated content")
+    builder.add("new-file.txt", "new content")
+
+    const commitOid = await builder.commit("main", "second commit")
+    assertExists(commitOid)
+
+    const log = await git.log({ ...context.config(), ref: "main" })
+    assertEquals(log[0].commit.message, "second commit\n")
+    assertEquals(log.length, 2)
+
+    const { blob: b1 } = await git.readBlob({
+      ...context.config(),
+      oid: commitOid!,
+      filepath: "file1.txt",
+    })
+    assertEquals(new TextDecoder().decode(b1), "updated content")
+
+    const { blob: b2 } = await git.readBlob({
+      ...context.config(),
+      oid: commitOid!,
+      filepath: "dir/file2.txt",
+    })
+    assertEquals(new TextDecoder().decode(b2), "content2")
+
+    const { blob: b3 } = await git.readBlob({
+      ...context.config(),
+      oid: commitOid!,
+      filepath: "new-file.txt",
+    })
+    assertEquals(new TextDecoder().decode(b3), "new content")
+  })
+
+  await t.step("handles binary data", async () => {
+    const builder = new CommitBuilder(context)
+    const binaryData = new Uint8Array([0, 1, 2, 3])
+    builder.add("binary.bin", binaryData)
+
+    const commitOid = await builder.commit("main", "binary commit")
+    assertExists(commitOid)
+
+    const { blob } = await git.readBlob({
+      ...context.config(),
+      oid: commitOid!,
+      filepath: "binary.bin",
+    })
+    assertEquals(blob, binaryData)
+  })
+
+  await t.step("creates deep directory structures", async () => {
+    const builder = new CommitBuilder(context)
+    builder.add("a/b/c/d/file.txt", "deep")
+
+    const commitOid = await builder.commit("main", "deep commit")
+    assertExists(commitOid)
+
+    const { blob } = await git.readBlob({
+      ...context.config(),
+      oid: commitOid!,
+      filepath: "a/b/c/d/file.txt",
+    })
+    assertEquals(new TextDecoder().decode(blob), "deep")
+  })
+
+  // Clean up
+  await Deno.remove(testDir, { recursive: true })
+})

--- a/cli/src/worker/commitBuilder.ts
+++ b/cli/src/worker/commitBuilder.ts
@@ -1,0 +1,146 @@
+import { default as git } from "isomorphic-git"
+import type { GitWorkerContext } from "./types/git-context.ts"
+
+export class CommitBuilder {
+  private updates: Map<string, Uint8Array> = new Map()
+
+  constructor(private context: GitWorkerContext) {}
+
+  add(path: string, content: string | Uint8Array) {
+    const data = typeof content === "string"
+      ? new TextEncoder().encode(content)
+      : content
+    this.updates.set(path, data)
+  }
+
+  async commit(branch: string, message: string) {
+    const options = this.context.config()
+    let parentCommit
+    let parentTree
+    try {
+      parentCommit = await git.resolveRef({ ...options, ref: branch })
+      const commitObj = await git.readCommit({ ...options, oid: parentCommit })
+      parentTree = commitObj.commit.tree
+    } catch {
+      // Branch might not exist or is empty
+      parentCommit = undefined
+      parentTree = undefined
+    }
+
+    const newTree = await this.buildTree(parentTree, this.updates)
+
+    if (!newTree) {
+      return undefined
+    }
+
+    const now = new Date()
+    const timestamp = Math.floor(now.getTime() / 1000)
+    const timezoneOffset = now.getTimezoneOffset()
+    const author = {
+      ...this.context.author,
+      timestamp,
+      timezoneOffset,
+    }
+
+    const commitOid = await git.writeCommit({
+      ...options,
+      commit: {
+        message,
+        tree: newTree,
+        parent: parentCommit ? [parentCommit] : [],
+        author,
+        committer: author,
+      },
+    })
+
+    await git.writeRef({
+      ...options,
+      ref: `refs/heads/${branch}`,
+      value: commitOid,
+      force: true,
+    })
+
+    return commitOid
+  }
+
+  private async buildTree(
+    baseOid: string | undefined,
+    updates: Map<string, Uint8Array>,
+  ): Promise<string> {
+    const options = this.context.config()
+    let entries: {
+      mode: string
+      path: string
+      oid: string
+      type: "blob" | "tree" | "commit"
+    }[] = []
+    if (baseOid) {
+      const treeResult = await git.readTree({ ...options, oid: baseOid })
+      entries = treeResult.tree
+    }
+
+    // Group updates by current path segment
+    const bySegment = new Map<string, Map<string, Uint8Array>>()
+    const fileUpdates = new Map<string, Uint8Array>()
+
+    for (const [path, content] of updates) {
+      const parts = path.split("/")
+      const segment = parts[0]
+      if (parts.length === 1) {
+        fileUpdates.set(segment, content)
+      } else {
+        if (!bySegment.has(segment)) {
+          bySegment.set(segment, new Map())
+        }
+        bySegment.get(segment)!.set(parts.slice(1).join("/"), content)
+      }
+    }
+
+    // Process subdirectories
+    for (const [segment, childUpdates] of bySegment) {
+      const existingEntryIndex = entries.findIndex((e) => e.path === segment)
+      const existingEntry = existingEntryIndex >= 0
+        ? entries[existingEntryIndex]
+        : undefined
+
+      const childBaseOid = existingEntry && existingEntry.type === "tree"
+        ? existingEntry.oid
+        : undefined
+
+      const newChildOid = await this.buildTree(childBaseOid, childUpdates)
+
+      const newEntry = {
+        mode: "040000",
+        path: segment,
+        oid: newChildOid,
+        type: "tree" as const,
+      }
+
+      if (existingEntryIndex >= 0) {
+        entries[existingEntryIndex] = newEntry
+      } else {
+        entries.push(newEntry)
+      }
+    }
+
+    // Process files
+    for (const [filename, content] of fileUpdates) {
+      const blobOid = await git.writeBlob({ ...options, blob: content })
+      const newEntry = {
+        mode: "100644",
+        path: filename,
+        oid: blobOid,
+        type: "blob" as const,
+      }
+
+      const existingEntryIndex = entries.findIndex((e) => e.path === filename)
+      if (existingEntryIndex >= 0) {
+        entries[existingEntryIndex] = newEntry
+      } else {
+        entries.push(newEntry)
+      }
+    }
+
+    return await git.writeTree({ ...options, tree: entries })
+  }
+}

--- a/cli/src/worker/git.test.ts
+++ b/cli/src/worker/git.test.ts
@@ -128,5 +128,5 @@ LICENSE annex.largefiles=nothing`),
       assertArrayIncludes(expectedFiles, [relativePath])
     }
   }
-  assertEquals(gitObjects, 10)
+  assertEquals(gitObjects, 15)
 })

--- a/cli/src/worker/git.ts
+++ b/cli/src/worker/git.ts
@@ -58,6 +58,15 @@ async function update(event: GitWorkerEventClone) {
     )
     // Make sure the default branch checkout is updated
     const defaultBranch = await getDefault(context)
+    // Merge remote default branch changes
+    await git.merge(
+      {
+        ...context.config(),
+        author: context.author,
+        ours: defaultBranch,
+        theirs: `origin/${defaultBranch}`,
+      },
+    )
     const ref = version || defaultBranch
     logger.info(`Checking out ${ref} branch.`)
     await git.checkout({

--- a/cli/src/worker/git.ts
+++ b/cli/src/worker/git.ts
@@ -17,6 +17,7 @@ import { GitWorkerContext } from "./types/git-context.ts"
 import { resetWorktree } from "./resetWorktree.ts"
 import { getDefault } from "./getDefault.ts"
 import { transformEol } from "./transformEol.ts"
+import { CommitBuilder } from "./commitBuilder.ts"
 
 let context: GitWorkerContext
 let attributesCache: GitAnnexAttributes
@@ -224,38 +225,6 @@ async function add(event: GitWorkerEventAdd) {
 }
 
 /**
- * Create the empty git-annex branch if needed
- */
-async function createAnnexBranch() {
-  const now = new Date()
-  const timestamp = Math.floor(now.getTime() / 1000)
-  const timezoneOffset = now.getTimezoneOffset()
-  const commit = {
-    message: "[OpenNeuro CLI] branch created",
-    tree: "4b825dc642cb6eb9a060e54bf8d69288fbee4904",
-    parent: [],
-    author: {
-      ...context.author,
-      timestamp,
-      timezoneOffset,
-    },
-    committer: {
-      ...context.author,
-      timestamp,
-      timezoneOffset,
-    },
-  }
-  const object = await git.writeCommit({ ...context.config(), commit })
-  await git.branch({
-    ...context.config(),
-    ref: "git-annex",
-    checkout: true,
-    // Commit added above
-    object,
-  })
-}
-
-/**
  * Generate a commit for remote.log updates if needed
  */
 async function remoteSetup(event: GitWorkerEventRemoteSetup) {
@@ -272,112 +241,77 @@ async function commitAnnexBranch(version?: string) {
   let uuidLog = ""
   try {
     uuidLog = await readAnnexPath("uuid.log", context)
-  } catch (err) {
-    if (err instanceof Error && err.name !== "NotFoundError") {
-      throw err
-    }
-  }
-  try {
-    try {
-      await git.checkout({
-        ...context.config(),
-        ref: "git-annex",
-      })
-    } catch (err) {
-      // Create the branch if it doesn't exist
-      if (err instanceof Error && err.name === "NotFoundError") {
-        await createAnnexBranch()
-      }
-    }
     for (const line of uuidLog.split(/\n/)) {
       if (line.includes(expectedRemote)) {
         const endUuid = line.indexOf(" ")
         uuid = line.slice(0, endUuid)
       }
     }
-    if (uuid) {
-      // Add a remote.log entry if one does not exist
-      let remoteLog = ""
-      const newRemoteLog =
-        `${uuid} autoenable=true name=openneuro type=external externaltype=openneuro encryption=none url=${context.repoEndpoint}\n`
-      try {
-        remoteLog = await context.fs.promises.readFile(
-          join(context.repoPath, "remote.log"),
-          { encoding: "utf8" },
-        )
-      } catch (_err) {
-        // Continue if the error is remote.log is not found, otherwise throw it here
-        if (
-          !(_err instanceof Error && "code" in _err && _err.code === "ENOENT")
-        ) {
-          throw _err
-        }
-      } finally {
-        // Add this remote if it's not already in remote.log
-        if (!remoteLog.includes(uuid)) {
-          // Continue if there's any errors and create remote.log
-          await context.fs.promises.writeFile(
-            join(context.repoPath, "remote.log"),
-            newRemoteLog + remoteLog,
-          )
-          await git.add({ ...context.config(), filepath: "remote.log" })
-        }
-      }
-      // Add logs for each annexed file
-      const annexKeys = await getAnnexKeys("HEAD", logger, context)
-      for (const [key, _path] of Object.entries(annexKeys)) {
-        const hashDir = join(...await hashDirLower(key))
-        const annexBranchPath = join(hashDir, `${key}.log`)
-        let log
-        try {
-          log = await readAnnexPath(annexBranchPath, context)
-        } catch (err) {
-          if (err instanceof Error && err.name === "NotFoundError") {
-            logger.debug(`Annex branch object "${annexBranchPath}" not found`)
-          } else {
-            throw err
-          }
-        }
-        if (log && log.includes(uuid)) {
-          continue
-        } else {
-          const timestamp = (performance.timeOrigin + performance.now()) /
-            1000.0
-          const newAnnexLog = `${timestamp}s 1 ${uuid}\n${log ? log : ""}`
-          await context.fs.promises.mkdir(join(context.repoPath, hashDir), {
-            recursive: true,
-          })
-          await context.fs.promises.writeFile(
-            join(context.repoPath, annexBranchPath),
-            newAnnexLog,
-          )
-          await git.add({ ...context.config(), filepath: annexBranchPath })
-        }
-      }
-      // Show a better commit message for when only the remote is updated
-      if (Object.keys(annexKeys).length === 0) {
-        // Only generate a commit if needed
-        if (!remoteLog.includes(uuid)) {
-          await git.commit({
-            ...context.config(),
-            message: "[OpenNeuro CLI] Configured remote",
-            author: context.author,
-          })
-        }
+  } catch (err) {
+    if (err instanceof Error && err.name !== "NotFoundError") {
+      throw err
+    }
+  }
+
+  // If no UUID was found for this repo, generate one and add it to the remote.log
+  if (!uuid) {
+    uuid = crypto.randomUUID()
+    logger.info(`Generated new UUID for this repository: ${uuid}`)
+  }
+
+  // Begin building commit for git-annex branch updates
+  const builder = new CommitBuilder(context)
+  let changes = false
+  // Add a remote.log entry if one does not exist
+  let remoteLog = ""
+  const newRemoteLog =
+    `${uuid} autoenable=true name=openneuro type=external externaltype=openneuro encryption=none url=${context.repoEndpoint}\n`
+  try {
+    remoteLog = await readAnnexPath("remote.log", context)
+  } catch (_err) {
+    // Continue if the error is remote.log is not found
+  }
+  // Add this remote if it's not already in remote.log
+  if (!remoteLog.includes(uuid)) {
+    builder.add("remote.log", newRemoteLog + remoteLog)
+    changes = true
+  }
+  // Add logs for each annexed file
+  const annexKeys = await getAnnexKeys("HEAD", logger, context)
+  for (const [key, _path] of Object.entries(annexKeys)) {
+    const hashDir = join(...await hashDirLower(key))
+    const annexBranchPath = join(hashDir, `${key}.log`)
+    let log
+    try {
+      log = await readAnnexPath(annexBranchPath, context)
+    } catch (err) {
+      if (err instanceof Error && err.name === "NotFoundError") {
+        logger.debug(`Annex branch object "${annexBranchPath}" not found`)
       } else {
-        await git.commit({
-          ...context.config(),
-          message: "[OpenNeuro CLI] Added annexed objects",
-          author: context.author,
-        })
+        throw err
       }
     }
-  } finally {
-    const defaultBranch = version || await getDefault(context)
-    await git.checkout({
-      ...context.config(),
-      ref: defaultBranch,
-    })
+    if (log && log.includes(uuid)) {
+      continue
+    } else {
+      const timestamp = (performance.timeOrigin + performance.now()) /
+        1000.0
+      const newAnnexLog = `${timestamp}s 1 ${uuid}\n${log ? log : ""}`
+      builder.add(annexBranchPath, newAnnexLog)
+      changes = true
+    }
+    // Skip commit if no changes are needed for either remote.log or new annexed objects
+    if (changes) {
+      // Show a better commit message for when only the remote is updated
+      if (Object.keys(annexKeys).length === 0) {
+        await builder.commit("git-annex", "[OpenNeuro CLI] Configured remote")
+      } else {
+        await builder.commit(
+          "git-annex",
+          "[OpenNeuro CLI] Added annexed objects",
+        )
+      }
+    }
   }
 }
 


### PR DESCRIPTION
This removes the need to checkout the git-annex branch during CLI uploads. Instead we construct the git-annex branches changes and generate the commit with the CommitBuilder class and write to the index. This is much faster than repeat checkouts and avoids the risk of incomplete checkouts polluting either branch.

Fixes #3775