### PR TITLE
ci(app): Run vite build and report bundle size

### DIFF
--- a/.github/workflows/vite.yml
+++ b/.github/workflows/vite.yml
@@ -1,0 +1,27 @@
+name: TypeScript tests and coverage
+
+on:
+  push: { branches: [master] }
+  pull_request: { branches: [master] }
+defaults:
+  run:
+    working-directory: ./services/datalad
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [22.x, 24.x]
+    steps:
+      - uses: actions/checkout@v6
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'yarn'
+      - run: yarn install
+      - name: Run production vite build
+        working-directory: ./packages/openneuro-app
+        run: yarn build
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -84,6 +84,63 @@ const RAW_RUNTIME_STATE =
         "linkType": "SOFT"\
       }]\
     ]],\
+    ["@actions/core", [\
+      ["npm:1.11.1", {\
+        "packageLocation": "./.yarn/cache/@actions-core-npm-1.11.1-ad090a2026-94f260e336.zip/node_modules/@actions/core/",\
+        "packageDependencies": [\
+          ["@actions/core", "npm:1.11.1"],\
+          ["@actions/exec", "npm:1.1.1"],\
+          ["@actions/http-client", "npm:2.2.3"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["@actions/exec", [\
+      ["npm:1.1.1", {\
+        "packageLocation": "./.yarn/cache/@actions-exec-npm-1.1.1-90973d2f96-c04bd25191.zip/node_modules/@actions/exec/",\
+        "packageDependencies": [\
+          ["@actions/exec", "npm:1.1.1"],\
+          ["@actions/io", "npm:1.1.3"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["@actions/github", [\
+      ["npm:6.0.1", {\
+        "packageLocation": "./.yarn/cache/@actions-github-npm-6.0.1-8c12ecff51-ba6a162a57.zip/node_modules/@actions/github/",\
+        "packageDependencies": [\
+          ["@actions/github", "npm:6.0.1"],\
+          ["@actions/http-client", "npm:2.2.3"],\
+          ["@octokit/core", "npm:5.2.2"],\
+          ["@octokit/plugin-paginate-rest", "virtual:8c12ecff5197746de5d84652e270da125c79cad2bdaa5a98d0dec549e94265661ee8ee72e2db58261ebc9dfda009968b75f8b48de275cc8a35d9cc488427a90c#npm:9.2.2"],\
+          ["@octokit/plugin-rest-endpoint-methods", "virtual:8c12ecff5197746de5d84652e270da125c79cad2bdaa5a98d0dec549e94265661ee8ee72e2db58261ebc9dfda009968b75f8b48de275cc8a35d9cc488427a90c#npm:10.4.1"],\
+          ["@octokit/request", "npm:8.4.1"],\
+          ["@octokit/request-error", "npm:5.1.1"],\
+          ["undici", "npm:5.29.0"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["@actions/http-client", [\
+      ["npm:2.2.3", {\
+        "packageLocation": "./.yarn/cache/@actions-http-client-npm-2.2.3-628748e0a3-0c0a540c79.zip/node_modules/@actions/http-client/",\
+        "packageDependencies": [\
+          ["@actions/http-client", "npm:2.2.3"],\
+          ["tunnel", "npm:0.0.6"],\
+          ["undici", "npm:5.29.0"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["@actions/io", [\
+      ["npm:1.1.3", {\
+        "packageLocation": "./.yarn/cache/@actions-io-npm-1.1.3-82d1cf012b-4de44e8d42.zip/node_modules/@actions/io/",\
+        "packageDependencies": [\
+          ["@actions/io", "npm:1.1.3"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
     ["@adobe/css-tools", [\
       ["npm:4.3.2", {\
         "packageLocation": "./.yarn/cache/@adobe-css-tools-npm-4.3.2-779f6c743d-973dcb7ba5.zip/node_modules/@adobe/css-tools/",\
@@ -1296,6 +1353,45 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./.yarn/cache/@chevrotain-utils-npm-9.1.0-5e5d6d7acc-707f3fac20.zip/node_modules/@chevrotain/utils/",\
         "packageDependencies": [\
           ["@chevrotain/utils", "npm:9.1.0"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["@codecov/bundler-plugin-core", [\
+      ["npm:1.9.1", {\
+        "packageLocation": "./.yarn/cache/@codecov-bundler-plugin-core-npm-1.9.1-07416efb88-bec8673503.zip/node_modules/@codecov/bundler-plugin-core/",\
+        "packageDependencies": [\
+          ["@actions/core", "npm:1.11.1"],\
+          ["@actions/github", "npm:6.0.1"],\
+          ["@codecov/bundler-plugin-core", "npm:1.9.1"],\
+          ["chalk", "npm:4.1.2"],\
+          ["semver", "npm:7.5.4"],\
+          ["unplugin", "npm:1.16.1"],\
+          ["zod", "npm:3.23.8"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["@codecov/vite-plugin", [\
+      ["npm:1.9.1", {\
+        "packageLocation": "./.yarn/cache/@codecov-vite-plugin-npm-1.9.1-6fb500fbbe-6c23b68178.zip/node_modules/@codecov/vite-plugin/",\
+        "packageDependencies": [\
+          ["@codecov/vite-plugin", "npm:1.9.1"]\
+        ],\
+        "linkType": "SOFT"\
+      }],\
+      ["virtual:4112afb9dad10978c159910bf10db9840b981b1333117623c8a4a8cf77481344a0a24735a5506e2920c18e3cfa2cc179489824b6a56c988bb070f4f60da40974#npm:1.9.1", {\
+        "packageLocation": "./.yarn/__virtual__/@codecov-vite-plugin-virtual-c1eac2f377/0/cache/@codecov-vite-plugin-npm-1.9.1-6fb500fbbe-6c23b68178.zip/node_modules/@codecov/vite-plugin/",\
+        "packageDependencies": [\
+          ["@codecov/bundler-plugin-core", "npm:1.9.1"],\
+          ["@codecov/vite-plugin", "virtual:4112afb9dad10978c159910bf10db9840b981b1333117623c8a4a8cf77481344a0a24735a5506e2920c18e3cfa2cc179489824b6a56c988bb070f4f60da40974#npm:1.9.1"],\
+          ["@types/vite", null],\
+          ["unplugin", "npm:1.16.1"],\
+          ["vite", "virtual:4112afb9dad10978c159910bf10db9840b981b1333117623c8a4a8cf77481344a0a24735a5506e2920c18e3cfa2cc179489824b6a56c988bb070f4f60da40974#npm:7.1.7"]\
+        ],\
+        "packagePeers": [\
+          "@types/vite",\
+          "vite"\
         ],\
         "linkType": "HARD"\
       }]\
@@ -3795,6 +3891,13 @@ const RAW_RUNTIME_STATE =
       }]\
     ]],\
     ["@octokit/openapi-types", [\
+      ["npm:20.0.0", {\
+        "packageLocation": "./.yarn/cache/@octokit-openapi-types-npm-20.0.0-1aac079689-9f60572af1.zip/node_modules/@octokit/openapi-types/",\
+        "packageDependencies": [\
+          ["@octokit/openapi-types", "npm:20.0.0"]\
+        ],\
+        "linkType": "HARD"\
+      }],\
       ["npm:24.2.0", {\
         "packageLocation": "./.yarn/cache/@octokit-openapi-types-npm-24.2.0-12708b95fa-000897ebc6.zip/node_modules/@octokit/openapi-types/",\
         "packageDependencies": [\
@@ -3819,6 +3922,27 @@ const RAW_RUNTIME_STATE =
           ["@octokit/plugin-paginate-rest", "npm:11.4.4-cjs.2"]\
         ],\
         "linkType": "SOFT"\
+      }],\
+      ["npm:9.2.2", {\
+        "packageLocation": "./.yarn/cache/@octokit-plugin-paginate-rest-npm-9.2.2-1b0382bc4a-9afdd61d24.zip/node_modules/@octokit/plugin-paginate-rest/",\
+        "packageDependencies": [\
+          ["@octokit/plugin-paginate-rest", "npm:9.2.2"]\
+        ],\
+        "linkType": "SOFT"\
+      }],\
+      ["virtual:8c12ecff5197746de5d84652e270da125c79cad2bdaa5a98d0dec549e94265661ee8ee72e2db58261ebc9dfda009968b75f8b48de275cc8a35d9cc488427a90c#npm:9.2.2", {\
+        "packageLocation": "./.yarn/__virtual__/@octokit-plugin-paginate-rest-virtual-8afec34ca6/0/cache/@octokit-plugin-paginate-rest-npm-9.2.2-1b0382bc4a-9afdd61d24.zip/node_modules/@octokit/plugin-paginate-rest/",\
+        "packageDependencies": [\
+          ["@octokit/core", "npm:5.2.2"],\
+          ["@octokit/plugin-paginate-rest", "virtual:8c12ecff5197746de5d84652e270da125c79cad2bdaa5a98d0dec549e94265661ee8ee72e2db58261ebc9dfda009968b75f8b48de275cc8a35d9cc488427a90c#npm:9.2.2"],\
+          ["@octokit/types", "npm:12.6.0"],\
+          ["@types/octokit__core", null]\
+        ],\
+        "packagePeers": [\
+          "@octokit/core",\
+          "@types/octokit__core"\
+        ],\
+        "linkType": "HARD"\
       }],\
       ["virtual:c7d56a556919f6d4c0ce05ac133766be64a69998f1f45fc673a6887d9d6ac115ac364a75488041278c979c475e9f94a3eea933c59c052e051b86c7a48d24a2f3#npm:11.4.4-cjs.2", {\
         "packageLocation": "./.yarn/__virtual__/@octokit-plugin-paginate-rest-virtual-4057c977e6/0/cache/@octokit-plugin-paginate-rest-npm-11.4.4-cjs.2-749142e7e5-e0f696b3b6.zip/node_modules/@octokit/plugin-paginate-rest/",\
@@ -3858,12 +3982,33 @@ const RAW_RUNTIME_STATE =
       }]\
     ]],\
     ["@octokit/plugin-rest-endpoint-methods", [\
+      ["npm:10.4.1", {\
+        "packageLocation": "./.yarn/cache/@octokit-plugin-rest-endpoint-methods-npm-10.4.1-3fc380dbdf-1090fc5a1b.zip/node_modules/@octokit/plugin-rest-endpoint-methods/",\
+        "packageDependencies": [\
+          ["@octokit/plugin-rest-endpoint-methods", "npm:10.4.1"]\
+        ],\
+        "linkType": "SOFT"\
+      }],\
       ["npm:13.3.2-cjs.1", {\
         "packageLocation": "./.yarn/cache/@octokit-plugin-rest-endpoint-methods-npm-13.3.2-cjs.1-0addfb2ebb-479827e624.zip/node_modules/@octokit/plugin-rest-endpoint-methods/",\
         "packageDependencies": [\
           ["@octokit/plugin-rest-endpoint-methods", "npm:13.3.2-cjs.1"]\
         ],\
         "linkType": "SOFT"\
+      }],\
+      ["virtual:8c12ecff5197746de5d84652e270da125c79cad2bdaa5a98d0dec549e94265661ee8ee72e2db58261ebc9dfda009968b75f8b48de275cc8a35d9cc488427a90c#npm:10.4.1", {\
+        "packageLocation": "./.yarn/__virtual__/@octokit-plugin-rest-endpoint-methods-virtual-f40c1304cf/0/cache/@octokit-plugin-rest-endpoint-methods-npm-10.4.1-3fc380dbdf-1090fc5a1b.zip/node_modules/@octokit/plugin-rest-endpoint-methods/",\
+        "packageDependencies": [\
+          ["@octokit/core", "npm:5.2.2"],\
+          ["@octokit/plugin-rest-endpoint-methods", "virtual:8c12ecff5197746de5d84652e270da125c79cad2bdaa5a98d0dec549e94265661ee8ee72e2db58261ebc9dfda009968b75f8b48de275cc8a35d9cc488427a90c#npm:10.4.1"],\
+          ["@octokit/types", "npm:12.6.0"],\
+          ["@types/octokit__core", null]\
+        ],\
+        "packagePeers": [\
+          "@octokit/core",\
+          "@types/octokit__core"\
+        ],\
+        "linkType": "HARD"\
       }],\
       ["virtual:c7d56a556919f6d4c0ce05ac133766be64a69998f1f45fc673a6887d9d6ac115ac364a75488041278c979c475e9f94a3eea933c59c052e051b86c7a48d24a2f3#npm:13.3.2-cjs.1", {\
         "packageLocation": "./.yarn/__virtual__/@octokit-plugin-rest-endpoint-methods-virtual-e943259a08/0/cache/@octokit-plugin-rest-endpoint-methods-npm-13.3.2-cjs.1-0addfb2ebb-479827e624.zip/node_modules/@octokit/plugin-rest-endpoint-methods/",\
@@ -3919,6 +4064,14 @@ const RAW_RUNTIME_STATE =
       }]\
     ]],\
     ["@octokit/types", [\
+      ["npm:12.6.0", {\
+        "packageLocation": "./.yarn/cache/@octokit-types-npm-12.6.0-3f6eea3eb3-19b77a8d25.zip/node_modules/@octokit/types/",\
+        "packageDependencies": [\
+          ["@octokit/openapi-types", "npm:20.0.0"],\
+          ["@octokit/types", "npm:12.6.0"]\
+        ],\
+        "linkType": "HARD"\
+      }],\
       ["npm:13.10.0", {\
         "packageLocation": "./.yarn/cache/@octokit-types-npm-13.10.0-aadb051232-32f8f5010d.zip/node_modules/@octokit/types/",\
         "packageDependencies": [\
@@ -3938,6 +4091,7 @@ const RAW_RUNTIME_STATE =
             "@jsr/bids__validator",\
             "npm:2.3.2::__archiveUrl=https%3A%2F%2Fnpm.jsr.io%2F~%2F11%2F%40jsr%2Fbids__validator%2F2.3.2.tgz"\
           ]],\
+          ["@codecov/vite-plugin", "virtual:4112afb9dad10978c159910bf10db9840b981b1333117623c8a4a8cf77481344a0a24735a5506e2920c18e3cfa2cc179489824b6a56c988bb070f4f60da40974#npm:1.9.1"],\
           ["@emotion/react", "virtual:dfc8861fb483e7f9493811b738b55fee97a3c3e2cb836e82763f82cb601d9955d5ee09c520fd30825cc5220c166a2003feb13430de5559fb2a330912125de5c2#npm:11.11.1"],\
           ["@emotion/styled", "virtual:dfc8861fb483e7f9493811b738b55fee97a3c3e2cb836e82763f82cb601d9955d5ee09c520fd30825cc5220c166a2003feb13430de5559fb2a330912125de5c2#npm:11.11.0"],\
           ["@niivue/niivue", "npm:0.57.0"],\
@@ -23900,6 +24054,17 @@ const RAW_RUNTIME_STATE =
         "linkType": "HARD"\
       }]\
     ]],\
+    ["unplugin", [\
+      ["npm:1.16.1", {\
+        "packageLocation": "./.yarn/cache/unplugin-npm-1.16.1-77bc28083a-4b46d7d2a6.zip/node_modules/unplugin/",\
+        "packageDependencies": [\
+          ["acorn", "npm:8.15.0"],\
+          ["unplugin", "npm:1.16.1"],\
+          ["webpack-virtual-modules", "npm:0.6.2"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
     ["unzipit", [\
       ["npm:1.4.3", {\
         "packageLocation": "./.yarn/cache/unzipit-npm-1.4.3-c1326da442-b499ac470d.zip/node_modules/unzipit/",\
@@ -24775,6 +24940,15 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./.yarn/cache/webidl-conversions-npm-7.0.0-e8c8e30c68-4c4f65472c.zip/node_modules/webidl-conversions/",\
         "packageDependencies": [\
           ["webidl-conversions", "npm:7.0.0"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["webpack-virtual-modules", [\
+      ["npm:0.6.2", {\
+        "packageLocation": "./.yarn/cache/webpack-virtual-modules-npm-0.6.2-6785315785-d9a0d035f7.zip/node_modules/webpack-virtual-modules/",\
+        "packageDependencies": [\
+          ["webpack-virtual-modules", "npm:0.6.2"]\
         ],\
         "linkType": "HARD"\
       }]\

--- a/packages/openneuro-app/package.json
+++ b/packages/openneuro-app/package.json
@@ -52,6 +52,7 @@
     "universal-cookie": "^4.0.4"
   },
   "devDependencies": {
+    "@codecov/vite-plugin": "^1.9.1",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "6.4.2",
     "@testing-library/react": "^14.2.1",

--- a/packages/openneuro-app/vite.config.js
+++ b/packages/openneuro-app/vite.config.js
@@ -1,5 +1,6 @@
 import { defineConfig } from "vite"
 import { nodePolyfills } from "vite-plugin-node-polyfills"
+import { codecovVitePlugin } from "@codecov/vite-plugin"
 
 /**
  * Vite plugin to hack a bug injected by the default assetImportMetaUrlPlugin
@@ -32,9 +33,7 @@ export default defineConfig({
   build: {
     sourcemap: true,
     rollupOptions: {
-      external: [
-        "/crn/config.js",
-      ],
+      external: ["/crn/config.js"],
     },
   },
   optimizeDeps: {
@@ -62,5 +61,15 @@ export default defineConfig({
       },
     ],
   },
-  plugins: [workaroundAssetImportMetaUrlPluginBug(), nodePolyfills()],
+  plugins: [
+    workaroundAssetImportMetaUrlPluginBug(),
+    nodePolyfills(),
+    /** @type {any} */ (
+      codecovVitePlugin({
+        enableBundleAnalysis: process.env.CODECOV_TOKEN !== undefined,
+        bundleName: "@openneuro/app",
+        uploadToken: process.env.CODECOV_TOKEN,
+      })
+    ),
+  ],
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,6 +5,57 @@ __metadata:
   version: 8
   cacheKey: 10
 
+"@actions/core@npm:^1.10.1":
+  version: 1.11.1
+  resolution: "@actions/core@npm:1.11.1"
+  dependencies:
+    "@actions/exec": "npm:^1.1.1"
+    "@actions/http-client": "npm:^2.0.1"
+  checksum: 10/94f260e33607cc16567ce4c88014f069cd7da92baaa443b72cff80fdf4f1dcd18192e135df0d51ec29e8b82cfe214218715d482f2a7804efa5095737d1245f38
+  languageName: node
+  linkType: hard
+
+"@actions/exec@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "@actions/exec@npm:1.1.1"
+  dependencies:
+    "@actions/io": "npm:^1.0.1"
+  checksum: 10/c04bd25191e522841c7e17862d70099de8db61278d2b4c744b69ac0197a48f85c75dba548e1c29c695c4cc5363d558846b4dcd3db9013463c18ba8cf36497c6d
+  languageName: node
+  linkType: hard
+
+"@actions/github@npm:^6.0.0":
+  version: 6.0.1
+  resolution: "@actions/github@npm:6.0.1"
+  dependencies:
+    "@actions/http-client": "npm:^2.2.0"
+    "@octokit/core": "npm:^5.0.1"
+    "@octokit/plugin-paginate-rest": "npm:^9.2.2"
+    "@octokit/plugin-rest-endpoint-methods": "npm:^10.4.0"
+    "@octokit/request": "npm:^8.4.1"
+    "@octokit/request-error": "npm:^5.1.1"
+    undici: "npm:^5.28.5"
+  checksum: 10/ba6a162a5727dea2f3f3fc450e02c5b336ceb65a0e26ba9ad9c62b20f4f5b2625ca347a9311a4905ef3c92378ca022caba841a283cb7f2e4175d79e3d1ecaf12
+  languageName: node
+  linkType: hard
+
+"@actions/http-client@npm:^2.0.1, @actions/http-client@npm:^2.2.0":
+  version: 2.2.3
+  resolution: "@actions/http-client@npm:2.2.3"
+  dependencies:
+    tunnel: "npm:^0.0.6"
+    undici: "npm:^5.25.4"
+  checksum: 10/0c0a540c79e50f795d214f696710bb9c50bdf5bb1458be288140f2aae3686adec73fdb464c43da5ef94f985ac7736273efef21cb5ba5a3b09e85b403d852c04b
+  languageName: node
+  linkType: hard
+
+"@actions/io@npm:^1.0.1":
+  version: 1.1.3
+  resolution: "@actions/io@npm:1.1.3"
+  checksum: 10/4de44e8d428ba9f20049c844b37ecd486b589ed201f8cc8c5b550a9e4c72d1f594271ee2a7a6cfe8a42ebfb5dd527ef65016454656db391a353d41eab4f147e1
+  languageName: node
+  linkType: hard
+
 "@adobe/css-tools@npm:^4.3.0":
   version: 4.3.2
   resolution: "@adobe/css-tools@npm:4.3.2"
@@ -916,6 +967,32 @@ __metadata:
   version: 9.1.0
   resolution: "@chevrotain/utils@npm:9.1.0"
   checksum: 10/707f3fac207f2e26243c44ad27650132a5be8a20f3e05e507ace201f7b10804f18a6a94d9dde08c722986dad7bd1fc805b1b3fb891227ce3977acbc920a065f2
+  languageName: node
+  linkType: hard
+
+"@codecov/bundler-plugin-core@npm:^1.9.1":
+  version: 1.9.1
+  resolution: "@codecov/bundler-plugin-core@npm:1.9.1"
+  dependencies:
+    "@actions/core": "npm:^1.10.1"
+    "@actions/github": "npm:^6.0.0"
+    chalk: "npm:4.1.2"
+    semver: "npm:^7.5.4"
+    unplugin: "npm:^1.10.1"
+    zod: "npm:^3.22.4"
+  checksum: 10/bec8673503fcf0bedd6fee44b91f8f45eb8528f69f0827adf21c0f19a3c8a40a36ccf7e47feb1216c1887b76f5aa6c272223a32fd034a2d6b46d2a97b55cd873
+  languageName: node
+  linkType: hard
+
+"@codecov/vite-plugin@npm:^1.9.1":
+  version: 1.9.1
+  resolution: "@codecov/vite-plugin@npm:1.9.1"
+  dependencies:
+    "@codecov/bundler-plugin-core": "npm:^1.9.1"
+    unplugin: "npm:^1.10.1"
+  peerDependencies:
+    vite: 4.x || 5.x || 6.x
+  checksum: 10/6c23b68178166a9219934e609260915f98fae31c5197a569a3088a621f622817e9ea37cd3ff6de272d6a3965d208ab96ee2884b9848ac3fe48db7600e226ff04
   languageName: node
   linkType: hard
 
@@ -2846,7 +2923,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@octokit/core@npm:^5.0.2":
+"@octokit/core@npm:^5.0.1, @octokit/core@npm:^5.0.2":
   version: 5.2.2
   resolution: "@octokit/core@npm:5.2.2"
   dependencies:
@@ -2882,6 +2959,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@octokit/openapi-types@npm:^20.0.0":
+  version: 20.0.0
+  resolution: "@octokit/openapi-types@npm:20.0.0"
+  checksum: 10/9f60572af1201dd92626c412253d83d986b8ab1956250b95f417013ee8e7baf25870eeb801d16672cabc2c420544bc9c2f0a979e07603ff5997eff038c71a8c3
+  languageName: node
+  linkType: hard
+
 "@octokit/openapi-types@npm:^24.2.0":
   version: 24.2.0
   resolution: "@octokit/openapi-types@npm:24.2.0"
@@ -2907,6 +2991,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@octokit/plugin-paginate-rest@npm:^9.2.2":
+  version: 9.2.2
+  resolution: "@octokit/plugin-paginate-rest@npm:9.2.2"
+  dependencies:
+    "@octokit/types": "npm:^12.6.0"
+  peerDependencies:
+    "@octokit/core": 5
+  checksum: 10/9afdd61d24a276ed7c2a8e436f735066d1b71601177deb97afa204a1f224257ca9c02681bc94dcda921d37c288a342124f7dfdd88393817306fe0b1ad1f0690f
+  languageName: node
+  linkType: hard
+
 "@octokit/plugin-request-log@npm:^4.0.0":
   version: 4.0.1
   resolution: "@octokit/plugin-request-log@npm:4.0.1"
@@ -2924,6 +3019,17 @@ __metadata:
   peerDependencies:
     "@octokit/core": ^5
   checksum: 10/479827e62466e55bc1a50129d51597807bddc6c909e56be9e8dd9c1a91efa0f466a2f56b7d80438649e21ab0a3a195f840b3fccf2ae7f11fb0a919db8e62bc62
+  languageName: node
+  linkType: hard
+
+"@octokit/plugin-rest-endpoint-methods@npm:^10.4.0":
+  version: 10.4.1
+  resolution: "@octokit/plugin-rest-endpoint-methods@npm:10.4.1"
+  dependencies:
+    "@octokit/types": "npm:^12.6.0"
+  peerDependencies:
+    "@octokit/core": 5
+  checksum: 10/1090fc5a1bebb7b48c512e178f8ad69a3ef8332e583274972f3a3035e9be9200093e22a5dbfe0f71aa1a7a8817e54bb915af3c2a3f88db1311a2873cef176552
   languageName: node
   linkType: hard
 
@@ -2962,6 +3068,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@octokit/types@npm:^12.6.0":
+  version: 12.6.0
+  resolution: "@octokit/types@npm:12.6.0"
+  dependencies:
+    "@octokit/openapi-types": "npm:^20.0.0"
+  checksum: 10/19b77a8d25af2a5df4561f8750f807edfc9fca5b07cfa9fb21dce4665e1b188c966688f5ed5e08089404428100dfe44ad353f8d8532f1d30fe47e61c5faa1440
+  languageName: node
+  linkType: hard
+
 "@octokit/types@npm:^13.0.0, @octokit/types@npm:^13.1.0, @octokit/types@npm:^13.7.0, @octokit/types@npm:^13.8.0":
   version: 13.10.0
   resolution: "@octokit/types@npm:13.10.0"
@@ -2978,6 +3093,7 @@ __metadata:
     "@apollo/client": "npm:3.13.8"
     "@artsy/fresnel": "npm:^1.3.1"
     "@bids/validator": "npm:@jsr/bids__validator@^2.3.2"
+    "@codecov/vite-plugin": "npm:^1.9.1"
     "@emotion/react": "npm:11.11.1"
     "@emotion/styled": "npm:11.11.0"
     "@niivue/niivue": "npm:0.57.0"
@@ -5828,7 +5944,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"acorn@npm:^8.14.1, acorn@npm:^8.15.0":
+"acorn@npm:^8.14.0, acorn@npm:^8.14.1, acorn@npm:^8.15.0":
   version: 8.15.0
   resolution: "acorn@npm:8.15.0"
   bin:
@@ -6997,7 +7113,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chalk@npm:4, chalk@npm:^4.0.0, chalk@npm:^4.1.0, chalk@npm:^4.1.2":
+"chalk@npm:4, chalk@npm:4.1.2, chalk@npm:^4.0.0, chalk@npm:^4.1.0, chalk@npm:^4.1.2":
   version: 4.1.2
   resolution: "chalk@npm:4.1.2"
   dependencies:
@@ -20029,7 +20145,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"undici@npm:^5.22.1":
+"undici@npm:^5.22.1, undici@npm:^5.25.4, undici@npm:^5.28.5":
   version: 5.29.0
   resolution: "undici@npm:5.29.0"
   dependencies:
@@ -20214,6 +20330,16 @@ __metadata:
   version: 1.0.0
   resolution: "unpipe@npm:1.0.0"
   checksum: 10/4fa18d8d8d977c55cb09715385c203197105e10a6d220087ec819f50cb68870f02942244f1017565484237f1f8c5d3cd413631b1ae104d3096f24fdfde1b4aa2
+  languageName: node
+  linkType: hard
+
+"unplugin@npm:^1.10.1":
+  version: 1.16.1
+  resolution: "unplugin@npm:1.16.1"
+  dependencies:
+    acorn: "npm:^8.14.0"
+    webpack-virtual-modules: "npm:^0.6.2"
+  checksum: 10/4b46d7d2a63d334a45111ba57a266b3f8993ef12a72b77d7b31ffc455e8a9bef9c0e37ea463eb409dbf7ccec0b9868aeb845dd42c690d9288e4b8ac2d90fbefd
   languageName: node
   linkType: hard
 
@@ -20722,6 +20848,13 @@ __metadata:
   version: 7.0.0
   resolution: "webidl-conversions@npm:7.0.0"
   checksum: 10/4c4f65472c010eddbe648c11b977d048dd96956a625f7f8b9d64e1b30c3c1f23ea1acfd654648426ce5c743c2108a5a757c0592f02902cf7367adb7d14e67721
+  languageName: node
+  linkType: hard
+
+"webpack-virtual-modules@npm:^0.6.2":
+  version: 0.6.2
+  resolution: "webpack-virtual-modules@npm:0.6.2"
+  checksum: 10/d9a0d035f7ec0c7f1055aaf88bfe48b7f96458043916a1b2926d9012fd61de3810a6b768e31a8cd4b3c84a9b6d55824361a9dd20aaf9f5ccfb6f017af216a178
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Add a smoke test for the production Vite build, occasionally dependency updates have broken this but not the dev build or test suite. Enables reporting the Vite bundle size in the codecov comment as well.