### PR TITLE
fix(server): Return a default Name if dataset_description.json exists but Name is undefined

### DIFF
--- a/packages/openneuro-server/src/datalad/__tests__/description.spec.ts
+++ b/packages/openneuro-server/src/datalad/__tests__/description.spec.ts
@@ -101,10 +101,10 @@ describe("datalad dataset descriptions", () => {
       const repaired = repairDescriptionTypes(description)
       expect(repaired.DatasetType).toEqual("raw")
     })
-    it("sets BIDSVersion to '1.8.0' if missing", () => {
+    it("sets BIDSVersion to '1.11.0' if missing", () => {
       const description = {}
       const repaired = repairDescriptionTypes(description)
-      expect(repaired.BIDSVersion).toEqual("1.8.0")
+      expect(repaired.BIDSVersion).toEqual("1.11.0")
     })
   })
   describe("getDescriptionObject()", () => {

--- a/packages/openneuro-server/src/datalad/description.ts
+++ b/packages/openneuro-server/src/datalad/description.ts
@@ -96,12 +96,16 @@ export const repairDescriptionTypes = (description) => {
       }
       // If it's already a string, no change needed.
     }
-    // If the field doesn't exist, we don't add it.
+    // If the field doesn't exist, we don't add it (except Name)
   }
 
   // Ensure BIDSVersion is present if missing (common default)
-  if (!Object.hasOwn(newDescription, "BIDSVersion")) {
-    newDescription.BIDSVersion = "1.8.0" // Or your desired default BIDS version
+  if (!newDescription.BIDSVersion) {
+    newDescription.BIDSVersion = "1.11.0"
+  }
+  // Ensure Name is present if missing
+  if (!newDescription.Name) {
+    newDescription.Name = "Unnamed Dataset"
   }
 
   return newDescription


### PR DESCRIPTION
Name is a required field. If the dataset_description existed and was not throwing an error related to UTF8 or JSON parsing, but lacking the name field this would lead to a 500 (displayed as 404). Bumps the assumed BIDS release to the latest.