### PR TITLE
fix(worker): Continue with export on non-zero git-annex S3 export calls

### DIFF
--- a/services/datalad/datalad_service/tasks/publish.py
+++ b/services/datalad/datalad_service/tasks/publish.py
@@ -156,10 +156,16 @@ async def export_dataset(
         # Push the most recent tag
         if tags:
             new_tag = tags[-1].name
-            await s3_export(dataset_path, get_s3_remote(), new_tag)
+            try:
+                await s3_export(dataset_path, get_s3_remote(), new_tag)
+            except subprocess.CalledProcessError as e:
+                logger.warning(f'S3 export failed for {dataset_id}@{new_tag}: {e}')
             if not public_dataset:
                 await set_s3_access_tag(dataset_id, 'private')
-            await s3_backup_push(dataset_path)
+            try:
+                await s3_backup_push(dataset_path)
+            except subprocess.CalledProcessError as e:
+                logger.warning(f'S3 backup push failed for {dataset_id}: {e}')
             # Once all S3 tags are exported, update GitHub
             if github_enabled and public_dataset:
                 # Perform all GitHub export steps


### PR DESCRIPTION
These have expected failures for purged files, continuing to the later steps on failures here should avoid sometimes failing to push to github on otherwise successful exports. Adds logging to track any other errors seen here.