### PR TITLE
fix(server): Only hide removed files, not flagged files

### DIFF
--- a/packages/openneuro-server/src/graphql/utils/file.ts
+++ b/packages/openneuro-server/src/graphql/utils/file.ts
@@ -3,7 +3,7 @@ import BadAnnexObject from "../../models/badAnnexObject"
 export const filterRemovedAnnexObjects =
   (datasetId, userInfo) => async (files) => {
     const removedAnnexObjectKeys = (
-      await BadAnnexObject.find({ datasetId }).exec()
+      await BadAnnexObject.find({ datasetId, removed: true }).exec()
     ).map(({ annexKey }) => annexKey)
     // keep files that haven't had their annex objects removed
     return userInfo?.admin


### PR DESCRIPTION
These annex keys in #3795 were flagged and hidden except for admin users. We should probably only hide these when they have been removed, not just when any user has flagged them.