### PR TITLE
fix(server): Prevent brainInitiative resolver error when Funding is not iterable

### DIFF
--- a/packages/openneuro-server/src/graphql/resolvers/brainInitiative.ts
+++ b/packages/openneuro-server/src/graphql/resolvers/brainInitiative.ts
@@ -36,9 +36,14 @@ export const brainInitiative = async (
         // Fetch snapshot if metadata didn't match
         const snapshot = await latestSnapshot(dataset, null, context)
         const snapshotDescription = await description(snapshot)
-        for (const funding of snapshotDescription.Funding) {
-          if (funding.match(brainInitiativeMatch)) {
-            return true
+        if (
+          snapshotDescription?.Funding &&
+          Array.isArray(snapshotDescription.Funding)
+        ) {
+          for (const funding of snapshotDescription.Funding) {
+            if (funding.match(brainInitiativeMatch)) {
+              return true
+            }
           }
         }
         // Check for grant ids too - filter to only alphanumeric to improve matching across format differences
@@ -55,9 +60,14 @@ export const brainInitiative = async (
           ) {
             return true
           }
-          for (const funding of snapshotDescription.Funding) {
-            if (funding.replace(/[^a-zA-Z0-9]/g, "").includes(grant)) {
-              return true
+          if (
+            snapshotDescription?.Funding &&
+            Array.isArray(snapshotDescription.Funding)
+          ) {
+            for (const funding of snapshotDescription.Funding) {
+              if (funding.replace(/[^a-zA-Z0-9]/g, "").includes(grant)) {
+                return true
+              }
             }
           }
         }


### PR DESCRIPTION
Minor fix for a common crash while indexing. Avoid iterating over the Funding field if it isn't present or not iterable.