### PR TITLE
fix: Raise LoginError if config file cannot be opened or parsed

### DIFF
--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -23,9 +23,14 @@ export function getConfig(
 ): ClientConfig {
   const url = Deno.env.get("OPENNEURO_URL") || instance
   const configPath = getConfigPath()
-  const config = JSON.parse(
-    new TextDecoder().decode(Deno.readFileSync(configPath)),
-  )
+  let config
+  try {
+    config = JSON.parse(
+      new TextDecoder().decode(Deno.readFileSync(configPath)),
+    )
+  } catch (err) {
+    throw new LoginError("Error reading config file. Rerun `openneuro login`.")
+  }
   const token = Object.hasOwn(config, url) && config[url]
   const errorReporting = Object.hasOwn(config, "errorReporting") &&
     config["errorReporting"] === true


### PR DESCRIPTION
This PR addresses an error found by a user who attempted to upload with the CLI without first running `login`:

```
error: Uncaught (in promise) NotFound: No such file or directory (os error 2): readfile '/home/<user>/.config/openneuro/config.json'
    new TextDecoder().decode(Deno.readFileSync(configPath)),
                                  ^
    at Object.readFileSync (ext:deno_fs/30_fs.js:765:10)
    at getConfig (https://jsr.io/@openneuro/cli/4.46.0/src/config.ts:27:35)
    at readConfig (https://jsr.io/@openneuro/cli/4.46.0/src/config.ts:45:18)
    at Command.uploadAction [as actionHandler] (https://jsr.io/@openneuro/cli/4.46.0/src/commands/upload.ts:64:24)
    at Command.execute (https://jsr.io/@effigies/cliffy-command/1.0.0-dev.8/command.ts:1940:18)
    at async Command.parseCommand (https://jsr.io/@effigies/cliffy-command/1.0.0-dev.8/command.ts:1772:14)
    at async commandLine (https://jsr.io/@openneuro/cli/4.46.0/src/options.ts:47:29)
    at async main (https://jsr.io/@openneuro/cli/4.46.0/mod.ts:21:5)
    at async https://jsr.io/@openneuro/cli/4.46.0/mod.ts:26:1
```

I'm just wrapping the whole line, treating `ENOENT`, `EPERM` and invalid JSON as a generic error reading the config file.