### PR TITLE
fix(dev): MongoDB startup issues on newer kernels and excessive wiredtiger cache allocation

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,7 +76,7 @@ services:
   # mongodb
   mongo:
     image: docker.io/library/mongo:8
-    command: ["--replSet", "rs0", "--bind_ip_all", "--port", "27017"]
+    command: ["--replSet", "rs0", "--bind_ip_all", "--port", "27017", "--wiredTigerCacheSizeGB", "1"]
     ports:
       - 27017:27017
     healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,6 +76,8 @@ services:
   # mongodb
   mongo:
     image: docker.io/library/mongo:8
+    environment:
+      GLIBC_TUNABLES: "glibc.cpu.hwcaps=-SHSTK"
     command: ["--replSet", "rs0", "--bind_ip_all", "--port", "27017", "--wiredTigerCacheSizeGB", "1"]
     ports:
       - 27017:27017


### PR DESCRIPTION
For development a cache larger than 1GB is not needed and could waste memory.

Disabling shadow stacks for MongoDB seems to be required to run MongoDB 8 on kernel 6.19 as well. https://jira.mongodb.org/browse/SERVER-120238