### PR TITLE
fix(freshdesk-widget): Pass current page URL as meta[referrer]

### DIFF
--- a/packages/openneuro-app/src/scripts/common/partials/__tests__/freshdesk-widget.spec.tsx
+++ b/packages/openneuro-app/src/scripts/common/partials/__tests__/freshdesk-widget.spec.tsx
@@ -1,0 +1,82 @@
+import { vi, describe, it, expect } from "vitest"
+import React from "react"
+import { render, screen } from "@testing-library/react"
+import { MemoryRouter } from "react-router-dom"
+import { MockedProvider } from "@apollo/client/testing"
+
+// Mock the dependencies
+vi.mock("react-cookie", () => ({
+  useCookies: () => [{}],
+}))
+
+vi.mock("../../authentication/profile", () => ({
+  getProfile: () => ({ email: "test@example.com" }),
+}))
+
+vi.mock("../../queries/user", () => ({
+  useUser: () => ({
+    user: { email: "test@example.com" },
+  }),
+}))
+
+import FreshdeskWidget from "../freshdesk-widget"
+
+describe("FreshdeskWidget component", () => {
+  it("includes meta[referrer] with current page URL in iframe src", () => {
+    const testRoute = "/datasets/ds000001"
+
+    render(
+      <MemoryRouter initialEntries={[testRoute]}>
+        <MockedProvider>
+          <FreshdeskWidget subject="Test" description="Test description" />
+        </MockedProvider>
+      </MemoryRouter>,
+    )
+
+    const iframe = screen.getByTitle("Feedback Form") as HTMLIFrameElement
+
+    // The iframe src should contain the current page URL as meta[referrer]
+    expect(iframe.src).toContain("meta[referrer]=")
+    // Verify it includes the test route pathname
+    expect(iframe.src).toContain("/datasets/ds000001")
+  })
+
+  it("includes prepopulated subject and description fields", () => {
+    const testRoute = "/datasets/ds000001"
+
+    render(
+      <MemoryRouter initialEntries={[testRoute]}>
+        <MockedProvider>
+          <FreshdeskWidget
+            subject="Test Issue"
+            description="This is a test"
+          />
+        </MockedProvider>
+      </MemoryRouter>,
+    )
+
+    const iframe = screen.getByTitle("Feedback Form") as HTMLIFrameElement
+
+    // Verify subject and description are in the iframe src
+    expect(iframe.src).toContain("helpdesk_ticket[subject]=Test%20Issue")
+    expect(iframe.src).toContain("helpdesk_ticket[description]=This%20is%20a%20test")
+  })
+
+  it("encodes special characters in the referrer URL correctly", () => {
+    const testRoute = "/search?query=test"
+
+    render(
+      <MemoryRouter initialEntries={[testRoute]}>
+        <MockedProvider>
+          <FreshdeskWidget subject="Test" />
+        </MockedProvider>
+      </MemoryRouter>,
+    )
+
+    const iframe = screen.getByTitle("Feedback Form") as HTMLIFrameElement
+
+    // Should properly encode the URL with query parameters
+    expect(iframe.src).toContain("meta[referrer]=")
+    expect(iframe.src).toContain("/search")
+  })
+})

--- a/packages/openneuro-app/src/scripts/common/partials/freshdesk-widget.jsx
+++ b/packages/openneuro-app/src/scripts/common/partials/freshdesk-widget.jsx
@@ -1,6 +1,7 @@
 import React from "react"
 import PropTypes from "prop-types"
 import { useCookies } from "react-cookie"
+import { useLocation } from "react-router-dom"
 import { getProfile } from "../../authentication/profile"
 import { config } from "../../config"
 import { useUser } from "../../queries/user"
@@ -10,13 +11,21 @@ const buildCustomQuery = (customText, prepopulatedFields) => {
     ...Object.entries(customText).map(([key, value]) => `${key}=${value}`),
     ...Object.entries(prepopulatedFields)
       .filter(([, value]) => value)
-      .map(([key, value]) => `helpdesk_ticket[${key}]=${value}`),
+      .map(([key, value]) => {
+        // Handle meta_ prefixed fields separately (e.g., meta_referrer -> meta[referrer])
+        if (key.startsWith("meta_")) {
+          const fieldName = key.replace(/^meta_/, "")
+          return `meta[${fieldName}]=${value}`
+        }
+        return `helpdesk_ticket[${key}]=${value}`
+      }),
   ]
   return customizerQueries.length ? `&${customizerQueries.join(";")}` : ""
 }
 
 function FreshdeskWidget({ subject, error, sentryId, description }) {
   const [cookies] = useCookies()
+  const { pathname } = useLocation()
   const profile = getProfile(cookies)
   const sentry = sentryId && `Sentry ID: ${sentryId}`
   const joinedDescription = [sentry, description, error]
@@ -38,6 +47,7 @@ function FreshdeskWidget({ subject, error, sentryId, description }) {
     requester: profile && user?.email,
     subject,
     description: joinedDescription,
+    meta_referrer: pathname,
   }
 
   return (

--- a/packages/openneuro-app/src/scripts/errors/freshdesk-widget.jsx
+++ b/packages/openneuro-app/src/scripts/errors/freshdesk-widget.jsx
@@ -1,6 +1,7 @@
 import React from "react"
 import PropTypes from "prop-types"
 import { useCookies } from "react-cookie"
+import { useLocation } from "react-router-dom"
 import { getProfile } from "../authentication/profile"
 import { config } from "../config"
 import { useUser } from "../queries/user"
@@ -10,13 +11,21 @@ const buildCustomQuery = (customText, prepopulatedFields) => {
     ...Object.entries(customText).map(([key, value]) => `${key}=${value}`),
     ...Object.entries(prepopulatedFields)
       .filter(([, value]) => value)
-      .map(([key, value]) => `helpdesk_ticket[${key}]=${value}`),
+      .map(([key, value]) => {
+        // Handle meta_ prefixed fields separately (e.g., meta_referrer -> meta[referrer])
+        if (key.startsWith("meta_")) {
+          const fieldName = key.replace(/^meta_/, "")
+          return `meta[${fieldName}]=${value}`
+        }
+        return `helpdesk_ticket[${key}]=${value}`
+      }),
   ]
   return customizerQueries.length ? `&${customizerQueries.join(";")}` : ""
 }
 
 function FreshdeskWidget({ subject, error, sentryId, description }) {
   const [cookies] = useCookies()
+  const { pathname } = useLocation()
   const profile = getProfile(cookies)
   const sentry = sentryId && `Sentry ID: ${sentryId}`
   const joinedDescription = [sentry, description, error]
@@ -39,6 +48,7 @@ function FreshdeskWidget({ subject, error, sentryId, description }) {
     requester: profile && user?.email,
     subject,
     description: joinedDescription,
+    meta_referrer: pathname,
   }
   return (
     <>

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,2 +1,21 @@
 import "@testing-library/jest-dom/vitest"
 import { vi } from "vitest"
+
+// Set up default global config for tests
+// This allows config.ts to load without errors when imported by components
+globalThis.OpenNeuroConfig = {
+  CRN_SERVER_URL: "http://localhost:8111",
+  GRAPHQL_URI: "http://localhost:8111/crn/graphql",
+  GOOGLE_CLIENT_ID: "test-client-id",
+  GLOBUS_CLIENT_ID: "test-globus-id",
+  ORCID_CLIENT_ID: "test-orcid-id",
+  ORCID_API_ENDPOINT: "https://orcid.org/orcid-pub",
+  GITHUB_CLIENT_ID: "test-github-id",
+  GOOGLE_TRACKING_IDS: "UA-test",
+  ENVIRONMENT: "development",
+  SENTRY_DSN: "",
+  SUPPORT_URL:
+    "https://openneuro.freshdesk.com/widgets/feedback_widget/new?&widgetType=embedded&screenshot=no",
+  DATALAD_GITHUB_ORG: "openneuro",
+  AWS_S3_PUBLIC_BUCKET: "test-bucket",
+} as any


### PR DESCRIPTION
It has been bugging me for some time that we lost the URL of the user who submitted an issue, always getting openneuro.org. I opened the widget and searched in the inspector for `openneuro.org` and found:

```html
    <div class="span6 omega">
      <input type="submit" name="commit" value="Request Support" id="helpdesk_ticket_submit" class="btn btn-primary omega" data-loading-text="Submitting.." data-disable-with="Request Support">
      <input type="hidden" name="meta[user_agent]" id="meta_user_agent" value="Mozilla/5.0 (X11; Linux x86_64; rv:148.0) Gecko/20100101 Firefox/148.0" autocomplete="off">
      <input type="hidden" name="meta[enterprise_enabled]" id="meta_enterprise_enabled" value="false" autocomplete="off">      <input type="hidden" name="meta[referrer]" id="meta_referrer" value="https://openneuro.org/" autocomplete="off">
    </div>
```

I used a test-driven-development agent to generate a failing test, propose a solution and verify that it passes local tests. It looks reasonable to me, and I want to see if it passes CI. Feel free to close if you don't want to review an LLM-generated PR.