### PR TITLE
fix(server): Prevent an error when provided JWT is unparsable

### DIFF
--- a/packages/openneuro-server/src/libs/authentication/jwt.ts
+++ b/packages/openneuro-server/src/libs/authentication/jwt.ts
@@ -156,9 +156,12 @@ export const decodeJWT = (token: string): OpenNeuroTokenProfile => {
 }
 
 export const parsedJwtFromRequest = (req) => {
-  const jwt = jwtFromRequest(req)
-  if (jwt) return decodeJWT(jwt)
-  else return null
+  try {
+    const jwt = decodeJWT(jwtFromRequest(req))
+    return jwt || null
+  } catch (_err) {
+    return null
+  }
 }
 
 const refreshToken = async (jwt) => {


### PR DESCRIPTION
Prevent an API crash with malformed JWT values.