### PR TITLE
fix(profile): Pass user ID (not ORCID) to GET_USER/UPDATE_USER queries, pass correct variable name to GET_USER

### DIFF
--- a/packages/openneuro-app/src/scripts/users/__tests__/user-account-view.spec.tsx
+++ b/packages/openneuro-app/src/scripts/users/__tests__/user-account-view.spec.tsx
@@ -33,7 +33,7 @@ const baseUser: User = {
 const userMock = {
   request: {
     query: userQueries.GET_USER,
-    variables: { id: baseUser.orcid },
+    variables: { userId: baseUser.id },
   },
   result: {
     data: {
@@ -50,13 +50,13 @@ describe("<UserAccountView />", () => {
         request: {
           query: userQueries.UPDATE_USER,
           variables: {
-            id: baseUser.orcid,
+            id: baseUser.id,
           },
         },
         result: {
           data: {
             updateUser: {
-              id: baseUser.orcid,
+              id: baseUser.id,
               location: "Marin, CA",
               links: ["https://newlink.com"],
               institution: "New University",
@@ -87,14 +87,14 @@ describe("<UserAccountView />", () => {
         request: {
           query: userQueries.UPDATE_USER,
           variables: {
-            id: baseUser.orcid,
+            id: baseUser.id,
             location: "Marin, CA",
           },
         },
         result: {
           data: {
             updateUser: {
-              id: baseUser.orcid,
+              id: baseUser.id,
               location: "Marin, CA",
               links: ["https://newlink.com"],
               institution: "New University",
@@ -128,14 +128,14 @@ describe("<UserAccountView />", () => {
       request: {
         query: userQueries.UPDATE_USER,
         variables: {
-          id: baseUser.orcid,
+          id: baseUser.id,
           institution: "New University",
         },
       },
       result: {
         data: {
           updateUser: {
-            id: baseUser.orcid,
+            id: baseUser.id,
             location: "Marin, CA",
             links: ["https://newlink.com"],
             institution: "New University",
@@ -168,14 +168,14 @@ describe("<UserAccountView />", () => {
       request: {
         query: userQueries.UPDATE_USER,
         variables: {
-          id: baseUser.orcid,
+          id: baseUser.id,
           links: ["https://newlink.com"],
         },
       },
       result: {
         data: {
           updateUser: {
-            id: baseUser.orcid,
+            id: baseUser.id,
             location: "Marin, CA",
             links: ["https://newlink.com"],
             institution: "New University",
@@ -208,14 +208,14 @@ describe("<UserAccountView />", () => {
       request: {
         query: userQueries.UPDATE_USER,
         variables: {
-          id: baseUser.orcid,
+          id: baseUser.id,
           links: ["https://newlink.com"],
         },
       },
       result: {
         data: {
           updateUser: {
-            id: baseUser.orcid,
+            id: baseUser.id,
             location: "Marin, CA",
             links: ["https://newlink.com"],
             institution: "New University",

--- a/packages/openneuro-app/src/scripts/users/user-account-view.tsx
+++ b/packages/openneuro-app/src/scripts/users/user-account-view.tsx
@@ -28,13 +28,13 @@ export const UserAccountView: React.FC<UserAccountViewProps> = ({
     try {
       await updateUser({
         variables: {
-          id: orcidUser?.orcid,
+          id: orcidUser.id,
           links: newLinks,
         },
         refetchQueries: [
           {
             query: GET_USER,
-            variables: { id: orcidUser?.orcid },
+            variables: { userId: orcidUser.id },
           },
         ],
       })
@@ -49,13 +49,13 @@ export const UserAccountView: React.FC<UserAccountViewProps> = ({
     try {
       await updateUser({
         variables: {
-          id: orcidUser?.orcid,
+          id: orcidUser.id,
           location: newLocation,
         },
         refetchQueries: [
           {
             query: GET_USER,
-            variables: { id: orcidUser?.orcid },
+            variables: { userId: orcidUser.id },
           },
         ],
       })
@@ -70,13 +70,13 @@ export const UserAccountView: React.FC<UserAccountViewProps> = ({
     try {
       await updateUser({
         variables: {
-          id: orcidUser?.orcid,
+          id: orcidUser.id,
           institution: newInstitution,
         },
         refetchQueries: [
           {
             query: GET_USER,
-            variables: { id: orcidUser?.orcid },
+            variables: { userId: orcidUser.id },
           },
         ],
       })

--- a/packages/openneuro-app/src/scripts/users/user-account-view.tsx
+++ b/packages/openneuro-app/src/scripts/users/user-account-view.tsx
@@ -14,12 +14,12 @@ import { pageTitle } from "../resources/strings.js"
 export const UserAccountView: React.FC<UserAccountViewProps> = ({
   orcidUser,
 }) => {
-  const [userLinks, setLinks] = useState<string[]>(orcidUser?.links || [])
+  const [userLinks, setLinks] = useState<string[]>(orcidUser.links ?? [])
   const [userLocation, setLocation] = useState<string>(
-    orcidUser?.location || "",
+    orcidUser.location ?? "",
   )
   const [userInstitution, setInstitution] = useState<string>(
-    orcidUser?.institution || "",
+    orcidUser.institution ?? "",
   )
   const [updateUser] = useMutation(UPDATE_USER)
 
@@ -107,7 +107,7 @@ export const UserAccountView: React.FC<UserAccountViewProps> = ({
             <span>ORCID:</span>
             {orcidUser.orcid}
           </li>
-          {orcidUser?.github &&
+          {orcidUser.github &&
             (
               <li>
                 <span>GitHub:</span>
@@ -128,7 +128,7 @@ export const UserAccountView: React.FC<UserAccountViewProps> = ({
           data-testid="links-section"
         />
 
-        {orcidUser?.id && orcidUser?.orcid !== undefined && (
+        {orcidUser.orcid !== undefined && (
           <div className={styles.umbOrcidConsent}>
             <div className={styles.umbOrcidHeading}>
               <h4>ORCID Integration</h4>


### PR DESCRIPTION
Another annoyance has been an inability to delete the link to my GitHub in my user links list since we added GitHub-syncing. While debugging, I realized that none of links/location/institution could be updated.

Comparing to the `orcid-consent-form.tsx`, which works, we were passing `id` instead of `userId`, and passing it `user.orcid` instead of `user.id`. That seems like the straightforward fix. Updated in both the original and the mock.

This feels like something that testing or typing should be able to catch, but I don't immediately see how.