### PR TITLE
fix(server): Check deletion state to avoid testing deleted datasets for data retention notices

### DIFF
--- a/packages/openneuro-server/src/datalad/__tests__/dataRetentionNotifications.spec.ts
+++ b/packages/openneuro-server/src/datalad/__tests__/dataRetentionNotifications.spec.ts
@@ -22,6 +22,7 @@ import notifications from "../../libs/notifications"
 import DataRetention from "../../models/dataRetention"
 import Permission from "../../models/permission"
 import User from "../../models/user"
+import Deletion from "../../models/deletion"
 import { checkDataRetentionNotifications } from "../dataRetentionNotifications"
 import * as draftModule from "../draft"
 import * as snapshotsModule from "../snapshots"
@@ -55,6 +56,7 @@ describe("checkDataRetentionNotifications", () => {
 
   beforeEach(async () => {
     await DataRetention.deleteMany({})
+    await Deletion.deleteMany({})
     await Permission.deleteMany({})
     await User.deleteMany({})
     vi.mocked(notifications.send).mockClear()
@@ -80,6 +82,19 @@ describe("checkDataRetentionNotifications", () => {
       snapshots as any,
     )
   }
+
+  it("skips notifications for deleted datasets", async () => {
+    await Deletion.create({
+      datasetId: TEST_DATASET,
+      reason: "test deletion",
+      user: { _id: TEST_USER.id },
+    })
+    mockDraft(daysAgo(15))
+    mockSnapshots([{ hexsha: "other" }])
+
+    await checkDataRetentionNotifications(TEST_DATASET)
+    expect(notifications.send).not.toHaveBeenCalled()
+  })
 
   it("does nothing when draft matches the latest snapshot", async () => {
     mockDraft(daysAgo(30), TEST_HEXSHA)

--- a/packages/openneuro-server/src/datalad/dataRetentionNotifications.ts
+++ b/packages/openneuro-server/src/datalad/dataRetentionNotifications.ts
@@ -3,6 +3,7 @@ import notifications from "../libs/notifications"
 import User from "../models/user"
 import Permission from "../models/permission"
 import DataRetention from "../models/dataRetention"
+import Deletion from "../models/deletion"
 import { getDraftInfo } from "./draft"
 import { getSnapshots } from "./snapshots"
 import { draftRetentionWarning } from "../libs/email/templates/draft-retention-warning"
@@ -40,6 +41,10 @@ async function notifyWriteUsers(
 export async function checkDataRetentionNotifications(
   datasetId: string,
 ): Promise<void> {
+  // Skip datasets that have been marked as deleted
+  const deleted = await Deletion.findOne({ datasetId }).exec()
+  if (deleted) return
+
   const draft = await getDraftInfo(datasetId)
   const snapshots = await getSnapshots(datasetId)
   const lastSnapshot = snapshots?.length


### PR DESCRIPTION
Skip the data retention policy notice check for deleted datasets.