### PR TITLE
fix(worker): Handle CRLF edits in snapshot creation

### DIFF
--- a/services/datalad/datalad_service/common/annex.py
+++ b/services/datalad/datalad_service/common/annex.py
@@ -388,7 +388,10 @@ async def edit_annexed_file(path, expected_content, new_content, encoding='utf-8
             real_path, 'r', encoding='utf-8', newline=''
         ) as annexed_file:
             annexed_file_contents = await annexed_file.read()
-            if expected_content != annexed_file_contents:
+            # Normalize only CRLF to LF before comparison
+            if expected_content.replace('\r\n', '\n') != annexed_file_contents.replace(
+                '\r\n', '\n'
+            ):
                 raise EditAnnexedFileException('unexpected {path} content')
     # Open the working tree path to overwrite
     if path != real_path:


### PR DESCRIPTION
This fixes an issue with automated edits (usually during snapshot creation) where CRLF in the edited files could lead to a mismatch between the expected content and the actual file. Normalizing CRLF to LF in this check solves it.