### PR TITLE
fix(server): Prevent throwing an error on createSnapshot mutation if reindex queue fails

### DIFF
--- a/packages/openneuro-server/src/queues/producer-methods.ts
+++ b/packages/openneuro-server/src/queues/producer-methods.ts
@@ -8,25 +8,33 @@ import * as Sentry from "@sentry/node"
  * @param datasetId Dataset to index
  */
 export function queueIndexDataset(datasetId: string) {
-  const msg = new ProducibleMessage()
-  msg.setQueue(OpenNeuroQueues.INDEXING).setBody({ datasetId })
-  producer.produce(msg, (err) => {
-    if (err) {
-      Sentry.captureException(err)
-    }
-  })
+  try {
+    const msg = new ProducibleMessage()
+    msg.setQueue(OpenNeuroQueues.INDEXING).setBody({ datasetId })
+    producer.produce(msg, (err) => {
+      if (err) {
+        Sentry.captureException(err)
+      }
+    })
+  } catch (err) {
+    Sentry.captureException(err)
+  }
 }
 
 /**
- * Queue search indexing for a dataset
- * @param datasetId Dataset to index
+ * Queue data retention check for a dataset
+ * @param datasetId Dataset to check
  */
 export function queueDataRetentionCheck(datasetId: string) {
-  const msg = new ProducibleMessage()
-  msg.setQueue(OpenNeuroQueues.DATARETENTION).setBody({ datasetId })
-  producer.produce(msg, (err) => {
-    if (err) {
-      Sentry.captureException(err)
-    }
-  })
+  try {
+    const msg = new ProducibleMessage()
+    msg.setQueue(OpenNeuroQueues.DATARETENTION).setBody({ datasetId })
+    producer.produce(msg, (err) => {
+      if (err) {
+        Sentry.captureException(err)
+      }
+    })
+  } catch (err) {
+    Sentry.captureException(err)
+  }
 }


### PR DESCRIPTION
Fixes #3839 by preventing this error from throwing during the createSnapshot mutation. It's not critical to queue a reindex and it will be indexed by the routine indexing if this fails. Log the underlying errors to Sentry.