### PR TITLE
fix: Resolve reviewer access regression

### DIFF
--- a/packages/openneuro-app/src/scripts/dataset/snapshot-container.tsx
+++ b/packages/openneuro-app/src/scripts/dataset/snapshot-container.tsx
@@ -185,12 +185,13 @@ export const SnapshotContainer: React.FC<SnapshotContainerProps> = ({
                 heading="Authors"
                 item={
                   <>
-                    {profile && (
-                      <RequestContributorButton
-                        dataset={dataset}
-                        currentUserId={currentUserId}
-                      />
-                    )}
+                    {profile && !profile.scopes.includes("dataset:reviewer") &&
+                      (
+                        <RequestContributorButton
+                          dataset={dataset}
+                          currentUserId={currentUserId}
+                        />
+                      )}
                     <ContributorsListDisplay
                       datasetId={dataset.id}
                       contributors={snapshot.contributors}

--- a/packages/openneuro-app/src/scripts/users/user-menu.tsx
+++ b/packages/openneuro-app/src/scripts/users/user-menu.tsx
@@ -5,6 +5,46 @@ import { useUser } from "../queries/user"
 import { useNotifications } from "./notifications/user-notifications-context"
 import "./scss/user-menu.scss"
 
+interface UserMenuListProps {
+  user: NonNullable<ReturnType<typeof useUser>["user"]>
+}
+
+function UserMenuList({ user }: UserMenuListProps) {
+  return (
+    <>
+      <li>
+        <Link
+          to={user.orcid ? `/user/${user.orcid}` : "/search?mydatasets"}
+        >
+          My Datasets
+        </Link>
+      </li>
+
+      {user.orcid && (
+        <li>
+          <Link to={`/user/${user.orcid}/account`}>Account Info</Link>
+        </li>
+      )}
+
+      <li className="user-menu-link">
+        <Link to="/keygen">Obtain an API Key</Link>
+      </li>
+
+      {user.provider !== "orcid" && (
+        <li className="user-menu-link">
+          <a href="/crn/auth/orcid?link=true">Link ORCID to my account</a>
+        </li>
+      )}
+
+      {user.admin && (
+        <li className="user-menu-link">
+          <Link to="/admin">Admin</Link>
+        </li>
+      )}
+    </>
+  )
+}
+
 export interface UserMenuProps {
   signOutAndRedirect: () => void
 }
@@ -14,6 +54,8 @@ export const UserMenu: React.FC<UserMenuProps> = ({ signOutAndRedirect }) => {
   const { notifications } = useNotifications()
 
   if (loading || !user) return null
+
+  const reviewer = user.id === "reviewer"
 
   const inboxCount =
     notifications?.filter((n) => n.status === "unread").length || 0
@@ -66,35 +108,7 @@ export const UserMenu: React.FC<UserMenuProps> = ({ signOutAndRedirect }) => {
               </p>
             </li>
 
-            <li>
-              <Link
-                to={user.orcid ? `/user/${user.orcid}` : "/search?mydatasets"}
-              >
-                My Datasets
-              </Link>
-            </li>
-
-            {user.orcid && (
-              <li>
-                <Link to={`/user/${user.orcid}/account`}>Account Info</Link>
-              </li>
-            )}
-
-            <li className="user-menu-link">
-              <Link to="/keygen">Obtain an API Key</Link>
-            </li>
-
-            {user.provider !== "orcid" && (
-              <li className="user-menu-link">
-                <a href="/crn/auth/orcid?link=true">Link ORCID to my account</a>
-              </li>
-            )}
-
-            {user.admin && (
-              <li className="user-menu-link">
-                <Link to="/admin">Admin</Link>
-              </li>
-            )}
+            {!reviewer && <UserMenuList user={user} />}
 
             <li className="user-menu-link">
               <a onClick={signOutAndRedirect} className="btn-submit-other">

--- a/packages/openneuro-server/src/graphql/resolvers/user.ts
+++ b/packages/openneuro-server/src/graphql/resolvers/user.ts
@@ -7,11 +7,53 @@ function isValidOrcid(orcid: string): boolean {
   return /^[0-9]{4}-[0-9]{4}-[0-9]{4}-[0-9]{3}[0-9X]$/.test(orcid || "")
 }
 
+// TODO - Use GraphQL codegen
+type GraphQLUserType = {
+  id: string
+  provider: "orcid" | "google"
+  avatar: string
+  orcid: string
+  created: Date
+  modified: Date
+  lastSeen: Date
+  email: string
+  name: string
+  admin: boolean
+  blocked: boolean
+  location: string
+  institution: string
+  github: string
+  githubSynced: Date
+  links: [string]
+  notifications: [Record<string, unknown>]
+  orcidConsent: boolean
+}
+
 export async function user(
   obj,
   { id },
   { userInfo }: { userInfo?: Record<string, unknown> } = {},
-) {
+): Promise<Partial<GraphQLUserType> | null> {
+  if (userInfo.reviewer) {
+    const oneWeekAgo = new Date()
+    oneWeekAgo.setDate(oneWeekAgo.getDate() - 7)
+    return {
+      id: "reviewer",
+      name: "Anonymous Reviewer",
+      email: "reviewer@openneuro.org",
+      provider: "orcid",
+      orcid: "0000-0000-0000-0000",
+      admin: false,
+      blocked: false,
+      location: "",
+      institution: "",
+      orcidConsent: true,
+      created: oneWeekAgo,
+      lastSeen: new Date(),
+      modified: oneWeekAgo,
+    }
+  }
+
   let user
   if (isValidOrcid(id)) {
     user = await User.findOne({
@@ -225,6 +267,11 @@ export const updateUser = async (
  */
 export async function notifications(obj, _, { userInfo }) {
   const userId = obj.id
+
+  // Reviewers never have notifications
+  if (userInfo.reviewer) {
+    return []
+  }
 
   // --- authorization ---
   if (!userInfo || (userInfo.id !== userId && !userInfo.admin)) {


### PR DESCRIPTION
Fixes reviewer users being immediately logged out and provides better compatibility for the frontend code by generating a mock user object for reviewers. Includes a fix to hide write actions from reviewers, previously a reviewer could make these requests even though they would throw errors.