### PR TITLE
fix(app): Render the snapshot header even when a validator summary isn't available

### DIFF
--- a/packages/openneuro-app/src/scripts/dataset/__tests__/snapshot-container.spec.tsx
+++ b/packages/openneuro-app/src/scripts/dataset/__tests__/snapshot-container.spec.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { render } from "@testing-library/react"
+import { render, screen } from "@testing-library/react"
 import Helmet from "react-helmet"
 import { SnapshotContainer } from "../snapshot-container"
 import { MockAppWrapper } from "../../fixtures/mock-app-wrapper"
@@ -34,5 +34,14 @@ describe("SnapshotContainer component", () => {
     })
     const header = Helmet.peek()
     expect(header).toMatchSnapshot()
+  })
+  it("renders the dataset header when summary is null", () => {
+    const snapshotWithoutSummary = { ...snapshot, summary: null }
+    render(
+      <SnapshotContainer dataset={dataset} snapshot={snapshotWithoutSummary} />,
+      { wrapper: MockAppWrapper },
+    )
+    const heading = screen.getByRole("heading", { level: 1 })
+    expect(heading).toHaveTextContent(snapshot.description.Name)
   })
 })

--- a/packages/openneuro-app/src/scripts/dataset/snapshot-container.tsx
+++ b/packages/openneuro-app/src/scripts/dataset/snapshot-container.tsx
@@ -95,41 +95,39 @@ export const SnapshotContainer: React.FC<SnapshotContainerProps> = ({
       <div
         className={`dataset dataset-draft dataset-page dataset-page-${modality?.toLowerCase()}`}
       >
-        {summary && (
-          <DatasetHeader
-            pageHeading={description.Name}
-            modality={summary?.modalities[0]}
-            datasetHeaderTools={
-              <div className="dataset-tool-buttons">
-                <DatasetTools
-                  hasEdit={hasEdit}
-                  isPublic={dataset.public}
-                  datasetId={datasetId}
-                  snapshotId={snapshot.tag}
-                  isAdmin={isAdmin}
-                  isDatasetAdmin={isDatasetAdmin}
-                  hasDerivatives={hasDerivatives}
-                />
-              </div>
-            }
-            datasetUserActions={
-              <FollowToggles>
-                <FollowDataset
-                  profile={profile !== null}
-                  datasetId={dataset.id}
-                  following={dataset.following}
-                  followers={dataset.followers.length}
-                />
-                <StarDataset
-                  profile={profile !== null}
-                  datasetId={dataset.id}
-                  starred={dataset.starred}
-                  stars={dataset.stars.length}
-                />
-              </FollowToggles>
-            }
-          />
-        )}
+        <DatasetHeader
+          pageHeading={description.Name}
+          modality={summary?.modalities[0]}
+          datasetHeaderTools={
+            <div className="dataset-tool-buttons">
+              <DatasetTools
+                hasEdit={hasEdit}
+                isPublic={dataset.public}
+                datasetId={datasetId}
+                snapshotId={snapshot.tag}
+                isAdmin={isAdmin}
+                isDatasetAdmin={isDatasetAdmin}
+                hasDerivatives={hasDerivatives}
+              />
+            </div>
+          }
+          datasetUserActions={
+            <FollowToggles>
+              <FollowDataset
+                profile={profile !== null}
+                datasetId={dataset.id}
+                following={dataset.following}
+                followers={dataset.followers.length}
+              />
+              <StarDataset
+                profile={profile !== null}
+                datasetId={dataset.id}
+                starred={dataset.starred}
+                stars={dataset.stars.length}
+              />
+            </FollowToggles>
+          }
+        />
         {!dataset.public && isDatasetAdmin && (
           <DatasetAlertPrivate
             datasetId={dataset.id}


### PR DESCRIPTION
It's rare for a version snapshot to be missing a summary but in this case we should still show the header.