### PR TITLE
fix: Refactor snapshot->downloadFiles resolver to use worker side cache

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -187,7 +187,24 @@ This will return any files below sub-01 in the tree for this version.
 }
 ```
 
-The full tree can be retrieved by recursively following tree objects.
+The full tree can be retrieved by recursively following tree objects. Alternatively clients downloading entire datasets may use the snapshot { downloadFiles } field.
+
+```graphql
+query downloadFiles {
+  dataset(id: "ds001234") {
+    latestSnapshot {
+      downloadFiles {
+        id
+        key
+        filename
+        urls
+      }
+    }
+  }
+}
+```
+
+This field is populated asynchronously after a version snapshot is created. Exports of newly created snapshots may take a few minutes to several hours before the field is populated. A client requesting this field should check for `dataset.latestSnapshot.downloadFiles` null value and retry with a backoff interval.
 
 ## Example Mutations
 

--- a/packages/openneuro-server/src/cache/types.ts
+++ b/packages/openneuro-server/src/cache/types.ts
@@ -11,7 +11,6 @@ export enum CacheType {
   snapshot = "snapshot",
   snapshotIndex = "snapshotIndex",
   participantCount = "participantCount",
-  snapshotDownload = "download",
   draftRevision = "revision",
   brainInitiative = "brainInitiative",
   validation = "validation",

--- a/packages/openneuro-server/src/datalad/__tests__/snapshots.spec.ts
+++ b/packages/openneuro-server/src/datalad/__tests__/snapshots.spec.ts
@@ -3,9 +3,10 @@ vi.mock("ioredis")
 import { MongoMemoryServer } from "mongodb-memory-server"
 import request from "superagent"
 import { createDataset } from "../dataset"
-import { createSnapshot } from "../snapshots"
+import { createSnapshot, downloadFiles } from "../snapshots"
 import { getDatasetWorker } from "../../libs/datalad-service"
 import { connect } from "mongoose"
+import Dataset from "../../models/dataset"
 
 // Mock requests to Datalad service
 vi.mock("superagent")
@@ -50,6 +51,68 @@ describe("snapshot model operations", () => {
           `${getDatasetWorker(dsId)}/datasets/${dsId}/snapshots/${tag}`,
         ),
       )
+    })
+  })
+
+  describe("downloadFiles()", () => {
+    const datasetId = "ds000001"
+    const tag = "1.0.0"
+    const workerUrl = `http://${
+      getDatasetWorker(datasetId)
+    }/datasets/${datasetId}/tree/${tag}?recursive=true`
+
+    beforeEach(() => {
+      vi.spyOn(Dataset, "findOne").mockImplementation(() =>
+        ({
+          lean: () => ({ exec: () => Promise.resolve({ public: true }) }),
+        }) as any
+      )
+    })
+
+    afterEach(() => {
+      vi.restoreAllMocks()
+    })
+
+    it("returns the parsed JSON body on a successful response", async () => {
+      const mockFiles = [
+        { filename: "sub-01/anat/T1w.nii.gz", size: 1234 },
+        { filename: "dataset_description.json", size: 56 },
+      ]
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(JSON.stringify(mockFiles), { status: 200 }),
+      )
+      const result = await downloadFiles(datasetId, tag)
+      expect(result).toEqual(mockFiles)
+      expect(globalThis.fetch).toHaveBeenCalledWith(workerUrl, {
+        signal: expect.any(AbortSignal),
+      })
+    })
+
+    it("returns null when the worker responds with 202 (cache populating)", async () => {
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(null, { status: 202 }),
+      )
+      const result = await downloadFiles(datasetId, tag)
+      expect(result).toBeNull()
+    })
+
+    it("throws when the worker responds with a non-ok status", async () => {
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response("Internal Server Error", { status: 500 }),
+      )
+      await expect(downloadFiles(datasetId, tag)).rejects.toThrow(
+        "Failed to fetch downloadFiles for ds000001:1.0.0 (500)",
+      )
+    })
+
+    it("returns null for non-public datasets", async () => {
+      vi.spyOn(Dataset, "findOne").mockImplementation(() =>
+        ({
+          lean: () => ({ exec: () => Promise.resolve({ public: false }) }),
+        }) as any
+      )
+      const result = await downloadFiles(datasetId, tag)
+      expect(result).toBeNull()
     })
   })
 })

--- a/packages/openneuro-server/src/datalad/snapshots.ts
+++ b/packages/openneuro-server/src/datalad/snapshots.ts
@@ -300,6 +300,10 @@ export const getPublicSnapshots = () => {
  * and returns 202 — we return null to signal "not ready yet".
  */
 export const downloadFiles = async (datasetId, tag) => {
+  // Only serve full file listings for public datasets (URLs are unsigned)
+  const ds = await Dataset.findOne({ id: datasetId }, "public").lean().exec()
+  if (!ds?.public) return null
+
   const response = await fetch(
     `http://${
       getDatasetWorker(datasetId)
@@ -313,7 +317,9 @@ export const downloadFiles = async (datasetId, tag) => {
     return null
   }
   if (!response.ok) {
-    return null
+    throw new Error(
+      `Failed to fetch downloadFiles for ${datasetId}:${tag} (${response.status})`,
+    )
   }
   const body = await response.json()
   return body

--- a/packages/openneuro-server/src/datalad/snapshots.ts
+++ b/packages/openneuro-server/src/datalad/snapshots.ts
@@ -20,7 +20,6 @@ import Snapshot from "../models/snapshot"
 import type { SnapshotDocument } from "../models/snapshot"
 import { updateDatasetRevision } from "./draft"
 import { getDatasetWorker } from "../libs/datalad-service"
-import { join } from "path"
 import { createEvent, updateEvent } from "../libs/events"
 import { queueIndexDataset } from "../queues/producer-methods"
 
@@ -294,33 +293,28 @@ export const getPublicSnapshots = () => {
 }
 
 /**
- * For snapshots, precache all trees for downloads
+ * For snapshots, return a pre-computed recursive file listing.
+ *
+ * The worker pre-caches this on disk after S3 export. For legacy snapshots
+ * without a cache, the worker queues a background task to populate it
+ * and returns 202 — we return null to signal "not ready yet".
  */
-export const downloadFiles = (datasetId, tag) => {
-  const downloadCache = new CacheItem(redis, CacheType.snapshotDownload, [
-    datasetId,
-    tag,
-  ], 432000)
-  // Return an existing cache object if we have one
-  return downloadCache.get(async () => {
-    // If not, fetch all trees sequentially and cache the result (hopefully some or all trees are cached)
-    const files = await getFilesRecursive(datasetId, tag, "")
-    files.sort()
-    return files
-  })
-}
-
-export async function getFilesRecursive(datasetId, tree, path = "") {
-  const files = []
-  // Fetch files
-  const fileTree = await getFiles(datasetId, tree)
-  for (const file of fileTree) {
-    const absPath = join(path, file.filename)
-    if (file.directory) {
-      files.push(...(await getFilesRecursive(datasetId, file.id, absPath)))
-    } else {
-      files.push({ ...file, filename: absPath })
-    }
+export const downloadFiles = async (datasetId, tag) => {
+  const response = await fetch(
+    `http://${
+      getDatasetWorker(datasetId)
+    }/datasets/${datasetId}/tree/${tag}?recursive=true`,
+    {
+      signal: AbortSignal.timeout(10000),
+    },
+  )
+  if (response.status === 202) {
+    // Cache is being populated, return null so the client knows to retry
+    return null
   }
-  return files
+  if (!response.ok) {
+    return null
+  }
+  const body = await response.json()
+  return body?.files ?? null
 }

--- a/packages/openneuro-server/src/datalad/snapshots.ts
+++ b/packages/openneuro-server/src/datalad/snapshots.ts
@@ -316,5 +316,5 @@ export const downloadFiles = async (datasetId, tag) => {
     return null
   }
   const body = await response.json()
-  return body?.files ?? null
+  return body
 }

--- a/packages/openneuro-server/src/graphql/schema.ts
+++ b/packages/openneuro-server/src/graphql/schema.ts
@@ -633,7 +633,7 @@ export const typeDefs = `
     onBrainlife: Boolean @cacheControl(maxAge: 10080, scope: PUBLIC)
     # Total size in bytes of this snapshot
     size: BigInt
-    # Single list of files to download this snapshot (only available on snapshots)
+    # Single list of files to download this snapshot (only available on snapshots), may be null if the snapshot is still being processed
     downloadFiles: [DatasetFile]
     # Contributors list from datacite.yml
     contributors: [Contributor]

--- a/services/datalad/datalad_service/common/annex.py
+++ b/services/datalad/datalad_service/common/annex.py
@@ -286,13 +286,17 @@ async def get_repo_urls(path, files):
     return files
 
 
-async def get_repo_files(dataset, dataset_path, tree):
-    """Read all files in a repo at a given branch, tag, or commit hash."""
+async def get_repo_files(dataset, dataset_path, tree, recursive=False):
+    """Read files in a repo at a given branch, tag, or commit hash.
+
+    When recursive=True, uses git ls-tree -r to list all files with full
+    paths in a single call. Otherwise lists one directory level.
+    """
+    ls_tree_args = ['git', 'ls-tree', '-l', tree]
+    if recursive:
+        ls_tree_args.append('-r')
     gitProcess = await asyncio.create_subprocess_exec(
-        'git',
-        'ls-tree',
-        '-l',
-        tree,
+        *ls_tree_args,
         cwd=dataset_path,
         stdout=asyncio.subprocess.PIPE,
     )
@@ -304,42 +308,43 @@ async def get_repo_files(dataset, dataset_path, tree):
         read_ls_tree_line(gitTreeLine, files, symlinkFilenames, symlinkObjects)
     await gitProcess.wait()
 
-    # After regular files, process all symlinks with one git cat-file --batch call
+    # Process all symlinks with one git cat-file --batch call
     # This is about 100x faster than one call per file for annexed file heavy datasets
-    catFileInput = '\n'.join(symlinkObjects)
-    catFileProcess = await asyncio.create_subprocess_exec(
-        'git',
-        'cat-file',
-        '--batch',
-        '--buffer',
-        cwd=dataset_path,
-        stdin=asyncio.subprocess.PIPE,
-        stdout=asyncio.subprocess.PIPE,
-    )
-    stdout, _ = await catFileProcess.communicate(input=catFileInput.encode('utf-8'))
-    # Output looks like this:
-    # dc9dde956f6f28e425a412a4123526e330668e7e blob 140
-    # ../../.git/annex/objects/Q0/VP/MD5E-s1618574--43762c4310549dcc8c5c25567f42722d.nii.gz/MD5E-s1618574--43762c4310549dcc8c5c25567f42722d.nii.gz
-    for index, line in enumerate(stdout.splitlines()):
-        # Skip metadata (even) lines
-        if index % 2 == 1:
-            key = line.rstrip().split(b'/')[-1].decode('utf-8')
-            # Get the size from key
-            size = int(key.split('-', 2)[1].lstrip('s'))
-            filename = symlinkFilenames[(index - 1) // 2]
-            file_id = compute_file_hash(key, filename)
-            files.append(
-                {
-                    'filename': filename,
-                    'size': int(size),
-                    'id': file_id,
-                    'key': key,
-                    'urls': [],
-                    'annexed': True,
-                    'directory': False,
-                }
-            )
-    # Now find URLs for each file if available
+    if symlinkObjects:
+        catFileInput = '\n'.join(symlinkObjects)
+        catFileProcess = await asyncio.create_subprocess_exec(
+            'git',
+            'cat-file',
+            '--batch',
+            '--buffer',
+            cwd=dataset_path,
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+        )
+        stdout, _ = await catFileProcess.communicate(input=catFileInput.encode('utf-8'))
+        # Output looks like this:
+        # dc9dde956f6f28e425a412a4123526e330668e7e blob 140
+        # ../../.git/annex/objects/Q0/VP/MD5E-s1618574--43762c4310549dcc8c5c25567f42722d.nii.gz/MD5E-s1618574--43762c4310549dcc8c5c25567f42722d.nii.gz
+        for index, line in enumerate(stdout.splitlines()):
+            # Skip metadata (even) lines
+            if index % 2 == 1:
+                key = line.rstrip().split(b'/')[-1].decode('utf-8')
+                # Get the size from key
+                size = int(key.split('-', 2)[1].lstrip('s'))
+                filename = symlinkFilenames[(index - 1) // 2]
+                file_id = compute_file_hash(key, filename)
+                files.append(
+                    {
+                        'filename': filename,
+                        'size': int(size),
+                        'id': file_id,
+                        'key': key,
+                        'urls': [],
+                        'annexed': True,
+                        'directory': False,
+                    }
+                )
+    # Find URLs for each file if available
     files = await get_repo_urls(dataset_path, files)
     # Provide fallbacks for any URLs that did not match rmet exports
     for f in files:

--- a/services/datalad/datalad_service/common/tag_cache.py
+++ b/services/datalad/datalad_service/common/tag_cache.py
@@ -1,0 +1,46 @@
+"""File-based cache for pre-computed snapshot file listings.
+
+Stores recursive file trees in .git/openneuro/tags/{tag}.json.gz so they
+can be served without recomputation. Uses gzip to keep disk usage low.
+"""
+
+import gzip
+import json
+import logging
+import os
+
+logger = logging.getLogger('datalad_service.' + __name__)
+
+
+def _cache_path(dataset_path, tag):
+    """Return the path to the cache file for a given tag."""
+    return os.path.join(dataset_path, '.git', 'openneuro', 'tags', f'{tag}.json.gz')
+
+
+def read_tag_cache_raw(dataset_path, tag):
+    """Read the raw gzip bytes for a tag cache, or return None on miss."""
+    path = _cache_path(dataset_path, tag)
+    try:
+        with open(path, 'rb') as f:
+            return f.read()
+    except (FileNotFoundError, OSError) as e:
+        logger.debug(f'Tag cache miss for {tag}: {e}')
+        return None
+
+
+def write_tag_cache(dataset_path, tag, files):
+    """Write a file listing to the tag cache."""
+    path = _cache_path(dataset_path, tag)
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with gzip.open(path, 'wt', encoding='utf-8') as f:
+        json.dump(files, f, separators=(',', ':'))
+    logger.info(f'Wrote tag cache for {tag} ({len(files)} files)')
+
+
+def delete_tag_cache(dataset_path, tag):
+    """Remove a cached file listing for a tag."""
+    path = _cache_path(dataset_path, tag)
+    try:
+        os.remove(path)
+    except FileNotFoundError:
+        pass

--- a/services/datalad/datalad_service/handlers/snapshots.py
+++ b/services/datalad/datalad_service/handlers/snapshots.py
@@ -5,6 +5,7 @@ import falcon
 
 from datalad_service.common.annex import EditAnnexedFileException
 from datalad_service.common.git import delete_tag
+from datalad_service.common.tag_cache import delete_tag_cache
 from datalad_service.tasks.snapshots import (
     create_snapshot,
     get_snapshot,
@@ -77,6 +78,7 @@ class SnapshotResource:
         if snapshot:
             dataset_path = self.store.get_dataset_path(dataset)
             delete_tag(dataset_path, snapshot)
+            delete_tag_cache(dataset_path, snapshot)
             resp.media = {}
             resp.status = falcon.HTTP_OK
         else:

--- a/services/datalad/datalad_service/handlers/tree.py
+++ b/services/datalad/datalad_service/handlers/tree.py
@@ -1,9 +1,11 @@
 import logging
 
 import falcon
+import pygit2
 
 from datalad_service.common.bids import dataset_sort
-from datalad_service.tasks.files import get_tree
+from datalad_service.common.tag_cache import read_tag_cache_raw
+from datalad_service.tasks.files import get_tree, populate_tag_cache
 
 
 class TreeResource:
@@ -12,9 +14,12 @@ class TreeResource:
         self.logger = logging.getLogger('datalad_service.' + __name__)
 
     async def on_get(self, req, resp, dataset, tree):
-        # Request for index of files
-        # Return a list of file objects
-        # {name, path, size}
+        if req.get_param_as_bool('recursive'):
+            await self._get_recursive(req, resp, dataset, tree)
+        else:
+            await self._get_single(req, resp, dataset, tree)
+
+    async def _get_single(self, req, resp, dataset, tree):
         try:
             files = await get_tree(self.store, dataset, tree)
             files.sort(key=dataset_sort)
@@ -23,3 +28,28 @@ class TreeResource:
         except FileNotFoundError:
             resp.status = falcon.HTTP_NOT_FOUND
             resp.media = {'error': 'Dataset does not exist'}
+
+    async def _get_recursive(self, req, resp, dataset, tree):
+        dataset_path = self.store.get_dataset_path(dataset)
+        # Only allow recursive listing for tags
+        try:
+            repo = pygit2.Repository(dataset_path)
+            repo.references[f'refs/tags/{tree}']
+        except (KeyError, pygit2.GitError):
+            resp.status = falcon.HTTP_BAD_REQUEST
+            resp.media = {'error': 'Recursive listing is only supported for tags'}
+            return
+
+        # Serve from on-disk cache (pre-compressed)
+        raw = read_tag_cache_raw(dataset_path, tree)
+        if raw is not None:
+            resp.status = falcon.HTTP_OK
+            resp.content_type = 'application/json'
+            resp.set_header('Content-Encoding', 'gzip')
+            resp.data = raw
+            return
+
+        # Cache miss — queue background task and tell client to retry
+        await populate_tag_cache.kiq(dataset, dataset_path, tree)
+        resp.status = falcon.HTTP_202
+        resp.media = {'error': 'Cache is being populated, try again soon'}

--- a/services/datalad/datalad_service/tasks/files.py
+++ b/services/datalad/datalad_service/tasks/files.py
@@ -9,6 +9,8 @@ import botocore
 import pygit2
 
 from datalad_service.common.annex import get_repo_files
+from datalad_service.common.tag_cache import write_tag_cache
+from datalad_service.broker import broker
 from datalad_service.common.git import (
     git_commit,
     git_commit_index,
@@ -45,6 +47,13 @@ async def get_tree(store, dataset, tree):
     """Get the working tree, optionally a branch tree."""
     dataset_path = store.get_dataset_path(dataset)
     return await get_repo_files(dataset, dataset_path, tree)
+
+
+@broker.task
+async def populate_tag_cache(dataset, dataset_path, tag):
+    """Compute recursive file listing for a tag and write to disk cache."""
+    files = await get_repo_files(dataset, dataset_path, tag, recursive=True)
+    write_tag_cache(dataset_path, tag, files)
 
 
 async def remove_files(store, dataset, paths, name=None, email=None, cookies=None):

--- a/services/datalad/datalad_service/tasks/publish.py
+++ b/services/datalad/datalad_service/tasks/publish.py
@@ -21,9 +21,14 @@ from datalad_service.config import AWS_ACCESS_KEY_ID
 from datalad_service.config import AWS_SECRET_ACCESS_KEY
 from datalad_service.config import GCP_ACCESS_KEY_ID
 from datalad_service.config import GCP_SECRET_ACCESS_KEY
-from datalad_service.common.annex import get_tag_info, is_git_annex_remote
+from datalad_service.common.annex import (
+    get_tag_info,
+    is_git_annex_remote,
+    get_repo_files,
+)
 from datalad_service.common.openneuro import clear_dataset_cache, is_public_dataset
 from datalad_service.common.git import git_show, git_tag, git_tag_tree
+from datalad_service.common.tag_cache import write_tag_cache
 from datalad_service.common.github import github_export
 from datalad_service.common.s3 import (
     s3_export,
@@ -172,6 +177,16 @@ async def export_dataset(
             if github_enabled and public_dataset:
                 # Perform all GitHub export steps
                 github_export(dataset_id, dataset_path, new_tag)
+            # Pre-compute recursive file listing while data is still local
+            try:
+                files = await get_repo_files(
+                    dataset_id, dataset_path, new_tag, recursive=True
+                )
+                write_tag_cache(dataset_path, new_tag, files)
+            except Exception as e:
+                logger.warning(
+                    f'Failed to populate tag cache for {dataset_id}@{new_tag}: {e}'
+                )
             # Drop cache once all exports are complete
             clear_dataset_cache(dataset_id)
             # Check and clean local annexed files once export is complete

--- a/services/datalad/tests/test_files.py
+++ b/services/datalad/tests/test_files.py
@@ -1,3 +1,4 @@
+import gzip
 import os
 import falcon
 from falcon import testing
@@ -427,12 +428,11 @@ def test_recursive_tree(client, new_dataset, datalad_store):
         f'/datasets/{ds_id}/tree/1.0.0', params={'recursive': 'true'}
     )
     assert recursive_response.status == falcon.HTTP_OK
-    recursive_content = json.loads(recursive_response.content)
-    recursive_files = recursive_content['files']
+    recursive_content = json.loads(gzip.decompress(recursive_response.content))
     # No directory entries in recursive output
-    assert all(not f['directory'] for f in recursive_files)
+    assert all(not f['directory'] for f in recursive_content)
     # Should contain nested file with full path
-    filenames = [f['filename'] for f in recursive_files]
+    filenames = [f['filename'] for f in recursive_content]
     assert 'sub-01/anat/sub-01_T1w.nii.gz' in filenames
     assert 'dataset_description.json' in filenames
     assert 'CHANGES' in filenames

--- a/services/datalad/tests/test_files.py
+++ b/services/datalad/tests/test_files.py
@@ -4,6 +4,7 @@ from falcon import testing
 import json
 from datalad.api import Dataset
 
+from datalad_service.common.tag_cache import write_tag_cache
 from datalad_service.tasks.files import parse_s3_annex_url
 
 
@@ -380,6 +381,70 @@ def test_delete_non_existing_file(client, new_dataset):
         json.loads(response.content)['error']
         == 'the following files not found: fake, test'
     )
+
+
+def test_recursive_tree(client, new_dataset, datalad_store):
+    """Test that ?recursive=true returns cached files for a tag."""
+    ds_id = os.path.basename(new_dataset.path)
+    dataset_path = datalad_store.get_dataset_path(ds_id)
+    # Add a nested file, commit, and tag
+    response = client.simulate_post(
+        f'/datasets/{ds_id}/files/sub-01:anat:sub-01_T1w.nii.gz',
+        body='fMRI data goes here',
+    )
+    assert response.status == falcon.HTTP_OK
+    response = client.simulate_post(f'/datasets/{ds_id}/draft')
+    assert response.status == falcon.HTTP_OK
+    response = client.simulate_post(f'/datasets/{ds_id}/snapshots/1.0.0')
+    assert response.status == falcon.HTTP_OK
+    # Non-recursive should include directories
+    root_response = client.simulate_get(f'/datasets/{ds_id}/tree/1.0.0')
+    assert root_response.status == falcon.HTTP_OK
+    root_content = json.loads(root_response.content)
+    dir_entries = [f for f in root_content['files'] if f['directory']]
+    assert len(dir_entries) > 0, 'Non-recursive listing should include directories'
+    # Pre-populate the tag cache with the flattened file list
+    # (normally done by export_dataset or populate_tag_cache task)
+    flat_files = []
+    for f in root_content['files']:
+        if not f['directory']:
+            flat_files.append(f)
+    # Add the nested file manually with its full path
+    flat_files.append(
+        {
+            'filename': 'sub-01/anat/sub-01_T1w.nii.gz',
+            'size': 19,
+            'id': 'test-id',
+            'key': 'test-key',
+            'urls': ['http://example.com/test'],
+            'annexed': True,
+            'directory': False,
+        }
+    )
+    write_tag_cache(dataset_path, '1.0.0', flat_files)
+    # Recursive should serve from cache
+    recursive_response = client.simulate_get(
+        f'/datasets/{ds_id}/tree/1.0.0', params={'recursive': 'true'}
+    )
+    assert recursive_response.status == falcon.HTTP_OK
+    recursive_content = json.loads(recursive_response.content)
+    recursive_files = recursive_content['files']
+    # No directory entries in recursive output
+    assert all(not f['directory'] for f in recursive_files)
+    # Should contain nested file with full path
+    filenames = [f['filename'] for f in recursive_files]
+    assert 'sub-01/anat/sub-01_T1w.nii.gz' in filenames
+    assert 'dataset_description.json' in filenames
+    assert 'CHANGES' in filenames
+
+
+def test_recursive_tree_requires_tag(client, new_dataset):
+    """Test that ?recursive=true rejects non-tag refs."""
+    ds_id = os.path.basename(new_dataset.path)
+    response = client.simulate_get(
+        f'/datasets/{ds_id}/tree/HEAD', params={'recursive': 'true'}
+    )
+    assert response.status == falcon.HTTP_400
 
 
 def test_parse_s3_annex_url():


### PR DESCRIPTION
Implements a cleaner version of the `downloadFiles` resolver. Instead of recursively following the tree API, we instead maintain a file cache on the workers for each tag and just stream this cache on request to API clients. If the cache isn't ready return null.

This batches the significant performance cost of returning the remote URLs for all files in the tree which can take minutes per request on large datasets.

Example usage:

```graphql
query downloadFiles {
  dataset(id: "ds001234") {
    latestSnapshot {
      downloadFiles {
        id
        filename
        urls
      }
    }
  }
}
```

In the case of a pending export or cache:
```json
{
  "data": {
    "dataset": {
      "latestSnapshot": {
        "downloadFiles": null
      }
   }
}
```

Once populated:
```json
{
  "data": {
    "dataset": {
      "latestSnapshot": {
        "downloadFiles": [
          {
            "id": "434d719164ca3cea650a86b18dd5ec2051fb665d",
            "filename": "dataset_description.json",
            "urls": [
              "https://openneuro.org/crn/datasets/ds001234/objects/a4116179a7728929e9a9579189cb50fed2b483bf"
            ]
          },
          {
            "id": "67bb157099cbc45f68fba7320e74f3f17b347c1e",
            "filename": "derivatives/mriqc/anatMRIQC.csv",
            "urls": [
              "https://s3.amazonaws.com/...."
            ]
          },
          ...
        ]
      }
    }
  }
}
```

See #3846