### PR TITLE
fix(worker): Use git-annex x-amz-tagging to set access tags

### DIFF
--- a/services/datalad/datalad_service/common/s3.py
+++ b/services/datalad/datalad_service/common/s3.py
@@ -19,7 +19,7 @@ class S3ConfigException(Exception):
     pass
 
 
-def generate_s3_annex_options(dataset_path, backup=False):
+def generate_s3_annex_options(dataset_path, backup=False, include_tagging=True):
     dataset_id = os.path.basename(dataset_path)
     annex_options = [
         'type=S3',
@@ -44,6 +44,8 @@ def generate_s3_annex_options(dataset_path, backup=False):
             'autoenable=true',
             f'publicurl=https://s3.amazonaws.com/{get_s3_bucket()}',
         ]
+        if include_tagging:
+            annex_options.append('x-amz-tagging=access=private')
     return annex_options
 
 
@@ -62,8 +64,7 @@ def backup_remote_env():
 
 def setup_s3_sibling(dataset_path):
     """Add a sibling for an S3 bucket publish."""
-    # Public remote
-    # TODO set ['x-amz-tagging=access=private'] if tagging is supported in git-annex
+    # Public S3 bucket remote
     subprocess.run(
         ['git-annex', 'initremote', get_s3_remote()]
         + generate_s3_annex_options(dataset_path),
@@ -122,16 +123,18 @@ def setup_s3_backup_sibling_workaround(dataset_path):
     )
 
 
-def update_s3_sibling(dataset_path):
+def update_s3_sibling(dataset_path, public_dataset):
     """Update S3 remote with latest config."""
     # note: enableremote command will only upsert config options, none are deleted
     if not is_git_annex_remote(dataset_path, get_s3_remote()):
         setup_s3_sibling(dataset_path)
     else:
-        # Update the remote config
+        # Update the remote config (and configure tagging for private datasets)
         subprocess.run(
             ['git-annex', 'enableremote', get_s3_remote()]
-            + generate_s3_annex_options(dataset_path),
+            + generate_s3_annex_options(
+                dataset_path, include_tagging=(not public_dataset)
+            ),
             check=True,
             cwd=dataset_path,
         )
@@ -142,7 +145,9 @@ def update_s3_sibling(dataset_path):
         # Update the backup remote config
         subprocess.run(
             ['git-annex', 'enableremote', get_s3_backup_remote()]
-            + generate_s3_annex_options(dataset_path, backup=True),
+            + generate_s3_annex_options(
+                dataset_path, backup=True, include_tagging=False
+            ),
             check=True,
             cwd=dataset_path,
             env=backup_remote_env(),
@@ -172,7 +177,9 @@ def validate_s3_config(dataset_path):
             options_line = line
     if options_line:
         # check that each of the expected annex options is what's actually configured
-        expected_options = generate_s3_annex_options(dataset_path)
+        expected_options = generate_s3_annex_options(
+            dataset_path, include_tagging=False
+        )
         for expected_option in expected_options:
             if not expected_option in options_line:
                 return False

--- a/services/datalad/datalad_service/tasks/publish.py
+++ b/services/datalad/datalad_service/tasks/publish.py
@@ -73,7 +73,7 @@ async def create_remotes_and_export(dataset_path, public=False):
     create_remotes(dataset_path)
     await export_dataset(dataset_path)
     if public:
-        await set_s3_access_tag(os.path.basename(dataset_path), 'public')
+        await set_remote_public(dataset_path)
 
 
 def create_remotes(dataset_path):
@@ -154,7 +154,7 @@ async def export_dataset(
         repo = pygit2.Repository(dataset_path)
         tags = sorted(git_tag(repo), key=lambda tag: tag.name)
         # Update configuration for the remote
-        update_s3_sibling(dataset_path)
+        update_s3_sibling(dataset_path, public_dataset)
         # Push the most recent tag
         if tags:
             new_tag = tags[-1].name
@@ -162,8 +162,6 @@ async def export_dataset(
                 await s3_export(dataset_path, get_s3_remote(), new_tag)
             except subprocess.CalledProcessError as e:
                 logger.warning(f'S3 export failed for {dataset_id}@{new_tag}: {e}')
-            if not public_dataset:
-                await set_s3_access_tag(dataset_id, 'private')
             try:
                 await s3_backup_push(dataset_path)
             except subprocess.CalledProcessError as e:
@@ -316,11 +314,11 @@ async def annex_drop(dataset_path, branches):
 
 async def set_remote_public(dataset):
     """Clear x-amz-meta-access when a dataset is made public."""
-    # If git-annex supports tags in the future, we'd modify this here.
-    # await run_check(
-    #    ['git-annex', 'enableremote', get_s3_remote(), 'x-amz-tagging=access=public'],
-    #    dataset_path,
-    # )
+    dataset_path = os.path.join(datalad_service.common.s3.get_datasets_path(), dataset)
+    await run_check(
+        ['git-annex', 'enableremote', get_s3_remote(), 'x-amz-tagging=access=public'],
+        dataset_path,
+    )
     await set_s3_access_tag(dataset, 'public')
 
 

--- a/services/datalad/tests/test_common_s3.py
+++ b/services/datalad/tests/test_common_s3.py
@@ -38,7 +38,7 @@ def test_s3_annex_options(monkeypatch):
     assert 'fileprefix=test00001/' in options
     assert 'bucket=a-fake-test-public-bucket' in options
     # Check that the private tag is applied by default
-    # assert 'x-amz-tagging=access=private' in options
+    assert 'x-amz-tagging=access=private' in options
 
 
 def test_s3_annex_backup_options(monkeypatch):
@@ -66,7 +66,7 @@ def test_update_s3_sibling(monkeypatch, no_init_remote, new_dataset):
     create_remotes(new_dataset.path)
     # This will break this dataset beyond here in tests, but make sure it fails at the enableremote step
     with pytest.raises(subprocess.CalledProcessError):
-        update_s3_sibling(new_dataset.path)
+        update_s3_sibling(new_dataset.path, False)
 
 
 def test_validate_s3_config(no_init_remote, new_dataset):


### PR DESCRIPTION
Switch to using git-annex support for `x-amz-tagging` to set access tags during exports.