### PR TITLE
feat(server): Change age type from Int to Float in GraphQL schema

### DIFF
--- a/packages/openneuro-search/src/mappings/datasets-mapping.json
+++ b/packages/openneuro-search/src/mappings/datasets-mapping.json
@@ -43,7 +43,7 @@
                 "participantId": { "type": "keyword" },
                 "group": { "type": "keyword" },
                 "sex": { "type": "keyword" },
-                "age": { "type": "integer" }
+                "age": { "type": "float" }
               }
             },
             "pet": {

--- a/packages/openneuro-server/src/graphql/schema.ts
+++ b/packages/openneuro-server/src/graphql/schema.ts
@@ -323,7 +323,7 @@ export const typeDefs = `
 
   input SubjectMetadataInput {
     participantId: String!
-    age: Int
+    age: Float
     sex: String
     group: String
   }
@@ -355,7 +355,7 @@ export const typeDefs = `
     openneuroPaperDOI: String
     seniorAuthor: String
     adminUsers: [String]
-    ages: [Int]
+    ages: [Float]
     modalities: [String]
     grantFunderName: String
     grantIdentifier: String
@@ -784,7 +784,7 @@ export const typeDefs = `
 
   type SubjectMetadata {
     participantId: String!
-    age: Int
+    age: Float
     sex: String
     group: String
   }
@@ -934,7 +934,7 @@ export const typeDefs = `
     openneuroPaperDOI: String
     seniorAuthor: String
     adminUsers: [String]
-    ages: [Int]
+    ages: [Float]
     modalities: [String]
     grantFunderName: String
     grantIdentifier: String

--- a/services/datalad/datalad_service/tasks/validator.py
+++ b/services/datalad/datalad_service/tasks/validator.py
@@ -2,6 +2,7 @@ import asyncio
 from pathlib import Path
 import json
 import logging
+import math
 import re
 
 import requests
@@ -73,12 +74,35 @@ async def validate_dataset_deno_call(dataset_path, ref, logger=logger):
     )
 
 
+def sanitize_age(age):
+    """Coerce age to a finite float or None.
+
+    The bids-validator may produce non-numeric ages (e.g. "89+") that
+    cannot be represented as a GraphQL Float.
+    """
+    if isinstance(age, (int, float)) and math.isfinite(age):
+        return float(age)
+    return None
+
+
+def sanitize_subject_metadata(subject_metadata):
+    """Sanitize subjectMetadata ages before sending to GraphQL."""
+    if not subject_metadata:
+        return subject_metadata
+    return [
+        {**s, 'age': sanitize_age(s.get('age'))} for s in subject_metadata
+    ]
+
+
 def summary_mutation(dataset_id, ref, validator_output, validator_metadata):
     """
     Return the OpenNeuro mutation to update a dataset summary.
     """
     summary = validator_output['summary']
     summary['datasetId'] = dataset_id
+    summary['subjectMetadata'] = sanitize_subject_metadata(
+        summary.get('subjectMetadata'),
+    )
     # Set the object id to the git sha256 ref
     summary['id'] = ref
     summary['validatorMetadata'] = validator_metadata

--- a/services/datalad/tests/test_validator.py
+++ b/services/datalad/tests/test_validator.py
@@ -2,9 +2,53 @@ import asyncio
 
 import pytest
 
-from datalad_service.tasks.validator import validate_dataset_deno_call
+from datalad_service.tasks.validator import (
+    sanitize_age,
+    sanitize_subject_metadata,
+    validate_dataset_deno_call,
+)
 from unittest.mock import Mock
 from types import SimpleNamespace
+
+
+@pytest.mark.parametrize(
+    "age, expected",
+    [
+        (25, 25.0),
+        (25.5, 25.5),
+        (0, 0.0),
+        (-1, -1.0),
+        (float("nan"), None),
+        (float("inf"), None),
+        (float("-inf"), None),
+        ("89+", None),
+        ("25", None),
+        (None, None),
+    ],
+)
+def test_sanitize_age(age, expected):
+    result = sanitize_age(age)
+    if expected is None:
+        assert result is None
+    else:
+        assert result == expected
+
+
+def test_sanitize_subject_metadata():
+    metadata = [
+        {"participantId": "01", "age": 25, "sex": "M"},
+        {"participantId": "02", "age": "89+", "sex": "F"},
+        {"participantId": "03", "sex": "M"},
+    ]
+    result = sanitize_subject_metadata(metadata)
+    assert result[0]["age"] == 25.0
+    assert result[1]["age"] is None
+    assert result[2]["age"] is None
+
+
+def test_sanitize_subject_metadata_passthrough():
+    assert sanitize_subject_metadata(None) is None
+    assert sanitize_subject_metadata([]) == []
 
 
 class MockLogger:


### PR DESCRIPTION
Allows non-integer ages from BIDS participants.tsv to be stored without truncation. Updates both the GraphQL SDL types and the Elasticsearch mapping for subjectMetadata.age.

This also sanitizes the validator output to filter non-finite-numeric ages and set them as `null`. The reason is that the use for these data is ElasticSearch, which needs continuous values. If the validator wants to treat `"89+"` as `89`, it may make that change. OpenNeuro will simply filter values it is given.

Fixes an issue where datasets with non-integral ages would fail to display metadata such as modalities.