### PR TITLE
fix(worker): Presign private URLs only

### DIFF
--- a/services/datalad/datalad_service/common/annex.py
+++ b/services/datalad/datalad_service/common/annex.py
@@ -140,7 +140,12 @@ def parse_remote_line(remoteLine):
     if remoteConfig['type'] == 'S3' and remoteConfig['bucket'] in S3_BUCKETS_WHITELIST:
         remoteUuid = remoteLine[0:36]
         remoteUrl = remoteConfig['publicurl'] if 'publicurl' in remoteConfig else None
-        return {'uuid': remoteUuid, 'url': remoteUrl, 'name': remoteConfig['name']}
+        return {
+            'uuid': remoteUuid,
+            'url': remoteUrl,
+            'name': remoteConfig['name'],
+            'x-amz-tagging': remoteConfig.get('x-amz-tagging'),
+        }
 
 
 def parse_rmet_line(remote, rmetLine):
@@ -153,12 +158,15 @@ def parse_rmet_line(remote, rmetLine):
         except UnicodeDecodeError:
             return None
     s3version, path = remoteData.split('#')
-    if remote['name'] == get_s3_remote():
+    if (
+        remote['name'] == get_s3_remote()
+        and remote.get('x-amz-tagging') == 'access=private'
+    ):
         # Presigned via OpenNeuro's credentials
         url = presign_remote_url(path, s3version)
         return url
     else:
-        # Anonymous access for any other buckets
+        # Anonymous access for public data or other buckets
         return encode_remote_url(
             '{}{}{}?versionId={}'.format(remote['url'], slash, path, s3version)
         )

--- a/services/datalad/tests/test_annex.py
+++ b/services/datalad/tests/test_annex.py
@@ -143,13 +143,14 @@ def test_parse_remote_line():
         'url': 'http://openneuro.org.s3.amazonaws.com/',
         'uuid': '57894849-d0c8-4c62-8418-3627be18a196',
         'name': 's3-PUBLIC',
+        'x-amz-tagging': None,
     }
 
 
 def test_parse_rmet_line():
     remote = {
         'name': 's3-PUBLIC',
-        'url': 'http://openneuro.org.s3.amazonaws.com/',
+        'url': 'https://s3.amazonaws.com/a-fake-test-public-bucket',
         'uuid': '57894849-d0c8-4c62-8418-3627be18a196',
     }
     url = parse_rmet_line(
@@ -157,16 +158,15 @@ def test_parse_rmet_line():
         """1590213748.042921433s 57894849-d0c8-4c62-8418-3627be18a196:V +iVcEk18e3J2WQys4zr_ANaTPfpUufW4Y#ds002778/dataset_description.json""",
     )
     assert (
-        'https://s3.amazonaws.com/a-fake-test-public-bucket/ds002778/dataset_description.json?versionId=iVcEk18e3J2WQys4zr_ANaTPfpUufW4Y&AWSAccessKeyId=aws-id'
+        'https://s3.amazonaws.com/a-fake-test-public-bucket/ds002778/dataset_description.json?versionId=iVcEk18e3J2WQys4zr_ANaTPfpUufW4Y'
         in url
     )
-    assert 'Signature=' in url
 
 
 def test_parse_rmet_line_https():
     remote = {
         'name': 's3-PUBLIC',
-        'url': 'https://s3.amazonaws.com/openneuro.org',
+        'url': 'https://s3.amazonaws.com/a-fake-test-public-bucket',
         'uuid': '57894849-d0c8-4c62-8418-3627be18a196',
     }
     url = parse_rmet_line(
@@ -174,16 +174,15 @@ def test_parse_rmet_line_https():
         """1590213748.042921433s 57894849-d0c8-4c62-8418-3627be18a196:V +iVcEk18e3J2WQys4zr_ANaTPfpUufW4Y#ds002778/dataset_description.json""",
     )
     assert (
-        'https://s3.amazonaws.com/a-fake-test-public-bucket/ds002778/dataset_description.json?versionId=iVcEk18e3J2WQys4zr_ANaTPfpUufW4Y&AWSAccessKeyId=aws-id'
+        'https://s3.amazonaws.com/a-fake-test-public-bucket/ds002778/dataset_description.json?versionId=iVcEk18e3J2WQys4zr_ANaTPfpUufW4Y'
         in url
     )
-    assert 'Signature=' in url
 
 
 def test_parse_rmet_line_base64():
     remote = {
         'name': 's3-PUBLIC',
-        'url': 'https://s3.amazonaws.com/openneuro.org',
+        'url': 'https://s3.amazonaws.com/a-fake-test-public-bucket',
         'uuid': '57894849-d0c8-4c62-8418-3627be18a196',
     }
     url = parse_rmet_line(
@@ -191,26 +190,24 @@ def test_parse_rmet_line_base64():
         """1590213748.042921433s 57894849-d0c8-4c62-8418-3627be18a196:V +!aVZjRWsxOGUzSjJXUXlzNHpyX0FOYVRQZnBVdWZXNFkjZHMwMDI3NzgvZGF0YXNldF9kZXNjcmlwdGlvbi5qc29u""",
     )
     assert (
-        'https://s3.amazonaws.com/a-fake-test-public-bucket/ds002778/dataset_description.json?versionId=iVcEk18e3J2WQys4zr_ANaTPfpUufW4Y&AWSAccessKeyId=aws-id'
+        'https://s3.amazonaws.com/a-fake-test-public-bucket/ds002778/dataset_description.json?versionId=iVcEk18e3J2WQys4zr_ANaTPfpUufW4Y'
         in url
     )
-    assert 'Signature=' in url
 
 
 def test_read_rmet_file():
     remote = {
         'name': 's3-PUBLIC',
-        'url': 'http://openneuro.org.s3.amazonaws.com/',
+        'url': 'https://s3.amazonaws.com/a-fake-test-public-bucket',
         'uuid': '57894849-d0c8-4c62-8418-3627be18a196',
     }
     catFile = io.BytesIO(b""":::99fe93bfea62c16a10488593da870df25d09be81
     1590213748.042921433s 57894849-d0c8-4c62-8418-3627be18a196:V +iVcEk18e3J2WQys4zr_ANaTPfpUufW4Y#ds002778/dataset_description.json""")
     url = read_rmet_file(remote, catFile)
     assert (
-        'https://s3.amazonaws.com/a-fake-test-public-bucket/ds002778/dataset_description.json?versionId=iVcEk18e3J2WQys4zr_ANaTPfpUufW4Y&AWSAccessKeyId=aws-id'
+        'https://s3.amazonaws.com/a-fake-test-public-bucket/ds002778/dataset_description.json?versionId=iVcEk18e3J2WQys4zr_ANaTPfpUufW4Y'
         in url
     )
-    assert 'Signature=' in url
 
 
 def test_remote_url_encoding():


### PR DESCRIPTION
This allows more aggressive caching for public datasets by eliminating the need to refresh the presigned URLs.

Depends on #3856 and related #3854