### PR TITLE
fix(app): Move accessToken checks to client side and prevent crash in notifications resolver

### DIFF
--- a/packages/openneuro-app/src/client.jsx
+++ b/packages/openneuro-app/src/client.jsx
@@ -15,11 +15,10 @@ import { relayStylePagination } from "@apollo/client/utilities"
 // TODO - This should be a global SCSS?
 import "./scripts/components/page/page.scss"
 import cookies from "./scripts/utils/cookies.js"
-import { getProfile, guardExpired } from "./scripts/authentication/profile"
+import { shouldRemoveToken } from "./scripts/authentication/profile"
 
-// Clear expired JWT before the app mounts to avoid stale auth state
-const profile = getProfile(cookies.getAll())
-if (profile && !guardExpired(profile)) {
+// Clear expired or corrupted JWT before the app mounts to avoid stale auth state
+if (shouldRemoveToken(cookies.getAll())) {
   cookies.remove("accessToken", { path: "/" })
 }
 

--- a/packages/openneuro-app/src/scripts/authentication/__tests__/profile.spec.js
+++ b/packages/openneuro-app/src/scripts/authentication/__tests__/profile.spec.js
@@ -1,23 +1,89 @@
-import { parseJwt } from "../profile"
+import {
+  getProfile,
+  guardExpired,
+  parseJwt,
+  shouldRemoveToken,
+} from "../profile"
+
+const header = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"
+const dummySig = "SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
 
 const asciiToken =
-  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+  `${header}.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.${dummySig}`
 const utf8Token =
-  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6Iuelnue1jOenkeWtpuiAhSIsImlhdCI6MTUxNjIzOTAyMn0.pUw2ARoXv4LkJXB1ZR3Th6xG83URT6mn1TftC7ac_O8"
+  `${header}.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6Iuelnue1jOenkeWtpuiAhSIsImlhdCI6MTUxNjIzOTAyMn0.${dummySig}`
+
+// Token with exp far in the future
+const validToken =
+  `${header}.eyJzdWIiOiJ1c2VyMTIzIiwiYWRtaW4iOmZhbHNlLCJpYXQiOjE1MTYyMzkwMjIsImV4cCI6OTk5OTk5OTk5OX0.${dummySig}`
+// Token with exp = 1 (long expired)
+const expiredToken =
+  `${header}.eyJzdWIiOiJ1c2VyMTIzIiwiYWRtaW4iOmZhbHNlLCJpYXQiOjE1MTYyMzkwMjIsImV4cCI6MX0.${dummySig}`
 
 describe("authentication/profile", () => {
-  it("decodes a JWT to Javascript object", () => {
-    expect(parseJwt(asciiToken)).toEqual({
-      sub: "1234567890",
-      name: "John Doe",
-      iat: 1516239022,
+  describe("parseJwt", () => {
+    it("decodes a JWT to Javascript object", () => {
+      expect(parseJwt(asciiToken)).toEqual({
+        sub: "1234567890",
+        name: "John Doe",
+        iat: 1516239022,
+      })
+    })
+    it("decodes a JWT with Unicode strings", () => {
+      expect(parseJwt(utf8Token)).toEqual({
+        sub: "1234567890",
+        name: "神経科学者",
+        iat: 1516239022,
+      })
     })
   })
-  it("decodes a JWT with Unicode strings", () => {
-    expect(parseJwt(utf8Token)).toEqual({
-      sub: "1234567890",
-      name: "神経科学者",
-      iat: 1516239022,
+
+  describe("getProfile", () => {
+    it("returns null when no accessToken cookie exists", () => {
+      expect(getProfile({})).toBeNull()
+    })
+    it("returns null for a corrupted token", () => {
+      expect(getProfile({ accessToken: "not-a-jwt" })).toBeNull()
+    })
+    it("returns the decoded profile for a valid token", () => {
+      const profile = getProfile({ accessToken: validToken })
+      expect(profile).toMatchObject({
+        sub: "user123",
+        admin: false,
+        exp: 9999999999,
+      })
+    })
+  })
+
+  describe("guardExpired", () => {
+    it("returns true for an unexpired token", () => {
+      const profile = getProfile({ accessToken: validToken })
+      expect(guardExpired(profile)).toBe(true)
+    })
+    it("returns false for an expired token", () => {
+      const profile = getProfile({ accessToken: expiredToken })
+      expect(guardExpired(profile)).toBe(false)
+    })
+    it("returns false for a null profile", () => {
+      expect(guardExpired(null)).toBe(false)
+    })
+  })
+
+  describe("shouldRemoveToken", () => {
+    it("removes nothing when no token is present", () => {
+      expect(shouldRemoveToken({})).toBe(false)
+    })
+    it("keeps a valid unexpired token", () => {
+      expect(shouldRemoveToken({ accessToken: validToken })).toBe(false)
+    })
+    it("removes an expired token", () => {
+      expect(shouldRemoveToken({ accessToken: expiredToken })).toBe(true)
+    })
+    it("removes a corrupted token", () => {
+      expect(shouldRemoveToken({ accessToken: "garbage" })).toBe(true)
+    })
+    it("removes an empty string token", () => {
+      expect(shouldRemoveToken({ accessToken: "" })).toBe(false)
     })
   })
 })

--- a/packages/openneuro-app/src/scripts/authentication/profile.ts
+++ b/packages/openneuro-app/src/scripts/authentication/profile.ts
@@ -37,6 +37,15 @@ export const getUnexpiredProfile = (cookies) => {
 }
 
 /**
+ * Check if the accessToken cookie should be removed due to expiration or corruption
+ */
+export function shouldRemoveToken(cookies): boolean {
+  const profile = getProfile(cookies)
+  const hasToken = !!cookies["accessToken"]
+  return hasToken && (!profile || !guardExpired(profile))
+}
+
+/**
  * Test for an expired token
  * @param {object} profile A profile returned by getProfile()
  * @returns {boolean} False if expired

--- a/packages/openneuro-app/src/scripts/queries/user.ts
+++ b/packages/openneuro-app/src/scripts/queries/user.ts
@@ -1,4 +1,3 @@
-import { useEffect } from "react"
 import { gql, useQuery } from "@apollo/client"
 import { useCookies } from "react-cookie"
 import { getProfile } from "../authentication/profile"
@@ -212,7 +211,7 @@ export const ADVANCED_SEARCH_DATASETS_QUERY = gql`
 
 // Reusable hook to fetch user data
 export const useUser = (userId?: string) => {
-  const [cookies, , removeCookie] = useCookies()
+  const [cookies] = useCookies()
   const profile = getProfile(cookies)
   const profileSub = profile?.sub
 
@@ -230,13 +229,6 @@ export const useUser = (userId?: string) => {
   if (userError) {
     Sentry.captureException(userError)
   }
-
-  // Clear invalid session: cookie exists but query failed or returned no user
-  useEffect(() => {
-    if (!userLoading && profile && (userError || !userData?.user)) {
-      removeCookie("accessToken", { path: "/" })
-    }
-  }, [userLoading, profile, userError, userData?.user, removeCookie])
 
   return {
     user: userData?.user,

--- a/packages/openneuro-server/src/graphql/resolvers/__tests__/user.spec.ts
+++ b/packages/openneuro-server/src/graphql/resolvers/__tests__/user.spec.ts
@@ -10,7 +10,8 @@ import {
 import { MongoMemoryServer } from "mongodb-memory-server"
 import mongoose, { Types } from "mongoose"
 import User from "../../../models/user"
-import { user, users } from "../user.js"
+import DatasetEvent from "../../../models/datasetEvents"
+import { notifications, user, users } from "../user.js"
 import type { GraphQLContext } from "../user.js"
 
 vi.mock("ioredis")
@@ -383,6 +384,59 @@ describe("user resolvers", () => {
       )
       expect(result.users.length).toBe(1)
       expect(result.totalCount).toBe(3) // u1, u4, u6 are admins
+    })
+  })
+
+  describe("notifications()", () => {
+    it("returns empty array for reviewer users", async () => {
+      const result = await notifications(
+        { id: "reviewer" },
+        null,
+        { userInfo: { reviewer: true, admin: false, blocked: false } },
+      )
+      expect(result).toEqual([])
+    })
+
+    it("does not crash when userInfo is undefined", async () => {
+      await expect(
+        notifications({ id: "u1" }, null, { userInfo: undefined }),
+      ).rejects.toThrow("Not authorized to view these notifications.")
+    })
+
+    it("returns notifications for a user viewing their own", async () => {
+      await DatasetEvent.create({
+        id: "event-1",
+        datasetId: "ds000001",
+        userId: "u1",
+        timestamp: new Date(),
+        event: {
+          type: "contributorCitation",
+          datasetId: "ds000001",
+          addedBy: "u2",
+          targetUserId: "u1",
+          contributorData: { name: "Test User" },
+        },
+        success: true,
+        note: "Added as contributor",
+      })
+      const result = await notifications(
+        { id: "u1" },
+        null,
+        { userInfo: { id: "u1", admin: false, userId: "u1" } },
+      )
+      expect(result.length).toBe(1)
+      expect(result[0].id).toBe("event-1")
+      expect(result[0].notificationStatus.status).toBe("UNREAD")
+    })
+
+    it("throws authorization error for regular user viewing another user's notifications", async () => {
+      await expect(
+        notifications(
+          { id: "u1" },
+          null,
+          { userInfo: { id: "u2", admin: false, userId: "u2" } },
+        ),
+      ).rejects.toThrow("Not authorized to view these notifications.")
     })
   })
 })

--- a/packages/openneuro-server/src/graphql/resolvers/user.ts
+++ b/packages/openneuro-server/src/graphql/resolvers/user.ts
@@ -279,7 +279,7 @@ export async function notifications(obj, _, { userInfo }) {
   const userId = obj.id
 
   // Reviewers never have notifications
-  if (userInfo.reviewer) {
+  if (userInfo?.reviewer) {
     return []
   }
 


### PR DESCRIPTION
Two fixes for the issue here, one the notifications resolver is sometimes crashing on a missing property but the larger problem is that the notifications resolver crashing would lead to a logout. This test was meant to catch auth errors but any kind of error lead to logout. The main auth error a real user might encounter here is token corruption, so instead of relying on the user resolver, we can just check this client side and clear a corrupted token. This won't logout a user with a badly signed token but they will still see the unauthenticated view and can start a new login, while a corrupted token was not consistently handled without this.

Adds test coverage for this client side token clearing logic and the notifications resolver.

Fixes #3842 