### PR TITLE
fix(app): Hide notifications inbox button for reviewers

### DIFF
--- a/packages/openneuro-app/src/scripts/users/user-menu.tsx
+++ b/packages/openneuro-app/src/scripts/users/user-menu.tsx
@@ -62,7 +62,7 @@ export const UserMenu: React.FC<UserMenuProps> = ({ signOutAndRedirect }) => {
 
   return (
     <span className="user-menu-wrap">
-      {user.orcid && (
+      {user.orcid && user.id !== "reviewer" && (
         <span className="notifications-link">
           <Link to={`/user/${user.orcid}/notifications/unread`}>
             <i className="fa fa-inbox">


### PR DESCRIPTION
Minor issue where reviewer users could see a button that when clicked takes them to a 404 page.