### PR TITLE
refactor(worker): Use pygit2 and support batching for tree requests

### DIFF
--- a/packages/openneuro-server/src/datalad/files.ts
+++ b/packages/openneuro-server/src/datalad/files.ts
@@ -200,6 +200,58 @@ async function entriesToDatasetFiles(
 }
 
 /**
+ * Fetch multiple trees from the worker in a single batch POST request.
+ * Returns a map of tree hash -> DatasetFile[].
+ */
+async function fetchTreesFromWorker(
+  datasetId: string,
+  treeHashes: string[],
+): Promise<Map<string, DatasetFile[]>> {
+  const response = await fetch(
+    `http://${getDatasetWorker(datasetId)}/datasets/${datasetId}/tree`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ trees: treeHashes }),
+      signal: AbortSignal.timeout(30000),
+    },
+  )
+  const body = await response.json()
+  const treesData: Record<string, DatasetFile[]> | undefined = body?.trees
+  const result = new Map<string, DatasetFile[]>()
+  if (treesData) {
+    for (const [hash, files] of Object.entries(treesData)) {
+      result.set(hash, files || [])
+    }
+  }
+  return result
+}
+
+/**
+ * Cache a batch of worker results, returning entries for each tree.
+ */
+async function cacheWorkerTrees(
+  datasetId: string,
+  workerResults: Map<string, DatasetFile[]>,
+): Promise<void> {
+  const needsPresign = await datasetNeedsPresign(datasetId)
+  for (const [hash, files] of workerResults) {
+    if (files.length > 0) {
+      const entries = files.map((f) => workerFileToEntry(f, needsPresign))
+      const allExported = files.every(
+        (f) => f.directory || f.urls[0]?.includes("s3.amazonaws.com"),
+      )
+      if (allExported) {
+        void setTree(redis, hash, entries)
+        void addDatasetTree(redis, datasetId, hash)
+      } else {
+        void setTree(redis, hash, entries, 600)
+      }
+    }
+  }
+}
+
+/**
  * Get files for a specific revision (tree hash or commit hash).
  * Uses content-addressed caching keyed by full git hash.
  */
@@ -213,31 +265,13 @@ export const getFiles = async (
     return entriesToDatasetFiles(cached, datasetId)
   }
 
-  // Cache miss: fetch from worker
-  const response = await fetch(
-    `http://${
-      getDatasetWorker(datasetId)
-    }/datasets/${datasetId}/tree/${treeish}`,
-    { signal: AbortSignal.timeout(10000) },
-  )
-  const body = await response.json()
-  const files: DatasetFile[] | undefined = body?.files
-
+  // Cache miss: fetch from worker via batch endpoint
+  const workerResults = await fetchTreesFromWorker(datasetId, [treeish])
+  await cacheWorkerTrees(datasetId, workerResults)
+  const files = workerResults.get(treeish)
   if (files && files.length > 0) {
     const needsPresign = await datasetNeedsPresign(datasetId)
     const entries = files.map((f) => workerFileToEntry(f, needsPresign))
-    // Check if all non-directory files have S3 URLs
-    const allExported = files.every(
-      (f) => f.directory || f.urls[0]?.includes("s3.amazonaws.com"),
-    )
-    if (allExported) {
-      // Exported trees are content-addressed and stable, cache permanently
-      void setTree(redis, treeish, entries)
-      void addDatasetTree(redis, datasetId, treeish)
-    } else {
-      // Still exporting — cache briefly to avoid repeated worker fetches
-      void setTree(redis, treeish, entries, 600)
-    }
     return entriesToDatasetFiles(entries, datasetId)
   }
   return []
@@ -258,11 +292,10 @@ export async function getFilesRecursive(
     // Bulk-fetch all trees in one pipeline
     const treesMap = await getTreesBulk(redis, cachedTreeHashes)
     if (treesMap.size < cachedTreeHashes.length) {
-      // Fetch only the missing trees from the worker (getFiles caches them)
+      // Batch-fetch all missing trees from the worker in one request
       const missingHashes = cachedTreeHashes.filter((h) => !treesMap.has(h))
-      await Promise.all(
-        missingHashes.map((hash) => getFiles(datasetId, hash)),
-      )
+      const workerResults = await fetchTreesFromWorker(datasetId, missingHashes)
+      await cacheWorkerTrees(datasetId, workerResults)
       // Re-read the now-cached entries in bulk
       const refetched = await getTreesBulk(redis, missingHashes)
       for (const [hash, entries] of refetched) {
@@ -272,9 +305,44 @@ export async function getFilesRecursive(
     return reconstructFromTrees(treesMap, tree, path, datasetId, tree)
   }
 
-  // Walk the tree recursively, collecting unique tree hashes along the way
+  // Breadth-first walk: batch all uncached trees per level into one request
+  const treesMap = new Map<string, TreeEntry[]>()
   const collectedHashes = new Set<string>()
-  const files = await walkTree(datasetId, tree, path, collectedHashes)
+
+  // Seed with the root tree
+  let pendingHashes = [tree]
+
+  while (pendingHashes.length > 0) {
+    // Check cache for all pending hashes
+    const cached = await getTreesBulk(redis, pendingHashes)
+    const uncached = pendingHashes.filter((h) => !cached.has(h))
+
+    // Fetch all uncached trees in one worker request
+    if (uncached.length > 0) {
+      const workerResults = await fetchTreesFromWorker(datasetId, uncached)
+      await cacheWorkerTrees(datasetId, workerResults)
+      const fetched = await getTreesBulk(redis, uncached)
+      for (const [hash, entries] of fetched) {
+        cached.set(hash, entries)
+      }
+    }
+
+    // Merge into treesMap and collect next level of directory hashes
+    const nextLevel: string[] = []
+    for (const hash of pendingHashes) {
+      collectedHashes.add(hash)
+      const entries = cached.get(hash)
+      if (entries) {
+        treesMap.set(hash, entries)
+        for (const entry of entries) {
+          if (entry.d && !collectedHashes.has(entry.h)) {
+            nextLevel.push(entry.h)
+          }
+        }
+      }
+    }
+    pendingHashes = nextLevel
+  }
 
   // Cache the commit-to-trees mapping for next time
   if (collectedHashes.size > 0) {
@@ -283,30 +351,7 @@ export async function getFilesRecursive(
     void addDatasetTrees(redis, datasetId, hashArray)
   }
 
-  return files
-}
-
-/** Walk a tree recursively, populating files and collecting tree hashes */
-async function walkTree(
-  datasetId: string,
-  tree: string,
-  path: string,
-  collectedHashes: Set<string>,
-): Promise<DatasetFile[]> {
-  collectedHashes.add(tree)
-  const fileTree = await getFiles(datasetId, tree)
-  // Parallelize sibling directory fetches
-  const results = await Promise.all(
-    fileTree.map(async (file) => {
-      const absPath = path ? join(path, file.filename) : file.filename
-      if (file.directory) {
-        return walkTree(datasetId, file.id, absPath, collectedHashes)
-      } else {
-        return [{ ...file, filename: absPath }]
-      }
-    }),
-  )
-  return results.flat()
+  return reconstructFromTrees(treesMap, tree, path, datasetId, tree)
 }
 
 /**

--- a/services/datalad/datalad_service/app.py
+++ b/services/datalad/datalad_service/app.py
@@ -135,7 +135,7 @@ def create_app():
     app.add_route('/datasets/{dataset:dataset}/info/{name}', dataset_info_resource)
     app.add_route('/datasets/{dataset:dataset}/files', dataset_files)
     app.add_route('/datasets/{dataset:dataset}/files/{filename:path}', dataset_files)
-    app.add_route('/datasets/{dataset:dataset}/tree/{tree}', dataset_tree)
+    app.add_route('/datasets/{dataset:dataset}/tree', dataset_tree)
     app.add_route('/datasets/{dataset:dataset}/objects/{obj}', dataset_objects)
 
     app.add_route('/datasets/{dataset:dataset}/snapshots', dataset_snapshots)

--- a/services/datalad/datalad_service/common/annex.py
+++ b/services/datalad/datalad_service/common/annex.py
@@ -298,7 +298,7 @@ def _read_tree_pygit2(repo, tree_obj):
     return files
 
 
-async def get_repo_files_batch(dataset_path, trees):
+async def get_repo_files(dataset_path, trees):
     """Read files for multiple trees using pygit2 with shared URL resolution."""
     repo = pygit2.Repository(dataset_path)
     per_tree_files = {}

--- a/services/datalad/datalad_service/common/annex.py
+++ b/services/datalad/datalad_service/common/annex.py
@@ -4,8 +4,10 @@ import hashlib
 import io
 import json
 from mmap import mmap
+import re
 import subprocess
 import os
+import posixpath
 import urllib.parse
 import time
 import uuid
@@ -27,6 +29,10 @@ S3_BUCKETS_WHITELIST = [
     'bobsrepository',
     'openneuro-datalad-public-nell-test',
 ]
+
+annex_key_re = re.compile(
+    r'^(?P<backend>[A-Z0-9]+)-s(?P<size>[0-9]+)--(?P<hash>[a-f0-9]+)'
+)
 
 
 class InitRemoteException(Exception):
@@ -239,13 +245,12 @@ def _should_skip(filename):
     )
 
 
-def _read_tree_pygit2(repo, tree_obj):
+def _read_tree_pygit2(repo, tree_obj, dataset_path):
     """Read a single tree object using pygit2.
 
-    Returns (files, symlink_entries) where symlink_entries need annex key resolution.
+    Returns a list of file entries with annex key resolution where applicable.
     """
     files = []
-    symlink_entries = []
     for entry in tree_obj:
         filename = entry.name
         if _should_skip(filename):
@@ -253,21 +258,42 @@ def _read_tree_pygit2(repo, tree_obj):
         mode = entry.filemode
         hex_hash = str(entry.id)
         if mode == 0o120000:
-            # Annexed file symlink — resolve target to get annex key
             blob = repo[entry.id]
             target = blob.data.decode('utf-8').rstrip()
             key = target.split('/')[-1]
-            size = int(key.split('-', 2)[1].lstrip('s'))
-            files.append(
-                {
-                    'filename': filename,
-                    'size': size,
-                    'id': key,
-                    'urls': [],
-                    'annexed': True,
-                    'directory': False,
-                }
-            )
+            if re.match(annex_key_re, key):
+                # Annexed file symlink — resolve target to get annex key
+                size = int(key.split('-', 2)[1].lstrip('s'))
+                files.append(
+                    {
+                        'filename': filename,
+                        'size': size,
+                        'id': key,
+                        'urls': [],
+                        'annexed': True,
+                        'symlink': False,
+                        'directory': False,
+                    }
+                )
+            else:
+                # In-tree symlink — validate target stays within the dataset
+                normalized = posixpath.normpath(target)
+                if posixpath.isabs(normalized):
+                    continue
+                parts = normalized.split('/')
+                if '.git' in parts:
+                    continue
+                files.append(
+                    {
+                        'filename': filename,
+                        'size': 0,
+                        'id': hex_hash,
+                        'directory': False,
+                        'urls': [],
+                        'symlink': True,
+                        'annexed': False,
+                    }
+                )
         elif mode == 0o160000:
             # Submodule — skip
             continue
@@ -278,6 +304,7 @@ def _read_tree_pygit2(repo, tree_obj):
                     'filename': filename,
                     'directory': True,
                     'annexed': False,
+                    'symlink': False,
                     'size': 0,
                     'urls': [],
                 }
@@ -293,6 +320,7 @@ def _read_tree_pygit2(repo, tree_obj):
                     'directory': False,
                     'urls': [],
                     'annexed': False,
+                    'symlink': False,
                 }
             )
     return files
@@ -312,7 +340,7 @@ async def get_repo_files(dataset_path, trees):
             if obj is None or obj.type != pygit2.GIT_OBJECT_TREE:
                 per_tree_files[tree_hash] = []
                 continue
-            per_tree_files[tree_hash] = _read_tree_pygit2(repo, obj)
+            per_tree_files[tree_hash] = _read_tree_pygit2(repo, obj, dataset_path)
         except (KeyError, ValueError):
             per_tree_files[tree_hash] = []
 

--- a/services/datalad/datalad_service/common/annex.py
+++ b/services/datalad/datalad_service/common/annex.py
@@ -339,6 +339,109 @@ async def get_repo_files(dataset, dataset_path, tree):
     return files
 
 
+def _should_skip(filename):
+    """Check if a file should be skipped (git/datalad internals)."""
+    return (
+        filename.startswith('.git')
+        or filename.startswith('.datalad')
+        or filename == '.gitattributes'
+    )
+
+
+def _read_tree_pygit2(repo, tree_obj):
+    """Read a single tree object using pygit2.
+
+    Returns (files, symlink_entries) where symlink_entries need annex key resolution.
+    """
+    files = []
+    symlink_entries = []
+    for entry in tree_obj:
+        filename = entry.name
+        if _should_skip(filename):
+            continue
+        mode = entry.filemode
+        hex_hash = str(entry.id)
+        if mode == 0o120000:
+            # Annexed file symlink — resolve target to get annex key
+            blob = repo[entry.id]
+            target = blob.data.decode('utf-8').rstrip()
+            key = target.split('/')[-1]
+            size = int(key.split('-', 2)[1].lstrip('s'))
+            files.append(
+                {
+                    'filename': filename,
+                    'size': size,
+                    'id': key,
+                    'urls': [],
+                    'annexed': True,
+                    'directory': False,
+                }
+            )
+        elif mode == 0o160000:
+            # Submodule — skip
+            continue
+        elif entry.type == pygit2.GIT_OBJECT_TREE:
+            files.append(
+                {
+                    'id': hex_hash,
+                    'filename': filename,
+                    'directory': True,
+                    'annexed': False,
+                    'size': 0,
+                    'urls': [],
+                }
+            )
+        else:
+            # Regular blob — get size directly
+            blob = repo[entry.id]
+            files.append(
+                {
+                    'filename': filename,
+                    'size': blob.size,
+                    'id': hex_hash,
+                    'directory': False,
+                    'urls': [],
+                    'annexed': False,
+                }
+            )
+    return files
+
+
+async def get_repo_files_batch(dataset, dataset_path, trees):
+    """Read files for multiple trees using pygit2 with shared URL resolution."""
+    repo = pygit2.Repository(dataset_path)
+    per_tree_files = {}
+
+    for tree_hash in trees:
+        try:
+            obj = repo.revparse_single(tree_hash)
+            # If this is a commit, peel to its tree
+            if obj.type == pygit2.GIT_OBJECT_COMMIT:
+                obj = obj.peel(pygit2.Tree)
+            if obj is None or obj.type != pygit2.GIT_OBJECT_TREE:
+                per_tree_files[tree_hash] = []
+                continue
+            per_tree_files[tree_hash] = _read_tree_pygit2(repo, obj)
+        except (KeyError, ValueError):
+            per_tree_files[tree_hash] = []
+
+    # Resolve URLs for all files across all trees in one pass
+    all_files = []
+    for files in per_tree_files.values():
+        all_files.extend(files)
+    all_files = await get_repo_urls(dataset_path, all_files)
+
+    # Redistribute files back to per-tree results
+    offset = 0
+    tree_results = {}
+    for tree_hash in trees:
+        count = len(per_tree_files[tree_hash])
+        tree_results[tree_hash] = all_files[offset : offset + count]
+        offset += count
+
+    return tree_results
+
+
 def get_tag_info(dataset_path, tag):
     """`git annex info <tag>`"""
     git_process = subprocess.run(

--- a/services/datalad/datalad_service/common/annex.py
+++ b/services/datalad/datalad_service/common/annex.py
@@ -298,7 +298,7 @@ def _read_tree_pygit2(repo, tree_obj):
     return files
 
 
-async def get_repo_files_batch(dataset, dataset_path, trees):
+async def get_repo_files_batch(dataset_path, trees):
     """Read files for multiple trees using pygit2 with shared URL resolution."""
     repo = pygit2.Repository(dataset_path)
     per_tree_files = {}

--- a/services/datalad/datalad_service/common/annex.py
+++ b/services/datalad/datalad_service/common/annex.py
@@ -70,59 +70,6 @@ def compute_file_hash(git_hash, path):
     return hashlib.sha1(f'{git_hash}:{path}'.encode()).hexdigest()
 
 
-def parse_ls_tree_line(gitTreeLine):
-    """Read one line of `git ls-tree` output and produce filename + metadata fields"""
-    metadata, filename = gitTreeLine.split('\t')
-    mode, obj_type, obj_hash, size = metadata.split()
-    return [filename, mode, obj_type, obj_hash, size]
-
-
-def read_ls_tree_line(gitTreeLine, files, symlinkFilenames, symlinkObjects):
-    """Read one line of `git ls-tree` and append to the correct buckets of files, symlinks, and objects."""
-    filename, mode, obj_type, obj_hash, size = parse_ls_tree_line(gitTreeLine)
-    # Skip git / datalad files
-    if filename.startswith('.git'):
-        return
-    if filename.startswith('.datalad'):
-        return
-    if filename == '.gitattributes':
-        return
-    # Check if the file is annexed or a submodule
-    if mode == '120000':
-        # Save annexed file symlinks for batch processing
-        symlinkFilenames.append(filename)
-        symlinkObjects.append(obj_hash)
-    elif mode == '160000':
-        # Skip submodules
-        return
-    else:
-        # Immediately append regular files
-        if size == '-':
-            # Tree objects do not have sizes and are never annexed
-            files.append(
-                {
-                    # Computing an id here is important but the client needs to manage the cache merge since only the client knows the parent directory
-                    'id': obj_hash,
-                    'filename': filename,
-                    'directory': True,
-                    'annexed': False,
-                    'size': 0,
-                    'urls': [],
-                }
-            )
-        else:
-            files.append(
-                {
-                    'filename': filename,
-                    'size': int(size),
-                    'id': obj_hash,
-                    'directory': False,
-                    'urls': [],
-                    'annexed': False,
-                }
-            )
-
-
 def compute_rmet(key):
     if len(key) == 40:
         key = f'GIT--{key}'
@@ -280,62 +227,6 @@ async def get_repo_urls(path, files):
                 # Add this URL to all files that reference this rmet
                 for file in rmetFiles[path]:
                     file['urls'].append(url)
-    return files
-
-
-async def get_repo_files(dataset, dataset_path, tree):
-    """Read all files in a repo at a given branch, tag, or commit hash."""
-    gitProcess = await asyncio.create_subprocess_exec(
-        'git',
-        'ls-tree',
-        '-l',
-        tree,
-        cwd=dataset_path,
-        stdout=asyncio.subprocess.PIPE,
-    )
-    files = []
-    symlinkFilenames = []
-    symlinkObjects = []
-    async for line in gitProcess.stdout:
-        gitTreeLine = line.decode('utf-8').rstrip()
-        read_ls_tree_line(gitTreeLine, files, symlinkFilenames, symlinkObjects)
-    await gitProcess.wait()
-
-    # After regular files, process all symlinks with one git cat-file --batch call
-    # This is about 100x faster than one call per file for annexed file heavy datasets
-    catFileInput = '\n'.join(symlinkObjects)
-    catFileProcess = await asyncio.create_subprocess_exec(
-        'git',
-        'cat-file',
-        '--batch',
-        '--buffer',
-        cwd=dataset_path,
-        stdin=asyncio.subprocess.PIPE,
-        stdout=asyncio.subprocess.PIPE,
-    )
-    stdout, _ = await catFileProcess.communicate(input=catFileInput.encode('utf-8'))
-    # Output looks like this:
-    # dc9dde956f6f28e425a412a4123526e330668e7e blob 140
-    # ../../.git/annex/objects/Q0/VP/MD5E-s1618574--43762c4310549dcc8c5c25567f42722d.nii.gz/MD5E-s1618574--43762c4310549dcc8c5c25567f42722d.nii.gz
-    for index, line in enumerate(stdout.splitlines()):
-        # Skip metadata (even) lines
-        if index % 2 == 1:
-            key = line.rstrip().split(b'/')[-1].decode('utf-8')
-            # Get the size from key
-            size = int(key.split('-', 2)[1].lstrip('s'))
-            filename = symlinkFilenames[(index - 1) // 2]
-            files.append(
-                {
-                    'filename': filename,
-                    'size': int(size),
-                    'id': key,
-                    'urls': [],
-                    'annexed': True,
-                    'directory': False,
-                }
-            )
-    # Now find URLs for each file if available
-    files = await get_repo_urls(dataset_path, files)
     return files
 
 

--- a/services/datalad/datalad_service/handlers/tree.py
+++ b/services/datalad/datalad_service/handlers/tree.py
@@ -2,8 +2,8 @@ import logging
 
 import falcon
 
+from datalad_service.common.annex import get_repo_files
 from datalad_service.common.bids import dataset_sort
-from datalad_service.tasks.files import get_trees
 
 
 class TreeResource:
@@ -20,7 +20,10 @@ class TreeResource:
                 resp.status = falcon.HTTP_BAD_REQUEST
                 resp.media = {'error': 'trees list is required'}
                 return
-            results = await get_trees(self.store, dataset, tree_hashes)
+            dataset_path = self.store.get_dataset_path(
+                dataset
+            )  # Check that dataset exists before doing git work
+            results = await get_repo_files(dataset_path, tree_hashes)
             for tree_hash in results:
                 results[tree_hash].sort(key=dataset_sort)
             resp.status = falcon.HTTP_OK

--- a/services/datalad/datalad_service/handlers/tree.py
+++ b/services/datalad/datalad_service/handlers/tree.py
@@ -3,7 +3,7 @@ import logging
 import falcon
 
 from datalad_service.common.bids import dataset_sort
-from datalad_service.tasks.files import get_tree
+from datalad_service.tasks.files import get_trees
 
 
 class TreeResource:
@@ -11,15 +11,20 @@ class TreeResource:
         self.store = store
         self.logger = logging.getLogger('datalad_service.' + __name__)
 
-    async def on_get(self, req, resp, dataset, tree):
-        # Request for index of files
-        # Return a list of file objects
-        # {name, path, size}
+    async def on_post(self, req, resp, dataset):
+        """Resolve one or more tree hashes in minimal git operations."""
         try:
-            files = await get_tree(self.store, dataset, tree)
-            files.sort(key=dataset_sort)
+            body = await req.get_media()
+            tree_hashes = body.get('trees', [])
+            if not tree_hashes:
+                resp.status = falcon.HTTP_BAD_REQUEST
+                resp.media = {'error': 'trees list is required'}
+                return
+            results = await get_trees(self.store, dataset, tree_hashes)
+            for tree_hash in results:
+                results[tree_hash].sort(key=dataset_sort)
             resp.status = falcon.HTTP_OK
-            resp.media = {'files': files}
+            resp.media = {'trees': results}
         except FileNotFoundError:
             resp.status = falcon.HTTP_NOT_FOUND
             resp.media = {'error': 'Dataset does not exist'}

--- a/services/datalad/datalad_service/handlers/upload.py
+++ b/services/datalad/datalad_service/handlers/upload.py
@@ -7,12 +7,9 @@ import aioshutil
 import falcon
 import pygit2
 
+from datalad_service.common.annex import annex_key_re
 from datalad_service.common.git import git_commit
 from datalad_service.common.user import get_user_info
-
-annex_key_re = re.compile(
-    r'^(?P<backend>[A-Z0-9]+)-s(?P<size>[0-9]+)--(?P<hash>[a-f0-9]+)'
-)
 
 
 async def move_files(upload_path, dataset_path):

--- a/services/datalad/datalad_service/tasks/files.py
+++ b/services/datalad/datalad_service/tasks/files.py
@@ -1,4 +1,3 @@
-import asyncio
 import json
 import logging
 import subprocess

--- a/services/datalad/datalad_service/tasks/files.py
+++ b/services/datalad/datalad_service/tasks/files.py
@@ -8,7 +8,6 @@ import boto3
 import botocore
 import pygit2
 
-from datalad_service.common.annex import get_repo_files_batch
 from datalad_service.common.git import (
     git_commit,
     git_commit_index,
@@ -39,12 +38,6 @@ async def commit_files(store, dataset, files, name=None, email=None, cookies=Non
     # Run the validator but don't block on the request
     await validate_dataset.kiq(dataset, dataset_path, str(ref), cookies)
     return ref
-
-
-async def get_trees(store, dataset, trees):
-    """Get multiple trees in a single batch operation."""
-    dataset_path = store.get_dataset_path(dataset)
-    return await get_repo_files_batch(dataset_path, trees)
 
 
 async def remove_files(store, dataset, paths, name=None, email=None, cookies=None):

--- a/services/datalad/datalad_service/tasks/files.py
+++ b/services/datalad/datalad_service/tasks/files.py
@@ -8,7 +8,7 @@ import boto3
 import botocore
 import pygit2
 
-from datalad_service.common.annex import get_repo_files
+from datalad_service.common.annex import get_repo_files, get_repo_files_batch
 from datalad_service.common.git import (
     git_commit,
     git_commit_index,
@@ -45,6 +45,12 @@ async def get_tree(store, dataset, tree):
     """Get the working tree, optionally a branch tree."""
     dataset_path = store.get_dataset_path(dataset)
     return await get_repo_files(dataset, dataset_path, tree)
+
+
+async def get_trees(store, dataset, trees):
+    """Get multiple trees in a single batch operation."""
+    dataset_path = store.get_dataset_path(dataset)
+    return await get_repo_files_batch(dataset, dataset_path, trees)
 
 
 async def remove_files(store, dataset, paths, name=None, email=None, cookies=None):

--- a/services/datalad/datalad_service/tasks/files.py
+++ b/services/datalad/datalad_service/tasks/files.py
@@ -8,7 +8,7 @@ import boto3
 import botocore
 import pygit2
 
-from datalad_service.common.annex import get_repo_files, get_repo_files_batch
+from datalad_service.common.annex import get_repo_files_batch
 from datalad_service.common.git import (
     git_commit,
     git_commit_index,
@@ -39,12 +39,6 @@ async def commit_files(store, dataset, files, name=None, email=None, cookies=Non
     # Run the validator but don't block on the request
     await validate_dataset.kiq(dataset, dataset_path, str(ref), cookies)
     return ref
-
-
-async def get_tree(store, dataset, tree):
-    """Get the working tree, optionally a branch tree."""
-    dataset_path = store.get_dataset_path(dataset)
-    return await get_repo_files(dataset, dataset_path, tree)
 
 
 async def get_trees(store, dataset, trees):

--- a/services/datalad/datalad_service/tasks/files.py
+++ b/services/datalad/datalad_service/tasks/files.py
@@ -44,7 +44,7 @@ async def commit_files(store, dataset, files, name=None, email=None, cookies=Non
 async def get_trees(store, dataset, trees):
     """Get multiple trees in a single batch operation."""
     dataset_path = store.get_dataset_path(dataset)
-    return await get_repo_files_batch(dataset, dataset_path, trees)
+    return await get_repo_files_batch(dataset_path, trees)
 
 
 async def remove_files(store, dataset, paths, name=None, email=None, cookies=None):

--- a/services/datalad/tests/test_annex.py
+++ b/services/datalad/tests/test_annex.py
@@ -1,110 +1,12 @@
 import io
 
 from datalad_service.common.annex import (
-    parse_ls_tree_line,
-    read_ls_tree_line,
     compute_rmet,
     parse_remote_line,
     parse_rmet_line,
     read_rmet_file,
     encode_remote_url,
 )
-
-expected_file_object = {
-    'filename': 'dataset_description.json',
-    'id': '838d19644b3296cf32637bbdf9ae5c87db34842f',
-    'size': 101,
-}
-
-
-def test_parse_ls_tree_line():
-    filename, mode, obj_type, obj_hash, size = parse_ls_tree_line(
-        """100644 blob a786c385bd1812410d01177affb6ce834d85facd     459	dataset_description.json"""
-    )
-    assert int(size) > 0
-
-
-def test_parse_ls_tree_line_annexed():
-    filename, mode, obj_type, obj_hash, size = parse_ls_tree_line(
-        """120000 blob 570cb4a3fd80de6e8491312c935bfe8029066361     141	derivatives/mriqc/reports/sub-01_ses-01_T1w.html"""
-    )
-    assert int(size) > 0
-
-
-def test_parse_ls_tree_line_submodule():
-    filename, mode, obj_type, obj_hash, size = parse_ls_tree_line(
-        """160000 commit fcafd17fbfa44495c7f5f8a0777e5ab610b09500       -	code/facedistid_analysis"""
-    )
-    assert size == '-'
-
-
-def test_get_ls_tree_line():
-    files = []
-    symlinkFilenames = []
-    symlinkObjects = []
-    read_ls_tree_line(
-        """100644 blob a786c385bd1812410d01177affb6ce834d85facd     459	dataset_description.json""",
-        files,
-        symlinkFilenames,
-        symlinkObjects,
-    )
-    assert files == [
-        {
-            'filename': 'dataset_description.json',
-            'size': 459,
-            'id': 'a786c385bd1812410d01177affb6ce834d85facd',
-            'urls': [],
-            'annexed': False,
-            'directory': False,
-        }
-    ]
-    assert symlinkFilenames == []
-    assert symlinkObjects == []
-
-
-def test_get_ls_tree_line_ignored():
-    files = []
-    symlinkFilenames = []
-    symlinkObjects = []
-    read_ls_tree_line(
-        """100644 blob a786c385bd1812410d01177affb6ce834d85facd     459	.gitattributes""",
-        files,
-        symlinkFilenames,
-        symlinkObjects,
-    )
-    assert files == []
-    assert symlinkFilenames == []
-    assert symlinkObjects == []
-
-
-def test_get_ls_tree_line_annexed():
-    files = []
-    symlinkFilenames = []
-    symlinkObjects = []
-    read_ls_tree_line(
-        """120000 blob 570cb4a3fd80de6e8491312c935bfe8029066361     141	derivatives/mriqc/reports/sub-01_ses-01_T1w.html""",
-        files,
-        symlinkFilenames,
-        symlinkObjects,
-    )
-    assert files == []
-    assert symlinkFilenames == ['derivatives/mriqc/reports/sub-01_ses-01_T1w.html']
-    assert symlinkObjects == ['570cb4a3fd80de6e8491312c935bfe8029066361']
-
-
-def test_get_ls_tree_line_submodule():
-    files = []
-    symlinkFilenames = []
-    symlinkObjects = []
-    read_ls_tree_line(
-        """160000 commit fcafd17fbfa44495c7f5f8a0777e5ab610b09500       -	code/facedistid_analysis""",
-        files,
-        symlinkFilenames,
-        symlinkObjects,
-    )
-    assert files == []
-    assert symlinkFilenames == []
-    assert symlinkObjects == []
 
 
 def test_compute_rmet_git():

--- a/services/datalad/tests/test_files.py
+++ b/services/datalad/tests/test_files.py
@@ -197,6 +197,7 @@ def test_file_indexing(client, new_dataset):
             'id': '838d19644b3296cf32637bbdf9ae5c87db34842f',
             'urls': [],
             'annexed': False,
+            'symlink': False,
             'directory': False,
         },
         {
@@ -205,6 +206,7 @@ def test_file_indexing(client, new_dataset):
             'id': 'MD5E-s8--4d87586dfb83dc4a5d15c6cfa6f61e27',
             'urls': [],
             'annexed': True,
+            'symlink': False,
             'directory': False,
         },
         {
@@ -212,6 +214,7 @@ def test_file_indexing(client, new_dataset):
             'filename': 'sub-01',
             'directory': True,
             'annexed': False,
+            'symlink': False,
             'size': 0,
             'urls': [],
         },
@@ -248,6 +251,7 @@ def test_file_indexing(client, new_dataset):
         'id': 'MD5E-s19--8149926e49b677a5ccecf1ad565acccf.nii.gz',
         'urls': [],
         'annexed': True,
+        'symlink': False,
         'directory': False,
     } in anat_files
 
@@ -279,6 +283,7 @@ def test_empty_file(client, new_dataset):
         'id': 'MD5E-s0--d41d8cd98f00b204e9800998ecf8427e',
         'urls': [],
         'annexed': True,
+        'symlink': False,
         'directory': False,
     } in tree_files
     assert {
@@ -287,6 +292,7 @@ def test_empty_file(client, new_dataset):
         'id': '838d19644b3296cf32637bbdf9ae5c87db34842f',
         'urls': [],
         'annexed': False,
+        'symlink': False,
         'directory': False,
     } in tree_files
 

--- a/services/datalad/tests/test_files.py
+++ b/services/datalad/tests/test_files.py
@@ -183,9 +183,13 @@ def test_file_indexing(client, new_dataset):
     response = client.simulate_post(f'/datasets/{ds_id}/draft')
     assert response.status == falcon.HTTP_OK
     # Get the files in the committed tree
-    root_response = client.simulate_get('/datasets/{}/tree/{}'.format(ds_id, 'HEAD'))
+    root_response = client.simulate_post(
+        f'/datasets/{ds_id}/tree',
+        json={'trees': ['HEAD']},
+    )
     assert root_response.status == falcon.HTTP_OK
     root_content = json.loads(root_response.content)
+    root_files = root_content['trees']['HEAD']
     for f in [
         {
             'filename': 'dataset_description.json',
@@ -212,31 +216,31 @@ def test_file_indexing(client, new_dataset):
             'urls': [],
         },
     ]:
-        assert f in root_content['files']
+        assert f in root_files
     # Test sub-01 directory
-    sub_response = client.simulate_get(
-        '/datasets/{}/tree/{}'.format(
-            ds_id,
-            next(
-                (f['id'] for f in root_content['files'] if f['filename'] == 'sub-01'),
-                None,
-            ),
-        )
+    sub_01_id = next(
+        (f['id'] for f in root_files if f['filename'] == 'sub-01'),
+        None,
+    )
+    sub_response = client.simulate_post(
+        f'/datasets/{ds_id}/tree',
+        json={'trees': [sub_01_id]},
     )
     assert sub_response.status == falcon.HTTP_OK
     sub_content = json.loads(sub_response.content)
+    sub_files = sub_content['trees'][sub_01_id]
     # Test sub-01/anat directory
-    anat_response = client.simulate_get(
-        '/datasets/{}/tree/{}'.format(
-            ds_id,
-            next(
-                (f['id'] for f in sub_content['files'] if f['filename'] == 'anat'),
-                None,
-            ),
-        )
+    anat_id = next(
+        (f['id'] for f in sub_files if f['filename'] == 'anat'),
+        None,
+    )
+    anat_response = client.simulate_post(
+        f'/datasets/{ds_id}/tree',
+        json={'trees': [anat_id]},
     )
     assert anat_response.status == falcon.HTTP_OK
     anat_content = json.loads(anat_response.content)
+    anat_files = anat_content['trees'][anat_id]
     # Test sub-01/anat/sub-01_T1w.nii.gz file
     assert {
         'filename': 'sub-01_T1w.nii.gz',
@@ -245,7 +249,7 @@ def test_file_indexing(client, new_dataset):
         'urls': [],
         'annexed': True,
         'directory': False,
-    } in anat_content['files']
+    } in anat_files
 
 
 def test_empty_file(client, new_dataset):
@@ -260,9 +264,13 @@ def test_empty_file(client, new_dataset):
     )
     assert response.status == falcon.HTTP_OK
     # Get the files in the committed tree
-    response = client.simulate_get(f'/datasets/{ds_id}/tree/HEAD')
+    response = client.simulate_post(
+        f'/datasets/{ds_id}/tree',
+        json={'trees': ['HEAD']},
+    )
     assert response.status == falcon.HTTP_OK
     response_content = json.loads(response.content)
+    tree_files = response_content['trees']['HEAD']
     # Check that all elements exist in both lists
     print(response_content)
     assert {
@@ -272,7 +280,7 @@ def test_empty_file(client, new_dataset):
         'urls': [],
         'annexed': True,
         'directory': False,
-    } in response_content['files']
+    } in tree_files
     assert {
         'filename': 'dataset_description.json',
         'size': 101,
@@ -280,7 +288,7 @@ def test_empty_file(client, new_dataset):
         'urls': [],
         'annexed': False,
         'directory': False,
-    } in response_content['files']
+    } in tree_files
 
 
 def test_duplicate_file_id(client, new_dataset):
@@ -300,23 +308,27 @@ def test_duplicate_file_id(client, new_dataset):
         f'/datasets/{ds_id}/draft', params={'validate': 'false'}
     )
     assert response.status == falcon.HTTP_OK
-    response = client.simulate_get(f'/datasets/{ds_id}/tree/HEAD')
+    response = client.simulate_post(
+        f'/datasets/{ds_id}/tree',
+        json={'trees': ['HEAD']},
+    )
     assert response.status == falcon.HTTP_OK
     response_content = json.loads(response.content)
+    root_files = response_content['trees']['HEAD']
     derivatives_tree = next(
-        (f['id'] for f in response_content['files'] if f['filename'] == 'derivatives'),
+        (f['id'] for f in root_files if f['filename'] == 'derivatives'),
         None,
     )
-    response = client.simulate_get(f'/datasets/{ds_id}/tree/{derivatives_tree}')
+    response = client.simulate_post(
+        f'/datasets/{ds_id}/tree',
+        json={'trees': [derivatives_tree]},
+    )
     assert response.status == falcon.HTTP_OK
     response_content = json.loads(response.content)
+    deriv_files = response_content['trees'][derivatives_tree]
     # Find each file in the results
-    file_one = next(
-        (f for f in response_content['files'] if f['filename'] == 'one.json'), None
-    )
-    file_two = next(
-        (f for f in response_content['files'] if f['filename'] == 'two.json'), None
-    )
+    file_one = next((f for f in deriv_files if f['filename'] == 'one.json'), None)
+    file_two = next((f for f in deriv_files if f['filename'] == 'two.json'), None)
     # With id as the raw object hash, identical content produces identical ids
     assert file_one['id'] == file_two['id']
 


### PR DESCRIPTION
To support recursive file tree queries, we need to batch request trees during a cache miss to avoid overwhelming the backend with HTTP requests for trees. This implements a batch version of get_repo_files to return multiple trees in one call using pygit2.