### PR TITLE
fix(server): Misc file tree resolver improvements

### DIFF
--- a/packages/openneuro-server/src/datalad/files.ts
+++ b/packages/openneuro-server/src/datalad/files.ts
@@ -23,7 +23,7 @@ import { join } from "node:path"
  * @param {String} path
  */
 export const encodeFilePath = (path: string): string => {
-  return path.replace(new RegExp("/", "g"), ":")
+  return path.replace(/\//g, ":")
 }
 
 /**
@@ -31,7 +31,7 @@ export const encodeFilePath = (path: string): string => {
  * @param {String} path
  */
 export const decodeFilePath = (path: string): string => {
-  return path.replace(new RegExp(":", "g"), "/")
+  return path.replace(/:/g, "/")
 }
 
 /**

--- a/packages/openneuro-server/src/datalad/files.ts
+++ b/packages/openneuro-server/src/datalad/files.ts
@@ -40,8 +40,8 @@ export const decodeFilePath = (path: string): string => {
  * @param {String} filename
  */
 export const getFileName = (path: string, filename: string): string => {
-  const filePath = path ? [path, filename].join("/") : filename
-  return filename ? encodeFilePath(filePath) : encodeFilePath(path)
+  if (!filename) return encodeFilePath(path)
+  return encodeFilePath(path ? `${path}/${filename}` : filename)
 }
 
 /**

--- a/packages/openneuro-server/src/datalad/files.ts
+++ b/packages/openneuro-server/src/datalad/files.ts
@@ -240,6 +240,7 @@ async function cacheWorkerTrees(
 ): Promise<Map<string, TreeEntry[]>> {
   const needsPresign = await datasetNeedsPresign(datasetId)
   const result = new Map<string, TreeEntry[]>()
+  const permanentHashes: string[] = []
   for (const [hash, files] of workerResults) {
     if (files.length > 0) {
       const entries = files.map((f) => workerFileToEntry(f, needsPresign))
@@ -249,11 +250,14 @@ async function cacheWorkerTrees(
       )
       if (allExported) {
         void setTree(redis, hash, entries)
-        void addDatasetTree(redis, datasetId, hash)
+        permanentHashes.push(hash)
       } else {
         void setTree(redis, hash, entries, 600)
       }
     }
+  }
+  if (permanentHashes.length > 0) {
+    void addDatasetTrees(redis, datasetId, permanentHashes)
   }
   return result
 }

--- a/packages/openneuro-server/src/datalad/files.ts
+++ b/packages/openneuro-server/src/datalad/files.ts
@@ -237,11 +237,13 @@ async function fetchTreesFromWorker(
 async function cacheWorkerTrees(
   datasetId: string,
   workerResults: Map<string, DatasetFile[]>,
-): Promise<void> {
+): Promise<Map<string, TreeEntry[]>> {
   const needsPresign = await datasetNeedsPresign(datasetId)
+  const result = new Map<string, TreeEntry[]>()
   for (const [hash, files] of workerResults) {
     if (files.length > 0) {
       const entries = files.map((f) => workerFileToEntry(f, needsPresign))
+      result.set(hash, entries)
       const allExported = files.every(
         (f) => f.directory || f.urls[0]?.includes("s3.amazonaws.com"),
       )
@@ -253,6 +255,7 @@ async function cacheWorkerTrees(
       }
     }
   }
+  return result
 }
 
 /**
@@ -271,11 +274,9 @@ export const getFiles = async (
 
   // Cache miss: fetch from worker via batch endpoint
   const workerResults = await fetchTreesFromWorker(datasetId, [treeish])
-  await cacheWorkerTrees(datasetId, workerResults)
-  const files = workerResults.get(treeish)
-  if (files && files.length > 0) {
-    const needsPresign = await datasetNeedsPresign(datasetId)
-    const entries = files.map((f) => workerFileToEntry(f, needsPresign))
+  const newEntriesMap = await cacheWorkerTrees(datasetId, workerResults)
+  const entries = newEntriesMap.get(treeish)
+  if (entries && entries.length > 0) {
     return entriesToDatasetFiles(entries, datasetId)
   }
   return []
@@ -299,10 +300,8 @@ export async function getFilesRecursive(
       // Batch-fetch all missing trees from the worker in one request
       const missingHashes = cachedTreeHashes.filter((h) => !treesMap.has(h))
       const workerResults = await fetchTreesFromWorker(datasetId, missingHashes)
-      await cacheWorkerTrees(datasetId, workerResults)
-      // Re-read the now-cached entries in bulk
-      const refetched = await getTreesBulk(redis, missingHashes)
-      for (const [hash, entries] of refetched) {
+      const newEntriesMap = await cacheWorkerTrees(datasetId, workerResults)
+      for (const [hash, entries] of newEntriesMap) {
         treesMap.set(hash, entries)
       }
     }
@@ -322,9 +321,8 @@ export async function getFilesRecursive(
     // Fetch all uncached trees in one worker request
     if (uncached.length > 0) {
       const workerResults = await fetchTreesFromWorker(datasetId, uncached)
-      await cacheWorkerTrees(datasetId, workerResults)
-      const fetched = await getTreesBulk(redis, uncached)
-      for (const [hash, entries] of fetched) {
+      const newEntriesMap = await cacheWorkerTrees(datasetId, workerResults)
+      for (const [hash, entries] of newEntriesMap) {
         cached.set(hash, entries)
       }
     }

--- a/packages/openneuro-server/src/datalad/files.ts
+++ b/packages/openneuro-server/src/datalad/files.ts
@@ -7,7 +7,6 @@ import {
 } from "../libs/presign"
 import Dataset from "../models/dataset"
 import {
-  addDatasetTree,
   addDatasetTrees,
   getCommitTrees,
   getTree,
@@ -237,8 +236,8 @@ async function fetchTreesFromWorker(
 async function cacheWorkerTrees(
   datasetId: string,
   workerResults: Map<string, DatasetFile[]>,
+  needsPresign: boolean,
 ): Promise<Map<string, TreeEntry[]>> {
-  const needsPresign = await datasetNeedsPresign(datasetId)
   const result = new Map<string, TreeEntry[]>()
   const permanentHashes: string[] = []
   for (const [hash, files] of workerResults) {
@@ -275,10 +274,14 @@ export const getFiles = async (
   if (cached) {
     return entriesToDatasetFiles(cached, datasetId)
   }
-
+  const needsPresign = await datasetNeedsPresign(datasetId)
   // Cache miss: fetch from worker via batch endpoint
   const workerResults = await fetchTreesFromWorker(datasetId, [treeish])
-  const newEntriesMap = await cacheWorkerTrees(datasetId, workerResults)
+  const newEntriesMap = await cacheWorkerTrees(
+    datasetId,
+    workerResults,
+    needsPresign,
+  )
   const entries = newEntriesMap.get(treeish)
   if (entries && entries.length > 0) {
     return entriesToDatasetFiles(entries, datasetId)
@@ -295,6 +298,7 @@ export async function getFilesRecursive(
   tree: string,
   path = "",
 ): Promise<DatasetFile[]> {
+  const needsPresign = await datasetNeedsPresign(datasetId)
   // Check for cached commit-to-trees mapping
   const cachedTreeHashes = await getCommitTrees(redis, tree)
   if (cachedTreeHashes) {
@@ -304,7 +308,11 @@ export async function getFilesRecursive(
       // Batch-fetch all missing trees from the worker in one request
       const missingHashes = cachedTreeHashes.filter((h) => !treesMap.has(h))
       const workerResults = await fetchTreesFromWorker(datasetId, missingHashes)
-      const newEntriesMap = await cacheWorkerTrees(datasetId, workerResults)
+      const newEntriesMap = await cacheWorkerTrees(
+        datasetId,
+        workerResults,
+        needsPresign,
+      )
       for (const [hash, entries] of newEntriesMap) {
         treesMap.set(hash, entries)
       }
@@ -325,7 +333,11 @@ export async function getFilesRecursive(
     // Fetch all uncached trees in one worker request
     if (uncached.length > 0) {
       const workerResults = await fetchTreesFromWorker(datasetId, uncached)
-      const newEntriesMap = await cacheWorkerTrees(datasetId, workerResults)
+      const newEntriesMap = await cacheWorkerTrees(
+        datasetId,
+        workerResults,
+        needsPresign,
+      )
       for (const [hash, entries] of newEntriesMap) {
         cached.set(hash, entries)
       }


### PR DESCRIPTION
A few small improvements to avoid extra round network trips and slow paths from profiling the recursive files resolver.

* Don't query public status for each directory level
* Batch tree cache writes to Redis
* Use regexp literals for filename conversion