### PR TITLE
fix(server): Improve reliability of enqueue for data retention checks

### DIFF
--- a/packages/openneuro-server/src/queues/producer-methods.ts
+++ b/packages/openneuro-server/src/queues/producer-methods.ts
@@ -25,14 +25,18 @@ export function queueIndexDataset(datasetId: string) {
  * Queue data retention check for a dataset
  * @param datasetId Dataset to check
  */
-export function queueDataRetentionCheck(datasetId: string) {
+export async function queueDataRetentionCheck(
+  datasetId: string,
+): Promise<void> {
   try {
     const msg = new ProducibleMessage()
     msg.setQueue(OpenNeuroQueues.DATARETENTION).setBody({ datasetId })
-    producer.produce(msg, (err) => {
-      if (err) {
-        Sentry.captureException(err)
-      }
+    msg.setTTL(64800000) // 18 hours in ms to survive the consumer rate limits
+    await new Promise<void>((resolve, reject) => {
+      producer.produce(msg, (err) => {
+        if (err) reject(err)
+        else resolve()
+      })
     })
   } catch (err) {
     Sentry.captureException(err)

--- a/packages/openneuro-server/src/queues/queue-schedule.ts
+++ b/packages/openneuro-server/src/queues/queue-schedule.ts
@@ -14,7 +14,7 @@ async function enqueueAllDatasetChecks(): Promise<void> {
   const cursor = Dataset.find({}, "id").cursor()
   for await (const dataset of cursor) {
     // Check data retention policy status and send notifications
-    queueDataRetentionCheck(dataset.id)
+    await queueDataRetentionCheck(dataset.id)
   }
 }
 


### PR DESCRIPTION
It looks possible we dropped some of these checks. Setting a long TTL on the messages and awaiting the queue response should help make this more reliable.