### PR TITLE
fix(server): Increase data retention checks to 1 per second

### DIFF
--- a/packages/openneuro-server/src/queues/queues.ts
+++ b/packages/openneuro-server/src/queues/queues.ts
@@ -55,6 +55,6 @@ export async function setupQueues(): Promise<void> {
   // Limit indexing queue to 8 runs per minute to avoid stacking indexing excessively
   await setRateLimit(OpenNeuroQueues.INDEXING, 8, 60000)
 
-  // Rate limit data retention queue to 16 runs per minute
-  await setRateLimit(OpenNeuroQueues.DATARETENTION, 16, 60000)
+  // Rate limit data retention queue to 60 runs per minute
+  await setRateLimit(OpenNeuroQueues.DATARETENTION, 60, 60000)
 }


### PR DESCRIPTION
Increase the rate limit for data retention checks, this was working well in production and should allow processing the full queue with less chance of running into consumer restarts.