### PR TITLE
feat: Add toggle for holding automated draft deletion

### DIFF
--- a/packages/openneuro-app/src/scripts/dataset/mutations/hold-deletion.tsx
+++ b/packages/openneuro-app/src/scripts/dataset/mutations/hold-deletion.tsx
@@ -1,0 +1,57 @@
+import React from "react"
+import { gql, useMutation, useQuery } from "@apollo/client"
+import { Button } from "../../components/button/Button"
+
+const GET_HOLD_DELETION = gql`
+  query getHoldDeletion($datasetId: ID!) {
+    dataset(id: $datasetId) {
+      id
+      holdDeletion
+    }
+  }
+`
+
+const HOLD_DELETION = gql`
+  mutation holdDeletion($datasetId: ID!, $hold: Boolean!) {
+    holdDeletion(datasetId: $datasetId, hold: $hold)
+  }
+`
+
+export const HoldDeletion = ({ datasetId }: { datasetId: string }) => {
+  const { data, loading: queryLoading } = useQuery(GET_HOLD_DELETION, {
+    variables: { datasetId },
+  })
+  const [holdDeletion, { loading: mutationLoading }] = useMutation(
+    HOLD_DELETION,
+    {
+      refetchQueries: [{ query: GET_HOLD_DELETION, variables: { datasetId } }],
+    },
+  )
+
+  const held = data?.dataset?.holdDeletion ?? false
+  const loading = queryLoading || mutationLoading
+
+  return (
+    <span>
+      <Button
+        icon={loading
+          ? "fa fa-spin fa-repeat"
+          : held
+          ? "fa fa-lock"
+          : "fa fa-unlock"}
+        label={loading
+          ? "Updating..."
+          : held
+          ? "Deletion Held"
+          : "Hold Deletion"}
+        primary={!held}
+        secondary={held}
+        size="small"
+        disabled={loading}
+        onClick={() => {
+          holdDeletion({ variables: { datasetId, hold: !held } })
+        }}
+      />
+    </span>
+  )
+}

--- a/packages/openneuro-app/src/scripts/dataset/routes/admin-datalad.jsx
+++ b/packages/openneuro-app/src/scripts/dataset/routes/admin-datalad.jsx
@@ -2,6 +2,7 @@ import React from "react"
 import PropTypes from "prop-types"
 import DatasetHistory from "../fragments/dataset-history.jsx"
 import CacheClear from "../mutations/cache-clear.jsx"
+import { HoldDeletion } from "../mutations/hold-deletion"
 import AdminExports from "../mutations/admin-exports"
 import { DatasetPageBorder } from "./styles/dataset-page-border"
 import { HeaderRow3, HeaderRow4 } from "./styles/header-row"
@@ -17,6 +18,15 @@ const AdminDataset = ({ dataset }) => (
     </p>
     <div className="dataset-form-controls">
       <CacheClear datasetId={dataset.id} />
+    </div>
+    <hr />
+    <HeaderRow4>Hold Automated Draft Deletion</HeaderRow4>
+    <p>
+      Pause automated deletion of stale draft data and prevent sending a final
+      notice for this dataset.
+    </p>
+    <div className="dataset-form-controls">
+      <HoldDeletion datasetId={dataset.id} />
     </div>
     <hr />
     <HeaderRow4>Rerun Exports</HeaderRow4>

--- a/packages/openneuro-server/src/datalad/__tests__/dataRetentionNotifications.spec.ts
+++ b/packages/openneuro-server/src/datalad/__tests__/dataRetentionNotifications.spec.ts
@@ -22,6 +22,7 @@ import notifications from "../../libs/notifications"
 import DataRetention from "../../models/dataRetention"
 import Permission from "../../models/permission"
 import User from "../../models/user"
+import Dataset from "../../models/dataset"
 import Deletion from "../../models/deletion"
 import { checkDataRetentionNotifications } from "../dataRetentionNotifications"
 import * as draftModule from "../draft"
@@ -55,6 +56,7 @@ describe("checkDataRetentionNotifications", () => {
   })
 
   beforeEach(async () => {
+    await Dataset.deleteMany({})
     await DataRetention.deleteMany({})
     await Deletion.deleteMany({})
     await Permission.deleteMany({})
@@ -89,6 +91,15 @@ describe("checkDataRetentionNotifications", () => {
       reason: "test deletion",
       user: { _id: TEST_USER.id },
     })
+    mockDraft(daysAgo(15))
+    mockSnapshots([{ hexsha: "other" }])
+
+    await checkDataRetentionNotifications(TEST_DATASET)
+    expect(notifications.send).not.toHaveBeenCalled()
+  })
+
+  it("skips notifications for datasets with holdDeletion flag", async () => {
+    await Dataset.create({ id: TEST_DATASET, holdDeletion: true })
     mockDraft(daysAgo(15))
     mockSnapshots([{ hexsha: "other" }])
 

--- a/packages/openneuro-server/src/datalad/dataRetentionNotifications.ts
+++ b/packages/openneuro-server/src/datalad/dataRetentionNotifications.ts
@@ -2,6 +2,7 @@ import config from "../config"
 import notifications from "../libs/notifications"
 import User from "../models/user"
 import Permission from "../models/permission"
+import Dataset from "../models/dataset"
 import DataRetention from "../models/dataRetention"
 import Deletion from "../models/deletion"
 import { getDraftInfo } from "./draft"
@@ -44,6 +45,10 @@ export async function checkDataRetentionNotifications(
   // Skip datasets that have been marked as deleted
   const deleted = await Deletion.findOne({ datasetId }).exec()
   if (deleted) return
+
+  // Skip datasets with deletion hold set by an admin
+  const dataset = await Dataset.findOne({ id: datasetId }).exec()
+  if (dataset?.holdDeletion) return
 
   const draft = await getDraftInfo(datasetId)
   const snapshots = await getSnapshots(datasetId)

--- a/packages/openneuro-server/src/graphql/resolvers/holdDeletion.ts
+++ b/packages/openneuro-server/src/graphql/resolvers/holdDeletion.ts
@@ -1,0 +1,21 @@
+import Dataset from "../../models/dataset"
+
+/**
+ * Toggle the holdDeletion flag on a dataset to prevent automated deletion.
+ * Requires site admin access.
+ */
+export async function holdDeletion(
+  _obj: Record<string, unknown>,
+  { datasetId, hold }: { datasetId: string; hold: boolean },
+  { userInfo }: { userInfo: { admin: boolean } },
+): Promise<boolean> {
+  if (userInfo?.admin && datasetId.length === 8 && datasetId.startsWith("ds")) {
+    try {
+      await Dataset.updateOne({ id: datasetId }, { holdDeletion: hold }).exec()
+      return true
+    } catch (_err) {
+      return false
+    }
+  }
+  return false
+}

--- a/packages/openneuro-server/src/graphql/resolvers/mutation.ts
+++ b/packages/openneuro-server/src/graphql/resolvers/mutation.ts
@@ -53,6 +53,7 @@ import {
 } from "./datasetEvents"
 import { createGitEvent } from "./gitEvents"
 import { fsckDataset, updateFileCheck } from "./fileCheck"
+import { holdDeletion } from "./holdDeletion"
 import { updateContributors } from "../../datalad/contributors"
 import { updateWorkerTask } from "./worker"
 
@@ -92,6 +93,7 @@ const Mutation = {
   cacheClear,
   revalidate,
   fsckDataset,
+  holdDeletion,
   prepareRepoAccess,
   reexportRemotes,
   resetDraft,

--- a/packages/openneuro-server/src/graphql/schema.ts
+++ b/packages/openneuro-server/src/graphql/schema.ts
@@ -241,6 +241,8 @@ export const typeDefs = `
       eventId: ID!
       status: ResponseStatusType!
     ): DatasetEvent
+    # Hold or release automated deletion for a dataset
+    holdDeletion(datasetId: ID!, hold: Boolean!): Boolean
     # Update worker task queue status
     updateWorkerTask(
       id: ID!,
@@ -527,6 +529,8 @@ export const typeDefs = `
     brainInitiative: Boolean
     # Log of events associated with this dataset
     events: [DatasetEvent]
+    # Hold automated deletion for this dataset
+    holdDeletion: Boolean
   }
 
   type DatasetDerivatives {

--- a/packages/openneuro-server/src/models/dataset.ts
+++ b/packages/openneuro-server/src/models/dataset.ts
@@ -29,6 +29,7 @@ export interface DatasetDocument extends Document {
   views: number
   related: [DatasetRelationDocument]
   schemaValidator: boolean
+  holdDeletion: boolean
   _conditions: object
 }
 
@@ -45,6 +46,7 @@ const datasetSchema = new Schema<DatasetDocument>(
     views: Number,
     related: [RelationSchema],
     schemaValidator: { type: Boolean, default: false },
+    holdDeletion: { type: Boolean, default: false },
   },
   { toJSON: { virtuals: true }, toObject: { virtuals: true } },
 )


### PR DESCRIPTION
This will pause draft deletion notifications and the future automation for any datasets where a site admin has set this toggle.

<img width="748" height="143" alt="Screenshot From 2026-04-15 12-03-32" src="https://github.com/user-attachments/assets/f09f64b0-93b8-4434-82bd-86d810da0abe" />
