### PR TITLE
fix(app): Set canonical URL for dataset pages

### DIFF
--- a/packages/openneuro-app/src/scripts/dataset/__tests__/dataset-canonical-url.spec.ts
+++ b/packages/openneuro-app/src/scripts/dataset/__tests__/dataset-canonical-url.spec.ts
@@ -1,0 +1,20 @@
+import { datasetCanonicalUrl } from "../dataset-canonical-url"
+import { dataset } from "../../fixtures/dataset-query"
+import { vitest } from "vitest"
+
+vitest.mock("../../config", () => ({
+  config: { url: "http://localhost:9876" },
+}))
+
+describe("datasetCanonicalUrl", () => {
+  it("returns the canonical URL for a dataset with snapshots", () => {
+    const url = datasetCanonicalUrl(dataset)
+    expect(url.href).toBe("http://localhost:9876/datasets/ds001032/versions/2.0.0")
+  })
+
+  it("returns the canonical URL for a draft dataset", () => {
+    const draftDataset = { ...dataset, snapshots: [] }
+    const url = datasetCanonicalUrl(draftDataset)
+    expect(url.href).toBe("http://localhost:9876/datasets/ds001032")
+  })
+})

--- a/packages/openneuro-app/src/scripts/dataset/dataset-canonical-url.ts
+++ b/packages/openneuro-app/src/scripts/dataset/dataset-canonical-url.ts
@@ -1,0 +1,14 @@
+import { config } from "../config"
+
+export function datasetCanonicalUrl(dataset): URL {
+  const siteUrl = config.url
+  if (dataset.snapshots.length) {
+    const latestSnapshot = dataset.snapshots.slice(-1)[0]
+    return new URL(
+      `/datasets/${dataset.id}/versions/${latestSnapshot.tag}`,
+      siteUrl,
+    )
+  } else {
+    return new URL(`/datasets/${dataset.id}`, siteUrl)
+  }
+}

--- a/packages/openneuro-app/src/scripts/dataset/dataset-query.jsx
+++ b/packages/openneuro-app/src/scripts/dataset/dataset-query.jsx
@@ -3,6 +3,7 @@ import * as Sentry from "@sentry/react"
 import PropTypes from "prop-types"
 import { useNavigate, useParams } from "react-router-dom"
 import { useApolloClient, useQuery } from "@apollo/client"
+import Helmet from "react-helmet"
 import { Loading } from "../components/loading/Loading"
 
 import DatasetQueryContext from "../datalad/dataset/dataset-query-context.js"
@@ -16,6 +17,7 @@ import { trackAnalytics } from "../utils/datalad"
 import FourOFourPage from "../errors/404page"
 import FourOThreePage from "../errors/403page"
 import { getDatasetPage, getDraftPage } from "../queries/dataset"
+import { datasetCanonicalUrl } from "./dataset-canonical-url"
 
 /**
  * Query to load and render dataset page - most dataset loading is done here
@@ -63,6 +65,12 @@ export const DatasetQueryHook = ({ datasetId, draft }) => {
   }
   return (
     <DatasetContext.Provider value={data.dataset}>
+      <Helmet>
+        <link
+          rel="canonical"
+          href={datasetCanonicalUrl(data.dataset).toString()}
+        />
+      </Helmet>
       <ErrorBoundary subject={"error in dataset page"}>
         <DatasetQueryContext.Provider
           value={{


### PR DESCRIPTION
Fixes a search indexing issue where the wrong snapshot would end up being promoted to the canonical search URL.