### PR TITLE
fix(server): Preserve annexed/symlink fields in cached files() resolver

### DIFF
--- a/packages/openneuro-server/src/cache/__tests__/tree.spec.ts
+++ b/packages/openneuro-server/src/cache/__tests__/tree.spec.ts
@@ -22,6 +22,8 @@ function makeEntry(overrides: Partial<TreeEntry> = {}): TreeEntry {
     b: "",
     p: false,
     d: false,
+    a: false,
+    l: false,
     ...overrides,
   }
 }

--- a/packages/openneuro-server/src/cache/tree.ts
+++ b/packages/openneuro-server/src/cache/tree.ts
@@ -19,6 +19,10 @@ export interface TreeEntry {
   p: boolean
   /** is directory */
   d: boolean
+  /** is annexed */
+  a: boolean
+  /** is a symlink */
+  l: boolean
 }
 
 function treeKey(hash: string): string {

--- a/packages/openneuro-server/src/datalad/__tests__/files.spec.ts
+++ b/packages/openneuro-server/src/datalad/__tests__/files.spec.ts
@@ -74,6 +74,8 @@ describe("datalad files", () => {
         b: "",
         p: false,
         d: true,
+        a: false,
+        l: false,
       }
       const result = await entryToDatasetFile(entry, "ds000001")
       expect(result).toEqual({
@@ -82,6 +84,8 @@ describe("datalad files", () => {
         directory: true,
         size: 0,
         urls: [],
+        annexed: false,
+        symlink: false,
       })
     })
     it("returns a presigned URL for private files", async () => {
@@ -94,6 +98,8 @@ describe("datalad files", () => {
         b: "private-bucket",
         p: true,
         d: false,
+        a: false,
+        l: false,
       }
       const result = await entryToDatasetFile(entry, "ds000001")
       expect(result).toEqual({
@@ -102,6 +108,8 @@ describe("datalad files", () => {
         directory: false,
         size: 12345,
         urls: ["https://s3.amazonaws.com/bucket/key?presigned=true"],
+        annexed: false,
+        symlink: false,
       })
     })
     it("returns a public S3 URL for public files with S3 keys", async () => {
@@ -114,6 +122,8 @@ describe("datalad files", () => {
         b: "",
         p: false,
         d: false,
+        a: false,
+        l: false,
       }
       const result = await entryToDatasetFile(entry, "ds000001")
       expect(result).toEqual({
@@ -122,6 +132,8 @@ describe("datalad files", () => {
         directory: false,
         size: 500,
         urls: ["https://s3.amazonaws.com/bucket/key?versionId=abc123"],
+        annexed: false,
+        symlink: false,
       })
     })
     it("falls back to server object URL when no S3 key/version", async () => {
@@ -135,6 +147,8 @@ describe("datalad files", () => {
         b: "",
         p: false,
         d: false,
+        a: false,
+        l: false,
       }
       const result = await entryToDatasetFile(entry, "ds000001")
       expect(result).toEqual({
@@ -145,6 +159,8 @@ describe("datalad files", () => {
         urls: [
           "https://openneuro.org/crn/datasets/ds000001/objects/jkl012?filename=sub-01_T1w.nii.gz",
         ],
+        annexed: false,
+        symlink: false,
       })
     })
   })
@@ -192,6 +208,8 @@ describe("datalad files", () => {
         directory: true,
         size: 0,
         urls: [],
+        annexed: false,
+        symlink: false,
       }
       expect(workerFileToEntry(file, false)).toEqual({
         n: "sub-01",
@@ -202,6 +220,8 @@ describe("datalad files", () => {
         b: "",
         p: false,
         d: true,
+        a: false,
+        l: false,
       })
     })
     it("converts a public file with S3 URL", () => {
@@ -213,6 +233,8 @@ describe("datalad files", () => {
         urls: [
           "https://s3.amazonaws.com/openneuro.org/datasets/ds000001/README?versionId=ver2",
         ],
+        annexed: false,
+        symlink: false,
       }
       const result = workerFileToEntry(file, false)
       expect(result).toEqual({
@@ -224,6 +246,8 @@ describe("datalad files", () => {
         b: "openneuro.org",
         p: false,
         d: false,
+        a: false,
+        l: false,
       })
     })
     it("stores empty bucket when it matches the default bucket", () => {
@@ -237,6 +261,8 @@ describe("datalad files", () => {
         urls: [
           "https://s3.amazonaws.com/openneuro.org/datasets/ds000001/README?versionId=ver2",
         ],
+        symlink: false,
+        annexed: false,
       }
       const result = workerFileToEntry(file, false)
       expect(result.b).toBe("")
@@ -251,6 +277,8 @@ describe("datalad files", () => {
         urls: [
           "https://s3.amazonaws.com/private-bucket/data.nii.gz?versionId=v1",
         ],
+        symlink: false,
+        annexed: false,
       }
       expect(workerFileToEntry(file, true).p).toBe(true)
       expect(workerFileToEntry(file, false).p).toBe(false)
@@ -262,6 +290,8 @@ describe("datalad files", () => {
         directory: false,
         size: 1000,
         urls: [],
+        symlink: false,
+        annexed: false,
       }
       const result = workerFileToEntry(file, false)
       expect(result.k).toBe("")

--- a/packages/openneuro-server/src/datalad/files.ts
+++ b/packages/openneuro-server/src/datalad/files.ts
@@ -86,6 +86,8 @@ export type DatasetFile = {
   directory: boolean
   size: number
   urls: string[]
+  symlink: boolean
+  annexed: boolean
 }
 
 /**
@@ -140,6 +142,8 @@ export function workerFileToEntry(
       b: "",
       p: false,
       d: true,
+      a: false,
+      l: false,
     }
   }
   const parsed = file.urls[0] ? parseS3Url(file.urls[0]) : null
@@ -155,6 +159,8 @@ export function workerFileToEntry(
     b: bucket,
     p: needsPresign,
     d: false,
+    a: file.annexed,
+    l: file.symlink,
   }
 }
 
@@ -170,6 +176,8 @@ export async function entryToDatasetFile(
       directory: true,
       size: 0,
       urls: [],
+      symlink: false,
+      annexed: false,
     }
   }
   let url: string
@@ -189,6 +197,8 @@ export async function entryToDatasetFile(
     directory: false,
     size: entry.s,
     urls: [url],
+    symlink: entry.l,
+    annexed: entry.a,
   }
 }
 
@@ -409,6 +419,8 @@ async function reconstructFromTrees(
       directory: false,
       size: entry.s,
       urls: [],
+      symlink: entry.l,
+      annexed: entry.a,
     }
     if (entry.p && entry.k && entry.v) {
       // To be presigned


### PR DESCRIPTION
Fixes an issue where the annexed field is null. The symlink field is new and unused but updating it now prevents dropping the cache again in the future.