### PR TITLE
fix(worker): Fix incorrect path resolution in set_remote_public

### DIFF
--- a/services/datalad/datalad_service/tasks/publish.py
+++ b/services/datalad/datalad_service/tasks/publish.py
@@ -305,14 +305,13 @@ async def annex_drop(dataset_path, branches):
     await run_check(command, dataset_path, env=env)
 
 
-async def set_remote_public(dataset):
+async def set_remote_public(dataset_path):
     """Clear x-amz-meta-access when a dataset is made public."""
-    dataset_path = os.path.join(datalad_service.common.s3.get_datasets_path(), dataset)
     await run_check(
         ['git-annex', 'enableremote', get_s3_remote(), 'x-amz-tagging=access=public'],
         dataset_path,
     )
-    await set_s3_access_tag(dataset, 'public')
+    await set_s3_access_tag(os.path.basename(dataset_path), 'public')
 
 
 def update_object_tag(client, s3_bucket, key, version_id, value):

--- a/services/datalad/tests/test_publish.py
+++ b/services/datalad/tests/test_publish.py
@@ -1,10 +1,10 @@
 import json
 import os
-from unittest.mock import AsyncMock, Mock, call
+from unittest.mock import AsyncMock, Mock, call, patch
 
 import falcon
 
-from datalad_service.tasks.publish import export_dataset, create_remotes
+from datalad_service.tasks.publish import export_dataset, create_remotes, set_remote_public
 from datalad_service.common.annex import is_git_annex_remote
 
 
@@ -68,3 +68,15 @@ async def test_export_snapshots(no_init_remote, client, new_dataset):
     dataset_id = os.path.basename(new_dataset.path)
     expect_calls = [call(dataset_id, new_dataset.path, 'refs/tags/2.0.0')]
     github_export_mock.assert_has_calls(expect_calls)
+
+
+@patch('datalad_service.tasks.publish.run_check', new_callable=AsyncMock)
+@patch('datalad_service.tasks.publish.set_s3_access_tag', new_callable=AsyncMock)
+async def test_set_remote_public(mock_set_s3_access_tag, mock_run_check, new_dataset):
+    await set_remote_public(new_dataset.path)
+    
+    mock_run_check.assert_called_once_with(
+        ['git-annex', 'enableremote', 's3-PUBLIC', 'x-amz-tagging=access=public'],
+        new_dataset.path,
+    )
+    mock_set_s3_access_tag.assert_called_once_with(os.path.basename(new_dataset.path), 'public')


### PR DESCRIPTION
Fixes a bad call in set_remote_public and adds basic test coverage for this function.