### PR TITLE
fix(app): Use recursive: true for native file API downloads

### DIFF
--- a/packages/openneuro-app/src/scripts/dataset/download/download-native.js
+++ b/packages/openneuro-app/src/scripts/dataset/download/download-native.js
@@ -43,65 +43,48 @@ class DownloadAbortError extends Error {
 let downloadCanceled
 
 /**
- * Recursive download for file trees via browser file access API
+ * Download for file trees via browser file access API
  */
 const downloadTree = async (
   { datasetId, snapshotTag, client, dirHandle, toastId },
   path = "",
-  tree = null,
 ) => {
   const filesToDownload = await downloadDataset(client)({
     datasetId,
     snapshotTag,
-    tree,
   })
   for (const [_index, file] of filesToDownload.entries()) {
     const downloadPath = path ? `${path}/${file.filename}` : file.filename
-    if (file.directory) {
-      // Next tree level
-      await downloadTree(
-        {
+    // Regular file
+    if (downloadCanceled) {
+      throw new DownloadAbortError("Download canceled by user request")
+    }
+    const fileHandle = await openFileTree(
+      dirHandle,
+      path ? `${path}/${file.filename}` : file.filename,
+    )
+    // Skip files which are already complete
+    if (fileHandle.size == file.size) continue
+    const writable = await fileHandle.createWritable()
+    const { body, status, statusText } = await fetch(file.urls[0])
+    let loaded = 0
+    const progress = new TransformStream({
+      transform(chunk, controller) {
+        downloadToastUpdate(toastId, loaded / file.size, {
           datasetId,
           snapshotTag,
-          client,
-          dirHandle,
-          toastId,
-        },
-        downloadPath,
-        file.key,
-      )
+          downloadPath,
+          dirName: dirHandle.name,
+        })
+        loaded += chunk.length
+        controller.enqueue(chunk)
+      },
+    })
+    if (status === 200) {
+      await body.pipeThrough(progress).pipeTo(writable)
     } else {
-      // Regular file
-      if (downloadCanceled) {
-        throw new DownloadAbortError("Download canceled by user request")
-      }
-      const fileHandle = await openFileTree(
-        dirHandle,
-        path ? `${path}/${file.filename}` : file.filename,
-      )
-      // Skip files which are already complete
-      if (fileHandle.size == file.size) continue
-      const writable = await fileHandle.createWritable()
-      const { body, status, statusText } = await fetch(file.urls[0])
-      let loaded = 0
-      const progress = new TransformStream({
-        transform(chunk, controller) {
-          downloadToastUpdate(toastId, loaded / file.size, {
-            datasetId,
-            snapshotTag,
-            downloadPath,
-            dirName: dirHandle.name,
-          })
-          loaded += chunk.length
-          controller.enqueue(chunk)
-        },
-      })
-      if (status === 200) {
-        await body.pipeThrough(progress).pipeTo(writable)
-      } else {
-        Sentry.captureException(statusText)
-        return requestFailureToast(file.filename)
-      }
+      Sentry.captureException(statusText)
+      return requestFailureToast(file.filename)
     }
   }
 }

--- a/packages/openneuro-app/src/scripts/dataset/download/download-query.js
+++ b/packages/openneuro-app/src/scripts/dataset/download/download-query.js
@@ -1,31 +1,29 @@
 import { gql } from "@apollo/client"
 
 export const DOWNLOAD_DATASET = gql`
-query downloadDraft($datasetId: ID!, $tree: String) {
-  dataset(id: $datasetId) {
-    id
-    draft {
+  query downloadDraft($datasetId: ID!) {
+    dataset(id: $datasetId) {
       id
-      files(tree: $tree) {
+      draft {
         id
-        key
-        directory
-        filename
-        size
-        urls
+        files(recursive: true) {
+          id
+          directory
+          filename
+          size
+          urls
+        }
       }
     }
   }
-}
 `
 
 export const DOWNLOAD_SNAPSHOT = gql`
-  query downloadSnapshot($datasetId: ID!, $tag: String!, $tree: String) {
+  query downloadSnapshot($datasetId: ID!, $tag: String!) {
     snapshot(datasetId: $datasetId, tag: $tag) {
       id
-      files(tree: $tree) {
+      files(recursive: true) {
         id
-        key
         directory
         filename
         size
@@ -36,14 +34,13 @@ export const DOWNLOAD_SNAPSHOT = gql`
 `
 
 export const downloadDataset =
-  (client) => async ({ datasetId, snapshotTag, tree = null }) => {
+  (client) => async ({ datasetId, snapshotTag }) => {
     if (snapshotTag) {
       const { data } = await client.query({
         query: DOWNLOAD_SNAPSHOT,
         variables: {
           datasetId,
           tag: snapshotTag,
-          tree: tree,
         },
       })
       return data.snapshot.files
@@ -52,7 +49,6 @@ export const downloadDataset =
         query: DOWNLOAD_DATASET,
         variables: {
           datasetId,
-          tree,
         },
       })
       return data.dataset.draft.files


### PR DESCRIPTION
Simplify native file API downloads to use the recursive flag and fixes the invalid query structure in #3907