### PR TITLE
feat(app): Display a link to the user's ORCID account in user menu

### DIFF
--- a/packages/openneuro-app/src/scripts/users/user-menu.tsx
+++ b/packages/openneuro-app/src/scripts/users/user-menu.tsx
@@ -3,6 +3,7 @@ import { Link } from "react-router-dom"
 import { Dropdown } from "../components/dropdown/Dropdown"
 import { useUser } from "../queries/user"
 import { useNotifications } from "./notifications/user-notifications-context"
+import orcidIcon from "../../assets/orcid_24x24.png"
 import "./scss/user-menu.scss"
 
 interface UserMenuListProps {
@@ -101,10 +102,18 @@ export const UserMenu: React.FC<UserMenuProps> = ({ signOutAndRedirect }) => {
               <p>
                 <span>Hello</span> <br />
                 {user.name} <br />
-                {user.email}
               </p>
               <p>
                 <span>signed in via {user.provider}</span>
+                {user?.orcid && (
+                      <a
+                        href={`https://orcid.org/${user.orcid}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        <img src={orcidIcon} alt="ORCID iD" /> {user.orcid}
+                      </a>
+                    ) || user.email}
               </p>
             </li>
 


### PR DESCRIPTION
Show the ORCID for the current user with a link in our user menu.

<img width="268" height="483" alt="Screenshot From 2026-04-28 13-30-43" src="https://github.com/user-attachments/assets/f6001cb7-0645-4f68-bee8-6a2593bfc32f" />

Fixes #3914 