### PR TITLE
feat(app): Enable public user profiles

### DIFF
--- a/packages/openneuro-app/src/scripts/queries/user.ts
+++ b/packages/openneuro-app/src/scripts/queries/user.ts
@@ -207,8 +207,15 @@ export const ADVANCED_SEARCH_DATASETS_QUERY = gql`
   }
 `
 
+interface UseUserOptions {
+  errorPolicy: "none" | "ignore" | "all"
+}
+
 // Reusable hook to fetch user data
-export const useUser = (userId?: string) => {
+export const useUser = (
+  userId?: string,
+  options: UseUserOptions = { errorPolicy: "none" },
+) => {
   const [cookies] = useCookies()
   const profile = getProfile(cookies)
   const profileSub = profile?.sub
@@ -222,6 +229,7 @@ export const useUser = (userId?: string) => {
   } = useQuery(GET_USER, {
     variables: { userId: finalUserId },
     skip: !finalUserId,
+    errorPolicy: options.errorPolicy,
   })
 
   if (userError) {

--- a/packages/openneuro-app/src/scripts/types/user-types.ts
+++ b/packages/openneuro-app/src/scripts/types/user-types.ts
@@ -33,6 +33,7 @@ export interface UserCardProps {
 
 export interface UserAccountViewProps {
   orcidUser: User
+  hasEdit: boolean
 }
 
 /** ------------------ Dataset ------------------ */

--- a/packages/openneuro-app/src/scripts/users/__tests__/user-account-view.spec.tsx
+++ b/packages/openneuro-app/src/scripts/users/__tests__/user-account-view.spec.tsx
@@ -68,7 +68,7 @@ describe("<UserAccountView />", () => {
     render(
       <BrowserRouter>
         <MockedProvider mocks={mocks} addTypename={false}>
-          <UserAccountView orcidUser={baseUser} />
+          <UserAccountView orcidUser={baseUser} hasEdit={true} />
         </MockedProvider>
       </BrowserRouter>,
     )
@@ -106,7 +106,7 @@ describe("<UserAccountView />", () => {
     render(
       <BrowserRouter>
         <MockedProvider mocks={mocks} addTypename={false}>
-          <UserAccountView orcidUser={baseUser} />
+          <UserAccountView orcidUser={baseUser} hasEdit={true} />
         </MockedProvider>
       </BrowserRouter>,
     )
@@ -146,7 +146,7 @@ describe("<UserAccountView />", () => {
     render(
       <BrowserRouter>
         <MockedProvider mocks={mocks} addTypename={false}>
-          <UserAccountView orcidUser={baseUser} />
+          <UserAccountView orcidUser={baseUser} hasEdit={true} />
         </MockedProvider>,
       </BrowserRouter>,
     )
@@ -186,7 +186,7 @@ describe("<UserAccountView />", () => {
     render(
       <BrowserRouter>
         <MockedProvider mocks={mocks} addTypename={false}>
-          <UserAccountView orcidUser={baseUser} />
+          <UserAccountView orcidUser={baseUser} hasEdit={true} />
         </MockedProvider>,
       </BrowserRouter>,
     )
@@ -226,7 +226,7 @@ describe("<UserAccountView />", () => {
     render(
       <BrowserRouter>
         <MockedProvider mocks={mocks} addTypename={false}>
-          <UserAccountView orcidUser={baseUser} />
+          <UserAccountView orcidUser={baseUser} hasEdit={true} />
         </MockedProvider>,
       </BrowserRouter>,
     )

--- a/packages/openneuro-app/src/scripts/users/__tests__/user-routes.spec.tsx
+++ b/packages/openneuro-app/src/scripts/users/__tests__/user-routes.spec.tsx
@@ -285,11 +285,6 @@ describe("UserRoutes Component", () => {
     expect(await screen.findByTestId("404-page")).toBeInTheDocument()
   })
 
-  it("renders FourOThreePage for restricted route /account when hasEdit is false", async () => {
-    setupUserRoutes(userToPass, "/account", false, true)
-    expect(await screen.findByTestId("403-page")).toBeInTheDocument()
-  })
-
   it("renders FourOThreePage for restricted route /notifications when hasEdit is false", async () => {
     setupUserRoutes(userToPass, "/notifications", false, true)
     expect(await screen.findByTestId("403-page")).toBeInTheDocument()

--- a/packages/openneuro-app/src/scripts/users/__tests__/user-tabs.spec.tsx
+++ b/packages/openneuro-app/src/scripts/users/__tests__/user-tabs.spec.tsx
@@ -23,14 +23,14 @@ const UserAccountTabsWrapper: React.FC = () => {
 }
 
 describe("UserAccountTabs Component", () => {
-  it("should not render tabs when hasEdit is false", () => {
+  it("should not notification render tab when hasEdit is false", () => {
     render(<UserAccountTabsWrapper />)
 
     expect(screen.getByText("My Datasets")).toBeInTheDocument()
 
     fireEvent.click(screen.getByText("Toggle hasEdit"))
 
-    expect(screen.queryByText("My Datasets")).not.toBeInTheDocument()
+    expect(screen.queryByText("Notifications")).not.toBeInTheDocument()
   })
 
   it("should render tabs when hasEdit is toggled back to true", () => {
@@ -39,10 +39,10 @@ describe("UserAccountTabs Component", () => {
     expect(screen.getByText("My Datasets")).toBeInTheDocument()
 
     fireEvent.click(screen.getByText("Toggle hasEdit"))
-    expect(screen.queryByText("My Datasets")).not.toBeInTheDocument()
+    expect(screen.queryByText("Notifications")).not.toBeInTheDocument()
 
     fireEvent.click(screen.getByText("Toggle hasEdit"))
-    expect(screen.getByText("My Datasets")).toBeInTheDocument()
+    expect(screen.getByText("Notifications")).toBeInTheDocument()
   })
 
   it("should update active class on the correct NavLink based on route", () => {

--- a/packages/openneuro-app/src/scripts/users/components/editable-content.tsx
+++ b/packages/openneuro-app/src/scripts/users/components/editable-content.tsx
@@ -13,6 +13,7 @@ interface EditableContentProps {
   heading: string
   validation?: RegExp | ((value: string) => boolean)
   validationMessage?: string
+  hasEdit?: boolean
   "data-testid"?: string
 }
 
@@ -23,6 +24,7 @@ export const EditableContent: React.FC<EditableContentProps> = ({
   heading,
   validation,
   validationMessage,
+  hasEdit,
   "data-testid": testId,
 }) => {
   const [editing, setEditing] = useState(false)
@@ -52,7 +54,7 @@ export const EditableContent: React.FC<EditableContentProps> = ({
         <h4>{heading}</h4>
         {editing
           ? <CloseButton action={closeEditing} />
-          : <EditButton action={() => setEditing(true)} />}
+          : hasEdit && <EditButton action={() => setEditing(true)} />}
       </span>
       {editing
         ? (

--- a/packages/openneuro-app/src/scripts/users/user-account-view.tsx
+++ b/packages/openneuro-app/src/scripts/users/user-account-view.tsx
@@ -13,6 +13,7 @@ import { pageTitle } from "../resources/strings.js"
 
 export const UserAccountView: React.FC<UserAccountViewProps> = ({
   orcidUser,
+  hasEdit,
 }) => {
   const [userLinks, setLinks] = useState<string[]>(orcidUser.links ?? [])
   const [userLocation, setLocation] = useState<string>(
@@ -89,7 +90,7 @@ export const UserAccountView: React.FC<UserAccountViewProps> = ({
     <>
       <Helmet>
         <title>
-            {orcidUser.name || "User"} profile - {pageTitle}
+          {orcidUser.name || "User"} profile - {pageTitle}
         </title>
       </Helmet>
       <div data-testid="user-account-view" className={styles.useraccountview}>
@@ -126,9 +127,10 @@ export const UserAccountView: React.FC<UserAccountViewProps> = ({
           validation={validateHttpHttpsUrl}
           validationMessage="Invalid URL format. Please start with http:// or https://"
           data-testid="links-section"
+          hasEdit={hasEdit}
         />
 
-        {orcidUser.orcid !== undefined && (
+        {hasEdit && orcidUser.orcid !== undefined && (
           <div className={styles.umbOrcidConsent}>
             <div className={styles.umbOrcidHeading}>
               <h4>ORCID Integration</h4>
@@ -144,11 +146,13 @@ export const UserAccountView: React.FC<UserAccountViewProps> = ({
           editableContent={userLocation}
           setRows={handleLocationChange}
           heading="Location"
+          hasEdit={hasEdit}
           data-testid="location-section"
         />
         <EditableContent
           editableContent={userInstitution}
           setRows={handleInstitutionChange}
+          hasEdit={hasEdit}
           heading="Institution"
           data-testid="institution-section"
         />

--- a/packages/openneuro-app/src/scripts/users/user-query.tsx
+++ b/packages/openneuro-app/src/scripts/users/user-query.tsx
@@ -10,22 +10,17 @@ import { useUser } from "../queries/user"
 
 export const UserQuery: React.FC = () => {
   const { orcid } = useParams()
-  const isOrcidValid = orcid && isValidOrcid(orcid)
-  const { user, loading, error } = useUser(orcid)
+  const { user, loading } = useUser(orcid, { errorPolicy: "all" })
 
   const [cookies] = useCookies()
   const profile = getProfile(cookies)
   const isAdminUser = isAdmin()
 
-  if (!isOrcidValid) {
+  if (!isValidOrcid(orcid)) {
     return <FourOFourPage />
   }
 
   if (loading) return <div>Loading...</div>
-
-  if (error || !user) {
-    return <FourOFourPage />
-  }
 
   // is admin or profile matches id from the user data being returned
   const isUser = (user?.id === profile?.sub) ? true : false

--- a/packages/openneuro-app/src/scripts/users/user-routes.tsx
+++ b/packages/openneuro-app/src/scripts/users/user-routes.tsx
@@ -60,9 +60,9 @@ export const UserRoutes: React.FC<UserRoutesProps> = (
           {/* This route handles the user account page */}
           <Route
             path="account"
-            element={hasEdit
-              ? <UserAccountView orcidUser={orcidUser} />
-              : <FourOThreePage />}
+            element={
+              <UserAccountView orcidUser={orcidUser} hasEdit={hasEdit} />
+            }
           />
           {/* This route handles the user notifications and its sub-routes */}
           <Route

--- a/packages/openneuro-app/src/scripts/users/user-tabs.tsx
+++ b/packages/openneuro-app/src/scripts/users/user-tabs.tsx
@@ -29,8 +29,6 @@ export const UserAccountTabs: React.FC<UserAccountTabsProps> = (
     setClicked(true)
   }
 
-  if (!hasEdit) return null
-
   return (
     <div className={styles.userAccountTabLinks}>
       <ul
@@ -50,16 +48,19 @@ export const UserAccountTabs: React.FC<UserAccountTabsProps> = (
             {isUser ? "My" : "User"} Datasets
           </NavLink>
         </li>
-        <li>
-          <NavLink
-            data-testid="user-notifications-tab"
-            to="notifications"
-            className={({ isActive }) => (isActive ? styles.active : "")}
-            onClick={handleClick}
-          >
-            Notifications
-          </NavLink>
-        </li>
+
+        {hasEdit && (
+          <li>
+            <NavLink
+              data-testid="user-notifications-tab"
+              to="notifications"
+              className={({ isActive }) => (isActive ? styles.active : "")}
+              onClick={handleClick}
+            >
+              Notifications
+            </NavLink>
+          </li>
+        )}
 
         <li>
           <NavLink


### PR DESCRIPTION
Enable anonymous access to user profiles. Notifications and emails are hidden publicly. The default landing page is the user's datasets list but a subset of the account info tab shows imported or edited fields.

Fixes #3913 