### PR TITLE
fix(worker): Throw HTTP 403 on invalid token signatures

### DIFF
--- a/services/datalad/datalad_service/middleware/auth.py
+++ b/services/datalad/datalad_service/middleware/auth.py
@@ -41,12 +41,14 @@ class AuthenticateMiddleware:
                     req.context['user'] = jwt.decode(
                         token, key=os.environ['JWT_SECRET'], algorithms=['HS256']
                     )
-                except (
-                    jwt.exceptions.InvalidSignatureError,
-                    jwt.exceptions.DecodeError,
-                ):
+                except jwt.exceptions.DecodeError:
                     resp.status = falcon.HTTP_BAD_REQUEST
                     resp.text = 'Token malformed and could not be decoded'
+                    resp.complete = True
+                    return
+                except jwt.exceptions.InvalidSignatureError:
+                    resp.status = falcon.HTTP_UNAUTHORIZED
+                    resp.text = 'Invalid token signature'
                     resp.complete = True
                     return
                 except jwt.exceptions.ExpiredSignatureError:


### PR DESCRIPTION
Previously this would throw HTTP 400 which is more suited to malformed tokens.