### PR TITLE
fix(app): Only show link GitHub button on your own profile page

### DIFF
--- a/packages/openneuro-app/src/scripts/users/user-account-view.tsx
+++ b/packages/openneuro-app/src/scripts/users/user-account-view.tsx
@@ -115,9 +115,11 @@ export const UserAccountView: React.FC<UserAccountViewProps> = ({
                 {orcidUser.github}
               </li>
             )}
-          <li>
-            <GitHubAuthButton sync={orcidUser.githubSynced} />
-          </li>
+          {hasEdit && (
+            <li>
+              <GitHubAuthButton sync={orcidUser.githubSynced} />
+            </li>
+          )}
         </ul>
 
         <EditableContent


### PR DESCRIPTION
Hide this button when viewing another user's profile.