### PR TITLE
fix: Thread userInfo correctly in updatePublic mutation

### DIFF
--- a/packages/openneuro-server/src/datalad/__tests__/dataset.spec.ts
+++ b/packages/openneuro-server/src/datalad/__tests__/dataset.spec.ts
@@ -23,7 +23,7 @@ describe("dataset model operations", () => {
       connect(mongod.getUri())
     })
     it("resolves to dataset id string", async () => {
-      const user = { id: "1234" }
+      const user = { id: "1234", userId: "1234", admin: false }
       const { id: dsId } = await createDataset(user.id, user, {
         affirmedDefaced: true,
         affirmedConsent: true,
@@ -32,7 +32,7 @@ describe("dataset model operations", () => {
       expect(dsId.slice(0, 2)).toBe("ds")
     })
     it("posts to the DataLad /datasets/{dsId} endpoint", async () => {
-      const user = { id: "1234" }
+      const user = { id: "1234", userId: "1234", admin: false }
       // Reset call count for request.post
       request.post.mockClear()
       const { id: dsId } = await createDataset(user.id, user, {

--- a/packages/openneuro-server/src/datalad/__tests__/snapshots.spec.ts
+++ b/packages/openneuro-server/src/datalad/__tests__/snapshots.spec.ts
@@ -34,7 +34,7 @@ describe("snapshot model operations", () => {
       connect(mongod.getUri())
     })
     it("posts to the DataLad /datasets/{dsId}/snapshots/{snapshot} endpoint", async () => {
-      const user = { id: "1234" }
+      const user = { id: "1234", userId: "1234", admin: false }
       const tag = "snapshot"
       const { id: dsId } = await createDataset(user.id, user, {
         affirmedDefaced: true,

--- a/packages/openneuro-server/src/datalad/dataset.ts
+++ b/packages/openneuro-server/src/datalad/dataset.ts
@@ -28,6 +28,7 @@ import { getDatasetWorker } from "../libs/datalad-service"
 import { createEvent, updateEvent } from "../libs/events"
 import Doi from "../models/doi"
 import { hideDoi, publishDoi } from "../libs/doi/index"
+import type { UserInfo } from "../graphql/builder"
 
 export const giveUploaderPermission = (datasetId, userId) => {
   const permission = new Permission({ datasetId, userId, level: "admin" })
@@ -498,7 +499,11 @@ export const flagAnnexObject = (
 /**
  * Update public state and transition DOI states accordingly.
  */
-export async function updatePublic(datasetId, publicFlag, user) {
+export async function updatePublic(
+  datasetId: string,
+  publicFlag: boolean,
+  user: UserInfo,
+) {
   const event = await createEvent(
     datasetId,
     user.id,

--- a/packages/openneuro-server/src/datalad/dataset.ts
+++ b/packages/openneuro-server/src/datalad/dataset.ts
@@ -30,7 +30,7 @@ import Doi from "../models/doi"
 import { hideDoi, publishDoi } from "../libs/doi/index"
 import type { UserInfo } from "../graphql/builder"
 
-export const giveUploaderPermission = (datasetId, userId) => {
+export const giveUploaderPermission = (datasetId: string, userId: string) => {
   const permission = new Permission({ datasetId, userId, level: "admin" })
   return permission.save()
 }
@@ -47,8 +47,11 @@ export const giveUploaderPermission = (datasetId, userId) => {
  */
 export const createDataset = async (
   uploader: string,
-  userInfo,
-  { affirmedDefaced, affirmedConsent },
+  userInfo: UserInfo,
+  { affirmedDefaced, affirmedConsent }: {
+    affirmedDefaced: boolean
+    affirmedConsent: boolean
+  },
 ) => {
   // Obtain an accession number
   const datasetId = await getAccessionNumber()
@@ -88,7 +91,7 @@ type DatasetWithRevision = Mongoose.FlattenMaps<DatasetDocument> & {
 /**
  * Fetch dataset document and related fields
  */
-export const getDataset = async (id): Promise<DatasetWithRevision | null> => {
+export const getDataset = async (id: string): Promise<DatasetWithRevision | null> => {
   const dataset = await Dataset.findOne({ id }).lean()
   return dataset && {
     ...dataset,
@@ -99,7 +102,7 @@ export const getDataset = async (id): Promise<DatasetWithRevision | null> => {
 /**
  * Delete dataset and associated documents
  */
-export const deleteDataset = async (datasetId, user) => {
+export const deleteDataset = async (datasetId: string, user: UserInfo) => {
   const event = await createEvent(
     datasetId,
     user.id,

--- a/packages/openneuro-server/src/graphql/resolvers/dataset.ts
+++ b/packages/openneuro-server/src/graphql/resolvers/dataset.ts
@@ -220,7 +220,7 @@ export const updatePublic = (
   { user, userInfo }: GraphQLContext,
 ) => {
   return checkDatasetWrite(datasetId, user, userInfo).then(() => {
-    return datalad.updatePublic(datasetId, publicFlag, user)
+    return datalad.updatePublic(datasetId, publicFlag, userInfo)
   })
 }
 


### PR DESCRIPTION
The updatePublic mutation was passing the user ID instead of userInfo to the `datalad/dataset.ts:updatePublic()` function.

Bug was identified because I attempted to write a script to set a dataset private using the graphql api and then tag the S3 objects as private. I got the following error:

```json
{
  "message": "DatasetEvent validation failed: userId: Path `userId` is required.",
  "locations": [{ "line": 2, "column": 3 }],
  "path": ["updatePublic"],
  "extensions": {
    "code": "INTERNAL_SERVER_ERROR",
    "stacktrace": [
      "ValidationError: DatasetEvent validation failed: userId: Path `userId` is required.",
      "    at Document.invalidate (/srv/.yarn/cache/mongoose-npm-8.9.5-46ee8d4aeb-74f38844ef.zip/node_modules/mongoose/lib/document.js:3334:32)",
      "    at /srv/.yarn/cache/mongoose-npm-8.9.5-46ee8d4aeb-74f38844ef.zip/node_modules/mongoose/lib/document.js:3095:17",
      "    at /srv/.yarn/cache/mongoose-npm-8.9.5-46ee8d4aeb-74f38844ef.zip/node_modules/mongoose/lib/schemaType.js:1407:9",
      "    at process.processTicksAndRejections (node:internal/process/task_queues:85:11)"
    ]
  }
}
```

Given that catching issues like this was part of the point of switching to a typed schema generator, I first updated the type annotation to verify that we get the correct error before fixing. I then also annotated neighboring functions, which identified minimal errors in the tests only.