### PR TITLE
feat(app): Add toggle for user profile privacy

### DIFF
--- a/packages/openneuro-app/src/scripts/queries/user.ts
+++ b/packages/openneuro-app/src/scripts/queries/user.ts
@@ -64,7 +64,8 @@ export const GET_USER = gql`
           status
         }
       }
-      orcidConsent 
+      orcidConsent
+      profilePrivate
     }
   }
 `
@@ -74,22 +75,25 @@ export const UPDATE_USER = gql`
   mutation updateUser(
     $id: ID!
     $location: String
-    $links: [String]
+    $links: [String!]
     $institution: String
-    $orcidConsent: Boolean 
+    $orcidConsent: Boolean
+    $profilePrivate: Boolean
   ) {
     updateUser(
       id: $id
       location: $location
       links: $links
       institution: $institution
-      orcidConsent: $orcidConsent 
+      orcidConsent: $orcidConsent
+      profilePrivate: $profilePrivate
     ) {
       id
       location
       links
       institution
       orcidConsent
+      profilePrivate
     }
   }
 `

--- a/packages/openneuro-app/src/scripts/types/user-types.ts
+++ b/packages/openneuro-app/src/scripts/types/user-types.ts
@@ -20,6 +20,7 @@ export interface User {
   githubSynced?: Date
   notifications?: Event[]
   orcidConsent?: boolean | null
+  profilePrivate?: boolean
 }
 
 export interface UserRoutesProps {

--- a/packages/openneuro-app/src/scripts/users/components/profile-privacy.tsx
+++ b/packages/openneuro-app/src/scripts/users/components/profile-privacy.tsx
@@ -1,0 +1,62 @@
+import React, { useEffect, useState } from "react"
+import * as Sentry from "@sentry/react"
+import { useMutation } from "@apollo/client"
+import { GET_USER, UPDATE_USER } from "../../queries/user"
+import { RadioGroup } from "../../components/radio/RadioGroup"
+
+export interface ProfilePrivacyProps {
+  userId: string
+  initialProfilePrivate: boolean
+}
+
+export const ProfilePrivacy: React.FC<ProfilePrivacyProps> = ({
+  userId,
+  initialProfilePrivate,
+}) => {
+  const initialValue = initialProfilePrivate ? "true" : "false"
+  const [value, setValue] = useState(initialValue)
+
+  useEffect(() => {
+    setValue(initialProfilePrivate ? "true" : "false")
+  }, [initialProfilePrivate])
+
+  const [updateUser] = useMutation(UPDATE_USER, {
+    refetchQueries: [{ query: GET_USER, variables: { userId } }],
+    onError: (error) => {
+      Sentry.captureException(error)
+    },
+  })
+
+  const handleChange = async (newValue: string) => {
+    setValue(newValue)
+    try {
+      await updateUser({
+        variables: { id: userId, profilePrivate: newValue === "true" },
+      })
+    } catch (error) {
+      Sentry.captureException(error)
+    }
+  }
+
+  const radioOptions = [
+    { label: "Public", value: "false" },
+    { label: "Private", value: "true" },
+  ]
+
+  return (
+    <div>
+      <p>
+        Set your profile to private to hide your profile page from public view.
+        Your datasets and contributions will still be visible based on each
+        dataset's published state.
+      </p>
+      <RadioGroup
+        name="profilePrivate"
+        layout="row"
+        radioArr={radioOptions}
+        selected={value}
+        setSelected={handleChange}
+      />
+    </div>
+  )
+}

--- a/packages/openneuro-app/src/scripts/users/user-account-view.tsx
+++ b/packages/openneuro-app/src/scripts/users/user-account-view.tsx
@@ -8,6 +8,7 @@ import styles from "./scss/useraccountview.module.scss"
 import { GitHubAuthButton } from "./github-auth-button"
 import type { UserAccountViewProps } from "../types/user-types"
 import { OrcidConsentForm } from "./components/orcid-consent-form"
+import { ProfilePrivacy } from "./components/profile-privacy"
 import { validateHttpHttpsUrl } from "../utils/validationUtils"
 import { pageTitle } from "../resources/strings.js"
 
@@ -122,15 +123,17 @@ export const UserAccountView: React.FC<UserAccountViewProps> = ({
           )}
         </ul>
 
-        <EditableContent
-          editableContent={userLinks}
-          setRows={handleLinksChange}
-          heading="Links"
-          validation={validateHttpHttpsUrl}
-          validationMessage="Invalid URL format. Please start with http:// or https://"
-          data-testid="links-section"
-          hasEdit={hasEdit}
-        />
+        {hasEdit && (
+          <div className={styles.umbOrcidConsent}>
+            <div className={styles.umbOrcidHeading}>
+              <h4>Profile Privacy</h4>
+            </div>
+            <ProfilePrivacy
+              userId={orcidUser.id}
+              initialProfilePrivate={orcidUser.profilePrivate ?? false}
+            />
+          </div>
+        )}
 
         {hasEdit && orcidUser.orcid !== undefined && (
           <div className={styles.umbOrcidConsent}>
@@ -144,6 +147,15 @@ export const UserAccountView: React.FC<UserAccountViewProps> = ({
           </div>
         )}
 
+        <EditableContent
+          editableContent={userLinks}
+          setRows={handleLinksChange}
+          heading="Links"
+          validation={validateHttpHttpsUrl}
+          validationMessage="Invalid URL format. Please start with http:// or https://"
+          data-testid="links-section"
+          hasEdit={hasEdit}
+        />
         <EditableContent
           editableContent={userLocation}
           setRows={handleLocationChange}

--- a/packages/openneuro-app/src/scripts/users/user-datasets-view.tsx
+++ b/packages/openneuro-app/src/scripts/users/user-datasets-view.tsx
@@ -1,6 +1,8 @@
 import React, { useCallback, useEffect, useState } from "react"
 import { useQuery } from "@apollo/client"
 import * as Sentry from "@sentry/react"
+import Helmet from "react-helmet"
+import { pageTitle } from "../resources/strings"
 import { DatasetCard } from "./dataset-card"
 import { UserDatasetFilters } from "./components/user-dataset-filters"
 import { ADVANCED_SEARCH_DATASETS_QUERY } from "../queries/user"
@@ -260,6 +262,11 @@ export const UserDatasetsView: React.FC<UserDatasetsViewProps> = ({
       className={styles.userDatasetsWrapper}
       data-testid="user-datasets-view"
     >
+      <Helmet>
+        <title>
+          {orcidUser.name || "User"}'s Datasets - {pageTitle}
+        </title>
+      </Helmet>
       <h3>{orcidUser.name}'s Datasets</h3>
 
       <UserDatasetFilters

--- a/packages/openneuro-app/src/scripts/users/user-query.tsx
+++ b/packages/openneuro-app/src/scripts/users/user-query.tsx
@@ -7,6 +7,7 @@ import { isAdmin } from "../authentication/admin-user"
 import { useCookies } from "react-cookie"
 import { getProfile } from "../authentication/profile"
 import { useUser } from "../queries/user"
+import FourOThreePage from "../errors/403page"
 
 export const UserQuery: React.FC = () => {
   const { orcid } = useParams()
@@ -21,6 +22,10 @@ export const UserQuery: React.FC = () => {
   }
 
   if (loading) return <div>Loading...</div>
+
+  if (!profile?.admin && user.profilePrivate) {
+    return <FourOThreePage />
+  }
 
   // is admin or profile matches id from the user data being returned
   const isUser = (user?.id === profile?.sub) ? true : false

--- a/packages/openneuro-server/src/graphql/resolvers/user.ts
+++ b/packages/openneuro-server/src/graphql/resolvers/user.ts
@@ -25,6 +25,7 @@ export type GraphQLUserType = {
   githubSynced: Date
   links: string[]
   orcidConsent: boolean | null
+  profilePrivate: boolean
 }
 
 export async function user(
@@ -50,6 +51,7 @@ export async function user(
       githubSynced: oneWeekAgo,
       links: [],
       orcidConsent: true,
+      profilePrivate: false,
       created: oneWeekAgo,
       lastSeen: new Date(),
       updatedAt: oneWeekAgo,
@@ -232,12 +234,13 @@ export const setBlocked = (
 
 export const updateUser = async (
   obj: unknown,
-  { id, location, institution, links, orcidConsent }: {
+  { id, location, institution, links, orcidConsent, profilePrivate }: {
     id: string
     location?: string
     institution?: string
     links?: string[]
     orcidConsent?: boolean
+    profilePrivate?: boolean
   },
   { userInfo }: GraphQLContext,
 ) => {
@@ -270,6 +273,7 @@ export const updateUser = async (
     if (institution !== undefined) user.institution = institution
     if (links !== undefined) user.links = links
     if (orcidConsent !== undefined) user.orcidConsent = orcidConsent
+    if (profilePrivate !== undefined) user.profilePrivate = profilePrivate
 
     await user.save()
 

--- a/packages/openneuro-server/src/graphql/schema/mutation.ts
+++ b/packages/openneuro-server/src/graphql/schema/mutation.ts
@@ -25,7 +25,7 @@ import {
   ValidatorInput,
 } from "./inputs"
 
-import Mutation from '../resolvers/mutation'
+import Mutation from "../resolvers/mutation"
 
 builder.mutationType({
   fields: (t) => ({
@@ -142,7 +142,8 @@ builder.mutationType({
         datasetId: t.arg.id({ required: true }),
         userId: t.arg.string({ required: true }),
       },
-      resolve: (root, args) => Mutation.removePermissions(root, args as never) as never,
+      resolve: (root, args) =>
+        Mutation.removePermissions(root, args as never) as never,
     }),
     removeUser: t.boolean({
       args: {
@@ -177,6 +178,7 @@ builder.mutationType({
         institution: t.arg.string(),
         links: t.arg.stringList(),
         orcidConsent: t.arg.boolean(),
+        profilePrivate: t.arg.boolean(),
       },
       resolve: (root, args, ctx) =>
         Mutation.updateUser(root, args as never, ctx),

--- a/packages/openneuro-server/src/graphql/schema/user.ts
+++ b/packages/openneuro-server/src/graphql/schema/user.ts
@@ -47,6 +47,7 @@ UserRef.implement({
       resolve: (obj, args, ctx) => notifications(obj, args, ctx),
     }),
     orcidConsent: t.boolean({ resolve: (obj) => obj.orcidConsent }),
+    profilePrivate: t.boolean({ resolve: (obj) => obj.profilePrivate }),
   }),
 })
 

--- a/packages/openneuro-server/src/models/user.ts
+++ b/packages/openneuro-server/src/models/user.ts
@@ -45,6 +45,8 @@ export interface UserDocument extends Document {
   githubSynced: Date
   // Defaults to NULL populated from ORCID Consent Form Mutation
   orcidConsent?: boolean | null
+  // Whether the user has opted out of public profile visibility
+  profilePrivate?: boolean
   givenName?: string
   familyName?: string
 }
@@ -72,6 +74,10 @@ const userSchema = new Schema({
   orcidConsent: {
     type: Boolean,
     default: null,
+  },
+  profilePrivate: {
+    type: Boolean,
+    default: false,
   },
 }, { timestamps: { createdAt: false, updatedAt: true } })
 


### PR DESCRIPTION
Allow users to opt out of public profiles. This mainly excludes the profile page from indexing. Site admin users can still browse and use the profile pages.