### PR TITLE
Add fitlins to list of derivative suffixies indexed from s3

### DIFF
--- a/packages/openneuro-server/src/graphql/resolvers/__tests__/derivatives.spec.ts
+++ b/packages/openneuro-server/src/graphql/resolvers/__tests__/derivatives.spec.ts
@@ -33,4 +33,15 @@ describe("GraphQL derivatives", () => {
       })
     })
   })
+  it("returns expected values for fmriprep", () => {
+      expect(derivativeObject("ds000002", "fitlins")).toEqual({
+        dataladUrl: new URL(
+          "https://github.com/OpenNeuroDerivatives/ds000002-fitlins.git",
+        ),
+        local: false,
+        name: "ds000002-fitlins",
+        s3Url: new URL("s3://openneuro-derivatives/fitlins/ds000002-fitlins"),
+      })
+    })
+
 })

--- a/packages/openneuro-server/src/graphql/resolvers/__tests__/derivatives.spec.ts
+++ b/packages/openneuro-server/src/graphql/resolvers/__tests__/derivatives.spec.ts
@@ -33,7 +33,7 @@ describe("GraphQL derivatives", () => {
       })
     })
   })
-  it("returns expected values for fmriprep", () => {
+  it("returns expected values for fitlins", () => {
       expect(derivativeObject("ds000002", "fitlins")).toEqual({
         dataladUrl: new URL(
           "https://github.com/OpenNeuroDerivatives/ds000002-fitlins.git",

--- a/packages/openneuro-server/src/graphql/resolvers/derivatives.ts
+++ b/packages/openneuro-server/src/graphql/resolvers/derivatives.ts
@@ -6,7 +6,7 @@ const S3_BUCKET = "openneuro-derivatives"
 const GITHUB_ORGANIZATION = "OpenNeuroDerivatives"
 
 // Available derivatives at this time
-type GitHubDerivative = "mriqc" | "fmriprep"
+type GitHubDerivative = "mriqc" | "fmriprep" | "fitlins"
 
 /**
  * Test for a derivative on GitHub via API
@@ -90,5 +90,9 @@ export const derivatives = async (
   if (await githubDerivative(datasetId, "fmriprep")) {
     available.push(derivativeObject(datasetId, "fmriprep"))
   }
+  if (await githubDerivative(datasetId, "fitlins")) {
+    available.push(derivativeObject(datasetId, "fitlins"))
+  }
+
   return available
 }


### PR DESCRIPTION
@jbwexler pushed the fitlins results to `s3://openneuro-derivatives` and the github org `OpenNeuroDerivatives` months ago.