### PR TITLE
fix(server): Return snapshot resolver created field unmodified

### DIFF
--- a/packages/openneuro-server/src/graphql/resolvers/snapshots.ts
+++ b/packages/openneuro-server/src/graphql/resolvers/snapshots.ts
@@ -54,7 +54,6 @@ export const snapshot = (obj, { datasetId, tag }, context: GraphQLContext) => {
     () => {
       return datalad.getSnapshot(datasetId, tag).then((snapshot) => ({
         ...snapshot,
-        created: snapshot.created ? new Date(snapshot.created) : undefined,
         datasetId,
         dataset: () => dataset(snapshot, { id: datasetId }, context),
         description: () => description(snapshot),


### PR DESCRIPTION
Fixes #3940. The created field can pass the raw string on the input side of the DateTime scalar which is interpreted as seconds instead of milliseconds.