### PR TITLE
fix(cli): Log server side push failure messages

### DIFF
--- a/cli/src/worker/git.ts
+++ b/cli/src/worker/git.ts
@@ -466,7 +466,7 @@ async function push() {
     logger.info("Pushing git-annex branch...")
     // Git push git-annex
     await git.push(
-      { ...context.config(), ref: "git-annex" },
+      { ...context.config(), ref: "git-annex", onMessage: console.log },
     )
   }
 
@@ -499,7 +499,7 @@ async function push() {
     console.log("Pushing changes...")
     // Git push
     await git.push(
-      context.config(),
+      { ...context.config(), onMessage: console.log },
     )
     const url = new URL(context.repoEndpoint)
     console.log(


### PR DESCRIPTION
The server can provide useful error responses for git pushes and these are currently lost. Logging them allows a user to debug a per-receive rejected push.