### PR TITLE
feat(server): Add syncDatasetDois mutation to bulk update the DOIs records for all snapshots

### DIFF
--- a/packages/openneuro-server/src/graphql/resolvers/doi.ts
+++ b/packages/openneuro-server/src/graphql/resolvers/doi.ts
@@ -1,0 +1,104 @@
+import { checkAdmin } from "../permissions"
+import type { GraphQLContext } from "../builder"
+import { getSnapshots } from "../../datalad/snapshots"
+import Doi from "../../models/doi"
+import DeprecatedSnapshot from "../../models/deprecatedSnapshot"
+import { assembleMetadata } from "../../libs/doi/metadata"
+import { buildPayload, hideDoi, upsertDoi } from "../../libs/doi/index"
+
+export interface SnapshotDoiSyncResult {
+  tag: string
+  doi: string | null
+  deprecated: boolean
+  action: string
+  datacite: object | null
+  error: string | null
+}
+
+export const syncDatasetDois = async (
+  _obj,
+  { datasetId, dryRun = false }: { datasetId: string; dryRun?: boolean },
+  { user, userInfo }: GraphQLContext,
+) => {
+  await checkAdmin(user, userInfo)
+
+  const snapshots = await getSnapshots(datasetId)
+  if (!snapshots) return { snapshots: [] }
+
+  const results: SnapshotDoiSyncResult[] = []
+
+  for (const snapshot of snapshots) {
+    const { tag } = snapshot
+    const deprecatedSnapshotId = `${datasetId}:${tag}`
+
+    const doiRecord = await Doi.findOne({ datasetId, snapshotId: tag })
+      .lean()
+      .exec()
+    if (!doiRecord) {
+      results.push({
+        tag,
+        doi: null,
+        deprecated: false,
+        action: "skip",
+        datacite: null,
+        error: null,
+      })
+      continue
+    }
+
+    const deprecatedRecord = await DeprecatedSnapshot.findOne({
+      id: deprecatedSnapshotId,
+    })
+      .lean()
+      .exec()
+    const isDeprecated = !!deprecatedRecord
+
+    let action: string
+    let datacite: object | null = null
+    let error: string | null = null
+
+    if (isDeprecated) {
+      if (doiRecord.state === "findable") {
+        action = "hide"
+        if (!dryRun) {
+          try {
+            await hideDoi(doiRecord.doi)
+            await Doi.updateOne(
+              { datasetId, snapshotId: tag },
+              { state: "registered" },
+            )
+          } catch (e) {
+            action = "error"
+            error = String(e)
+          }
+        }
+      } else {
+        action = "skip"
+      }
+    } else {
+      action = "update_metadata"
+      try {
+        const attributes = await assembleMetadata(datasetId, tag, tag)
+        datacite = attributes
+        if (!dryRun) {
+          const payload = buildPayload(attributes)
+          await upsertDoi(payload)
+        }
+      } catch (e) {
+        action = "error"
+        error = String(e)
+      }
+    }
+
+    results.push({
+      tag,
+      doi: doiRecord.doi,
+      deprecated: isDeprecated,
+      action,
+      datacite,
+      error,
+    })
+  }
+
+  return { snapshots: results }
+}

--- a/packages/openneuro-server/src/graphql/resolvers/mutation.ts
+++ b/packages/openneuro-server/src/graphql/resolvers/mutation.ts
@@ -56,6 +56,7 @@ import { fsckDataset, updateFileCheck } from "./fileCheck"
 import { holdDeletion } from "./holdDeletion"
 import { updateContributors } from "../../datalad/contributors"
 import { updateWorkerTask } from "./worker"
+import { syncDatasetDois } from "./doi"
 
 const Mutation = {
   createDataset,
@@ -114,6 +115,7 @@ const Mutation = {
   updateEventStatus,
   updateContributors,
   updateWorkerTask,
+  syncDatasetDois,
 }
 
 export default Mutation

--- a/packages/openneuro-server/src/graphql/schema/misc.ts
+++ b/packages/openneuro-server/src/graphql/schema/misc.ts
@@ -152,3 +152,29 @@ export const DatasetDerivatives = builder.simpleObject("DatasetDerivatives", {
     dataladUrl: t.string(),
   }),
 })
+
+export const SnapshotDoiSyncResult = builder.simpleObject(
+  "SnapshotDoiSyncResult",
+  {
+    fields: (t) => ({
+      tag: t.string({ nullable: false }),
+      doi: t.string(),
+      deprecated: t.boolean({ nullable: false }),
+      action: t.string({ nullable: false }),
+      datacite: t.field({ type: "JSON" }),
+      error: t.string(),
+    }),
+  },
+)
+
+export const SyncDatasetDoisPayload = builder.simpleObject(
+  "SyncDatasetDoisPayload",
+  {
+    fields: (t) => ({
+      snapshots: t.field({
+        type: [SnapshotDoiSyncResult],
+        nullable: false,
+      }),
+    }),
+  },
+)

--- a/packages/openneuro-server/src/graphql/schema/mutation.ts
+++ b/packages/openneuro-server/src/graphql/schema/mutation.ts
@@ -5,7 +5,12 @@ import { Description, UpdateContributorsPayload } from "./description"
 import { Summary } from "./metadata"
 import { Metadata } from "./metadata"
 import { UploadMetadata } from "./upload"
-import { FileCheck, RepoMetadata, UserNotificationStatus } from "./misc"
+import {
+  FileCheck,
+  RepoMetadata,
+  SyncDatasetDoisPayload,
+  UserNotificationStatus,
+} from "./misc"
 import { DatasetReviewer } from "./reviewer"
 import { WorkerTask } from "./worker"
 import { FollowDatasetResponse, StarDatasetResponse } from "./misc"
@@ -546,6 +551,16 @@ builder.mutationType({
       },
       resolve: (root, args, ctx) =>
         Mutation.updateWorkerTask(root, args as never, ctx),
+    }),
+    syncDatasetDois: t.field({
+      type: SyncDatasetDoisPayload,
+      nullable: false,
+      args: {
+        datasetId: t.arg.id({ required: true }),
+        dryRun: t.arg.boolean(),
+      },
+      resolve: (root, args, ctx) =>
+        Mutation.syncDatasetDois(root, args as never, ctx) as never,
     }),
   }),
 })


### PR DESCRIPTION
Add a mutation to sync the datacite DOI metadata for all snapshots of a given dataset and update the state based on if the snapshot has been deprecated. Includes a dry run flag and a response field to preview the metadata sent to allow for scripting bulk updates with quick review.