### PR TITLE
fix(cli): Align very long annex object extension (32+ character) behavior with git-annex

### DIFF
--- a/cli/src/worker/annex.ts
+++ b/cli/src/worker/annex.ts
@@ -94,7 +94,14 @@ export async function annexAdd(
   let extension = ""
   if (hash.endsWith("E")) {
     const filename = basename(relativePath)
-    extension = filename.substring(filename.indexOf("."))
+    const dotIndex = filename.indexOf(".")
+    if (dotIndex !== -1) {
+      extension = filename.substring(dotIndex)
+      // Prevent excessively long extensions from violating OS file path limits
+      if (extension.length > 32) {
+        extension = filename.substring(filename.lastIndexOf(".")).slice(0, 32)
+      }
+    }
   }
   // Compute hash
   const computeHash = hash.startsWith("MD5")


### PR DESCRIPTION
The CLI would calculate a different annex object path than git-annex if all extensions for a file was longer than 32 characters. Git-annex trims these to prevent excessively long filenames.