### PR TITLE
fix(server): Add fallback for older DOIs in syncDatasetDois

### DIFF
--- a/packages/openneuro-server/src/graphql/resolvers/doi.ts
+++ b/packages/openneuro-server/src/graphql/resolvers/doi.ts
@@ -4,7 +4,14 @@ import { getSnapshots } from "../../datalad/snapshots"
 import Doi from "../../models/doi"
 import DeprecatedSnapshot from "../../models/deprecatedSnapshot"
 import { assembleMetadata } from "../../libs/doi/metadata"
-import { buildPayload, hideDoi, upsertDoi } from "../../libs/doi/index"
+import type { DoiState } from "../../types/datacite"
+import {
+  buildPayload,
+  createDOI,
+  fetchDoiFromDatacite,
+  hideDoi,
+  upsertDoi,
+} from "../../libs/doi/index"
 
 export interface SnapshotDoiSyncResult {
   tag: string
@@ -31,19 +38,51 @@ export const syncDatasetDois = async (
     const { tag } = snapshot
     const deprecatedSnapshotId = `${datasetId}:${tag}`
 
-    const doiRecord = await Doi.findOne({ datasetId, snapshotId: tag })
+    let doiRecord = await Doi.findOne({ datasetId, snapshotId: tag })
       .lean()
       .exec()
     if (!doiRecord) {
-      results.push({
-        tag,
-        doi: null,
-        deprecated: false,
-        action: "skip",
-        datacite: null,
-        error: null,
-      })
-      continue
+      const expectedDoi = createDOI(datasetId, tag)
+      // eslint-disable-next-line no-useless-assignment
+      let dataciteRecord: { doi: string; state: DoiState } | null = null
+      try {
+        dataciteRecord = await fetchDoiFromDatacite(expectedDoi)
+      } catch (e) {
+        results.push({
+          tag,
+          doi: null,
+          deprecated: false,
+          action: "error",
+          datacite: null,
+          error: String(e),
+        })
+        continue
+      }
+      if (!dataciteRecord) {
+        results.push({
+          tag,
+          doi: null,
+          deprecated: false,
+          action: "skip",
+          datacite: null,
+          error: null,
+        })
+        continue
+      }
+      if (!dryRun) {
+        await Doi.create({
+          datasetId,
+          snapshotId: tag,
+          doi: dataciteRecord.doi,
+          state: dataciteRecord.state,
+        })
+      }
+      doiRecord = {
+        datasetId,
+        snapshotId: tag,
+        doi: dataciteRecord.doi,
+        state: dataciteRecord.state,
+      } as typeof doiRecord
     }
 
     const deprecatedRecord = await DeprecatedSnapshot.findOne({

--- a/packages/openneuro-server/src/libs/doi/index.ts
+++ b/packages/openneuro-server/src/libs/doi/index.ts
@@ -1,5 +1,9 @@
 import config from "../../config"
-import type { DataCite, DataciteDoiRequest } from "../../types/datacite"
+import type {
+  DataCite,
+  DataciteDoiRequest,
+  DoiState,
+} from "../../types/datacite"
 
 /**
  * @param {Object} doiConfig
@@ -120,4 +124,31 @@ export async function publishDoi(doi: string): Promise<void> {
  */
 export async function hideDoi(doi: string): Promise<void> {
   await updateDoiState(doi, "hide")
+}
+
+/**
+ * Fetch a DOI record from DataCite. Returns the DOI string and state if it
+ * exists, or null if it does not (404). Throws on other errors.
+ */
+export async function fetchDoiFromDatacite(
+  doi: string,
+): Promise<{ doi: string; state: DoiState } | null> {
+  const url = `${config.doi.url}dois/${encodeURIComponent(doi)}`
+  const response = await fetch(url, {
+    headers: { Authorization: formatBasicAuth(config.doi) },
+  })
+  if (response.status === 404) return null
+  if (!response.ok) {
+    const body = await response.text()
+    throw new Error(
+      `Datacite API error ${response.status} fetching ${doi}: ${body}`,
+    )
+  }
+  const json = (await response.json()) as {
+    data: { attributes: { doi: string; state: string } }
+  }
+  return {
+    doi: json.data.attributes.doi,
+    state: json.data.attributes.state as DoiState,
+  }
 }


### PR DESCRIPTION
Syncing would skip too many older DOIs that don't have a database model record. Add a fallback to check the DataCite API and create the missing database record.