### PR TITLE
fix(server): Set publication year on DOI updates based on snapshot date

### DIFF
--- a/packages/openneuro-server/src/graphql/resolvers/doi.ts
+++ b/packages/openneuro-server/src/graphql/resolvers/doi.ts
@@ -117,7 +117,12 @@ export const syncDatasetDois = async (
     } else {
       action = "update_metadata"
       try {
-        const attributes = await assembleMetadata(datasetId, tag, tag)
+        const attributes = await assembleMetadata(
+          datasetId,
+          tag,
+          tag,
+          snapshot.created,
+        )
         datacite = attributes
         if (!dryRun) {
           const payload = buildPayload(attributes)

--- a/packages/openneuro-server/src/handlers/doi.ts
+++ b/packages/openneuro-server/src/handlers/doi.ts
@@ -26,7 +26,12 @@ export async function createSnapshotDoi(req, res) {
   }
 
   try {
-    const attributes = await assembleMetadata(datasetId, snapshotId)
+    const attributes = await assembleMetadata(
+      datasetId,
+      snapshotId,
+      snapshotId,
+      snapExists.created,
+    )
     const doi = await createDraftDoi(attributes)
 
     await Doi.updateOne(

--- a/packages/openneuro-server/src/libs/doi/metadata.ts
+++ b/packages/openneuro-server/src/libs/doi/metadata.ts
@@ -20,6 +20,7 @@ export async function assembleMetadata(
   datasetId: string,
   snapshotId: string,
   revision?: string,
+  snapshotDate?: Date,
 ): Promise<DataCite> {
   const doi = createDOI(datasetId, snapshotId)
   const url = `${config.url}/datasets/${datasetId}/versions/${snapshotId}`
@@ -84,7 +85,7 @@ export async function assembleMetadata(
     creators: creators as DataCite["creators"],
     titles: titles as DataCite["titles"],
     publisher: { name: "OpenNeuro" },
-    publicationYear: String(new Date().getFullYear()),
+    publicationYear: String((snapshotDate ?? new Date()).getFullYear()),
     types: {
       resourceTypeGeneral: "Dataset",
       ...(resourceType ? { resourceType } : {}),


### PR DESCRIPTION
Use the snapshot creation time instead of the current date for publication year in DOIs.