### PR TITLE
fix(server): Coerce string dates in assembleMetadata

### DIFF
--- a/packages/openneuro-server/src/libs/doi/metadata.ts
+++ b/packages/openneuro-server/src/libs/doi/metadata.ts
@@ -20,7 +20,7 @@ export async function assembleMetadata(
   datasetId: string,
   snapshotId: string,
   revision?: string,
-  snapshotDate?: Date,
+  snapshotDate?: Date | string,
 ): Promise<DataCite> {
   const doi = createDOI(datasetId, snapshotId)
   const url = `${config.url}/datasets/${datasetId}/versions/${snapshotId}`
@@ -85,7 +85,8 @@ export async function assembleMetadata(
     creators: creators as DataCite["creators"],
     titles: titles as DataCite["titles"],
     publisher: { name: "OpenNeuro" },
-    publicationYear: String((snapshotDate ?? new Date()).getFullYear()),
+    publicationYear: (snapshotDate ? new Date(snapshotDate) : new Date())
+      .getFullYear().toString(),
     types: {
       resourceTypeGeneral: "Dataset",
       ...(resourceType ? { resourceType } : {}),


### PR DESCRIPTION
One more bug for DOI syncing features. The string case needs to be handled to prevent an error when fetching snapshot data from the worker.