### PR TITLE
chore(server): Fix duplicate index warning for WorkerTask collection

### DIFF
--- a/packages/openneuro-server/src/models/worker-task.ts
+++ b/packages/openneuro-server/src/models/worker-task.ts
@@ -28,8 +28,6 @@ const workerTaskSchema = new Schema({
   executionTime: { type: Number },
 })
 
-workerTaskSchema.index({ id: 1 })
-
 const WorkerTaskModel = model<WorkerTaskDocument>(
   "WorkerTask",
   workerTaskSchema,


### PR DESCRIPTION
Unique implies index creation. Fixes a warning.