### PR TITLE
fix(cli): Show --help if no arguments are provided

### DIFF
--- a/cli/src/options.ts
+++ b/cli/src/options.ts
@@ -46,6 +46,10 @@ export async function commandLine(
 ): Promise<OpenNeuroOptions> {
   const { args, options } = await openneuroCommand.parse(argumentOverride)
 
+  if (args.length === 0) {
+    openneuroCommand.showHelp()
+    Deno.exit(1)
+  }
   return {
     datasetPath: args[0] as string,
     ...options,


### PR DESCRIPTION
Show `--help` if no arguments are provided.