### PR TITLE
fix(worker): Add public tag to enableremote updates

### DIFF
--- a/services/datalad/datalad_service/common/s3.py
+++ b/services/datalad/datalad_service/common/s3.py
@@ -20,7 +20,7 @@ class S3ConfigException(Exception):
     pass
 
 
-def generate_s3_annex_options(dataset_path, backup=False, include_tagging=True):
+def generate_s3_annex_options(dataset_path, backup=False, public=False):
     dataset_id = os.path.basename(dataset_path)
     annex_options = [
         'type=S3',
@@ -45,7 +45,9 @@ def generate_s3_annex_options(dataset_path, backup=False, include_tagging=True):
             'autoenable=true',
             f'publicurl=https://s3.amazonaws.com/{get_s3_bucket()}',
         ]
-        if include_tagging:
+        if public:
+            annex_options.append('x-amz-tagging=access=public')
+        else:
             annex_options.append('x-amz-tagging=access=private')
     return annex_options
 
@@ -63,12 +65,12 @@ def backup_remote_env():
     return backup_remote_env
 
 
-def setup_s3_sibling(dataset_path):
+def setup_s3_sibling(dataset_path, public=False):
     """Add a sibling for an S3 bucket publish."""
     # Public S3 bucket remote
     subprocess.run(
         ['git-annex', 'initremote', get_s3_remote()]
-        + generate_s3_annex_options(dataset_path),
+        + generate_s3_annex_options(dataset_path, public=public),
         cwd=dataset_path,
     )
 
@@ -130,14 +132,12 @@ def update_s3_sibling(dataset_path, public_dataset):
     """Update S3 remote with latest config."""
     # note: enableremote command will only upsert config options, none are deleted
     if not is_git_annex_remote(dataset_path, get_s3_remote()):
-        setup_s3_sibling(dataset_path)
+        setup_s3_sibling(dataset_path, public=public_dataset)
     else:
         # Update the remote config (and configure tagging for private datasets)
         subprocess.run(
             ['git-annex', 'enableremote', get_s3_remote()]
-            + generate_s3_annex_options(
-                dataset_path, include_tagging=(not public_dataset)
-            ),
+            + generate_s3_annex_options(dataset_path, public=public_dataset),
             check=True,
             cwd=dataset_path,
         )
@@ -148,9 +148,7 @@ def update_s3_sibling(dataset_path, public_dataset):
         # Update the backup remote config
         subprocess.run(
             ['git-annex', 'enableremote', get_s3_backup_remote()]
-            + generate_s3_annex_options(
-                dataset_path, backup=True, include_tagging=False
-            ),
+            + generate_s3_annex_options(dataset_path, backup=True),
             check=True,
             cwd=dataset_path,
             env=backup_remote_env(),
@@ -180,11 +178,9 @@ def validate_s3_config(dataset_path):
             options_line = line
     if options_line:
         # check that each of the expected annex options is what's actually configured
-        expected_options = generate_s3_annex_options(
-            dataset_path, include_tagging=False
-        )
+        expected_options = generate_s3_annex_options(dataset_path)
         for expected_option in expected_options:
-            if not expected_option in options_line:
+            if expected_option not in options_line:
                 return False
     return True
 


### PR DESCRIPTION
Fixes some cases where the public tag was not set on a public remote leading to private only exports.