### PR TITLE
fix(app): Shell quote URLs and filenames in generated download scripts

### DIFF
--- a/packages/openneuro-app/src/scripts/dataset/download/__tests__/download-script.spec.tsx
+++ b/packages/openneuro-app/src/scripts/dataset/download/__tests__/download-script.spec.tsx
@@ -56,7 +56,7 @@ describe("DownloadScript", () => {
   describe("generateDownloadScript()", () => {
     it("generates output grouped in an accession number directory", async () => {
       const script = generateDownloadScript(mockData)
-      expect(script).toContain("-o ds000001-1.0.0/stimuli/meg/f074.bmp")
+      expect(script).toContain("-o 'ds000001-1.0.0/stimuli/meg/f074.bmp'")
     })
   })
 })

--- a/packages/openneuro-app/src/scripts/dataset/download/download-script.tsx
+++ b/packages/openneuro-app/src/scripts/dataset/download/download-script.tsx
@@ -25,7 +25,9 @@ export function generateDownloadScript(data): string {
   const directory = data.snapshot.id.split(":").join("-")
   let script = "#!/bin/sh\n"
   for (const f of data.snapshot.files) {
-    script += `curl --create-dirs ${f.urls[0]} -o ${directory}/${f.filename}\n`
+    script += `curl --create-dirs '${
+      f.urls[0]
+    }' -o '${directory}/${f.filename}'\n`
   }
   return script
 }


### PR DESCRIPTION
Minor fix for filenames with shell characters in them, single quote filenames and the URLs passed to curl in our generated download scripts.

Fixes #2962 