### PR TITLE
refactor(worker): Drop commit_files and run validation via on_head hook

### DIFF
--- a/services/datalad/datalad_service/common/onchange.py
+++ b/services/datalad/datalad_service/common/onchange.py
@@ -1,8 +1,16 @@
+from pathlib import Path
+
+import pygit2
+
 from datalad_service.tasks.fsck import git_annex_fsck_local
+from datalad_service.tasks.validator import validate_dataset
 
 
 async def on_head(dataset_path):
     """Called after any change to HEAD."""
+    dataset_id = Path(dataset_path).name
+    ref = pygit2.Repository(dataset_path).head.target
+    await validate_dataset.kiq(dataset_id, dataset_path, str(ref))
     await git_annex_fsck_local.kiq(dataset_path)
 
 

--- a/services/datalad/datalad_service/handlers/draft.py
+++ b/services/datalad/datalad_service/handlers/draft.py
@@ -47,20 +47,13 @@ class DraftResource:
             if name and email:
                 media_dict['name'] = name
                 media_dict['email'] = email
-            try:
-                dataset_path = self.store.get_dataset_path(dataset)
-                repo = pygit2.Repository(dataset_path)
-                # Add all changes to the index
-                if name and email:
-                    author = pygit2.Signature(name, email)
-                    media_dict['ref'] = str(await git_commit(repo, ['.'], author))
-                else:
-                    media_dict['ref'] = str(await git_commit(repo, ['.']))
-                resp.media = media_dict
-                resp.status = falcon.HTTP_OK
-            except:
-                raise
-                resp.status = falcon.HTTP_INTERNAL_SERVER_ERROR
+            dataset_path = self.store.get_dataset_path(dataset)
+            repo = pygit2.Repository(dataset_path)
+            # Add all changes to the index
+            author = pygit2.Signature(name, email) if name and email else None
+            media_dict['ref'] = str(await git_commit(repo, ['.'], author))
+            resp.media = media_dict
+            resp.status = falcon.HTTP_OK
         else:
             resp.media = {'error': 'Missing or malformed dataset parameter in request.'}
             resp.status = falcon.HTTP_UNPROCESSABLE_ENTITY

--- a/services/datalad/datalad_service/handlers/reset.py
+++ b/services/datalad/datalad_service/handlers/reset.py
@@ -2,7 +2,6 @@ import falcon
 import subprocess
 
 from datalad_service.common.user import get_user_info
-from datalad_service.tasks.files import commit_files
 
 
 class ResetResource:

--- a/services/datalad/datalad_service/handlers/upload.py
+++ b/services/datalad/datalad_service/handlers/upload.py
@@ -33,9 +33,7 @@ async def move_files(upload_path, dataset_path):
             await aioshutil.move(str(filename), target)
 
 
-async def move_files_into_repo(
-    dataset_id, dataset_path, upload_path, name, email, cookies
-):
+async def move_files_into_repo(dataset_path, upload_path, name, email):
     repo = pygit2.Repository(dataset_path)
     unlock_files = [
         os.path.relpath(filename, start=upload_path)
@@ -45,11 +43,8 @@ async def move_files_into_repo(
         )
     ]
     await move_files(upload_path, dataset_path)
-    if name and email:
-        author = pygit2.Signature(name, email)
-        hexsha = str(await git_commit(repo, unlock_files, author))
-    else:
-        hexsha = str(await git_commit(repo, unlock_files))
+    author = pygit2.Signature(name, email) if name and email else None
+    await git_commit(repo, unlock_files, author)
 
 
 class UploadResource:
@@ -57,13 +52,11 @@ class UploadResource:
         self.store = store
         self.logger = logging.getLogger('datalad_service.' + __name__)
 
-    async def _finish_upload(self, dataset_id, upload, name, email, cookies):
+    async def _finish_upload(self, dataset_id, upload, name, email):
         try:
             dataset_path = self.store.get_dataset_path(dataset_id)
             upload_path = self.store.get_upload_path(dataset_id, upload)
-            await move_files_into_repo(
-                dataset_id, dataset_path, upload_path, name, email, cookies
-            )
+            await move_files_into_repo(dataset_path, upload_path, name, email)
             await aioshutil.rmtree(upload_path)
         except:
             self.logger.exception('Dataset upload could not be finalized')
@@ -71,6 +64,6 @@ class UploadResource:
     async def on_post(self, req, resp, dataset, upload):
         """Copy uploaded data into dataset"""
         name, email = get_user_info(req)
-        await self._finish_upload(dataset, upload, name, email, req.cookies)
+        await self._finish_upload(dataset, upload, name, email)
         resp.media = {}
         resp.status = falcon.HTTP_OK

--- a/services/datalad/datalad_service/tasks/description.py
+++ b/services/datalad/datalad_service/tasks/description.py
@@ -2,9 +2,10 @@ import aiofiles
 import json
 import os
 
+import pygit2
+
 from datalad_service.common.annex import edit_annexed_file
-from datalad_service.common.git import git_show_content
-from datalad_service.tasks.files import commit_files
+from datalad_service.common.git import git_commit, git_show_content
 
 
 def edit_description(description, new_fields):
@@ -31,10 +32,8 @@ async def update_description(store, dataset, description_fields, name=None, emai
         new_content = json.dumps(updated, indent=4, ensure_ascii=False)
         new_content += '\n'
         await edit_annexed_file(path, description, new_content)
-        # Commit new content, run validator
-        await commit_files(
-            store, dataset, ['dataset_description.json'], name=name, email=email
-        )
+        author = pygit2.Signature(name, email) if name and email else None
+        await git_commit(repo, ['dataset_description.json'], author)
         return updated
     else:
         return description_json

--- a/services/datalad/datalad_service/tasks/files.py
+++ b/services/datalad/datalad_service/tasks/files.py
@@ -7,36 +7,10 @@ import boto3
 import botocore
 import pygit2
 
-from datalad_service.common.git import (
-    git_commit,
-    git_commit_index,
-    COMMITTER_EMAIL,
-    COMMITTER_NAME,
-)
-from datalad_service.tasks.validator import validate_dataset
+from datalad_service.common.git import git_commit_index
 from datalad_service.config import AWS_ACCESS_KEY_ID
 from datalad_service.config import AWS_SECRET_ACCESS_KEY
 from datalad_service.config import AWS_S3_PUBLIC_BUCKET
-
-
-async def commit_files(store, dataset, files, name=None, email=None, cookies=None):
-    """
-    Commit a list of files with the email and name provided.
-
-    Returns the commit hash generated.
-    """
-    dataset_path = store.get_dataset_path(dataset)
-    repo = pygit2.Repository(dataset_path)
-    author = (
-        name
-        and email
-        and pygit2.Signature(name, email)
-        or pygit2.Signature(COMMITTER_NAME, COMMITTER_EMAIL)
-    )
-    ref = await git_commit(repo, files, author)
-    # Run the validator but don't block on the request
-    await validate_dataset.kiq(dataset, dataset_path, str(ref), cookies)
-    return ref
 
 
 async def remove_files(store, dataset, paths, name=None, email=None, cookies=None):
@@ -49,9 +23,7 @@ async def remove_files(store, dataset, paths, name=None, email=None, cookies=Non
     repo.index.remove_all(paths)
     repo.index.write()
     repo.checkout_index()
-    hexsha = str(
-        await git_commit_index(repo, author, message='[OpenNeuro] Files removed')
-    )
+    await git_commit_index(repo, author, message='[OpenNeuro] Files removed')
 
 
 def parse_s3_annex_url(url, bucket_name=AWS_S3_PUBLIC_BUCKET):

--- a/services/datalad/datalad_service/tasks/remote_import.py
+++ b/services/datalad/datalad_service/tasks/remote_import.py
@@ -1,3 +1,4 @@
+import asyncio
 import os
 import shutil
 import traceback
@@ -13,9 +14,7 @@ def download_file(url, destination_filename):
             shutil.copyfileobj(r.raw, f)
 
 
-def remote_dataset_import(
-    dataset_path, upload_path, import_id, url, name, email, cookies
-):
+def remote_dataset_import(dataset_path, upload_path, import_id, url, name, email):
     """Given a zip file URL, download and unpack the URL into a dataset."""
     download_path = os.path.join(upload_path, f'{import_id}.zip')
     os.makedirs(upload_path, exist_ok=True)
@@ -32,9 +31,8 @@ def remote_dataset_import(
     else:
         data_path = os.path.join(unpack_path, top_level_dirs[0])
 
-    # Copy into the repo
-    dataset_id = os.path.basename(dataset_path)
-    move_files_into_repo(dataset_id, dataset_path, data_path, name, email, cookies)
+    # Copy into the repo (this task runs sync in an executor thread)
+    asyncio.run(move_files_into_repo(dataset_path, data_path, name, email))
 
     # Clean up all upload temporary data
     shutil.rmtree(upload_path)
@@ -67,9 +65,7 @@ def remote_import(dataset_path, upload_path, import_id, url, name, email, cookie
     success = True
     message = ''
     try:
-        remote_dataset_import(
-            dataset_path, upload_path, import_id, url, name, email, cookies
-        )
+        remote_dataset_import(dataset_path, upload_path, import_id, url, name, email)
     except Exception as e:
         success = False
         message = ''.join(traceback.format_exception(type(e), e, e.__traceback__))

--- a/services/datalad/datalad_service/tasks/snapshots.py
+++ b/services/datalad/datalad_service/tasks/snapshots.py
@@ -5,10 +5,9 @@ import re
 import pygit2
 
 from datalad_service.common.annex import edit_annexed_file
-from datalad_service.common.git import git_show, git_show_content, git_tag
+from datalad_service.common.git import git_commit, git_show, git_show_content, git_tag
 from datalad_service.tasks.dataset import create_datalad_config
 from datalad_service.tasks.description import update_description
-from datalad_service.tasks.files import commit_files
 from datalad_service.common.onchange import on_tag
 
 
@@ -131,8 +130,7 @@ async def update_changes(store, dataset, tag, new_changes):
     if new_changes is not None and len(new_changes) > 0:
         current_date = datetime.today().strftime('%Y-%m-%d')
         updated = await write_new_changes(dataset_path, tag, new_changes, current_date)
-        # Commit new content, run validator
-        await commit_files(store, dataset, ['CHANGES'])
+        await git_commit(pygit2.Repository(dataset_path), ['CHANGES'])
         return updated
     else:
         return await get_head_changes(dataset_path)
@@ -154,7 +152,7 @@ async def validate_datalad_config(store, dataset):
         git_show(repo, 'HEAD', '.datalad/config')
     except KeyError:
         create_datalad_config(dataset_path)
-        await commit_files(store, dataset, ['.datalad/config'])
+        await git_commit(repo, ['.datalad/config'])
 
 
 async def save_snapshot(store, dataset, snapshot):

--- a/services/datalad/tests/conftest.py
+++ b/services/datalad/tests/conftest.py
@@ -246,16 +246,13 @@ def mock_validate_dataset_task(monkeypatch):
     """
     Mocks the validate_dataset task to prevent event loop errors in tests.
     """
-
-    async def async_noop_validator(*args, **kwargs):
-        return None
-
-    # Mock task kiq for taskiq
-    async_noop_validator.kiq = async_noop_validator
-
+    mock_kiq = mock.AsyncMock()
+    # The kiq method is what's called to enqueue the task.
+    # We mock it on the task object itself.
     monkeypatch.setattr(
-        'datalad_service.tasks.files.validate_dataset', async_noop_validator
+        'datalad_service.tasks.validator.validate_dataset.kiq', mock_kiq
     )
+    yield mock_kiq
 
 
 @pytest.fixture(autouse=True)

--- a/services/datalad/tests/test_datalad.py
+++ b/services/datalad/tests/test_datalad.py
@@ -8,9 +8,8 @@ import pygit2
 from datalad.api import Dataset
 
 from datalad_service.common.annex import init_annex
-from datalad_service.common.git import OpenNeuroGitError
+from datalad_service.common.git import OpenNeuroGitError, git_commit
 from datalad_service.tasks.dataset import create_dataset, delete_dataset
-from datalad_service.tasks.files import commit_files
 
 
 async def test_create_dataset(datalad_store):
@@ -45,7 +44,7 @@ async def test_create_dataset_master(datalad_store):
     file_path = os.path.join(ds.path, 'LICENSE')
     with open(file_path, 'w') as fd:
         fd.write("""MIT""")
-    await commit_files(datalad_store, ds_id, ['LICENSE'])
+    await git_commit(repo, ['LICENSE'])
     # Verify the branch is now set to main
     assert ds.repo.get_active_branch() == 'main'
 
@@ -71,6 +70,6 @@ async def test_commit_file(datalad_store, new_dataset):
     file_path = os.path.join(new_dataset.path, 'LICENSE')
     with open(file_path, 'w') as fd:
         fd.write("""GPL""")
-    await commit_files(datalad_store, ds_id, ['LICENSE'])
+    await git_commit(pygit2.Repository(new_dataset.path), ['LICENSE'])
     dataset = Dataset(os.path.join(datalad_store.annex_path, ds_id))
     assert not dataset.repo.dirty

--- a/services/datalad/tests/test_draft.py
+++ b/services/datalad/tests/test_draft.py
@@ -35,3 +35,18 @@ def test_get_draft(client, new_dataset):
     response = client.simulate_get(f'/datasets/{ds_id}/draft')
     assert response.status == falcon.HTTP_OK
     assert len(json.loads(response.content)['hexsha']) == 40
+
+
+def test_draft_commit_runs_validation(client, new_dataset, mock_validate_dataset_task):
+    ds_id = os.path.basename(new_dataset.path)
+    response = client.simulate_post(
+        f'/datasets/{ds_id}/files/NEW_FILE', body='new file contents'
+    )
+    assert response.status == falcon.HTTP_OK
+    mock_validate_dataset_task.reset_mock()
+    response = client.simulate_post(f'/datasets/{ds_id}/draft')
+    assert response.status == falcon.HTTP_OK
+    ref = json.loads(response.content)['ref']
+    dataset_id, dataset_path, validated_ref = mock_validate_dataset_task.call_args.args
+    assert dataset_id == ds_id
+    assert validated_ref == ref


### PR DESCRIPTION
Consolidate git_commit and commit_files. This runs validation for all changes where head advances. Avoids relying on the fallback validation in some cases (such as on file deletion).