### PR TITLE
Public object tagging fixes

### DIFF
--- a/services/datalad/datalad_service/common/s3.py
+++ b/services/datalad/datalad_service/common/s3.py
@@ -72,6 +72,7 @@ def setup_s3_sibling(dataset_path, public=False):
         ['git-annex', 'initremote', get_s3_remote()]
         + generate_s3_annex_options(dataset_path, public=public),
         cwd=dataset_path,
+        check=True,
     )
 
 

--- a/services/datalad/datalad_service/tasks/publish.py
+++ b/services/datalad/datalad_service/tasks/publish.py
@@ -71,9 +71,11 @@ async def create_remotes_and_export(dataset_path, public=False):
     Called by publish handler to make a dataset public initially.
     """
     create_remotes(dataset_path)
-    await export_dataset(dataset_path)
     if public:
         await set_remote_public(dataset_path)
+    await export_dataset(dataset_path)
+    if public:
+        await set_s3_access_tag(os.path.basename(dataset_path), 'public')
 
 
 def create_remotes(dataset_path):
@@ -311,7 +313,6 @@ async def set_remote_public(dataset_path):
         ['git-annex', 'enableremote', get_s3_remote(), 'x-amz-tagging=access=public'],
         dataset_path,
     )
-    await set_s3_access_tag(os.path.basename(dataset_path), 'public')
 
 
 def update_object_tag(client, s3_bucket, key, version_id, value):

--- a/services/datalad/datalad_service/tasks/publish.py
+++ b/services/datalad/datalad_service/tasks/publish.py
@@ -118,8 +118,11 @@ async def export_backup_and_drop(dataset_path):
                 await s3_export(dataset_path, get_s3_remote(), tag.name)
         await fsck_and_drop(dataset_path, [tag.name for tag in tags])
         logger.info(f'Exporting/dropping tags for {dataset_id} complete')
-    if not public_dataset:
-        logger.info(f'Setting access tag for {dataset_id}')
+    if public_dataset:
+        logger.info(f'Setting public access tag for {dataset_id}')
+        await set_s3_access_tag(dataset_id, 'public')
+    else:
+        logger.info(f'Setting private access tag for {dataset_id}')
         await set_s3_access_tag(dataset_id, 'private')
     logger.info(f'{dataset_id} export_backup_and_drop complete')
 

--- a/services/datalad/tests/test_publish.py
+++ b/services/datalad/tests/test_publish.py
@@ -4,7 +4,11 @@ from unittest.mock import AsyncMock, Mock, call, patch
 
 import falcon
 
-from datalad_service.tasks.publish import export_dataset, create_remotes, set_remote_public
+from datalad_service.tasks.publish import (
+    export_dataset,
+    create_remotes,
+    set_remote_public,
+)
 from datalad_service.common.annex import is_git_annex_remote
 
 
@@ -71,12 +75,10 @@ async def test_export_snapshots(no_init_remote, client, new_dataset):
 
 
 @patch('datalad_service.tasks.publish.run_check', new_callable=AsyncMock)
-@patch('datalad_service.tasks.publish.set_s3_access_tag', new_callable=AsyncMock)
-async def test_set_remote_public(mock_set_s3_access_tag, mock_run_check, new_dataset):
+async def test_set_remote_public(mock_run_check, new_dataset):
     await set_remote_public(new_dataset.path)
-    
+
     mock_run_check.assert_called_once_with(
         ['git-annex', 'enableremote', 's3-PUBLIC', 'x-amz-tagging=access=public'],
         new_dataset.path,
     )
-    mock_set_s3_access_tag.assert_called_once_with(os.path.basename(new_dataset.path), 'public')


### PR DESCRIPTION
A few more small fixes for possible public object tagging issues.

* Not throwing an error if initremote fails.
* Avoid retagging new objects on an export by updating the configuration first. This also prevents the update from getting skipped if the much longer export task is interrupted and not resumed.
* Set the public tag on export_backup_and_drop (not just private)