### PR TITLE
fix(worker): Restore access tags in set_remote_public

### DIFF
--- a/services/datalad/datalad_service/tasks/publish.py
+++ b/services/datalad/datalad_service/tasks/publish.py
@@ -72,7 +72,7 @@ async def create_remotes_and_export(dataset_path, public=False):
     """
     create_remotes(dataset_path)
     if public:
-        await set_remote_public(dataset_path)
+        await enableremote_tag_public(dataset_path)
     await export_dataset(dataset_path)
     if public:
         await set_s3_access_tag(os.path.basename(dataset_path), 'public')
@@ -311,7 +311,13 @@ async def annex_drop(dataset_path, branches):
 
 
 async def set_remote_public(dataset_path):
-    """Clear x-amz-meta-access when a dataset is made public."""
+    """Configure x-amz-meta-access when a dataset is made public and update the S3 access tags."""
+    await enableremote_tag_public(dataset_path)
+    await set_s3_access_tag(os.path.basename(dataset_path), 'public')
+
+
+async def enableremote_tag_public(dataset_path):
+    """Configure x-amz-meta-access when a dataset is made public."""
     await run_check(
         ['git-annex', 'enableremote', get_s3_remote(), 'x-amz-tagging=access=public'],
         dataset_path,

--- a/services/datalad/tests/test_publish.py
+++ b/services/datalad/tests/test_publish.py
@@ -75,10 +75,14 @@ async def test_export_snapshots(no_init_remote, client, new_dataset):
 
 
 @patch('datalad_service.tasks.publish.run_check', new_callable=AsyncMock)
-async def test_set_remote_public(mock_run_check, new_dataset):
+@patch('datalad_service.tasks.publish.set_s3_access_tag', new_callable=AsyncMock)
+async def test_set_remote_public(mock_set_s3_access_tag, mock_run_check, new_dataset):
     await set_remote_public(new_dataset.path)
 
     mock_run_check.assert_called_once_with(
         ['git-annex', 'enableremote', 's3-PUBLIC', 'x-amz-tagging=access=public'],
         new_dataset.path,
+    )
+    mock_set_s3_access_tag.assert_called_once_with(
+        os.path.basename(new_dataset.path), 'public'
     )


### PR DESCRIPTION
This was in use by the tag-public script, restores the original functionality and separates the enableremote call into another function.