### PR TITLE
fix(app): Remove stale @openneuro/client dependency

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -213,13 +213,6 @@ const RAW_RUNTIME_STATE =
       }]\
     ]],\
     ["@apollo/client", [\
-      ["npm:3.11.8", {\
-        "packageLocation": "./.yarn/cache/@apollo-client-npm-3.11.8-dc37a540fe-ea9f8d8e55.zip/node_modules/@apollo/client/",\
-        "packageDependencies": [\
-          ["@apollo/client", "npm:3.11.8"]\
-        ],\
-        "linkType": "SOFT"\
-      }],\
       ["npm:3.13.8", {\
         "packageLocation": "./.yarn/cache/@apollo-client-npm-3.13.8-c567dd23c8-a2fb3990ea.zip/node_modules/@apollo/client/",\
         "packageDependencies": [\
@@ -297,7 +290,7 @@ const RAW_RUNTIME_STATE =
           ["prop-types", "npm:15.7.2"],\
           ["react", "npm:18.2.0"],\
           ["react-dom", "virtual:6d9c0fee0b376eb0bb6824eb7a3246834ef21d870b31f75eebe59bb4d027e50f2607ba168fd29d446567f4e9c2a5cad2442c4741fa92c92e0b7e9145c3a3e3a7#npm:18.2.0"],\
-          ["rehackt", "virtual:700612a435c8f07f880398815cae177c1d52ef9a9599c39d2214205ded243670b954b7b3a913f88de23f6c008d78920baf22853a2c977f78789b6367447db7eb#npm:0.1.0"],\
+          ["rehackt", "virtual:612bb711624572f1aec3678d05acad098495d290e9f6b87238adb8d57dab10794dadb3e8ca5d8cb2768a0fd0c13a47e23ce78cde18343b38ced0590a46ded1ec#npm:0.1.0"],\
           ["subscriptions-transport-ws", null],\
           ["symbol-observable", "npm:4.0.0"],\
           ["ts-invariant", "npm:0.10.3"],\
@@ -341,48 +334,6 @@ const RAW_RUNTIME_STATE =
           ["react-dom", "virtual:5148e374b2f49833c3f7514c2095ec0af094f6c5e346ce4ba8adb95e0597e6f51ae2f2e99eac071ee032895cb0111a1d357ceb69109f0fefb6a34bd6fffe8d6d#npm:17.0.2"],\
           ["response-iterator", "npm:0.2.6"],\
           ["subscriptions-transport-ws", null],\
-          ["symbol-observable", "npm:4.0.0"],\
-          ["ts-invariant", "npm:0.10.3"],\
-          ["tslib", "npm:2.3.1"],\
-          ["zen-observable-ts", "npm:1.2.5"]\
-        ],\
-        "packagePeers": [\
-          "@types/graphql-ws",\
-          "@types/graphql",\
-          "@types/react-dom",\
-          "@types/react",\
-          "@types/subscriptions-transport-ws",\
-          "graphql-ws",\
-          "graphql",\
-          "react",\
-          "subscriptions-transport-ws"\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["virtual:cd7a862e0b955475fa0357e97cd56b069d38049d7f4ddc10830abcb7eb98ad100c2d3db85378520ca03e272094d53f153971b11fad649d897398edb231750ffb#npm:3.11.8", {\
-        "packageLocation": "./.yarn/__virtual__/@apollo-client-virtual-700612a435/0/cache/@apollo-client-npm-3.11.8-dc37a540fe-ea9f8d8e55.zip/node_modules/@apollo/client/",\
-        "packageDependencies": [\
-          ["@apollo/client", "virtual:cd7a862e0b955475fa0357e97cd56b069d38049d7f4ddc10830abcb7eb98ad100c2d3db85378520ca03e272094d53f153971b11fad649d897398edb231750ffb#npm:3.11.8"],\
-          ["@graphql-typed-document-node/core", "virtual:8233cac6686bf49bf82442079dc25221f6e5a51405accb24796911ef793ef9c58742843f148d9b1b9fc87d90d074c06211d7c3e35b5ce9cc76be6e3ebea9155e#npm:3.1.1"],\
-          ["@types/graphql", null],\
-          ["@types/graphql-ws", null],\
-          ["@types/react", null],\
-          ["@types/react-dom", null],\
-          ["@types/subscriptions-transport-ws", null],\
-          ["@wry/caches", "npm:1.0.1"],\
-          ["@wry/equality", "npm:0.5.7"],\
-          ["@wry/trie", "npm:0.5.0"],\
-          ["graphql", "npm:16.8.1"],\
-          ["graphql-tag", "virtual:8233cac6686bf49bf82442079dc25221f6e5a51405accb24796911ef793ef9c58742843f148d9b1b9fc87d90d074c06211d7c3e35b5ce9cc76be6e3ebea9155e#npm:2.12.6"],\
-          ["graphql-ws", null],\
-          ["hoist-non-react-statics", "npm:3.3.2"],\
-          ["optimism", "npm:0.18.0"],\
-          ["prop-types", "npm:15.7.2"],\
-          ["react", "npm:18.2.0"],\
-          ["react-dom", "virtual:700612a435c8f07f880398815cae177c1d52ef9a9599c39d2214205ded243670b954b7b3a913f88de23f6c008d78920baf22853a2c977f78789b6367447db7eb#npm:17.0.2"],\
-          ["rehackt", "virtual:700612a435c8f07f880398815cae177c1d52ef9a9599c39d2214205ded243670b954b7b3a913f88de23f6c008d78920baf22853a2c977f78789b6367447db7eb#npm:0.1.0"],\
-          ["response-iterator", "npm:0.2.6"],\
-          ["subscriptions-transport-ws", "virtual:cd7a862e0b955475fa0357e97cd56b069d38049d7f4ddc10830abcb7eb98ad100c2d3db85378520ca03e272094d53f153971b11fad649d897398edb231750ffb#npm:0.11.0"],\
           ["symbol-observable", "npm:4.0.0"],\
           ["ts-invariant", "npm:0.10.3"],\
           ["tslib", "npm:2.3.1"],\
@@ -486,7 +437,7 @@ const RAW_RUNTIME_STATE =
           ["@apollo/utils.logger", "npm:3.0.0"],\
           ["@apollo/utils.usagereporting", "virtual:c1bf08cce633f36ebfdad14cbc2fb0f6d7e713772070118b1222a2b09b2268ac26253df0fc39fbe20ce7172ad788400450fad3429a0601ea2f40f0ae53696953#npm:2.1.0"],\
           ["@apollo/utils.withrequired", "npm:3.0.0"],\
-          ["@graphql-tools/schema", "virtual:7551ce9da6a1d08fa7e13a80e2f973b491766328bd179cc2db79caffc61371ac135c2ad0ad653010fa4ab35dcca89d6c85968158f6af4813bc27a96b906e116a#npm:10.0.0"],\
+          ["@graphql-tools/schema", "virtual:6d9c0fee0b376eb0bb6824eb7a3246834ef21d870b31f75eebe59bb4d027e50f2607ba168fd29d446567f4e9c2a5cad2442c4741fa92c92e0b7e9145c3a3e3a7#npm:10.0.0"],\
           ["@types/graphql", null],\
           ["async-retry", "npm:1.3.3"],\
           ["body-parser", "npm:2.2.2"],\
@@ -2344,38 +2295,12 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "SOFT"\
       }],\
-      ["virtual:ffeefcb01a94ecc209d575011147be79722c0ebcafcbce04435dc0063cd956502253ee7389b85184221a04133c4e58c8bb65339bb155bd897a9b75c5ab0bf5ef#npm:9.0.0", {\
-        "packageLocation": "./.yarn/__virtual__/@graphql-tools-merge-virtual-5c6675c9ba/0/cache/@graphql-tools-merge-npm-9.0.0-757ea851f1-7bf74f71a2.zip/node_modules/@graphql-tools/merge/",\
+      ["virtual:1728807850d6df0af9808e024ec3115cb3a28ce8c7ad87b1d3ee8124c91d8ff09a08592411c8193e2748c7895f1c61da00300feeec8e95b0ed1136d58819aba8#npm:9.0.0", {\
+        "packageLocation": "./.yarn/__virtual__/@graphql-tools-merge-virtual-8ec19c6885/0/cache/@graphql-tools-merge-npm-9.0.0-757ea851f1-7bf74f71a2.zip/node_modules/@graphql-tools/merge/",\
         "packageDependencies": [\
-          ["@graphql-tools/merge", "virtual:ffeefcb01a94ecc209d575011147be79722c0ebcafcbce04435dc0063cd956502253ee7389b85184221a04133c4e58c8bb65339bb155bd897a9b75c5ab0bf5ef#npm:9.0.0"],\
-          ["@graphql-tools/utils", "virtual:7551ce9da6a1d08fa7e13a80e2f973b491766328bd179cc2db79caffc61371ac135c2ad0ad653010fa4ab35dcca89d6c85968158f6af4813bc27a96b906e116a#npm:10.0.4"],\
+          ["@graphql-tools/merge", "virtual:1728807850d6df0af9808e024ec3115cb3a28ce8c7ad87b1d3ee8124c91d8ff09a08592411c8193e2748c7895f1c61da00300feeec8e95b0ed1136d58819aba8#npm:9.0.0"],\
+          ["@graphql-tools/utils", "virtual:1728807850d6df0af9808e024ec3115cb3a28ce8c7ad87b1d3ee8124c91d8ff09a08592411c8193e2748c7895f1c61da00300feeec8e95b0ed1136d58819aba8#npm:10.0.4"],\
           ["@types/graphql", null],\
-          ["graphql", "npm:16.8.1"],\
-          ["tslib", "npm:2.6.1"]\
-        ],\
-        "packagePeers": [\
-          "@types/graphql",\
-          "graphql"\
-        ],\
-        "linkType": "HARD"\
-      }]\
-    ]],\
-    ["@graphql-tools/mock", [\
-      ["npm:9.0.0", {\
-        "packageLocation": "./.yarn/cache/@graphql-tools-mock-npm-9.0.0-9719e612fa-4b2c43d20d.zip/node_modules/@graphql-tools/mock/",\
-        "packageDependencies": [\
-          ["@graphql-tools/mock", "npm:9.0.0"]\
-        ],\
-        "linkType": "SOFT"\
-      }],\
-      ["virtual:cd7a862e0b955475fa0357e97cd56b069d38049d7f4ddc10830abcb7eb98ad100c2d3db85378520ca03e272094d53f153971b11fad649d897398edb231750ffb#npm:9.0.0", {\
-        "packageLocation": "./.yarn/__virtual__/@graphql-tools-mock-virtual-7551ce9da6/0/cache/@graphql-tools-mock-npm-9.0.0-9719e612fa-4b2c43d20d.zip/node_modules/@graphql-tools/mock/",\
-        "packageDependencies": [\
-          ["@graphql-tools/mock", "virtual:cd7a862e0b955475fa0357e97cd56b069d38049d7f4ddc10830abcb7eb98ad100c2d3db85378520ca03e272094d53f153971b11fad649d897398edb231750ffb#npm:9.0.0"],\
-          ["@graphql-tools/schema", "virtual:7551ce9da6a1d08fa7e13a80e2f973b491766328bd179cc2db79caffc61371ac135c2ad0ad653010fa4ab35dcca89d6c85968158f6af4813bc27a96b906e116a#npm:10.0.0"],\
-          ["@graphql-tools/utils", "virtual:7551ce9da6a1d08fa7e13a80e2f973b491766328bd179cc2db79caffc61371ac135c2ad0ad653010fa4ab35dcca89d6c85968158f6af4813bc27a96b906e116a#npm:10.0.4"],\
-          ["@types/graphql", null],\
-          ["fast-json-stable-stringify", "npm:2.1.0"],\
           ["graphql", "npm:16.8.1"],\
           ["tslib", "npm:2.6.1"]\
         ],\
@@ -2394,12 +2319,12 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "SOFT"\
       }],\
-      ["virtual:7551ce9da6a1d08fa7e13a80e2f973b491766328bd179cc2db79caffc61371ac135c2ad0ad653010fa4ab35dcca89d6c85968158f6af4813bc27a96b906e116a#npm:10.0.0", {\
-        "packageLocation": "./.yarn/__virtual__/@graphql-tools-schema-virtual-ffeefcb01a/0/cache/@graphql-tools-schema-npm-10.0.0-5ffcf6b81a-dd784bcc46.zip/node_modules/@graphql-tools/schema/",\
+      ["virtual:6d9c0fee0b376eb0bb6824eb7a3246834ef21d870b31f75eebe59bb4d027e50f2607ba168fd29d446567f4e9c2a5cad2442c4741fa92c92e0b7e9145c3a3e3a7#npm:10.0.0", {\
+        "packageLocation": "./.yarn/__virtual__/@graphql-tools-schema-virtual-1728807850/0/cache/@graphql-tools-schema-npm-10.0.0-5ffcf6b81a-dd784bcc46.zip/node_modules/@graphql-tools/schema/",\
         "packageDependencies": [\
-          ["@graphql-tools/merge", "virtual:ffeefcb01a94ecc209d575011147be79722c0ebcafcbce04435dc0063cd956502253ee7389b85184221a04133c4e58c8bb65339bb155bd897a9b75c5ab0bf5ef#npm:9.0.0"],\
-          ["@graphql-tools/schema", "virtual:7551ce9da6a1d08fa7e13a80e2f973b491766328bd179cc2db79caffc61371ac135c2ad0ad653010fa4ab35dcca89d6c85968158f6af4813bc27a96b906e116a#npm:10.0.0"],\
-          ["@graphql-tools/utils", "virtual:7551ce9da6a1d08fa7e13a80e2f973b491766328bd179cc2db79caffc61371ac135c2ad0ad653010fa4ab35dcca89d6c85968158f6af4813bc27a96b906e116a#npm:10.0.4"],\
+          ["@graphql-tools/merge", "virtual:1728807850d6df0af9808e024ec3115cb3a28ce8c7ad87b1d3ee8124c91d8ff09a08592411c8193e2748c7895f1c61da00300feeec8e95b0ed1136d58819aba8#npm:9.0.0"],\
+          ["@graphql-tools/schema", "virtual:6d9c0fee0b376eb0bb6824eb7a3246834ef21d870b31f75eebe59bb4d027e50f2607ba168fd29d446567f4e9c2a5cad2442c4741fa92c92e0b7e9145c3a3e3a7#npm:10.0.0"],\
+          ["@graphql-tools/utils", "virtual:1728807850d6df0af9808e024ec3115cb3a28ce8c7ad87b1d3ee8124c91d8ff09a08592411c8193e2748c7895f1c61da00300feeec8e95b0ed1136d58819aba8#npm:10.0.4"],\
           ["@types/graphql", null],\
           ["graphql", "npm:16.8.1"],\
           ["tslib", "npm:2.6.1"],\
@@ -2420,10 +2345,10 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "SOFT"\
       }],\
-      ["virtual:7551ce9da6a1d08fa7e13a80e2f973b491766328bd179cc2db79caffc61371ac135c2ad0ad653010fa4ab35dcca89d6c85968158f6af4813bc27a96b906e116a#npm:10.0.4", {\
-        "packageLocation": "./.yarn/__virtual__/@graphql-tools-utils-virtual-c1719fda93/0/cache/@graphql-tools-utils-npm-10.0.4-08baeb0bb2-f716d19e57.zip/node_modules/@graphql-tools/utils/",\
+      ["virtual:1728807850d6df0af9808e024ec3115cb3a28ce8c7ad87b1d3ee8124c91d8ff09a08592411c8193e2748c7895f1c61da00300feeec8e95b0ed1136d58819aba8#npm:10.0.4", {\
+        "packageLocation": "./.yarn/__virtual__/@graphql-tools-utils-virtual-67ac2471be/0/cache/@graphql-tools-utils-npm-10.0.4-08baeb0bb2-f716d19e57.zip/node_modules/@graphql-tools/utils/",\
         "packageDependencies": [\
-          ["@graphql-tools/utils", "virtual:7551ce9da6a1d08fa7e13a80e2f973b491766328bd179cc2db79caffc61371ac135c2ad0ad653010fa4ab35dcca89d6c85968158f6af4813bc27a96b906e116a#npm:10.0.4"],\
+          ["@graphql-tools/utils", "virtual:1728807850d6df0af9808e024ec3115cb3a28ce8c7ad87b1d3ee8124c91d8ff09a08592411c8193e2748c7895f1c61da00300feeec8e95b0ed1136d58819aba8#npm:10.0.4"],\
           ["@graphql-typed-document-node/core", "virtual:8233cac6686bf49bf82442079dc25221f6e5a51405accb24796911ef793ef9c58742843f148d9b1b9fc87d90d074c06211d7c3e35b5ce9cc76be6e3ebea9155e#npm:3.1.1"],\
           ["@types/graphql", null],\
           ["dset", "npm:3.1.4"],\
@@ -4440,22 +4365,6 @@ const RAW_RUNTIME_STATE =
         "linkType": "SOFT"\
       }]\
     ]],\
-    ["@openneuro/client", [\
-      ["npm:4.30.2", {\
-        "packageLocation": "./.yarn/cache/@openneuro-client-npm-4.30.2-cd7a862e0b-287761d75b.zip/node_modules/@openneuro/client/",\
-        "packageDependencies": [\
-          ["@apollo/client", "virtual:cd7a862e0b955475fa0357e97cd56b069d38049d7f4ddc10830abcb7eb98ad100c2d3db85378520ca03e272094d53f153971b11fad649d897398edb231750ffb#npm:3.11.8"],\
-          ["@graphql-tools/mock", "virtual:cd7a862e0b955475fa0357e97cd56b069d38049d7f4ddc10830abcb7eb98ad100c2d3db85378520ca03e272094d53f153971b11fad649d897398edb231750ffb#npm:9.0.0"],\
-          ["@openneuro/client", "npm:4.30.2"],\
-          ["crypto-hash", "npm:1.3.0"],\
-          ["graphql", "npm:16.8.1"],\
-          ["react", "npm:18.2.0"],\
-          ["semver", "npm:5.7.2"],\
-          ["subscriptions-transport-ws", "virtual:cd7a862e0b955475fa0357e97cd56b069d38049d7f4ddc10830abcb7eb98ad100c2d3db85378520ca03e272094d53f153971b11fad649d897398edb231750ffb#npm:0.11.0"]\
-        ],\
-        "linkType": "HARD"\
-      }]\
-    ]],\
     ["@openneuro/components", [\
       ["npm:4.33.4", {\
         "packageLocation": "./.yarn/cache/@openneuro-components-npm-4.33.4-dfc8861fb4-ea1a0569ba.zip/node_modules/@openneuro/components/",\
@@ -4485,7 +4394,6 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["@apollo/client", "virtual:e74940e35978632a0c14fa5497dc52825a9c66f5b1078eb2e64acf3c410407bb81bc4632771c0031555903c2ed0410b5bd9f7005884e1b336a14c40f1d7762b1#npm:3.13.8"],\
           ["@elastic/elasticsearch", "npm:8.13.1"],\
-          ["@openneuro/client", "npm:4.30.2"],\
           ["@openneuro/indexer", "workspace:packages/openneuro-indexer"],\
           ["@openneuro/search", "workspace:packages/openneuro-search"],\
           ["@types/jsonwebtoken", "npm:8.5.5"],\
@@ -4526,7 +4434,7 @@ const RAW_RUNTIME_STATE =
           ["@apollo/utils.keyvadapter", "npm:3.0.0"],\
           ["@as-integrations/express5", "virtual:6d9c0fee0b376eb0bb6824eb7a3246834ef21d870b31f75eebe59bb4d027e50f2607ba168fd29d446567f4e9c2a5cad2442c4741fa92c92e0b7e9145c3a3e3a7#npm:1.1.2"],\
           ["@elastic/elasticsearch", "npm:8.13.1"],\
-          ["@graphql-tools/schema", "virtual:7551ce9da6a1d08fa7e13a80e2f973b491766328bd179cc2db79caffc61371ac135c2ad0ad653010fa4ab35dcca89d6c85968158f6af4813bc27a96b906e116a#npm:10.0.0"],\
+          ["@graphql-tools/schema", "virtual:6d9c0fee0b376eb0bb6824eb7a3246834ef21d870b31f75eebe59bb4d027e50f2607ba168fd29d446567f4e9c2a5cad2442c4741fa92c92e0b7e9145c3a3e3a7#npm:10.0.0"],\
           ["@keyv/redis", "virtual:6d9c0fee0b376eb0bb6824eb7a3246834ef21d870b31f75eebe59bb4d027e50f2607ba168fd29d446567f4e9c2a5cad2442c4741fa92c92e0b7e9145c3a3e3a7#npm:4.5.0"],\
           ["@openneuro/search", "workspace:packages/openneuro-search"],\
           ["@openneuro/server", "workspace:packages/openneuro-server"],\
@@ -8871,15 +8779,6 @@ const RAW_RUNTIME_STATE =
         "linkType": "HARD"\
       }]\
     ]],\
-    ["backo2", [\
-      ["npm:1.0.2", {\
-        "packageLocation": "./.yarn/cache/backo2-npm-1.0.2-e933aab18a-fda8d0a0f4.zip/node_modules/backo2/",\
-        "packageDependencies": [\
-          ["backo2", "npm:1.0.2"]\
-        ],\
-        "linkType": "HARD"\
-      }]\
-    ]],\
     ["bail", [\
       ["npm:2.0.2", {\
         "packageLocation": "./.yarn/cache/bail-npm-2.0.2-42130cb251-aab4e8ccdc.zip/node_modules/bail/",\
@@ -10536,15 +10435,6 @@ const RAW_RUNTIME_STATE =
         "linkType": "HARD"\
       }]\
     ]],\
-    ["crypto-hash", [\
-      ["npm:1.3.0", {\
-        "packageLocation": "./.yarn/cache/crypto-hash-npm-1.3.0-8ec42184ed-d7e33a7fb6.zip/node_modules/crypto-hash/",\
-        "packageDependencies": [\
-          ["crypto-hash", "npm:1.3.0"]\
-        ],\
-        "linkType": "HARD"\
-      }]\
-    ]],\
     ["css.escape", [\
       ["npm:1.5.1", {\
         "packageLocation": "./.yarn/cache/css.escape-npm-1.5.1-b24d2ba77a-f6d38088d8.zip/node_modules/css.escape/",\
@@ -12150,13 +12040,6 @@ const RAW_RUNTIME_STATE =
       }]\
     ]],\
     ["eventemitter3", [\
-      ["npm:3.1.2", {\
-        "packageLocation": "./.yarn/cache/eventemitter3-npm-3.1.2-a68b03e1ea-e2886001be.zip/node_modules/eventemitter3/",\
-        "packageDependencies": [\
-          ["eventemitter3", "npm:3.1.2"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
       ["npm:4.0.7", {\
         "packageLocation": "./.yarn/cache/eventemitter3-npm-4.0.7-7afcdd74ae-8030029382.zip/node_modules/eventemitter3/",\
         "packageDependencies": [\
@@ -13572,7 +13455,7 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./.yarn/__virtual__/graphql-tools-virtual-c2fc35037a/0/cache/graphql-tools-npm-9.0.0-97df0ba519-b97ff2cc66.zip/node_modules/graphql-tools/",\
         "packageDependencies": [\
           ["@apollo/client", "virtual:c2fc35037a51b13304ddc4a4f25c3411d55a80c181781e6c56a152593bcaa12f612a1386ba9ffd9b2aac9a28a54af34cae57545073625b704d851c124fed9d3b#npm:3.7.17"],\
-          ["@graphql-tools/schema", "virtual:7551ce9da6a1d08fa7e13a80e2f973b491766328bd179cc2db79caffc61371ac135c2ad0ad653010fa4ab35dcca89d6c85968158f6af4813bc27a96b906e116a#npm:10.0.0"],\
+          ["@graphql-tools/schema", "virtual:6d9c0fee0b376eb0bb6824eb7a3246834ef21d870b31f75eebe59bb4d027e50f2607ba168fd29d446567f4e9c2a5cad2442c4741fa92c92e0b7e9145c3a3e3a7#npm:10.0.0"],\
           ["@types/graphql", null],\
           ["graphql", "npm:16.8.1"],\
           ["graphql-tools", "virtual:6d9c0fee0b376eb0bb6824eb7a3246834ef21d870b31f75eebe59bb4d027e50f2607ba168fd29d446567f4e9c2a5cad2442c4741fa92c92e0b7e9145c3a3e3a7#npm:9.0.0"],\
@@ -15327,15 +15210,6 @@ const RAW_RUNTIME_STATE =
           ["html-escaper", "npm:2.0.2"],\
           ["istanbul-lib-report", "npm:3.0.0"],\
           ["istanbul-reports", "npm:3.2.0"]\
-        ],\
-        "linkType": "HARD"\
-      }]\
-    ]],\
-    ["iterall", [\
-      ["npm:1.3.0", {\
-        "packageLocation": "./.yarn/cache/iterall-npm-1.3.0-a2cb04809f-700c3e9ae1.zip/node_modules/iterall/",\
-        "packageDependencies": [\
-          ["iterall", "npm:1.3.0"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -20609,22 +20483,6 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "HARD"\
       }],\
-      ["virtual:700612a435c8f07f880398815cae177c1d52ef9a9599c39d2214205ded243670b954b7b3a913f88de23f6c008d78920baf22853a2c977f78789b6367447db7eb#npm:17.0.2", {\
-        "packageLocation": "./.yarn/__virtual__/react-dom-virtual-9b9060cab0/0/cache/react-dom-npm-17.0.2-f551215af1-0b3836131a.zip/node_modules/react-dom/",\
-        "packageDependencies": [\
-          ["@types/react", null],\
-          ["loose-envify", "npm:1.4.0"],\
-          ["object-assign", "npm:4.1.1"],\
-          ["react", "npm:18.2.0"],\
-          ["react-dom", "virtual:700612a435c8f07f880398815cae177c1d52ef9a9599c39d2214205ded243670b954b7b3a913f88de23f6c008d78920baf22853a2c977f78789b6367447db7eb#npm:17.0.2"],\
-          ["scheduler", "npm:0.20.2"]\
-        ],\
-        "packagePeers": [\
-          "@types/react",\
-          "react"\
-        ],\
-        "linkType": "HARD"\
-      }],\
       ["virtual:dfc8861fb483e7f9493811b738b55fee97a3c3e2cb836e82763f82cb601d9955d5ee09c520fd30825cc5220c166a2003feb13430de5559fb2a330912125de5c2#npm:18.2.0", {\
         "packageLocation": "./.yarn/__virtual__/react-dom-virtual-3e570ac438/0/cache/react-dom-npm-18.2.0-dd675bca1c-ca5e7762ec.zip/node_modules/react-dom/",\
         "packageDependencies": [\
@@ -21328,12 +21186,12 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "HARD"\
       }],\
-      ["virtual:700612a435c8f07f880398815cae177c1d52ef9a9599c39d2214205ded243670b954b7b3a913f88de23f6c008d78920baf22853a2c977f78789b6367447db7eb#npm:0.1.0", {\
-        "packageLocation": "./.yarn/__virtual__/rehackt-virtual-ad584c6594/0/cache/rehackt-npm-0.1.0-7bb788765d-c81adead82.zip/node_modules/rehackt/",\
+      ["virtual:612bb711624572f1aec3678d05acad098495d290e9f6b87238adb8d57dab10794dadb3e8ca5d8cb2768a0fd0c13a47e23ce78cde18343b38ced0590a46ded1ec#npm:0.1.0", {\
+        "packageLocation": "./.yarn/__virtual__/rehackt-virtual-92835b1e0a/0/cache/rehackt-npm-0.1.0-7bb788765d-c81adead82.zip/node_modules/rehackt/",\
         "packageDependencies": [\
           ["@types/react", null],\
           ["react", "npm:18.2.0"],\
-          ["rehackt", "virtual:700612a435c8f07f880398815cae177c1d52ef9a9599c39d2214205ded243670b954b7b3a913f88de23f6c008d78920baf22853a2c977f78789b6367447db7eb#npm:0.1.0"]\
+          ["rehackt", "virtual:612bb711624572f1aec3678d05acad098495d290e9f6b87238adb8d57dab10794dadb3e8ca5d8cb2768a0fd0c13a47e23ce78cde18343b38ced0590a46ded1ec#npm:0.1.0"]\
         ],\
         "packagePeers": [\
           "@types/react",\
@@ -22938,33 +22796,6 @@ const RAW_RUNTIME_STATE =
         "linkType": "HARD"\
       }]\
     ]],\
-    ["subscriptions-transport-ws", [\
-      ["npm:0.11.0", {\
-        "packageLocation": "./.yarn/cache/subscriptions-transport-ws-npm-0.11.0-6fa3639659-3835ce8154.zip/node_modules/subscriptions-transport-ws/",\
-        "packageDependencies": [\
-          ["subscriptions-transport-ws", "npm:0.11.0"]\
-        ],\
-        "linkType": "SOFT"\
-      }],\
-      ["virtual:cd7a862e0b955475fa0357e97cd56b069d38049d7f4ddc10830abcb7eb98ad100c2d3db85378520ca03e272094d53f153971b11fad649d897398edb231750ffb#npm:0.11.0", {\
-        "packageLocation": "./.yarn/__virtual__/subscriptions-transport-ws-virtual-6694ebc707/0/cache/subscriptions-transport-ws-npm-0.11.0-6fa3639659-3835ce8154.zip/node_modules/subscriptions-transport-ws/",\
-        "packageDependencies": [\
-          ["@types/graphql", null],\
-          ["backo2", "npm:1.0.2"],\
-          ["eventemitter3", "npm:3.1.2"],\
-          ["graphql", "npm:16.8.1"],\
-          ["iterall", "npm:1.3.0"],\
-          ["subscriptions-transport-ws", "virtual:cd7a862e0b955475fa0357e97cd56b069d38049d7f4ddc10830abcb7eb98ad100c2d3db85378520ca03e272094d53f153971b11fad649d897398edb231750ffb#npm:0.11.0"],\
-          ["symbol-observable", "npm:1.2.0"],\
-          ["ws", "virtual:6694ebc7071bcc109fdba67d87af84187d573469b926e0f17d07d1d99359f13fc27c5bc284614c1529753ed8569fc1a11161a29e31f550fc26b56fc073844098#npm:7.5.11"]\
-        ],\
-        "packagePeers": [\
-          "@types/graphql",\
-          "graphql"\
-        ],\
-        "linkType": "HARD"\
-      }]\
-    ]],\
     ["superagent", [\
       ["npm:3.8.3", {\
         "packageLocation": "./.yarn/cache/superagent-npm-3.8.3-8bdf672d54-7226a514eb.zip/node_modules/superagent/",\
@@ -23072,13 +22903,6 @@ const RAW_RUNTIME_STATE =
       }]\
     ]],\
     ["symbol-observable", [\
-      ["npm:1.2.0", {\
-        "packageLocation": "./.yarn/cache/symbol-observable-npm-1.2.0-9e812a0a39-4684327a2f.zip/node_modules/symbol-observable/",\
-        "packageDependencies": [\
-          ["symbol-observable", "npm:1.2.0"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
       ["npm:4.0.0", {\
         "packageLocation": "./.yarn/cache/symbol-observable-npm-4.0.0-5c36594410-983aef3912.zip/node_modules/symbol-observable/",\
         "packageDependencies": [\
@@ -25419,13 +25243,6 @@ const RAW_RUNTIME_STATE =
       }]\
     ]],\
     ["ws", [\
-      ["npm:7.5.11", {\
-        "packageLocation": "./.yarn/cache/ws-npm-7.5.11-420a347b21-486141e4a0.zip/node_modules/ws/",\
-        "packageDependencies": [\
-          ["ws", "npm:7.5.11"]\
-        ],\
-        "linkType": "SOFT"\
-      }],\
       ["npm:8.16.0", {\
         "packageLocation": "./.yarn/cache/ws-npm-8.16.0-46943f6199-7c511c59e9.zip/node_modules/ws/",\
         "packageDependencies": [\
@@ -25441,23 +25258,6 @@ const RAW_RUNTIME_STATE =
           ["bufferutil", null],\
           ["utf-8-validate", null],\
           ["ws", "virtual:0882c285649663854fc9376ef4fdad62eee53d0f2ccc1db91eaa70ae8c00459b585dd4f3dd56dc258dc13e3c886f0fe0752ac7070426c2931e315bcd13a41533#npm:8.16.0"]\
-        ],\
-        "packagePeers": [\
-          "@types/bufferutil",\
-          "@types/utf-8-validate",\
-          "bufferutil",\
-          "utf-8-validate"\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["virtual:6694ebc7071bcc109fdba67d87af84187d573469b926e0f17d07d1d99359f13fc27c5bc284614c1529753ed8569fc1a11161a29e31f550fc26b56fc073844098#npm:7.5.11", {\
-        "packageLocation": "./.yarn/__virtual__/ws-virtual-6776ee1479/0/cache/ws-npm-7.5.11-420a347b21-486141e4a0.zip/node_modules/ws/",\
-        "packageDependencies": [\
-          ["@types/bufferutil", null],\
-          ["@types/utf-8-validate", null],\
-          ["bufferutil", null],\
-          ["utf-8-validate", null],\
-          ["ws", "virtual:6694ebc7071bcc109fdba67d87af84187d573469b926e0f17d07d1d99359f13fc27c5bc284614c1529753ed8569fc1a11161a29e31f550fc26b56fc073844098#npm:7.5.11"]\
         ],\
         "packagePeers": [\
           "@types/bufferutil",\

--- a/packages/openneuro-app/vite.config.js
+++ b/packages/openneuro-app/vite.config.js
@@ -33,7 +33,7 @@ export default defineConfig({
   build: {
     sourcemap: true,
     rollupOptions: {
-      external: ["/crn/config.js"],
+      external: ["/crn/config.js", "subscriptions-transport-ws"],
     },
   },
   optimizeDeps: {
@@ -44,7 +44,7 @@ export default defineConfig({
       "@apollo/client/link/ws",
       "@apollo/client/utilities",
     ],
-    exclude: ["stream-browserify"],
+    exclude: ["stream-browserify", "subscriptions-transport-ws"],
   },
   resolve: {
     alias: [

--- a/packages/openneuro-indexer/package.json
+++ b/packages/openneuro-indexer/package.json
@@ -11,7 +11,6 @@
   "dependencies": {
     "@apollo/client": "3.13.8",
     "@elastic/elasticsearch": "8.13.1",
-    "@openneuro/client": "^4.30.2",
     "@openneuro/search": "^5.4.0-alpha.0",
     "graphql": "16.8.1",
     "ts-node": "10.9.2",

--- a/packages/openneuro-indexer/src/datasetGenerator.ts
+++ b/packages/openneuro-indexer/src/datasetGenerator.ts
@@ -1,0 +1,138 @@
+import { gql } from "@apollo/client"
+
+export const getDatasets = gql`
+  query getDatasets(
+    $cursor: String
+    $orderBy: DatasetSort = { created: descending }
+    $filterBy: DatasetFilter = {}
+    $myDatasets: Boolean = false
+  ) {
+    datasets(
+      first: 25
+      after: $cursor
+      orderBy: $orderBy
+      filterBy: $filterBy
+      myDatasets: $myDatasets
+    ) {
+      edges {
+        node {
+          id
+          created
+          uploader {
+            id
+            name
+            orcid
+          }
+          public
+          permissions {
+            id
+            userPermissions {
+              userId
+              level
+              access: level
+              user {
+                id
+                name
+                email
+                provider
+              }
+            }
+          }
+          draft {
+            id
+            summary {
+              modalities
+              secondaryModalities
+              sessions
+              subjects
+              subjectMetadata {
+                participantId
+                age
+                sex
+                group
+              }
+              tasks
+              size
+              totalFiles
+              dataProcessed
+              pet {
+                BodyPart
+                ScannerManufacturer
+                ScannerManufacturersModelName
+                TracerName
+                TracerRadionuclide
+              }
+            }
+            issues {
+              severity
+            }
+            description {
+              Name
+            }
+          }
+          analytics {
+            views
+            downloads
+          }
+          stars {
+            userId
+            datasetId
+          }
+          followers {
+            userId
+            datasetId
+          }
+          snapshots {
+            id
+            created
+            tag
+          }
+        }
+      }
+      pageInfo {
+        startCursor
+        endCursor
+        hasPreviousPage
+        hasNextPage
+        count
+      }
+    }
+  }
+`
+
+/**
+ * Iterator over all public datasets associated with a client connection
+ * @param {import('@apollo/client').ApolloClient} client
+ * @param {*} query
+ */
+export async function* datasetGenerator(client, query = getDatasets) {
+  let cursor
+  while (true) {
+    try {
+      const { data } = await client.query({
+        query,
+        variables: { cursor },
+        errorPolicy: "all",
+      })
+      for (const edge of data.datasets.edges) {
+        if (edge && Object.hasOwn(edge, "node")) {
+          // Yield one dataset if it did not error
+          yield edge.node
+        } else {
+          continue
+        }
+      }
+      if (data.datasets.pageInfo.hasNextPage) {
+        // Next query with new cursor
+        cursor = data.datasets.pageInfo.endCursor
+      } else {
+        // Exit if done
+        return null
+      }
+    } catch (e) {
+      // eslint-disable-next-line no-console
+      console.error(e)
+      return null
+    }
+  }
+}

--- a/packages/openneuro-indexer/src/index.ts
+++ b/packages/openneuro-indexer/src/index.ts
@@ -3,9 +3,11 @@ import { indexingToken, indexQuery } from "@openneuro/search"
 import { setContext } from "@apollo/client/link/context"
 import { RetryLink } from "@apollo/client/link/retry"
 import { Client } from "@elastic/elasticsearch"
-import { createClient, datasetGenerator } from "@openneuro/client"
+import { datasetGenerator } from "./datasetGenerator"
 import indexDatasets from "./indexDatasets"
 import { createIndices } from "./createIndices"
+import { InMemoryCache } from "@apollo/client/cache/inmemory/inMemoryCache"
+import { ApolloClient } from "@apollo/client/core/ApolloClient"
 
 /**
  * Indexer entrypoint
@@ -33,9 +35,12 @@ export default async function main(): Promise<void> {
     }
   })
 
-  const apolloClient = createClient(process.env.GRAPHQL_URI, {
-    links: [retryLink, authLink],
+  const apolloClient = new ApolloClient({
+    uri: process.env.GRAPHQL_URI,
+    cache: new InMemoryCache(),
+    link: authLink.concat(retryLink),
   })
+
   const elasticClient = new Client({
     node: process.env.ELASTICSEARCH_CONNECTION,
     maxRetries: 10,

--- a/yarn.lock
+++ b/yarn.lock
@@ -107,43 +107,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@apollo/client@npm:3.11.8":
-  version: 3.11.8
-  resolution: "@apollo/client@npm:3.11.8"
-  dependencies:
-    "@graphql-typed-document-node/core": "npm:^3.1.1"
-    "@wry/caches": "npm:^1.0.0"
-    "@wry/equality": "npm:^0.5.6"
-    "@wry/trie": "npm:^0.5.0"
-    graphql-tag: "npm:^2.12.6"
-    hoist-non-react-statics: "npm:^3.3.2"
-    optimism: "npm:^0.18.0"
-    prop-types: "npm:^15.7.2"
-    rehackt: "npm:^0.1.0"
-    response-iterator: "npm:^0.2.6"
-    symbol-observable: "npm:^4.0.0"
-    ts-invariant: "npm:^0.10.3"
-    tslib: "npm:^2.3.0"
-    zen-observable-ts: "npm:^1.2.5"
-  peerDependencies:
-    graphql: ^15.0.0 || ^16.0.0
-    graphql-ws: ^5.5.5
-    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0
-    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0
-    subscriptions-transport-ws: ^0.9.0 || ^0.11.0
-  peerDependenciesMeta:
-    graphql-ws:
-      optional: true
-    react:
-      optional: true
-    react-dom:
-      optional: true
-    subscriptions-transport-ws:
-      optional: true
-  checksum: 10/ea9f8d8e5575bd2f2e897c53c4c3cbbea741aa2b40a103a41df0ff2fd0ff43ede127f65f0bdb6dfded28c2e2cada32551b2f558db702ebb40cf88aab9127dc1c
-  languageName: node
-  linkType: hard
-
 "@apollo/client@npm:3.13.8":
   version: 3.13.8
   resolution: "@apollo/client@npm:3.13.8"
@@ -1776,20 +1739,6 @@ __metadata:
   peerDependencies:
     graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
   checksum: 10/7bf74f71a22d87dbc47fc778cf6d0366bcd36ae0a271cc5b382ffa90020f033e227ad97c94d785ac2943317ffce9e904119c60d72b3da5b655b5837e78652b82
-  languageName: node
-  linkType: hard
-
-"@graphql-tools/mock@npm:^9.0.0":
-  version: 9.0.0
-  resolution: "@graphql-tools/mock@npm:9.0.0"
-  dependencies:
-    "@graphql-tools/schema": "npm:^10.0.0"
-    "@graphql-tools/utils": "npm:^10.0.0"
-    fast-json-stable-stringify: "npm:^2.1.0"
-    tslib: "npm:^2.4.0"
-  peerDependencies:
-    graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
-  checksum: 10/4b2c43d20d851d91d6fa876627c5888c9c2ce01c01b41bb3fb2fd1f67088c15e8f0cee8a347d9bf73c9a5a29deab72e11e3bb08a51b26392e4a16f986520489c
   languageName: node
   linkType: hard
 
@@ -3449,21 +3398,6 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@openneuro/client@npm:^4.30.2":
-  version: 4.30.2
-  resolution: "@openneuro/client@npm:4.30.2"
-  dependencies:
-    "@apollo/client": "npm:3.11.8"
-    "@graphql-tools/mock": "npm:^9.0.0"
-    crypto-hash: "npm:^1.3.0"
-    graphql: "npm:16.8.1"
-    react: "npm:^18.2.0"
-    semver: "npm:^5.5.0"
-    subscriptions-transport-ws: "npm:^0.11.0"
-  checksum: 10/287761d75b99bbdc84f9caaa307f9b6d3912b56d48d248b3df4e24fb72381acdfa194c7dd0a50fa3cb61b9d5bd30c97dbcd3985e637b1204ab20b1e02d2b6f94
-  languageName: node
-  linkType: hard
-
 "@openneuro/components@npm:^4.33.4":
   version: 4.33.4
   resolution: "@openneuro/components@npm:4.33.4"
@@ -3492,7 +3426,6 @@ __metadata:
   dependencies:
     "@apollo/client": "npm:3.13.8"
     "@elastic/elasticsearch": "npm:8.13.1"
-    "@openneuro/client": "npm:^4.30.2"
     "@openneuro/search": "npm:^5.4.0-alpha.0"
     "@types/jsonwebtoken": "npm:^8"
     "@types/node": "npm:20.12.7"
@@ -6855,13 +6788,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"backo2@npm:^1.0.2":
-  version: 1.0.2
-  resolution: "backo2@npm:1.0.2"
-  checksum: 10/fda8d0a0f4810068d23715f2f45153146d6ee8f62dd827ce1e0b6cc3c8328e84ad61e11399a83931705cef702fe7cbb457856bf99b9bd10c4ed57b0786252385
-  languageName: node
-  linkType: hard
-
 "bail@npm:^2.0.0":
   version: 2.0.2
   resolution: "bail@npm:2.0.2"
@@ -8335,13 +8261,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"crypto-hash@npm:^1.3.0":
-  version: 1.3.0
-  resolution: "crypto-hash@npm:1.3.0"
-  checksum: 10/d7e33a7fb61650ad24a7b5fd4b266a242bd9f610caa433e7a9b6605e52e83d6ca4ba52629f0fe52332fea6a5b569d91bee8222781c19060089637699b99e18c9
-  languageName: node
-  linkType: hard
-
 "css.escape@npm:^1.5.1":
   version: 1.5.1
   resolution: "css.escape@npm:1.5.1"
@@ -9743,13 +9662,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eventemitter3@npm:^3.1.0":
-  version: 3.1.2
-  resolution: "eventemitter3@npm:3.1.2"
-  checksum: 10/e2886001beb52cd2fe47d2470fd6266b7c70bd3ac356c0041a7e64336ed57bb1fc9b07bc9043d34b39913488a8d81bfcde62d3af597974980aa01b50844d869b
-  languageName: node
-  linkType: hard
-
 "eventemitter3@npm:^4.0.4":
   version: 4.0.7
   resolution: "eventemitter3@npm:4.0.7"
@@ -9906,7 +9818,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-json-stable-stringify@npm:^2.0.0, fast-json-stable-stringify@npm:^2.1.0":
+"fast-json-stable-stringify@npm:^2.0.0":
   version: 2.1.0
   resolution: "fast-json-stable-stringify@npm:2.1.0"
   checksum: 10/2c20055c1fa43c922428f16ca8bb29f2807de63e5c851f665f7ac9790176c01c3b40335257736b299764a8d383388dabc73c8083b8e1bc3d99f0a941444ec60e
@@ -12560,13 +12472,6 @@ __metadata:
     html-escaper: "npm:^2.0.0"
     istanbul-lib-report: "npm:^3.0.0"
   checksum: 10/6773a1d5c7d47eeec75b317144fe2a3b1da84a44b6282bebdc856e09667865e58c9b025b75b3d87f5bc62939126cbba4c871ee84254537d934ba5da5d4c4ec4e
-  languageName: node
-  linkType: hard
-
-"iterall@npm:^1.2.1":
-  version: 1.3.0
-  resolution: "iterall@npm:1.3.0"
-  checksum: 10/700c3e9ae194a00b66dc8dcb449195f84add4e64afaf7ed624177e19565393f9bddd34d621ea70c8eceab87a8536fc0e45bb1c9d1ea7c710d41ed0c3d937b19f
   languageName: node
   linkType: hard
 
@@ -19490,21 +19395,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"subscriptions-transport-ws@npm:^0.11.0":
-  version: 0.11.0
-  resolution: "subscriptions-transport-ws@npm:0.11.0"
-  dependencies:
-    backo2: "npm:^1.0.2"
-    eventemitter3: "npm:^3.1.0"
-    iterall: "npm:^1.2.1"
-    symbol-observable: "npm:^1.0.4"
-    ws: "npm:^5.2.0 || ^6.0.0 || ^7.0.0"
-  peerDependencies:
-    graphql: ^15.7.2 || ^16.0.0
-  checksum: 10/3835ce81543e8d11909e4b03f17315104b5934a8a134f0d652f3e8a60d8dc3715ebc75eb5048af8f87082e14709cd7a07dae5a854d073d2965072abd632a1d1a
-  languageName: node
-  linkType: hard
-
 "superagent-proxy@npm:^3.0.0":
   version: 3.0.0
   resolution: "superagent-proxy@npm:3.0.0"
@@ -19593,13 +19483,6 @@ __metadata:
   version: 1.0.0
   resolution: "supports-preserve-symlinks-flag@npm:1.0.0"
   checksum: 10/a9dc19ae2220c952bd2231d08ddeecb1b0328b61e72071ff4000c8384e145cc07c1c0bdb3b5a1cb06e186a7b2790f1dee793418b332f6ddf320de25d9125be7e
-  languageName: node
-  linkType: hard
-
-"symbol-observable@npm:^1.0.4":
-  version: 1.2.0
-  resolution: "symbol-observable@npm:1.2.0"
-  checksum: 10/4684327a2fef2453dcd4238b5bd8f69c460a4708fb8c024a824c6a707ca644b2b2a586e36e5197d0d1162ff48e288299a48844a8c46274ffcfd9260e03df7692
   languageName: node
   linkType: hard
 
@@ -21400,21 +21283,6 @@ __metadata:
     type-fest: "npm:^0.4.1"
     write-json-file: "npm:^3.2.0"
   checksum: 10/7864d44370f42a6761f6898d07ee2818c7a2faad45116580cf779f3adaf94e4bea5557612533a6c421c32323253ecb63b50615094960a637aeaef5df0fd2d6cd
-  languageName: node
-  linkType: hard
-
-"ws@npm:^5.2.0 || ^6.0.0 || ^7.0.0":
-  version: 7.5.11
-  resolution: "ws@npm:7.5.11"
-  peerDependencies:
-    bufferutil: ^4.0.1
-    utf-8-validate: ^5.0.2
-  peerDependenciesMeta:
-    bufferutil:
-      optional: true
-    utf-8-validate:
-      optional: true
-  checksum: 10/486141e4a01bb75883f9ba39317309c2427e24db1cb75e340fad6e5886b65c03d994a34209f0e4ba06dd6cb9ec95dd1b6a09c52c05eed9a34d6376f4fbbf617c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This removes the last reference to the @openneuro/client package which was still being used in the indexer for a few functions despite being long deprecated.