### PR TITLE
fix(server): Increase json payload limit to 200mb

### DIFF
--- a/packages/openneuro-server/src/app.ts
+++ b/packages/openneuro-server/src/app.ts
@@ -51,8 +51,8 @@ export async function expressApolloSetup() {
   })
   app.use(morgan("short"))
   app.use(cookieParser())
-  app.use(urlencoded({ extended: false, limit: "100mb" }))
-  app.use(json({ limit: "100mb" }))
+  app.use(urlencoded({ extended: false, limit: "200mb" }))
+  app.use(json({ limit: "200mb" }))
 
   // routing ---------------------------------------------------------
   app.use("/sitemap.xml", sitemapHandler)


### PR DESCRIPTION
Occasionally the 100mb limit is exceeded by validation output even with the 50k issues limit.