### PR TITLE
perf(cli): Batch index adds instead of staging one file at a time

### DIFF
--- a/cli/src/worker/annex.ts
+++ b/cli/src/worker/annex.ts
@@ -155,11 +155,8 @@ export async function annexAdd(
     await context.fs.promises.rm(fileRepoPath, { force: true })
     // Create our new symlink pointing at the right annex object
     await context.fs.promises.symlink(symlinkTarget, fileRepoPath)
-    const options = {
-      ...context.config(),
-      filepath: relativePath,
-    }
-    await git.add(options)
+    // Staging is left to the caller so adds can be batched - see ADD_BATCH_SIZE
+    // in git.ts. Adding one path at a time rewrites the whole index per file.
     return true
   } else {
     return false

--- a/cli/src/worker/git.ts
+++ b/cli/src/worker/git.ts
@@ -175,7 +175,30 @@ async function shouldBeAnnexed(
 /**
  * git-annex add equivalent
  */
+/**
+ * How many paths to stage per git.add call.
+ *
+ * isomorphic-git re-serializes and rewrites the whole index on every add, so
+ * adding one path at a time costs O(n) per file and O(n^2) overall. Batching
+ * makes the index cost negligible: staging 20k files took 1173s one at a time
+ * and 6.1s in batches of 1000.
+ *
+ * The batch is flushed after every chunk and again at the end, so at most this
+ * many files need restaging if the process dies mid-run.
+ */
+const ADD_BATCH_SIZE = 500
+
 async function add(event: GitWorkerEventAdd) {
+  const pending: string[] = []
+  const flushPending = async () => {
+    if (pending.length === 0) return
+    await git.add({
+      ...context.config(),
+      filepath: pending.length === 1 ? pending[0] : [...pending],
+    })
+    pending.length = 0
+  }
+
   for (const file of event.data.paths) {
     let size
     try {
@@ -197,10 +220,6 @@ async function add(event: GitWorkerEventAdd) {
     const annexed = await shouldBeAnnexed(file.relativePath, size)
     if (annexed === "GIT") {
       // Simple add case
-      const options = {
-        ...context.config(),
-        filepath: file.relativePath,
-      }
       const targetPath = join(context.repoPath, file.relativePath)
       // Verify parent directories exist
       await context.fs.promises.mkdir(dirname(targetPath), { recursive: true })
@@ -216,18 +235,23 @@ async function add(event: GitWorkerEventAdd) {
         // Copy all other non-annexed files for git index creation
         await context.fs.promises.copyFile(file.path, targetPath)
       }
-      await git.add(options)
+      pending.push(file.relativePath)
       logger.info(`Add\t${file.relativePath}`)
     } else {
       if (
         await annexAdd(annexed, file.path, file.relativePath, size, context)
       ) {
+        pending.push(file.relativePath)
         logger.info(`Annexed\t${file.relativePath}`)
       } else {
         logger.info(`Unchanged\t${file.relativePath}`)
       }
     }
+    if (pending.length >= ADD_BATCH_SIZE) {
+      await flushPending()
+    }
   }
+  await flushPending()
 }
 
 /**


### PR DESCRIPTION
Fixes #4055

## Problem

`annexAdd` stages each file with its own `git.add`, and isomorphic-git
re-serializes and rewrites the entire index on every call. Staging is therefore
O(n) per file and O(n²) overall.

On a 185k-file dataset the rate fell from ~300 files/min to ~30 files/min by 83k
files, projecting roughly four more days of staging before any transfer started.

## Change

Collect paths and stage them in batches of 500. `annexAdd` no longer calls
`git.add` itself; it returns `true` and the caller batches. `git.add` already
accepts an array, so no upstream change is required.

## Measurement

isomorphic-git 1.36.3, 20,000 files, local NVMe:

```
per-file add    1173.3s    rate decays 8840 -> 541 files/min   (rate x n constant)
batched (1000)     6.1s    rate flat, ~180k files/min
```

192x faster, and the rate no longer decays. Confirmed in production on a 185k-file
dataset: ~200 files/min and falling became ~1200 files/min and steady.

## Testing

- `deno test` — 36 passed, 0 failed
- `deno fmt --check` and `deno lint` clean on the changed files
- Ran the end-to-end worker test with `ADD_BATCH_SIZE` set to 1, 2 and 500 to
  exercise both the multi-flush and single-flush paths. All produce an identical
  repository — that test asserts an exact git object count, so a staging error
  would surface.

## Note for review

With batching, up to `ADD_BATCH_SIZE - 1` files can be staged on disk but not yet
recorded in the index if the process dies mid-run. Staging is idempotent so a rerun
redoes them. 500 is a compromise between that window and the per-flush cost; the
benchmark is already flat by ~2000 files, so a smaller batch would cost nothing
measurable if you would prefer a tighter bound.
