### PR TITLE
fix(server): Prioritize BIDS valid READMEs falling back to anything else only if none are present

### DIFF
--- a/packages/openneuro-server/src/datalad/__tests__/readme.spec.ts
+++ b/packages/openneuro-server/src/datalad/__tests__/readme.spec.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import CacheItem from "../../cache/item"
+import { readme, readmeExtensions, readmeUrl } from "../readme"
+
+vi.mock("../../config.ts")
+vi.mock("../../cache/item")
+vi.mock("../../libs/redis", () => ({
+  getRedis: vi.fn(),
+}))
+
+const mockFetch = vi.fn()
+global.fetch = mockFetch
+
+const mockCacheItemGet = vi.fn()
+vi.mocked(CacheItem).mockImplementation(() => {
+  return { get: mockCacheItemGet } as unknown as CacheItem
+})
+
+const MOCK_DATASET_ID = "ds000001"
+const MOCK_REVISION = "dce4b7b6653bcde9bdb7226a7c2b9499e77f2724"
+
+/** A 404 for one extension probe */
+const notFound = () => ({ status: 404, text: () => Promise.resolve("") })
+/** A 200 for one extension probe */
+const found = (body: string) => ({
+  status: 200,
+  text: () => Promise.resolve(body),
+})
+
+describe("datalad README files", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // Always treat the cache as a miss so the fetcher runs
+    mockCacheItemGet.mockImplementation((fetcher) => fetcher())
+  })
+
+  describe("readmeUrl()", () => {
+    it.each([
+      ["md", "README.md"],
+      ["rst", "README.rst"],
+      ["txt", "README.txt"],
+      ["", "README"],
+    ])("appends %s as %s", (extension, filename) => {
+      expect(readmeUrl(MOCK_DATASET_ID, MOCK_REVISION, extension)).toBe(
+        `http://datalad-0/datasets/${MOCK_DATASET_ID}/snapshots/${MOCK_REVISION}/files/${filename}`,
+      )
+    })
+  })
+
+  describe("readme()", () => {
+    it.each(readmeExtensions.map((extension, index) => [extension, index]))(
+      "returns the README with extension '%s' after earlier extensions 404",
+      async (extension, index) => {
+        // Every extension preferred over this one is missing
+        for (let n = 0; n < index; n++) {
+          mockFetch.mockResolvedValueOnce(notFound())
+        }
+        mockFetch.mockResolvedValueOnce(found(`# ${extension || "bare"}`))
+        const result = await readme({
+          id: MOCK_DATASET_ID,
+          revision: MOCK_REVISION,
+        })
+        expect(result).toBe(`# ${extension || "bare"}`)
+        // Probes stop at the first hit, in preference order
+        expect(mockFetch).toHaveBeenCalledTimes(index + 1)
+        expect(mockFetch).toHaveBeenLastCalledWith(
+          readmeUrl(MOCK_DATASET_ID, MOCK_REVISION, extension),
+        )
+      },
+    )
+
+    it("returns null when no extension exists", async () => {
+      mockFetch.mockResolvedValue(notFound())
+      const result = await readme({
+        id: MOCK_DATASET_ID,
+        revision: MOCK_REVISION,
+      })
+      expect(result).toBeNull()
+      expect(mockFetch).toHaveBeenCalledTimes(readmeExtensions.length)
+    })
+
+    it("resolves a snapshot parent object", async () => {
+      mockFetch.mockResolvedValueOnce(found("# snapshot readme"))
+      const result = await readme({
+        id: `${MOCK_DATASET_ID}:1.0.0`,
+        tag: "1.0.0",
+        hexsha: MOCK_REVISION,
+      })
+      expect(result).toBe("# snapshot readme")
+      expect(mockFetch).toHaveBeenCalledWith(
+        readmeUrl(MOCK_DATASET_ID, MOCK_REVISION, "md"),
+      )
+    })
+  })
+})

--- a/packages/openneuro-server/src/datalad/readme.ts
+++ b/packages/openneuro-server/src/datalad/readme.ts
@@ -4,12 +4,16 @@ import CacheItem, { CacheType } from "../cache/item"
 import { getDatasetWorker } from "../libs/datalad-service"
 import { datasetOrSnapshot } from "../utils/datasetOrSnapshot"
 
-export const readmeUrl = (datasetId, revision) => {
+/** Valid README extensions in preference order, "" for a bare README */
+export const readmeExtensions = ["md", "rst", "txt", ""]
+
+export const readmeUrl = (datasetId, revision, extension) => {
+  const filename = extension ? `README.${extension}` : "README"
   return `http://${
     getDatasetWorker(
       datasetId,
     )
-  }/datasets/${datasetId}/snapshots/${revision}/files/README`
+  }/datasets/${datasetId}/snapshots/${revision}/files/${filename}`
 }
 
 export const readme = (obj) => {
@@ -25,12 +29,13 @@ export const readme = (obj) => {
      *
      * We may want to use less superagent anyways just to avoid library weight
      */
-    const readmeReq = await fetch(readmeUrl(datasetId, revision))
-    if (readmeReq.status === 200) {
-      return await readmeReq.text()
-    } else {
-      return null
+    for (const extension of readmeExtensions) {
+      const readmeReq = await fetch(readmeUrl(datasetId, revision, extension))
+      if (readmeReq.status === 200) {
+        return await readmeReq.text()
+      }
     }
+    return null
   })
 }
 


### PR DESCRIPTION
The README resolver would request README at the top level and resolve to whatever matching extension was read first in filesystem order. This means that usually if you had README.md and README.html, you'd get README.html when the intention is to prioritize README.md as allowed by BIDS. Instead we check all the BIDS URLs first and only fallback to others if none are present.

Fix #4020 
