### PR TITLE
fix(server): Snapshot worker response type fixes

### DIFF
--- a/packages/openneuro-server/src/datalad/snapshots.ts
+++ b/packages/openneuro-server/src/datalad/snapshots.ts
@@ -21,6 +21,10 @@ import { getDatasetWorker } from "../libs/datalad-service"
 import { createEvent, updateEvent } from "../libs/events"
 import { queueIndexDataset } from "../queues/producer-methods"
 
+type SnapshotResponse = Omit<SnapshotDocument, "created"> & {
+  created: number // DataLad service `created` is a timestamp in seconds, not a Date object
+}
+
 const lockSnapshot = (datasetId, tag) => {
   return getRedlock().lock(
     `openneuro:create-snapshot-lock:${datasetId}:${tag}`,
@@ -108,9 +112,9 @@ const postSnapshot = async (
  * This is equivalent to `git tag` on the repository
  *
  * @param {string} datasetId Dataset accession number
- * @returns {Promise<import('../models/snapshot').SnapshotDocument[]>}
+ * @returns {Promise<SnapshotResponse[]>}
  */
-export const getSnapshots = async (datasetId): Promise<SnapshotDocument[]> => {
+export const getSnapshots = async (datasetId): Promise<SnapshotResponse[]> => {
   const dataset = await Dataset.findOne({ id: datasetId })
   if (!dataset) return null
   const cache = new CacheItem(

--- a/packages/openneuro-server/src/datalad/snapshots.ts
+++ b/packages/openneuro-server/src/datalad/snapshots.ts
@@ -21,7 +21,7 @@ import { getDatasetWorker } from "../libs/datalad-service"
 import { createEvent, updateEvent } from "../libs/events"
 import { queueIndexDataset } from "../queues/producer-methods"
 
-type SnapshotResponse = Omit<SnapshotDocument, "created"> & {
+export type SnapshotResponse = Omit<SnapshotDocument, "created"> & {
   created: number // DataLad service `created` is a timestamp in seconds, not a Date object
 }
 

--- a/packages/openneuro-server/src/utils/__tests__/snapshots.spec.ts
+++ b/packages/openneuro-server/src/utils/__tests__/snapshots.spec.ts
@@ -3,11 +3,11 @@ import { snapshotCreationComparison } from "../snapshots"
 describe("snapshotCreationComparison()", () => {
   it('sorts array of objects by the "created" and "tag" properties', () => {
     const testArray = [
-      { id: 2, created: new Date("2018-11-20T00:05:43.473Z"), tag: "1.0.0" },
-      { id: 1, created: new Date("2018-11-19T00:05:43.473Z"), tag: "1.0.1" },
-      { id: 3, created: new Date("2018-11-23T00:05:43.473Z"), tag: "1.0.2" },
-      { id: 5, created: new Date("2018-11-23T00:05:43.473Z"), tag: "1.0.10" },
-      { id: 4, created: new Date("2018-11-23T00:05:43.473Z"), tag: "1.0.3" },
+      { id: 2, created: 1542672343473, tag: "1.0.0" },
+      { id: 1, created: 1542585943473, tag: "1.0.1" },
+      { id: 3, created: 1542931543473, tag: "1.0.2" },
+      { id: 5, created: 1542931543473, tag: "1.0.10" },
+      { id: 4, created: 1542931543473, tag: "1.0.3" },
     ]
     const sorted = testArray.sort(snapshotCreationComparison)
     expect(sorted[0].id).toBe(2)
@@ -29,13 +29,13 @@ describe("snapshotCreationComparison()", () => {
   })
   it("sorts non-semver tags mixed with semver tags", () => {
     const testArray = [
-      { id: 2, created: new Date("2018-11-19T00:05:43.473Z"), tag: "1.0.2" },
+      { id: 2, created: 1542585943473, tag: "1.0.2" },
       {
         id: 1,
-        created: new Date("2018-11-19T00:05:43.473Z"),
+        created: 1542585943473,
         tag: "57fed018cce88d000ac1757f",
       },
-      { id: 3, created: new Date("2018-11-19T00:05:43.473Z"), tag: "1.0.1" },
+      { id: 3, created: 1542585943473, tag: "1.0.1" },
     ]
     const sorted = testArray.sort(snapshotCreationComparison)
     expect(sorted[0].id).toBe(2)
@@ -46,17 +46,17 @@ describe("snapshotCreationComparison()", () => {
     const testArray = [
       {
         id: 2,
-        created: new Date("2018-11-19T00:05:43.473Z"),
+        created: 1542585943473,
         tag: "00001",
       },
       {
         id: 1,
-        created: new Date("2018-11-19T00:05:43.473Z"),
+        created: 1542585943473,
         tag: "57fed018cce88d000ac1757f",
       },
       {
         id: 3,
-        created: new Date("2018-11-19T00:05:43.473Z"),
+        created: 1542585943473,
         tag: "57fed018cce88d000ac1757f",
       },
     ]

--- a/packages/openneuro-server/src/utils/snapshots.ts
+++ b/packages/openneuro-server/src/utils/snapshots.ts
@@ -1,12 +1,16 @@
 import semver from "semver"
 
 export const snapshotCreationComparison = (
-  { created: a, tag: a_tag }: { created: Date | string; tag: string },
-  { created: b, tag: b_tag }: { created: Date | string; tag: string },
+  { created: a, tag: a_tag }: { created: string | number; tag: string },
+  { created: b, tag: b_tag }: { created: string | number; tag: string },
 ) => {
   if (semver.valid(a_tag) && semver.valid(b_tag)) {
     return semver.compare(a_tag, b_tag)
   } else {
-    return new Date(a).getTime() - new Date(b).getTime()
+    if (typeof a === "number" && typeof b === "number") {
+      return new Date(a * 1000).getTime() - new Date(b * 1000).getTime()
+    } else {
+      return new Date(a).getTime() - new Date(b).getTime()
+    }
   }
 }


### PR DESCRIPTION
This separates the SnapshotDocument and SnapshotResponse types to match the MongoDB representation and the response from the worker API correctly. Previously these were often conflated but usually equivalent.