### PR TITLE
feat: Support syncing works to ORCID

### DIFF
--- a/packages/openneuro-server/src/graphql/resolvers/__tests__/orcid.spec.ts
+++ b/packages/openneuro-server/src/graphql/resolvers/__tests__/orcid.spec.ts
@@ -1,0 +1,335 @@
+import { vi } from "vitest"
+import type * as OrcidTokenModule from "../../../libs/orcid/token"
+import type * as OrcidWorksModule from "../../../libs/orcid/works"
+
+vi.mock("ioredis")
+vi.mock("@sentry/node", () => ({ captureException: vi.fn() }))
+vi.mock("../../../config", () => ({
+  default: {
+    url: "https://openneuro.org",
+    auth: {
+      orcid: { clientID: "APP-OPENNEURO", apiURI: "https://api.orcid.org" },
+    },
+  },
+}))
+
+const userFindOne = vi.fn()
+vi.mock("../../../models/user", () => ({
+  default: { findOne: (...args) => userFindOne(...args) },
+}))
+
+const orcidWorkFindOne = vi.fn()
+const orcidWorkUpdateOne = vi.fn()
+vi.mock("../../../models/orcidWork", () => ({
+  default: {
+    findOne: (...args) => orcidWorkFindOne(...args),
+    updateOne: (...args) => orcidWorkUpdateOne(...args),
+  },
+}))
+
+const getOrcidAccessToken = vi.fn()
+vi.mock("../../../libs/orcid/token", async () => {
+  const actual = await vi.importActual<typeof OrcidTokenModule>(
+    "../../../libs/orcid/token",
+  )
+  return {
+    ...actual,
+    getOrcidAccessToken: (...args) => getOrcidAccessToken(...args),
+  }
+})
+
+const getWorkSummaries = vi.fn()
+const createWork = vi.fn()
+const updateWork = vi.fn()
+vi.mock("../../../libs/orcid/works", async () => {
+  const actual = await vi.importActual<typeof OrcidWorksModule>(
+    "../../../libs/orcid/works",
+  )
+  return {
+    ...actual,
+    getWorkSummaries: (...args) => getWorkSummaries(...args),
+    createWork: (...args) => createWork(...args),
+    updateWork: (...args) => updateWork(...args),
+  }
+})
+
+const eligibleDatasets = vi.fn()
+const isDataciteContributor = vi.fn()
+const latestUndeprecatedSnapshot = vi.fn()
+vi.mock("../../../libs/orcid/eligible-datasets", () => ({
+  eligibleDatasets: (...args) => eligibleDatasets(...args),
+  isDataciteContributor: (...args) => isDataciteContributor(...args),
+  latestUndeprecatedSnapshot: (...args) => latestUndeprecatedSnapshot(...args),
+  snapshotRevision: vi.fn().mockResolvedValue("abcdef1"),
+}))
+
+const assembleMetadata = vi.fn()
+vi.mock("../../../libs/doi/metadata", () => ({
+  assembleMetadata: (...args) => assembleMetadata(...args),
+}))
+
+import { syncOrcidWorks } from "../orcid"
+
+const ORCID = "0000-0002-1825-0097"
+const DATASET_URL = "https://openneuro.org/datasets/ds000001"
+
+const context = { user: "user-1", userInfo: { id: "user-1" } } as never
+
+const mockUser = (overrides = {}) => {
+  userFindOne.mockReturnValue({
+    exec: () =>
+      Promise.resolve({
+        id: "user-1",
+        orcid: ORCID,
+        orcidConsent: true,
+        ...overrides,
+      }),
+  })
+}
+
+const mockDataset = (kind = "uploader") => {
+  eligibleDatasets.mockResolvedValue({
+    candidates: new Map([["ds000001", kind]]),
+    searchError: null,
+  })
+  latestUndeprecatedSnapshot.mockResolvedValue({
+    tag: "1.0.1",
+    hexsha: "abcdef1",
+    created: new Date("2024-03-05T12:00:00Z"),
+  })
+  assembleMetadata.mockResolvedValue({
+    doi: "10.18112/openneuro.ds000001.v1.0.1",
+    url: `${DATASET_URL}/versions/1.0.1`,
+    creators: [{ name: "Doe, Jane", nameType: "Personal" }],
+    titles: [{ title: "A Test Dataset" }],
+    publisher: { name: "OpenNeuro" },
+    publicationYear: "2024",
+    types: { resourceTypeGeneral: "Dataset" },
+  })
+}
+
+beforeEach(() => {
+  getOrcidAccessToken.mockResolvedValue("access-token")
+  getWorkSummaries.mockResolvedValue([])
+  orcidWorkFindOne.mockReturnValue({ lean: () => ({ exec: () => null }) })
+  orcidWorkUpdateOne.mockResolvedValue({})
+  createWork.mockResolvedValue(1000)
+  isDataciteContributor.mockResolvedValue(true)
+})
+
+describe("syncOrcidWorks()", () => {
+  it("rejects unauthenticated requests", async () => {
+    await expect(
+      syncOrcidWorks(null, {}, { user: null, userInfo: null } as never),
+    ).rejects.toThrow(/must be logged in/)
+    expect(userFindOne).not.toHaveBeenCalled()
+  })
+
+  it("rejects a token whose user no longer exists", async () => {
+    userFindOne.mockReturnValue({ exec: () => Promise.resolve(null) })
+    await expect(syncOrcidWorks(null, {}, context)).rejects.toThrow(
+      /must be logged in/,
+    )
+  })
+
+  it("requires a linked ORCID iD", async () => {
+    mockUser({ orcid: undefined })
+    await expect(syncOrcidWorks(null, {}, context)).rejects.toThrow(
+      /Link an ORCID iD/,
+    )
+  })
+
+  it("requires consent before writing to a record", async () => {
+    mockUser({ orcidConsent: null })
+    await expect(syncOrcidWorks(null, {}, context)).rejects.toThrow(/Consent/)
+    expect(createWork).not.toHaveBeenCalled()
+  })
+
+  it("creates a work for a dataset with no existing record", async () => {
+    mockUser()
+    mockDataset()
+    const result = await syncOrcidWorks(null, {}, context)
+    expect(result.orcid).toBe(ORCID)
+    expect(result.works).toEqual([
+      {
+        datasetId: "ds000001",
+        snapshotTag: "1.0.1",
+        putCode: "1000",
+        action: "created",
+        reason: null,
+      },
+    ])
+    expect(createWork).toHaveBeenCalledWith(
+      ORCID,
+      "access-token",
+      expect.objectContaining({ type: "data-set" }),
+    )
+    expect(orcidWorkUpdateOne).toHaveBeenCalledWith(
+      { userId: "user-1", datasetId: "ds000001" },
+      expect.objectContaining({
+        $set: expect.objectContaining({ putCode: 1000, snapshotTag: "1.0.1" }),
+      }),
+      { upsert: true },
+    )
+  })
+
+  it("makes no ORCID write when the dataset has not changed", async () => {
+    mockUser()
+    mockDataset()
+    // Reuse the hash the resolver would compute by syncing once first
+    const first = await syncOrcidWorks(null, {}, context)
+    const hash = orcidWorkUpdateOne.mock.calls[0][1].$set.hash
+    expect(first.works[0].action).toBe("created")
+
+    orcidWorkFindOne.mockReturnValue({
+      lean: () => ({ exec: () => ({ putCode: 1000, hash }) }),
+    })
+    createWork.mockClear()
+    updateWork.mockClear()
+
+    const second = await syncOrcidWorks(null, {}, context)
+    expect(second.works[0].action).toBe("unchanged")
+    expect(second.works[0].putCode).toBe("1000")
+    expect(createWork).not.toHaveBeenCalled()
+    expect(updateWork).not.toHaveBeenCalled()
+  })
+
+  it("updates the existing work when the metadata changed", async () => {
+    mockUser()
+    mockDataset()
+    orcidWorkFindOne.mockReturnValue({
+      lean: () => ({ exec: () => ({ putCode: 1000, hash: "stale" }) }),
+    })
+    const result = await syncOrcidWorks(null, {}, context)
+    expect(result.works[0]).toMatchObject({
+      action: "updated",
+      putCode: "1000",
+    })
+    expect(updateWork).toHaveBeenCalledWith(
+      ORCID,
+      "access-token",
+      1000,
+      expect.objectContaining({ type: "data-set" }),
+    )
+    expect(createWork).not.toHaveBeenCalled()
+  })
+
+  it("adopts a work already on the record instead of duplicating it", async () => {
+    mockUser()
+    mockDataset()
+    getWorkSummaries.mockResolvedValue([
+      {
+        "put-code": 555,
+        source: {
+          "source-client-id": {
+            uri: "https://orcid.org/client/APP-OPENNEURO",
+            path: "APP-OPENNEURO",
+            host: "orcid.org",
+          },
+        },
+        "external-ids": {
+          "external-id": [
+            {
+              "external-id-type": "uri",
+              "external-id-value": DATASET_URL,
+              "external-id-relationship": "self",
+            },
+          ],
+        },
+      },
+    ])
+    const result = await syncOrcidWorks(null, {}, context)
+    expect(result.works[0]).toMatchObject({ action: "updated", putCode: "555" })
+    expect(createWork).not.toHaveBeenCalled()
+    expect(updateWork).toHaveBeenCalledWith(
+      ORCID,
+      "access-token",
+      555,
+      expect.anything(),
+    )
+  })
+
+  it("fails rather than risking duplicates when the record cannot be read", async () => {
+    mockUser()
+    mockDataset()
+    getWorkSummaries.mockRejectedValue(new Error("ORCID API error 503"))
+    await expect(syncOrcidWorks(null, {}, context)).rejects.toThrow(
+      /Could not read existing works/,
+    )
+    expect(createWork).not.toHaveBeenCalled()
+  })
+
+  it("skips datasets whose only snapshots are deprecated", async () => {
+    mockUser()
+    mockDataset()
+    latestUndeprecatedSnapshot.mockResolvedValue(null)
+    const result = await syncOrcidWorks(null, {}, context)
+    expect(result.works[0]).toMatchObject({
+      action: "skipped",
+      snapshotTag: null,
+    })
+    expect(createWork).not.toHaveBeenCalled()
+  })
+
+  it("skips search hits the snapshot datacite.yml does not confirm", async () => {
+    mockUser()
+    mockDataset("contributor")
+    isDataciteContributor.mockResolvedValue(false)
+    const result = await syncOrcidWorks(null, {}, context)
+    expect(result.works[0].action).toBe("skipped")
+    expect(result.works[0].reason).toMatch(/datacite\.yml/)
+    expect(createWork).not.toHaveBeenCalled()
+  })
+
+  it("does not recheck datacite.yml for datasets the user uploaded", async () => {
+    mockUser()
+    mockDataset("uploader")
+    await syncOrcidWorks(null, {}, context)
+    expect(isDataciteContributor).not.toHaveBeenCalled()
+    expect(createWork).toHaveBeenCalled()
+  })
+
+  it("reports the intended action without writing on a dry run", async () => {
+    mockUser()
+    mockDataset()
+    const result = await syncOrcidWorks(null, { dryRun: true }, context)
+    expect(result.works[0]).toMatchObject({ action: "created", putCode: null })
+    expect(createWork).not.toHaveBeenCalled()
+    expect(orcidWorkUpdateOne).not.toHaveBeenCalled()
+  })
+
+  it("reports a failed dataset without aborting the rest of the sync", async () => {
+    mockUser()
+    mockDataset()
+    eligibleDatasets.mockResolvedValue({
+      candidates: new Map([
+        ["ds000001", "uploader"],
+        ["ds000002", "uploader"],
+      ]),
+      searchError: null,
+    })
+    assembleMetadata.mockRejectedValueOnce(new Error("no metadata"))
+    const result = await syncOrcidWorks(null, {}, context)
+    expect(result.works).toHaveLength(2)
+    expect(result.works[0]).toMatchObject({
+      datasetId: "ds000001",
+      action: "error",
+    })
+    expect(result.works[1]).toMatchObject({
+      datasetId: "ds000002",
+      action: "created",
+    })
+  })
+
+  it("passes through a search index failure so uploads still sync", async () => {
+    mockUser()
+    mockDataset()
+    eligibleDatasets.mockResolvedValue({
+      candidates: new Map([["ds000001", "uploader"]]),
+      searchError: "Error: connect ECONNREFUSED",
+    })
+    const result = await syncOrcidWorks(null, {}, context)
+    expect(result.searchError).toMatch(/ECONNREFUSED/)
+    expect(result.works[0].action).toBe("created")
+  })
+})

--- a/packages/openneuro-server/src/graphql/resolvers/mutation.ts
+++ b/packages/openneuro-server/src/graphql/resolvers/mutation.ts
@@ -57,6 +57,7 @@ import { holdDeletion } from "./holdDeletion"
 import { updateContributors } from "../../datalad/contributors"
 import { updateWorkerTask } from "./worker"
 import { syncDatasetDois } from "./doi"
+import { syncOrcidWorks } from "./orcid"
 
 const Mutation = {
   createDataset,
@@ -116,6 +117,7 @@ const Mutation = {
   updateContributors,
   updateWorkerTask,
   syncDatasetDois,
+  syncOrcidWorks,
 }
 
 export default Mutation

--- a/packages/openneuro-server/src/graphql/resolvers/orcid.ts
+++ b/packages/openneuro-server/src/graphql/resolvers/orcid.ts
@@ -1,0 +1,261 @@
+/**
+ * Publish the datasets a user has contributed to as works on their ORCID record.
+ */
+import * as Sentry from "@sentry/node"
+import type { GraphQLContext } from "../builder"
+import User from "../../models/user"
+import OrcidWork from "../../models/orcidWork"
+import { assembleMetadata } from "../../libs/doi/metadata"
+import { hashObject } from "../../libs/authentication/crypto"
+import {
+  getOrcidAccessToken,
+  OrcidAuthorizationError,
+} from "../../libs/orcid/token"
+import {
+  createWork,
+  getWorkSummaries,
+  openNeuroWorkPutCodes,
+  updateWork,
+} from "../../libs/orcid/works"
+import {
+  buildOrcidWork,
+  datasetExternalIdValue,
+} from "../../libs/orcid/work-metadata"
+import {
+  eligibleDatasets,
+  isDataciteContributor,
+  latestUndeprecatedSnapshot,
+  snapshotRevision,
+} from "../../libs/orcid/eligible-datasets"
+
+/** What the sync did with one dataset */
+export type OrcidWorkSyncAction =
+  | "created"
+  | "updated"
+  | "unchanged"
+  | "skipped"
+  | "error"
+
+export interface OrcidWorkSyncResult {
+  datasetId: string
+  snapshotTag: string | null
+  putCode: string | null
+  action: OrcidWorkSyncAction
+  reason: string | null
+}
+
+export interface SyncOrcidWorksPayload {
+  orcid: string
+  works: OrcidWorkSyncResult[]
+  searchError: string | null
+}
+
+/**
+ * Publish or refresh the ORCID work for one dataset.
+ *
+ * Idempotency comes from two places, the put-code we recorded the last time
+ * this dataset was published and the put-codes already on the ORCID record
+ * keyed by the dataset URL. The second recovers works whose local record was
+ * lost so a repeated sync updates rather than duplicates.
+ */
+const syncDatasetWork = async (
+  {
+    datasetId,
+    orcid,
+    userId,
+    accessToken,
+    knownPutCodes,
+    dryRun,
+    requireDataciteContributor,
+  }: {
+    datasetId: string
+    orcid: string
+    userId: string
+    accessToken: string
+    knownPutCodes: Map<string, number>
+    dryRun: boolean
+    requireDataciteContributor: boolean
+  },
+): Promise<OrcidWorkSyncResult> => {
+  const snapshot = await latestUndeprecatedSnapshot(datasetId)
+  if (!snapshot) {
+    return {
+      datasetId,
+      snapshotTag: null,
+      putCode: null,
+      action: "skipped",
+      reason: "No snapshot available that has not been deprecated",
+    }
+  }
+
+  const revision = await snapshotRevision(datasetId, snapshot)
+
+  // The search index only nominates candidates, datacite.yml decides
+  if (
+    requireDataciteContributor &&
+    !(await isDataciteContributor(datasetId, snapshot.tag, revision, orcid))
+  ) {
+    return {
+      datasetId,
+      snapshotTag: snapshot.tag,
+      putCode: null,
+      action: "skipped",
+      reason: "ORCID iD is not listed in datacite.yml for this snapshot",
+    }
+  }
+
+  const attributes = await assembleMetadata(
+    datasetId,
+    snapshot.tag,
+    revision,
+    snapshot.created,
+  )
+  const work = buildOrcidWork(
+    datasetId,
+    attributes,
+    new Date(snapshot.created * 1000),
+  )
+  const hash = hashObject(work)
+
+  const record = await OrcidWork.findOne({ userId, datasetId }).lean().exec()
+  const putCode = record?.putCode ??
+    knownPutCodes.get(datasetExternalIdValue(datasetId)) ?? null
+
+  if (putCode !== null && record?.putCode === putCode && record.hash === hash) {
+    return {
+      datasetId,
+      snapshotTag: snapshot.tag,
+      putCode: String(putCode),
+      action: "unchanged",
+      reason: null,
+    }
+  }
+
+  if (dryRun) {
+    return {
+      datasetId,
+      snapshotTag: snapshot.tag,
+      putCode: putCode === null ? null : String(putCode),
+      action: putCode === null ? "created" : "updated",
+      reason: null,
+    }
+  }
+
+  let action: OrcidWorkSyncAction
+  let resultPutCode: number
+  if (putCode === null) {
+    resultPutCode = await createWork(orcid, accessToken, work)
+    action = "created"
+  } else {
+    await updateWork(orcid, accessToken, putCode, work)
+    resultPutCode = putCode
+    action = "updated"
+  }
+
+  await OrcidWork.updateOne(
+    { userId, datasetId },
+    {
+      $set: {
+        userId,
+        orcid,
+        datasetId,
+        putCode: resultPutCode,
+        snapshotTag: snapshot.tag,
+        doi: attributes.doi,
+        hash,
+      },
+    },
+    { upsert: true },
+  )
+
+  return {
+    datasetId,
+    snapshotTag: snapshot.tag,
+    putCode: String(resultPutCode),
+    action,
+    reason: null,
+  }
+}
+
+/**
+ * Publish every eligible dataset for the authenticated user as an ORCID work.
+ *
+ * Safe to call repeatedly, each dataset maps to exactly one work which is
+ * updated in place when its latest undeprecated snapshot changes.
+ */
+export const syncOrcidWorks = async (
+  _obj,
+  { dryRun = false }: { dryRun?: boolean },
+  { userInfo }: GraphQLContext,
+): Promise<SyncOrcidWorksPayload> => {
+  if (!userInfo?.id) {
+    throw new Error("You must be logged in to publish works to ORCID.")
+  }
+
+  const user = await User.findOne({ id: userInfo.id }).exec()
+  if (!user) {
+    throw new Error("You must be logged in to publish works to ORCID.")
+  }
+  if (!user.orcid) {
+    throw new Error(
+      "Link an ORCID iD to your account to publish works to ORCID.",
+    )
+  }
+  if (user.orcidConsent !== true) {
+    throw new Error(
+      "Consent to publishing datasets to your ORCID record is required.",
+    )
+  }
+
+  const accessToken = await getOrcidAccessToken(user)
+  const { candidates, searchError } = await eligibleDatasets(
+    user.id,
+    user.orcid,
+  )
+
+  // Works already on the record let us adopt anything we have lost track of
+  let knownPutCodes: Map<string, number>
+  try {
+    knownPutCodes = openNeuroWorkPutCodes(
+      await getWorkSummaries(user.orcid, accessToken),
+    )
+  } catch (err) {
+    if (err instanceof OrcidAuthorizationError) throw err
+    // Creating a duplicate is worse than failing, so do not continue blind
+    Sentry.captureException(err)
+    throw new Error(
+      `Could not read existing works from ORCID: ${err.message}`,
+      {
+        cause: err,
+      },
+    )
+  }
+
+  const works: OrcidWorkSyncResult[] = []
+  for (const [datasetId, kind] of candidates) {
+    try {
+      works.push(
+        await syncDatasetWork({
+          datasetId,
+          orcid: user.orcid,
+          userId: user.id,
+          accessToken,
+          knownPutCodes,
+          dryRun,
+          requireDataciteContributor: kind === "contributor",
+        }),
+      )
+    } catch (err) {
+      Sentry.captureException(err)
+      works.push({
+        datasetId,
+        snapshotTag: null,
+        putCode: null,
+        action: "error",
+        reason: String(err),
+      })
+    }
+  }
+
+  return { orcid: user.orcid, works, searchError }
+}

--- a/packages/openneuro-server/src/graphql/schema/mutation.ts
+++ b/packages/openneuro-server/src/graphql/schema/mutation.ts
@@ -11,6 +11,7 @@ import {
   SyncDatasetDoisPayload,
   UserNotificationStatus,
 } from "./misc"
+import { SyncOrcidWorksPayload } from "./orcid"
 import { DatasetReviewer } from "./reviewer"
 import { WorkerTask } from "./worker"
 import { FollowDatasetResponse, StarDatasetResponse } from "./misc"
@@ -561,6 +562,17 @@ builder.mutationType({
       },
       resolve: (root, args, ctx) =>
         Mutation.syncDatasetDois(root, args as never, ctx) as never,
+    }),
+    syncOrcidWorks: t.field({
+      type: SyncOrcidWorksPayload,
+      nullable: false,
+      description:
+        "Publish every dataset the authenticated user has contributed to as a work on their ORCID record",
+      args: {
+        dryRun: t.arg.boolean(),
+      },
+      resolve: (root, args, ctx) =>
+        Mutation.syncOrcidWorks(root, args as never, ctx) as never,
     }),
   }),
 })

--- a/packages/openneuro-server/src/graphql/schema/orcid.ts
+++ b/packages/openneuro-server/src/graphql/schema/orcid.ts
@@ -1,0 +1,31 @@
+import { builder } from "../builder"
+
+export const OrcidWorkSyncResult = builder.simpleObject("OrcidWorkSyncResult", {
+  description: "Outcome of publishing one dataset to an ORCID record",
+  fields: (t) => ({
+    datasetId: t.id({ nullable: false }),
+    snapshotTag: t.string(),
+    putCode: t.id(),
+    action: t.string({
+      nullable: false,
+      description: "One of created, updated, unchanged, skipped or error",
+    }),
+    reason: t.string({
+      description: "Why a dataset was skipped or failed to publish",
+    }),
+  }),
+})
+
+export const SyncOrcidWorksPayload = builder.simpleObject(
+  "SyncOrcidWorksPayload",
+  {
+    fields: (t) => ({
+      orcid: t.string({ nullable: false }),
+      works: t.field({ type: [OrcidWorkSyncResult], nullable: false }),
+      searchError: t.string({
+        description:
+          "Set when the search index could not be queried, uploaded datasets are still synced",
+      }),
+    }),
+  },
+)

--- a/packages/openneuro-server/src/libs/authentication/passport.ts
+++ b/packages/openneuro-server/src/libs/authentication/passport.ts
@@ -8,6 +8,7 @@ import User from "../../models/user"
 import { encrypt } from "./crypto"
 import { addJWT, jwtFromRequest } from "./jwt"
 import orcid from "../orcid"
+import { orcidTokenFields } from "../orcid/token"
 import { setupGitHubAuth } from "./github"
 
 export const PROVIDERS = {
@@ -88,21 +89,29 @@ export const verifyGoogleUser = (accessToken, refreshToken, profile, done) => {
   }
 }
 
+/**
+ * passport-oauth2 calls five argument verify callbacks with the raw token
+ * response (`params`) before the OAuth profile, and ORCID returns the iD and
+ * name in that token response rather than in a profile lookup.
+ */
 export const verifyORCIDUser = (
   accessToken,
   refreshToken,
-  profile,
   params,
+  profile,
   done,
 ) => {
   orcid
-    .getProfile(profile.orcid, profile.access_token)
+    .getProfile(params.orcid, params.access_token)
     .then((info) => {
-      profile.info = info
-      profile.provider = PROVIDERS.ORCID
-      const profileUpdate = loadProfile(profile)
+      params.info = info
+      params.provider = PROVIDERS.ORCID
+      const profileUpdate = loadProfile(params)
+      if (profileUpdate instanceof Error) return done(profileUpdate, null)
+      // Retain the granted token so we can write works back to their record
+      Object.assign(profileUpdate, orcidTokenFields(params))
       User.findOneAndUpdate(
-        { providerId: profile.orcid, provider: profile.provider },
+        { providerId: params.orcid, provider: params.provider },
         profileUpdate,
         { upsert: true, new: true, setDefaultsOnInsert: true },
       ).then((user) => done(null, addJWT(config)(user.toObject())))

--- a/packages/openneuro-server/src/libs/orcid/__tests__/eligible-datasets.spec.ts
+++ b/packages/openneuro-server/src/libs/orcid/__tests__/eligible-datasets.spec.ts
@@ -1,0 +1,202 @@
+import { vi } from "vitest"
+
+vi.mock("ioredis")
+vi.mock("@sentry/node", () => ({
+  captureException: vi.fn(),
+  captureMessage: vi.fn(),
+}))
+vi.mock("../../../config", () => ({
+  default: {
+    url: "https://openneuro.org",
+    auth: {
+      orcid: { clientID: "APP-OPENNEURO", apiURI: "https://api.orcid.org" },
+    },
+  },
+}))
+
+const getSnapshots = vi.fn()
+vi.mock("../../../datalad/snapshots", () => ({
+  getSnapshots: (...args) => getSnapshots(...args),
+}))
+
+const deprecatedFind = vi.fn()
+vi.mock("../../../models/deprecatedSnapshot", () => ({
+  default: { find: (...args) => deprecatedFind(...args) },
+}))
+
+const datasetFind = vi.fn()
+vi.mock("../../../models/dataset", () => ({
+  default: { find: (...args) => datasetFind(...args) },
+}))
+
+const snapshotFindOne = vi.fn()
+vi.mock("../../../models/snapshot", () => ({
+  default: { findOne: (...args) => snapshotFindOne(...args) },
+}))
+
+const contributors = vi.fn()
+vi.mock("../../../datalad/contributors", () => ({
+  contributors: (...args) => contributors(...args),
+}))
+
+const search = vi.fn()
+vi.mock("../../../elasticsearch/elastic-client", () => ({
+  getElasticClient: () => ({ search: (...args) => search(...args) }),
+}))
+
+import {
+  eligibleDatasets,
+  isDataciteContributor,
+  latestUndeprecatedSnapshot,
+  searchContributorDatasetIds,
+} from "../eligible-datasets"
+
+const ORCID = "0000-0002-1825-0097"
+
+const leanExec = (value) => ({ lean: () => ({ exec: () => value }) })
+
+const mockDeprecated = (ids: string[]) =>
+  deprecatedFind.mockReturnValue(leanExec(ids.map((id) => ({ id }))))
+
+const snapshot = (tag: string, created: string) => ({
+  tag,
+  created: new Date(created),
+  hexsha: `sha-${tag}`,
+})
+
+describe("latestUndeprecatedSnapshot()", () => {
+  it("returns the newest snapshot when none are deprecated", async () => {
+    getSnapshots.mockResolvedValue([
+      snapshot("1.0.0", "2024-01-01"),
+      snapshot("1.0.2", "2024-03-01"),
+      snapshot("1.0.1", "2024-02-01"),
+    ])
+    mockDeprecated([])
+    const latest = await latestUndeprecatedSnapshot("ds000001")
+    expect(latest.tag).toBe("1.0.2")
+  })
+
+  it("falls back past deprecated snapshots", async () => {
+    getSnapshots.mockResolvedValue([
+      snapshot("1.0.0", "2024-01-01"),
+      snapshot("1.0.1", "2024-02-01"),
+      snapshot("1.0.2", "2024-03-01"),
+    ])
+    mockDeprecated(["ds000001:1.0.2", "ds000001:1.0.1"])
+    const latest = await latestUndeprecatedSnapshot("ds000001")
+    expect(latest.tag).toBe("1.0.0")
+  })
+
+  it("returns null when every snapshot is deprecated", async () => {
+    getSnapshots.mockResolvedValue([snapshot("1.0.0", "2024-01-01")])
+    mockDeprecated(["ds000001:1.0.0"])
+    expect(await latestUndeprecatedSnapshot("ds000001")).toBeNull()
+  })
+
+  it("returns null for a dataset with no snapshots", async () => {
+    getSnapshots.mockResolvedValue([])
+    expect(await latestUndeprecatedSnapshot("ds000001")).toBeNull()
+  })
+
+  it("returns null when the dataset does not exist", async () => {
+    getSnapshots.mockResolvedValue(null)
+    expect(await latestUndeprecatedSnapshot("ds000001")).toBeNull()
+  })
+})
+
+describe("searchContributorDatasetIds()", () => {
+  it("filters the index to public datasets listing this ORCID iD", async () => {
+    search.mockResolvedValue({
+      hits: { total: { value: 2 }, hits: [{ _source: { id: "ds000001" } }] },
+    })
+    expect(await searchContributorDatasetIds(ORCID)).toEqual(["ds000001"])
+    expect(search).toHaveBeenCalledWith(
+      expect.objectContaining({
+        index: "datasets",
+        query: {
+          bool: {
+            filter: [
+              { term: { public: true } },
+              { term: { "latestSnapshot.contributors.orcid.keyword": ORCID } },
+            ],
+          },
+        },
+      }),
+    )
+  })
+})
+
+describe("eligibleDatasets()", () => {
+  // Mongo is only queried a second time when the index adds new candidates, so
+  // drop any unconsumed queued results between cases
+  beforeEach(() => datasetFind.mockReset())
+
+  it("combines uploads with confirmed public search hits", async () => {
+    datasetFind
+      .mockReturnValueOnce(leanExec([{ id: "ds000001" }]))
+      .mockReturnValueOnce(leanExec([{ id: "ds000002" }]))
+    search.mockResolvedValue({
+      hits: {
+        total: { value: 2 },
+        hits: [{ _source: { id: "ds000002" } }, {
+          _source: { id: "ds000003" },
+        }],
+      },
+    })
+
+    const { candidates, searchError } = await eligibleDatasets("user-1", ORCID)
+    expect(searchError).toBeNull()
+    expect([...candidates]).toEqual([
+      ["ds000001", "uploader"],
+      ["ds000002", "contributor"],
+    ])
+    // ds000003 was in the index but Mongo did not confirm it as public
+    expect(candidates.has("ds000003")).toBe(false)
+    expect(datasetFind).toHaveBeenCalledWith(
+      { uploader: "user-1", public: true },
+      "id",
+    )
+  })
+
+  it("keeps uploads as uploader matches even when also in the index", async () => {
+    datasetFind
+      .mockReturnValueOnce(leanExec([{ id: "ds000001" }]))
+      .mockReturnValueOnce(leanExec([]))
+    search.mockResolvedValue({
+      hits: { total: { value: 1 }, hits: [{ _source: { id: "ds000001" } }] },
+    })
+    const { candidates } = await eligibleDatasets("user-1", ORCID)
+    expect(candidates.get("ds000001")).toBe("uploader")
+  })
+
+  it("reports a search failure but still returns uploads", async () => {
+    datasetFind.mockReturnValueOnce(leanExec([{ id: "ds000001" }]))
+    search.mockRejectedValue(new Error("connect ECONNREFUSED"))
+    const { candidates, searchError } = await eligibleDatasets("user-1", ORCID)
+    expect(candidates.get("ds000001")).toBe("uploader")
+    expect(searchError).toMatch(/ECONNREFUSED/)
+  })
+})
+
+describe("isDataciteContributor()", () => {
+  it("reads contributors at the snapshot revision", async () => {
+    contributors.mockResolvedValue([{ name: "Doe, Jane", orcid: ORCID }])
+    expect(
+      await isDataciteContributor("ds000001", "1.0.1", "sha-1.0.1", ORCID),
+    ).toBe(true)
+    expect(contributors).toHaveBeenCalledWith({
+      id: "ds000001:1.0.1",
+      tag: "1.0.1",
+      hexsha: "sha-1.0.1",
+    })
+  })
+
+  it("is false when the ORCID iD is absent", async () => {
+    contributors.mockResolvedValue([
+      { name: "Roe, Richard", orcid: undefined },
+    ])
+    expect(
+      await isDataciteContributor("ds000001", "1.0.1", "sha-1.0.1", ORCID),
+    ).toBe(false)
+  })
+})

--- a/packages/openneuro-server/src/libs/orcid/__tests__/token.spec.ts
+++ b/packages/openneuro-server/src/libs/orcid/__tests__/token.spec.ts
@@ -1,0 +1,165 @@
+import { vi } from "vitest"
+import type { UserDocument } from "../../../models/user"
+
+vi.mock("ioredis")
+vi.mock("@sentry/node", () => ({ captureException: vi.fn() }))
+vi.mock("../../../config", () => ({
+  default: {
+    url: "https://openneuro.org",
+    auth: {
+      jwt: { secret: "test-secret-for-orcid-tokens" },
+      orcid: {
+        clientID: "APP-OPENNEURO",
+        clientSecret: "secret",
+        apiURI: "https://api.sandbox.orcid.org",
+      },
+    },
+  },
+}))
+
+const userUpdateOne = vi.fn()
+vi.mock("../../../models/user", () => ({
+  default: { updateOne: (...args) => userUpdateOne(...args) },
+}))
+
+import { decrypt } from "../../authentication/crypto"
+import {
+  getOrcidAccessToken,
+  OrcidAuthorizationError,
+  orcidOauthUrl,
+  orcidTokenFields,
+} from "../token"
+
+const user = (overrides: Partial<UserDocument> = {}) =>
+  ({
+    id: "user-1",
+    orcid: "0000-0002-1825-0097",
+    ...overrides,
+  }) as UserDocument
+
+describe("orcidOauthUrl()", () => {
+  it("uses the sandbox host when the API endpoint is a sandbox", () => {
+    expect(orcidOauthUrl()).toBe("https://sandbox.orcid.org")
+  })
+})
+
+describe("orcidTokenFields()", () => {
+  it("encrypts both tokens at rest", () => {
+    const fields = orcidTokenFields({
+      access_token: "access-1",
+      refresh_token: "refresh-1",
+      expires_in: 631138518,
+      scope: "/activities/update /read-limited",
+    })
+    expect(fields.orcidAccessToken).not.toContain("access-1")
+    expect(decrypt(fields.orcidAccessToken)).toBe("access-1")
+    expect(decrypt(fields.orcidRefreshToken)).toBe("refresh-1")
+    expect(fields.orcidScope).toBe("/activities/update /read-limited")
+    expect(fields.orcidTokenExpires.getTime()).toBeGreaterThan(Date.now())
+  })
+
+  it("returns nothing without an access token", () => {
+    expect(orcidTokenFields({})).toEqual({})
+  })
+})
+
+describe("getOrcidAccessToken()", () => {
+  beforeEach(() => {
+    userUpdateOne.mockResolvedValue({})
+  })
+
+  it("returns the stored token when it has not expired", async () => {
+    const stored = orcidTokenFields({
+      access_token: "access-1",
+      scope: "/activities/update",
+      expires_in: 3600,
+    })
+    await expect(getOrcidAccessToken(user(stored))).resolves.toBe("access-1")
+  })
+
+  it("treats a token with no recorded expiry as usable", async () => {
+    const stored = orcidTokenFields({ access_token: "access-1" })
+    await expect(getOrcidAccessToken(user(stored))).resolves.toBe("access-1")
+  })
+
+  it("asks for re-authorization when no token is stored", async () => {
+    await expect(getOrcidAccessToken(user())).rejects.toThrow(
+      OrcidAuthorizationError,
+    )
+  })
+
+  it("asks for re-authorization when the granted scope cannot write", async () => {
+    const stored = orcidTokenFields({
+      access_token: "access-1",
+      scope: "/read-limited",
+    })
+    await expect(getOrcidAccessToken(user(stored))).rejects.toThrow(
+      /cannot update your record/,
+    )
+  })
+
+  it("asks for re-authorization when an expired token cannot be refreshed", async () => {
+    const stored = orcidTokenFields({
+      access_token: "access-1",
+      scope: "/activities/update",
+    })
+    await expect(
+      getOrcidAccessToken(
+        user({ ...stored, orcidTokenExpires: new Date(Date.now() - 1000) }),
+      ),
+    ).rejects.toThrow(/expired/)
+  })
+
+  it("refreshes and stores an expired token", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        access_token: "access-2",
+        refresh_token: "refresh-2",
+        expires_in: 3600,
+        scope: "/activities/update",
+      }),
+    })
+    vi.stubGlobal("fetch", fetchMock)
+
+    const stored = orcidTokenFields({
+      access_token: "access-1",
+      refresh_token: "refresh-1",
+      scope: "/activities/update",
+    })
+    await expect(
+      getOrcidAccessToken(
+        user({ ...stored, orcidTokenExpires: new Date(Date.now() - 1000) }),
+      ),
+    ).resolves.toBe("access-2")
+
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      "https://sandbox.orcid.org/oauth/token",
+    )
+    const [{ orcidAccessToken }] = userUpdateOne.mock.calls[0].slice(1)
+    expect(decrypt(orcidAccessToken)).toBe("access-2")
+    vi.unstubAllGlobals()
+  })
+
+  it("asks for re-authorization when ORCID rejects the refresh", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 400,
+        json: async () => ({ error_description: "invalid refresh token" }),
+      }),
+    )
+    const stored = orcidTokenFields({
+      access_token: "access-1",
+      refresh_token: "refresh-1",
+      scope: "/activities/update",
+    })
+    await expect(
+      getOrcidAccessToken(
+        user({ ...stored, orcidTokenExpires: new Date(Date.now() - 1000) }),
+      ),
+    ).rejects.toThrow(/invalid refresh token/)
+    vi.unstubAllGlobals()
+  })
+})

--- a/packages/openneuro-server/src/libs/orcid/__tests__/work-metadata.spec.ts
+++ b/packages/openneuro-server/src/libs/orcid/__tests__/work-metadata.spec.ts
@@ -1,0 +1,130 @@
+import { vi } from "vitest"
+import type { DataCite } from "../../../types/datacite"
+
+vi.mock("ioredis")
+vi.mock("../../../config", () => ({
+  default: {
+    url: "https://openneuro.org",
+    auth: { orcid: { clientID: "APP-TEST", apiURI: "https://api.orcid.org" } },
+  },
+}))
+
+import { buildOrcidWork, datasetExternalIdValue } from "../work-metadata"
+
+const attributes: DataCite = {
+  doi: "10.18112/openneuro.ds000001.v1.0.1",
+  url: "https://openneuro.org/datasets/ds000001/versions/1.0.1",
+  creators: [
+    {
+      name: "Doe, Jane",
+      nameType: "Personal",
+      nameIdentifiers: [
+        {
+          nameIdentifier: "https://orcid.org/0000-0002-1825-0097",
+          nameIdentifierScheme: "ORCID",
+        },
+      ],
+    },
+    { name: "Roe, Richard", nameType: "Personal" },
+  ],
+  titles: [{ title: "A Test Dataset" }],
+  publisher: { name: "OpenNeuro" },
+  publicationYear: "2024",
+  types: { resourceTypeGeneral: "Dataset" },
+  schemaVersion: "http://datacite.org/schema/kernel-4",
+  descriptions: [
+    { description: "An abstract.", descriptionType: "Abstract" },
+  ],
+}
+
+describe("buildOrcidWork()", () => {
+  const snapshotDate = new Date("2024-03-05T12:00:00Z")
+
+  it("maps Datacite metadata onto an ORCID data-set work", () => {
+    const work = buildOrcidWork("ds000001", attributes, snapshotDate)
+    expect(work.type).toBe("data-set")
+    expect(work.title.title.value).toBe("A Test Dataset")
+    expect(work["short-description"]).toBe("An abstract.")
+    expect(work.url).toEqual({ value: attributes.url })
+    expect(work["journal-title"]).toEqual({ value: "OpenNeuro" })
+  })
+
+  it("uses a zero padded publication date from the snapshot", () => {
+    const work = buildOrcidWork("ds000001", attributes, snapshotDate)
+    expect(work["publication-date"]).toEqual({
+      year: { value: "2024" },
+      month: { value: "03" },
+      day: { value: "05" },
+    })
+  })
+
+  it("includes a version independent external id for the dataset", () => {
+    const work = buildOrcidWork("ds000001", attributes, snapshotDate)
+    const externalIds = work["external-ids"]["external-id"]
+    expect(externalIds).toContainEqual({
+      "external-id-type": "uri",
+      "external-id-value": "https://openneuro.org/datasets/ds000001",
+      "external-id-url": { value: "https://openneuro.org/datasets/ds000001" },
+      "external-id-relationship": "self",
+    })
+    expect(externalIds).toContainEqual({
+      "external-id-type": "doi",
+      "external-id-value": "10.18112/openneuro.ds000001.v1.0.1",
+      "external-id-url": {
+        value: "https://doi.org/10.18112/openneuro.ds000001.v1.0.1",
+      },
+      "external-id-relationship": "self",
+    })
+  })
+
+  it("keeps the same stable external id across snapshots", () => {
+    const later = buildOrcidWork(
+      "ds000001",
+      { ...attributes, doi: "10.18112/openneuro.ds000001.v2.0.0" },
+      new Date("2025-01-01T00:00:00Z"),
+    )
+    expect(later["external-ids"]["external-id"][0]["external-id-value"]).toBe(
+      datasetExternalIdValue("ds000001"),
+    )
+  })
+
+  it("attaches ORCID iDs to creators that have one", () => {
+    const work = buildOrcidWork("ds000001", attributes, snapshotDate)
+    const [first, second] = work.contributors.contributor
+    expect(first["contributor-orcid"]).toEqual({
+      uri: "https://orcid.org/0000-0002-1825-0097",
+      path: "0000-0002-1825-0097",
+      host: "orcid.org",
+    })
+    expect(first["contributor-attributes"]).toEqual({
+      "contributor-sequence": "first",
+      "contributor-role": "author",
+    })
+    expect(second["contributor-orcid"]).toBeUndefined()
+    expect(second["credit-name"]).toEqual({ value: "Roe, Richard" })
+  })
+
+  it("truncates descriptions ORCID would reject", () => {
+    const work = buildOrcidWork(
+      "ds000001",
+      {
+        ...attributes,
+        descriptions: [{
+          description: "x".repeat(6000),
+          descriptionType: "Abstract",
+        }],
+      },
+      snapshotDate,
+    )
+    expect(work["short-description"].length).toBe(5000)
+  })
+
+  it("falls back to the accession number when no title is present", () => {
+    const work = buildOrcidWork(
+      "ds000001",
+      { ...attributes, titles: [] },
+      snapshotDate,
+    )
+    expect(work.title.title.value).toBe("ds000001")
+  })
+})

--- a/packages/openneuro-server/src/libs/orcid/__tests__/works.spec.ts
+++ b/packages/openneuro-server/src/libs/orcid/__tests__/works.spec.ts
@@ -1,0 +1,181 @@
+import { vi } from "vitest"
+import type { OrcidWorkSummary } from "../../../types/orcid"
+
+vi.mock("ioredis")
+vi.mock("../../../config", () => ({
+  default: {
+    url: "https://openneuro.org",
+    auth: {
+      orcid: { clientID: "APP-OPENNEURO", apiURI: "https://api.orcid.org" },
+    },
+  },
+}))
+
+import {
+  createWork,
+  getWorkSummaries,
+  isOpenNeuroWork,
+  openNeuroWorkPutCodes,
+  putCodeFromLocation,
+  updateWork,
+} from "../works"
+
+const summary = (
+  putCode: number,
+  clientId: string,
+  externalIdValue: string,
+): OrcidWorkSummary => ({
+  "put-code": putCode,
+  source: {
+    "source-client-id": {
+      uri: `https://orcid.org/client/${clientId}`,
+      path: clientId,
+      host: "orcid.org",
+    },
+  },
+  "external-ids": {
+    "external-id": [
+      {
+        "external-id-type": "uri",
+        "external-id-value": externalIdValue,
+        "external-id-relationship": "self",
+      },
+    ],
+  },
+})
+
+const work = {
+  title: { title: { value: "A Test Dataset" } },
+  type: "data-set",
+  "external-ids": {
+    "external-id": [
+      {
+        "external-id-type": "uri" as const,
+        "external-id-value": "https://openneuro.org/datasets/ds000001",
+        "external-id-relationship": "self" as const,
+      },
+    ],
+  },
+}
+
+describe("putCodeFromLocation()", () => {
+  it("reads the put-code out of a creation Location header", () => {
+    expect(
+      putCodeFromLocation(
+        "https://api.orcid.org/v3.0/0000-0002-1825-0097/work/12345",
+      ),
+    ).toBe(12345)
+  })
+  it("returns null without a Location header", () => {
+    expect(putCodeFromLocation(null)).toBeNull()
+  })
+  it("returns null for an unexpected Location header", () => {
+    expect(putCodeFromLocation("https://api.orcid.org/v3.0/works")).toBeNull()
+  })
+})
+
+describe("isOpenNeuroWork()", () => {
+  it("matches works created by this client", () => {
+    expect(isOpenNeuroWork(summary(1, "APP-OPENNEURO", "uri"))).toBe(true)
+  })
+  it("rejects works created by other systems", () => {
+    expect(isOpenNeuroWork(summary(1, "APP-CROSSREF", "uri"))).toBe(false)
+  })
+})
+
+describe("openNeuroWorkPutCodes()", () => {
+  const datasetUrl = "https://openneuro.org/datasets/ds000001"
+
+  it("indexes our own works by external id", () => {
+    const putCodes = openNeuroWorkPutCodes([
+      summary(42, "APP-OPENNEURO", datasetUrl),
+    ])
+    expect(putCodes.get(datasetUrl)).toBe(42)
+  })
+
+  it("ignores works from other sources so they are never overwritten", () => {
+    const putCodes = openNeuroWorkPutCodes([
+      summary(7, "APP-CROSSREF", datasetUrl),
+    ])
+    expect(putCodes.has(datasetUrl)).toBe(false)
+  })
+
+  it("converges on the lowest put-code when a work was added twice", () => {
+    const putCodes = openNeuroWorkPutCodes([
+      summary(90, "APP-OPENNEURO", datasetUrl),
+      summary(11, "APP-OPENNEURO", datasetUrl),
+    ])
+    expect(putCodes.get(datasetUrl)).toBe(11)
+  })
+})
+
+describe("ORCID works API", () => {
+  const fetchMock = vi.fn()
+
+  beforeEach(() => {
+    fetchMock.mockReset()
+    vi.stubGlobal("fetch", fetchMock)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it("flattens work summary groups", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        group: [
+          { "work-summary": [summary(1, "APP-OPENNEURO", "a")] },
+          { "work-summary": [summary(2, "APP-OPENNEURO", "b")] },
+          {},
+        ],
+      }),
+    })
+    const summaries = await getWorkSummaries("0000-0002-1825-0097", "token")
+    expect(summaries.map((s) => s["put-code"])).toEqual([1, 2])
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.orcid.org/v3.0/0000-0002-1825-0097/works",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer token",
+        }),
+      }),
+    )
+  })
+
+  it("returns the put-code assigned to a new work", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      headers: {
+        get: () => "https://api.orcid.org/v3.0/0000-0002-1825-0097/work/987654",
+      },
+    })
+    await expect(createWork("0000-0002-1825-0097", "token", work)).resolves
+      .toBe(987654)
+    const [url, options] = fetchMock.mock.calls[0]
+    expect(url).toBe("https://api.orcid.org/v3.0/0000-0002-1825-0097/work")
+    expect(options.method).toBe("POST")
+  })
+
+  it("sends the put-code in the body when updating a work", async () => {
+    fetchMock.mockResolvedValue({ ok: true })
+    await updateWork("0000-0002-1825-0097", "token", 987654, work)
+    const [url, options] = fetchMock.mock.calls[0]
+    expect(url).toBe(
+      "https://api.orcid.org/v3.0/0000-0002-1825-0097/work/987654",
+    )
+    expect(options.method).toBe("PUT")
+    expect(JSON.parse(options.body)["put-code"]).toBe(987654)
+  })
+
+  it("raises the ORCID response body on failure", async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 409,
+      text: async () => "conflict: work already exists",
+    })
+    await expect(createWork("0000-0002-1825-0097", "token", work)).rejects
+      .toThrow(/409.*work already exists/)
+  })
+})

--- a/packages/openneuro-server/src/libs/orcid/eligible-datasets.ts
+++ b/packages/openneuro-server/src/libs/orcid/eligible-datasets.ts
@@ -1,0 +1,168 @@
+/**
+ * Find the datasets a user has contributed to for publication as ORCID works.
+ *
+ * A user is a contributor when they uploaded the dataset or when their ORCID iD
+ * appears in the dataset's datacite.yml. Uploads come straight from Mongo, but
+ * datacite.yml lives in each dataset repository so the search index is used to
+ * narrow the field before the authoritative file is read.
+ */
+import * as Sentry from "@sentry/node"
+import { getElasticClient } from "../../elasticsearch/elastic-client"
+import Dataset from "../../models/dataset"
+import DeprecatedSnapshot from "../../models/deprecatedSnapshot"
+import Snapshot from "../../models/snapshot"
+import type { SnapshotDocument } from "../../models/snapshot"
+import { getSnapshots } from "../../datalad/snapshots"
+import type { SnapshotResponse } from "../../datalad/snapshots"
+import { snapshotCreationComparison } from "../../utils/snapshots"
+import { contributors } from "../../datalad/contributors"
+
+const ELASTIC_INDEX = "datasets"
+
+/** Upper bound on contributor matches returned from the search index */
+const MAX_SEARCH_RESULTS = 1000
+
+/** How a user is associated with a dataset */
+export type ContributionKind = "uploader" | "contributor"
+
+/**
+ * The most recent snapshot of a dataset that has not been deprecated.
+ *
+ * Deprecated snapshots are withdrawn from the record, so their metadata must
+ * never be the source for a work.
+ */
+export const latestUndeprecatedSnapshot = async (
+  datasetId: string,
+): Promise<SnapshotResponse | null> => {
+  const snapshots = await getSnapshots(datasetId)
+  if (!snapshots?.length) return null
+
+  const newestFirst = [...snapshots].sort(snapshotCreationComparison).reverse()
+  const deprecated = await DeprecatedSnapshot.find({
+    id: { $in: newestFirst.map(({ tag }) => `${datasetId}:${tag}`) },
+  })
+    .lean()
+    .exec()
+  const deprecatedIds = new Set(deprecated.map(({ id }) => id))
+
+  return newestFirst.find(
+    ({ tag }) => !deprecatedIds.has(`${datasetId}:${tag}`),
+  ) || null
+}
+
+/**
+ * Snapshots returned from the datalad worker may not carry a hexsha, so fall
+ * back to the tag which git resolves the same way.
+ */
+export const snapshotRevision = async (
+  datasetId: string,
+  snapshot: SnapshotResponse | SnapshotDocument,
+): Promise<string> => {
+  if (snapshot.hexsha) return snapshot.hexsha
+  const stored = await Snapshot.findOne({ datasetId, tag: snapshot.tag })
+    .lean()
+    .exec()
+  return stored?.hexsha || snapshot.tag
+}
+
+/**
+ * Dataset ids the search index lists this ORCID iD as a contributor of.
+ *
+ * These are candidates only - the index trails the repositories, so every hit
+ * is confirmed against datacite.yml before anything is written to ORCID.
+ */
+export const searchContributorDatasetIds = async (
+  orcid: string,
+): Promise<string[]> => {
+  const result = await getElasticClient().search<{ id: string }>({
+    index: ELASTIC_INDEX,
+    size: MAX_SEARCH_RESULTS,
+    _source: ["id"],
+    query: {
+      bool: {
+        filter: [
+          { term: { public: true } },
+          { term: { "latestSnapshot.contributors.orcid.keyword": orcid } },
+        ],
+      },
+    },
+  })
+  const total = typeof result.hits.total === "number"
+    ? result.hits.total
+    : result.hits.total?.value ?? 0
+  if (total > MAX_SEARCH_RESULTS) {
+    Sentry.captureMessage(
+      `ORCID works sync found ${total} contributor datasets for ${orcid}, only the first ${MAX_SEARCH_RESULTS} will be published`,
+    )
+  }
+  return result.hits.hits
+    .map((hit) => hit._source?.id)
+    .filter(Boolean) as string[]
+}
+
+export interface EligibleDatasets {
+  candidates: Map<string, ContributionKind>
+  /** Set when the search index could not be reached, uploads are still synced */
+  searchError: string | null
+}
+
+/**
+ * Every public dataset this user may have a work published for.
+ *
+ * Uploader matches are authoritative. Contributor matches come from the search
+ * index and still need confirming with {@link isDataciteContributor}.
+ */
+export const eligibleDatasets = async (
+  userId: string,
+  orcid: string,
+): Promise<EligibleDatasets> => {
+  const candidates = new Map<string, ContributionKind>()
+
+  const uploaded = await Dataset.find({ uploader: userId, public: true }, "id")
+    .lean()
+    .exec()
+  for (const { id } of uploaded) candidates.set(id, "uploader")
+
+  let searchIds: string[] = []
+  let searchError: string | null = null
+  try {
+    searchIds = await searchContributorDatasetIds(orcid)
+  } catch (err) {
+    // Uploaded datasets can still be published without the index
+    Sentry.captureException(err)
+    searchError = String(err)
+  }
+
+  const unseen = searchIds.filter((id) => !candidates.has(id))
+  if (unseen.length) {
+    // Recheck the public flag against Mongo in case the index is stale
+    const published = await Dataset.find(
+      { id: { $in: unseen }, public: true },
+      "id",
+    )
+      .lean()
+      .exec()
+    for (const { id } of published) candidates.set(id, "contributor")
+  }
+
+  return { candidates, searchError }
+}
+
+/**
+ * Confirm an ORCID iD is listed in a snapshot's datacite.yml contributors.
+ */
+export const isDataciteContributor = async (
+  datasetId: string,
+  tag: string,
+  hexsha: string,
+  orcid: string,
+): Promise<boolean> => {
+  const snapshotContributors = await contributors({
+    id: `${datasetId}:${tag}`,
+    tag,
+    hexsha,
+  })
+  return snapshotContributors.some(
+    (contributor) => contributor.orcid === orcid,
+  )
+}

--- a/packages/openneuro-server/src/libs/orcid/index.ts
+++ b/packages/openneuro-server/src/libs/orcid/index.ts
@@ -1,6 +1,6 @@
 // Camel case rule is disabled since ORCID API uses snake case variables
 import xmldoc from "xmldoc"
-import config from "../config"
+import config from "../../config"
 import * as Sentry from "@sentry/node"
 
 export default {

--- a/packages/openneuro-server/src/libs/orcid/token.ts
+++ b/packages/openneuro-server/src/libs/orcid/token.ts
@@ -1,0 +1,147 @@
+/**
+ * Storage and retrieval of the per user ORCID OAuth tokens needed to write to a
+ * user's ORCID record.
+ *
+ * Tokens are encrypted at rest with the same key used for other stored OAuth
+ * credentials.
+ */
+import * as Sentry from "@sentry/node"
+import config from "../../config"
+import { decrypt, encrypt } from "../authentication/crypto"
+import User from "../../models/user"
+import type { UserDocument } from "../../models/user"
+
+/** Scope required to add or update works on a record */
+export const ACTIVITIES_UPDATE_SCOPE = "/activities/update"
+
+/**
+ * Raised when a user has no usable ORCID token so callers can tell this apart
+ * from a transient ORCID API failure and prompt for re-authorization.
+ */
+export class OrcidAuthorizationError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = "OrcidAuthorizationError"
+  }
+}
+
+/**
+ * OAuth base URL for ORCID, which differs between sandbox and production.
+ *
+ * passport-orcid derives this from a sandbox flag, we derive it from the
+ * configured API endpoint so only one variable has to be set.
+ */
+export const orcidOauthUrl = (): string => {
+  if (config.auth.orcid.URI) return config.auth.orcid.URI
+  return config.auth.orcid.apiURI?.includes("sandbox")
+    ? "https://sandbox.orcid.org"
+    : "https://orcid.org"
+}
+
+/**
+ * Token fields to persist on a user from an ORCID OAuth token response.
+ *
+ * passport-oauth2 hands the raw token response to the verify callback as
+ * `params`, which for ORCID carries the granted scope and expiration alongside
+ * the tokens.
+ */
+export const orcidTokenFields = (params: {
+  access_token?: string
+  refresh_token?: string
+  expires_in?: number
+  scope?: string
+}): Partial<UserDocument> => {
+  if (!params?.access_token) return {}
+  return {
+    orcidAccessToken: encrypt(params.access_token),
+    ...(params.refresh_token
+      ? { orcidRefreshToken: encrypt(params.refresh_token) }
+      : {}),
+    ...(params.expires_in
+      ? { orcidTokenExpires: new Date(Date.now() + params.expires_in * 1000) }
+      : {}),
+    ...(params.scope ? { orcidScope: params.scope } : {}),
+  } as Partial<UserDocument>
+}
+
+/**
+ * Exchange a refresh token for a new access token.
+ */
+const refreshAccessToken = async (
+  refreshToken: string,
+): Promise<{
+  access_token: string
+  refresh_token?: string
+  expires_in?: number
+  scope?: string
+}> => {
+  const form = new URLSearchParams({
+    client_id: config.auth.orcid.clientID,
+    client_secret: config.auth.orcid.clientSecret,
+    grant_type: "refresh_token",
+    refresh_token: refreshToken,
+  })
+  const response = await fetch(`${orcidOauthUrl()}/oauth/token`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+      "Accept": "application/json",
+    },
+    body: form,
+  })
+  const body = await response.json()
+  if (!response.ok || !body.access_token) {
+    throw new OrcidAuthorizationError(
+      body.error_description ||
+        `Could not refresh the ORCID access token (${response.status})`,
+    )
+  }
+  return body
+}
+
+/**
+ * Return an access token usable for writing to this user's ORCID record,
+ * refreshing it first if it has expired.
+ *
+ * @throws {OrcidAuthorizationError} when the user must authorize with ORCID again
+ */
+export const getOrcidAccessToken = async (
+  user: UserDocument,
+): Promise<string> => {
+  if (!user.orcidAccessToken) {
+    throw new OrcidAuthorizationError(
+      "No ORCID authorization is stored for this account. Sign in with ORCID again to grant access.",
+    )
+  }
+  if (
+    user.orcidScope && !user.orcidScope.includes(ACTIVITIES_UPDATE_SCOPE)
+  ) {
+    throw new OrcidAuthorizationError(
+      "The stored ORCID authorization cannot update your record. Sign in with ORCID again to grant access.",
+    )
+  }
+
+  const expired = user.orcidTokenExpires &&
+    user.orcidTokenExpires.getTime() <= Date.now()
+  if (!expired) {
+    return decrypt(user.orcidAccessToken)
+  }
+
+  if (!user.orcidRefreshToken) {
+    throw new OrcidAuthorizationError(
+      "Your ORCID authorization has expired. Sign in with ORCID again to grant access.",
+    )
+  }
+
+  try {
+    const refreshed = await refreshAccessToken(decrypt(user.orcidRefreshToken))
+    await User.updateOne({ id: user.id }, orcidTokenFields(refreshed))
+    return refreshed.access_token
+  } catch (err) {
+    if (err instanceof OrcidAuthorizationError) throw err
+    Sentry.captureException(err)
+    throw new OrcidAuthorizationError(
+      "Your ORCID authorization could not be refreshed. Sign in with ORCID again to grant access.",
+    )
+  }
+}

--- a/packages/openneuro-server/src/libs/orcid/work-metadata.ts
+++ b/packages/openneuro-server/src/libs/orcid/work-metadata.ts
@@ -1,0 +1,143 @@
+/**
+ * Translate the DataCite metadata for DOIs into the ORCID work format.
+ */
+import config from "../../config"
+import { validateOrcid } from "../../utils/orcid-utils"
+import type { DataCite } from "../../types/datacite"
+import type {
+  OrcidContributor,
+  OrcidExternalId,
+  OrcidPublicationDate,
+  OrcidWork,
+} from "../../types/orcid"
+
+/** ORCID work type for a dataset in the 3.0 schema */
+const ORCID_WORK_TYPE = "data-set"
+
+/** ORCID rejects descriptions longer than this */
+const MAX_DESCRIPTION_LENGTH = 5000
+
+/** ORCID rejects titles longer than this */
+const MAX_TITLE_LENGTH = 1000
+
+/**
+ * Stable identifier for a dataset across all of its versions.
+ *
+ * This is what lets the sync find the work it created for a dataset on a later
+ * run - the DOI changes with every snapshot, this does not.
+ */
+export const datasetExternalIdValue = (datasetId: string): string =>
+  `${config.url}/datasets/${datasetId}`
+
+const truncate = (value: string, length: number): string =>
+  value.length > length ? `${value.slice(0, length - 1)}…` : value
+
+/**
+ * ORCID wants zero padded string components and rejects partial dates that skip
+ * a level, so month and day are only included together with what precedes them.
+ */
+const publicationDate = (date: Date): OrcidPublicationDate => ({
+  year: { value: String(date.getUTCFullYear()) },
+  month: { value: String(date.getUTCMonth() + 1).padStart(2, "0") },
+  day: { value: String(date.getUTCDate()).padStart(2, "0") },
+})
+
+/**
+ * DataCite creators become ORCID contributors with the author role.
+ */
+const workContributors = (
+  attributes: DataCite,
+): OrcidContributor[] =>
+  (attributes.creators || []).map((creator, index) => {
+    const creatorOrcid = validateOrcid(
+      creator.nameIdentifiers?.find(
+        (identifier) => identifier.nameIdentifierScheme === "ORCID",
+      )?.nameIdentifier,
+    )
+    return {
+      ...(creatorOrcid
+        ? {
+          "contributor-orcid": {
+            uri: `https://orcid.org/${creatorOrcid}`,
+            path: creatorOrcid,
+            host: "orcid.org",
+          },
+        }
+        : {}),
+      "credit-name": { value: creator.name },
+      "contributor-attributes": {
+        "contributor-sequence": index === 0
+          ? ("first" as const)
+          : ("additional" as const),
+        "contributor-role": "author",
+      },
+    }
+  })
+
+const workExternalIds = (
+  datasetId: string,
+  attributes: DataCite,
+): OrcidExternalId[] => {
+  const datasetUrl = datasetExternalIdValue(datasetId)
+  const externalIds: OrcidExternalId[] = [
+    {
+      "external-id-type": "uri",
+      "external-id-value": datasetUrl,
+      "external-id-url": { value: datasetUrl },
+      "external-id-relationship": "self",
+    },
+  ]
+  if (attributes.doi) {
+    externalIds.push({
+      "external-id-type": "doi",
+      "external-id-value": attributes.doi,
+      "external-id-url": { value: `https://doi.org/${attributes.doi}` },
+      "external-id-relationship": "self",
+    })
+  }
+  return externalIds
+}
+
+/**
+ * Build the ORCID work describing one dataset at one snapshot.
+ *
+ * @param datasetId Dataset accession number
+ * @param attributes DataCite metadata for the snapshot being published
+ * @param snapshotDate Creation date of the snapshot
+ */
+export const buildOrcidWork = (
+  datasetId: string,
+  attributes: DataCite,
+  snapshotDate: Date,
+): OrcidWork => {
+  const abstract = attributes.descriptions?.find(
+    (description) => description.descriptionType === "Abstract",
+  ) || attributes.descriptions?.[0]
+
+  return {
+    title: {
+      title: {
+        value: truncate(
+          attributes.titles?.[0]?.title || datasetId,
+          MAX_TITLE_LENGTH,
+        ),
+      },
+    },
+    "journal-title": { value: "OpenNeuro" },
+    ...(abstract?.description
+      ? {
+        "short-description": truncate(
+          abstract.description,
+          MAX_DESCRIPTION_LENGTH,
+        ),
+      }
+      : {}),
+    type: ORCID_WORK_TYPE,
+    "publication-date": publicationDate(snapshotDate),
+    "external-ids": { "external-id": workExternalIds(datasetId, attributes) },
+    ...(attributes.url ? { url: { value: attributes.url } } : {}),
+    ...(attributes.creators?.length
+      ? { contributors: { contributor: workContributors(attributes) } }
+      : {}),
+  }
+}

--- a/packages/openneuro-server/src/libs/orcid/works.ts
+++ b/packages/openneuro-server/src/libs/orcid/works.ts
@@ -1,0 +1,147 @@
+/**
+ * Client for the ORCID Member API 3.0 works endpoints.
+ *
+ * Writing to a user's ORCID record requires an access token issued to that user
+ * with the /activities/update scope. See libs/orcid/token.ts for how those are
+ * loaded.
+ */
+import config from "../../config"
+import type {
+  OrcidWork,
+  OrcidWorksResponse,
+  OrcidWorkSummary,
+} from "../../types/orcid"
+
+const ORCID_API_VERSION = "v3.0"
+
+const orcidApiUrl = (path: string): string =>
+  `${config.auth.orcid.apiURI}/${ORCID_API_VERSION}/${path}`
+
+const orcidHeaders = (accessToken: string): Record<string, string> => ({
+  "Authorization": `Bearer ${accessToken}`,
+  "Content-Type": "application/vnd.orcid+json",
+  "Accept": "application/json",
+})
+
+/**
+ * ORCID returns errors as JSON but falls back to HTML for some failures, so
+ * read the body as text and only summarize it in the thrown error.
+ */
+const orcidError = async (
+  response: Response,
+  action: string,
+): Promise<Error> => {
+  const body = await response.text().catch(() => "")
+  return new Error(
+    `ORCID API error ${response.status} while ${action}: ${body.slice(0, 500)}`,
+  )
+}
+
+/**
+ * Parse the put-code out of the Location header returned by a work creation.
+ *
+ * Location looks like `https://api.orcid.org/v3.0/0000-0000-0000-0000/work/12345`
+ */
+export const putCodeFromLocation = (
+  location: string | null,
+): number | null => {
+  if (!location) return null
+  const match = location.match(/\/work\/(\d+)\/?$/)
+  return match ? Number(match[1]) : null
+}
+
+/**
+ * Every work summary on an ORCID record, including works added by other systems.
+ */
+export const getWorkSummaries = async (
+  orcid: string,
+  accessToken: string,
+): Promise<OrcidWorkSummary[]> => {
+  const response = await fetch(orcidApiUrl(`${orcid}/works`), {
+    headers: orcidHeaders(accessToken),
+  })
+  if (!response.ok) {
+    throw await orcidError(response, `reading works for ${orcid}`)
+  }
+  const body = (await response.json()) as OrcidWorksResponse
+  return (body.group || []).flatMap((group) => group["work-summary"] || [])
+}
+
+/**
+ * True if a work summary was created by this OpenNeuro deployment.
+ *
+ * Works added by other systems (or by hand) must never be modified, ORCID
+ * rejects those writes but this avoids relying on that.
+ */
+export const isOpenNeuroWork = (summary: OrcidWorkSummary): boolean =>
+  summary.source?.["source-client-id"]?.path === config.auth.orcid.clientID
+
+/**
+ * Map of external id value to put-code for works this deployment created.
+ *
+ * Used to recover put-codes for works we have no local record of, which keeps
+ * the sync idempotent even if our records are lost or a work is added twice.
+ */
+export const openNeuroWorkPutCodes = (
+  summaries: OrcidWorkSummary[],
+): Map<string, number> => {
+  const putCodes = new Map<string, number>()
+  for (const summary of summaries.filter(isOpenNeuroWork)) {
+    for (const externalId of summary["external-ids"]?.["external-id"] || []) {
+      const value = externalId["external-id-value"]
+      // Keep the lowest put-code so repeated runs converge on one work
+      const existing = putCodes.get(value)
+      if (existing === undefined || summary["put-code"] < existing) {
+        putCodes.set(value, summary["put-code"])
+      }
+    }
+  }
+  return putCodes
+}
+
+/**
+ * Add a new work to a user's ORCID record, returning the assigned put-code.
+ */
+export const createWork = async (
+  orcid: string,
+  accessToken: string,
+  work: OrcidWork,
+): Promise<number> => {
+  const response = await fetch(orcidApiUrl(`${orcid}/work`), {
+    method: "POST",
+    headers: orcidHeaders(accessToken),
+    body: JSON.stringify(work),
+  })
+  if (!response.ok) {
+    throw await orcidError(response, `creating a work for ${orcid}`)
+  }
+  const putCode = putCodeFromLocation(response.headers.get("location"))
+  if (putCode === null) {
+    throw new Error(
+      `ORCID API did not return a put-code when creating a work for ${orcid}`,
+    )
+  }
+  return putCode
+}
+
+/**
+ * Replace an existing work on a user's ORCID record.
+ */
+export const updateWork = async (
+  orcid: string,
+  accessToken: string,
+  putCode: number,
+  work: OrcidWork,
+): Promise<void> => {
+  const response = await fetch(orcidApiUrl(`${orcid}/work/${putCode}`), {
+    method: "PUT",
+    headers: orcidHeaders(accessToken),
+    body: JSON.stringify({ ...work, "put-code": putCode }),
+  })
+  if (!response.ok) {
+    throw await orcidError(
+      response,
+      `updating work ${putCode} for ${orcid}`,
+    )
+  }
+}

--- a/packages/openneuro-server/src/models/orcidWork.ts
+++ b/packages/openneuro-server/src/models/orcidWork.ts
@@ -1,0 +1,44 @@
+import mongoose from "mongoose"
+import type { Document } from "mongoose"
+const { Schema, model } = mongoose
+
+/**
+ * A dataset published as a work on one user's ORCID record.
+ *
+ * Tracking the put-code lets a later sync update the existing work instead of
+ * adding a duplicate, and the hash lets us skip ORCID writes for datasets that
+ * have not changed since the last sync.
+ */
+export interface OrcidWorkDocument extends Document {
+  // OpenNeuro user id the work belongs to
+  userId: string
+  // ORCID iD the work was written to
+  orcid: string
+  // Dataset accession number
+  datasetId: string
+  // ORCID assigned identifier for this work
+  putCode: number
+  // Snapshot tag the published metadata came from
+  snapshotTag: string
+  // DOI of that snapshot, when one has been minted
+  doi?: string
+  // Hash of the last work payload sent to ORCID
+  hash: string
+  updatedAt: Date
+}
+
+const orcidWorkSchema = new Schema<OrcidWorkDocument>({
+  userId: { type: String, required: true },
+  orcid: { type: String, required: true },
+  datasetId: { type: String, required: true },
+  putCode: { type: Number, required: true },
+  snapshotTag: { type: String, required: true },
+  doi: { type: String },
+  hash: { type: String, required: true },
+}, { timestamps: { createdAt: false, updatedAt: true } })
+
+orcidWorkSchema.index({ userId: 1, datasetId: 1 }, { unique: true })
+
+const OrcidWork = model<OrcidWorkDocument>("OrcidWork", orcidWorkSchema)
+
+export default OrcidWork

--- a/packages/openneuro-server/src/models/user.ts
+++ b/packages/openneuro-server/src/models/user.ts
@@ -45,6 +45,14 @@ export interface UserDocument extends Document {
   githubSynced: Date
   // Defaults to NULL populated from ORCID Consent Form Mutation
   orcidConsent?: boolean | null
+  // Encrypted ORCID OAuth access token, used to write works to the user's record
+  orcidAccessToken?: string
+  // Encrypted ORCID OAuth refresh token
+  orcidRefreshToken?: string
+  // Expiration of orcidAccessToken
+  orcidTokenExpires?: Date
+  // Space separated scopes granted with orcidAccessToken
+  orcidScope?: string
   // Whether the user has opted out of public profile visibility
   profilePrivate?: boolean
   givenName?: string
@@ -75,6 +83,10 @@ const userSchema = new Schema({
     type: Boolean,
     default: null,
   },
+  orcidAccessToken: String,
+  orcidRefreshToken: String,
+  orcidTokenExpires: { type: Date },
+  orcidScope: String,
   profilePrivate: {
     type: Boolean,
     default: false,

--- a/packages/openneuro-server/src/types/orcid.ts
+++ b/packages/openneuro-server/src/types/orcid.ts
@@ -1,0 +1,94 @@
+/**
+ * Types for the ORCID Member API 3.0 works endpoints.
+ *
+ * https://info.orcid.org/documentation/api-tutorials/
+ *
+ * The ORCID JSON representation uses hyphenated keys so these interfaces do not
+ * follow the usual camelCase convention.
+ */
+
+export interface OrcidValue {
+  value: string
+}
+
+/** Relationship of an external id to the work it is attached to */
+export type OrcidExternalIdRelationship = "self" | "part-of" | "version-of"
+
+export interface OrcidExternalId {
+  "external-id-type": string
+  "external-id-value": string
+  "external-id-url"?: OrcidValue
+  "external-id-relationship": OrcidExternalIdRelationship
+}
+
+export interface OrcidExternalIds {
+  "external-id": OrcidExternalId[]
+}
+
+export interface OrcidTitle {
+  title: OrcidValue
+  subtitle?: OrcidValue
+  "translated-title"?: OrcidValue & { "language-code": string }
+}
+
+export interface OrcidPublicationDate {
+  year: OrcidValue
+  month?: OrcidValue
+  day?: OrcidValue
+}
+
+export interface OrcidContributorOrcid {
+  uri: string
+  path: string
+  host: string
+}
+
+export interface OrcidContributor {
+  "contributor-orcid"?: OrcidContributorOrcid
+  "credit-name"?: OrcidValue
+  "contributor-attributes"?: {
+    "contributor-sequence"?: "first" | "additional"
+    "contributor-role": string
+  }
+}
+
+export interface OrcidContributors {
+  contributor: OrcidContributor[]
+}
+
+/**
+ * A work as sent to POST /work and PUT /work/{putCode}.
+ *
+ * `put-code` is omitted on create and required on update.
+ */
+export interface OrcidWork {
+  "put-code"?: number
+  title: OrcidTitle
+  "journal-title"?: OrcidValue
+  "short-description"?: string
+  type: string
+  "publication-date"?: OrcidPublicationDate
+  "external-ids": OrcidExternalIds
+  url?: OrcidValue
+  contributors?: OrcidContributors
+  "language-code"?: string
+}
+
+export interface OrcidSource {
+  "source-client-id"?: { uri: string; path: string; host: string }
+  "source-orcid"?: { uri: string; path: string; host: string }
+  "source-name"?: OrcidValue
+}
+
+export interface OrcidWorkSummary {
+  "put-code": number
+  source?: OrcidSource
+  "external-ids"?: OrcidExternalIds
+  title?: OrcidTitle
+}
+
+export interface OrcidWorksResponse {
+  group?: {
+    "work-summary"?: OrcidWorkSummary[]
+  }[]
+}


### PR DESCRIPTION
This adds the mutations to automatically sync any works from a user's uploaded datasets or any datasets where they are listed by ORCID in datacite.yml.

The mutation works for the user that called it. This PR does not include any user interface for this, just the raw mutation. This should support both calling from the frontend when a user requests to manually sync their ORCID works and periodic automation once the manual sync further testing.

One major per-requisite is the storage of the ORCID token and push codes. The sync mutation will not work until a user has logged since this change but should give an appropriate error in that case.

One limitation is that because we find contributors with the search index, newly updated datasets may have a small delay before they can be synced as a work.