### PR TITLE
fix(server): Lower MongoDB timeouts to avoid throwing errors after connection close

### DIFF
--- a/packages/openneuro-server/src/config.ts
+++ b/packages/openneuro-server/src/config.ts
@@ -40,7 +40,6 @@ const config = {
   mongo: {
     url: process.env.MONGO_URL,
     dbName: "crn",
-    connectTimeoutMS: 1000,
   },
   redis: {
     port: parseInt(process.env.REDIS_PORT),

--- a/packages/openneuro-server/src/server.ts
+++ b/packages/openneuro-server/src/server.ts
@@ -8,7 +8,9 @@ import { initQueues } from "./queues/setup"
 
 void mongoose.connect(config.mongo.url, {
   dbName: config.mongo.dbName,
-  connectTimeoutMS: config.mongo.connectTimeoutMS,
+  connectTimeoutMS: 1000,
+  serverSelectionTimeoutMS: 5000,
+  socketTimeoutMS: 10000,
 })
 
 async function init() {


### PR DESCRIPTION
The default timeouts here are 30 seconds which can easily block longer than the available HTTP timeout. Lowering these to 5-10 seconds will fail faster in the case of connection issues and produce better error messages than a 502 Bad Gateway error.