### PR TITLE
fix(server): Resolve async issues with passport auth and raise errors on auth failure

### DIFF
--- a/packages/openneuro-server/src/libs/authentication/__tests__/jwt.spec.ts
+++ b/packages/openneuro-server/src/libs/authentication/__tests__/jwt.spec.ts
@@ -1,6 +1,13 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { vi } from "vitest"
 import User from "../../../models/user"
-import { addJWT, jwtFromRequest } from "../jwt"
+import passport from "passport"
+import {
+  addJWT,
+  authenticate,
+  jwtFromRequest,
+  parsedJwtFromRequest,
+} from "../jwt"
 
 vi.mock("ioredis")
 vi.mock("../../../config.ts")
@@ -54,6 +61,89 @@ describe("jwt auth", () => {
         headers: {},
       }
       expect(jwtFromRequest(req)).toEqual(null)
+    })
+  })
+  describe("parsedJwtFromRequest()", () => {
+    it("returns null for invalid token strings", () => {
+      const req = {
+        headers: { authorization: "Bearer invalid.token.payload" },
+      }
+      expect(parsedJwtFromRequest(req)).toBeNull()
+    })
+  })
+  describe("authenticate()", () => {
+    it("calls next() when user is unauthenticated", async () => {
+      vi.spyOn(passport, "authenticate").mockImplementation(
+        (_strategy, _options, callback: any) => {
+          return (_req, _res, _next) => {
+            callback(null, false)
+          }
+        },
+      )
+      const req: any = { headers: {}, cookies: {} }
+      const res: any = { cookie: vi.fn() }
+      const next = vi.fn()
+      await authenticate(req, res, next)
+      expect(next).toHaveBeenCalledWith()
+    })
+    it("forwards authentication error to next(err)", async () => {
+      const authErr = new Error("DB failure")
+      vi.spyOn(passport, "authenticate").mockImplementation(
+        (_strategy, _options, callback: any) => {
+          return (_req, _res, _next) => {
+            callback(authErr, null)
+          }
+        },
+      )
+      const req: any = { headers: {}, cookies: {} }
+      const res: any = { cookie: vi.fn() }
+      const next = vi.fn()
+      await authenticate(req, res, next)
+      expect(next).toHaveBeenCalledWith(authErr)
+    })
+    it("logs in user and sets Sentry context when authenticated", async () => {
+      const mockUser = { id: "user-123" }
+      vi.spyOn(passport, "authenticate").mockImplementation(
+        (_strategy, _options, callback: any) => {
+          return (_req, _res, _next) => {
+            callback(null, mockUser)
+          }
+        },
+      )
+      const req: any = {
+        headers: { "x-forwarded-for": "127.0.0.1" },
+        cookies: {},
+        login: vi.fn((_user, _opts, cb) => cb(null)),
+      }
+      const res: any = { cookie: vi.fn() }
+      const next = vi.fn()
+      await authenticate(req, res, next)
+      expect(req.login).toHaveBeenCalledWith(
+        mockUser,
+        { session: false },
+        expect.any(Function),
+      )
+      expect(next).toHaveBeenCalledWith()
+    })
+    it("forwards login error to next(err)", async () => {
+      const mockUser = { id: "user-123" }
+      const loginErr = new Error("Login failed")
+      vi.spyOn(passport, "authenticate").mockImplementation(
+        (_strategy, _options, callback: any) => {
+          return (_req, _res, _next) => {
+            callback(null, mockUser)
+          }
+        },
+      )
+      const req: any = {
+        headers: {},
+        cookies: {},
+        login: vi.fn((_user, _opts, cb) => cb(loginErr)),
+      }
+      const res: any = { cookie: vi.fn() }
+      const next = vi.fn()
+      await authenticate(req, res, next)
+      expect(next).toHaveBeenCalledWith(loginErr)
     })
   })
 })

--- a/packages/openneuro-server/src/libs/authentication/jwt.ts
+++ b/packages/openneuro-server/src/libs/authentication/jwt.ts
@@ -157,8 +157,15 @@ export const decodeJWT = (token: string): OpenNeuroTokenProfile => {
 
 export const parsedJwtFromRequest = (req) => {
   try {
-    const jwt = decodeJWT(jwtFromRequest(req))
-    return jwt || null
+    const token = jwtFromRequest(req)
+    if (!token) return null
+    if (config.auth?.jwt?.secret) {
+      return jwt.verify(token, config.auth.jwt.secret, {
+        ignoreExpiration: true,
+      }) as OpenNeuroTokenProfile
+    } else {
+      return decodeJWT(token)
+    }
   } catch (_err) {
     return null
   }
@@ -177,7 +184,7 @@ const refreshToken = async (jwt) => {
 }
 
 // Shared options for Express response.cookie()
-const cookieOptions = { sameSite: "Lax" }
+const cookieOptions = { sameSite: "lax" as const }
 
 // Obtain client IP address from request, considering possible proxies
 function getClientIp(req: Request): string | undefined {
@@ -194,32 +201,54 @@ function getClientIp(req: Request): string | undefined {
 
 // attach user obj to request based on jwt
 // if user does not exist, continue
-export const authenticate = (req, res, next) => {
-  const authenticateAsync = async () => {
+export const authenticate = async (req, res, next) => {
+  try {
     const jwt = parsedJwtFromRequest(req)
     if (jwt && Date.now() > jwt.exp * 1000) {
-      const token = await refreshToken(jwt)
-      if (token) {
-        req.cookies.accessToken = token
-        res.cookie("accessToken", token, cookieOptions)
+      try {
+        const token = await refreshToken(jwt)
+        if (token) {
+          if (!req.cookies) {
+            req.cookies = {}
+          }
+          req.cookies.accessToken = token
+          if (req.headers.authorization) {
+            req.headers.authorization = `Bearer ${token}`
+          }
+          res.cookie("accessToken", token, cookieOptions)
+        }
+      } catch {
+        // Continue to passport.authenticate if token refresh fails
       }
     }
     passport.authenticate("jwt", { session: false }, (err, user) => {
-      req.login(user, { session: false }, () => {
-        if (user) {
+      if (err) {
+        return next(err)
+      }
+      if (user) {
+        req.login(user, { session: false }, (loginErr) => {
+          if (loginErr) {
+            return next(loginErr)
+          }
           Sentry.setUser({
             id: user.id,
             ip_address: getClientIp(req),
           })
-        }
+          Sentry.setContext("request_headers", {
+            "x-forwarded-for": req.headers["x-forwarded-for"],
+          })
+          next()
+        })
+      } else {
         Sentry.setContext("request_headers", {
           "x-forwarded-for": req.headers["x-forwarded-for"],
         })
         next()
-      })
+      }
     })(req, res, next)
+  } catch (err) {
+    next(err)
   }
-  authenticateAsync()
 }
 
 export const authSuccessHandler = (req, res, next) => {


### PR DESCRIPTION
Passport authentication could silently swallow errors during authentication and throw an unrelated error instead of passing the specific failure to the express error handler. Fixes the wrapped unhandled promise.